### PR TITLE
Updated to reuse session id if available

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -55,6 +55,7 @@ def recursive_execute(server, prompt, outputs, current_item, extra_data={}):
 
     input_data_all = get_input_data(inputs, class_def, outputs, prompt, extra_data)
     if server.client_id is not None:
+        server.last_node_id = unique_id
         server.send_sync("executing", { "node": unique_id }, server.client_id)
     obj = class_def()
 
@@ -188,6 +189,7 @@ class PromptExecutor:
                 for x in executed:
                     self.old_prompt[x] = copy.deepcopy(prompt[x])
             finally:
+                self.server.last_node_id = None
                 if self.server.client_id is not None:
                     self.server.send_sync("executing", { "node": None }, self.server.client_id)
 

--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -28,7 +28,13 @@ class ComfyApi extends EventTarget {
 		}
 
 		let opened = false;
-		this.socket = new WebSocket(`ws${window.location.protocol === "https:" ? "s" : ""}://${location.host}/ws`);
+		let existingSession = sessionStorage["Comfy.SessionId"] || "";
+		if (existingSession) {
+			existingSession = "?clientId=" + existingSession;
+		}
+		this.socket = new WebSocket(
+			`ws${window.location.protocol === "https:" ? "s" : ""}://${location.host}/ws${existingSession}`
+		);
 
 		this.socket.addEventListener("open", () => {
 			opened = true;
@@ -62,6 +68,7 @@ class ComfyApi extends EventTarget {
 					case "status":
 						if (msg.data.sid) {
 							this.clientId = msg.data.sid;
+							sessionStorage["Comfy.SessionId"] = this.clientId;
 						}
 						this.dispatchEvent(new CustomEvent("status", { detail: msg.data.status }));
 						break;


### PR DESCRIPTION
Client will reuse the same id for the lifetime of the tab
Server stores last executing node and will send to client on connect allowing it to display active node/progress