### PR TITLE
create output dir if none is present

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -493,6 +493,9 @@ class SaveImage:
             counter = max(filter(lambda a: a[1][:-1] == filename_prefix and a[1][-1] == "_", map(map_filename, os.listdir(self.output_dir))))[0] + 1
         except ValueError:
             counter = 1
+        except FileNotFoundError:
+            os.mkdir(self.output_dir)
+            counter = 1
         for image in images:
             i = 255. * image.cpu().numpy()
             img = Image.fromarray(i.astype(np.uint8))


### PR DESCRIPTION
FileNotFoundError occurs if no output directory is present, this fixes it by making new directory where there should be one.

Another discussion that should be opened is whether it should be possible to  configure multiple custom directories (eg multiple output dirs, multiple model dirs, etc).