### PR TITLE
feat: support random seed before generation

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -285,7 +285,7 @@ app.registerExtension({
 				}
 
 				if (widget.type === "number") {
-					addRandomizeWidget(this, widget, "Random after every gen");
+					addRandomizeWidget(this, widget, "randomize", "off");
 				}
 
 				// When our value changes, update other widgets to reflect our changes

--- a/web/scripts/defaultGraph.js
+++ b/web/scripts/defaultGraph.js
@@ -56,7 +56,7 @@ export const defaultGraph = {
 			],
 			outputs: [{ name: "LATENT", type: "LATENT", links: [7], slot_index: 0 }],
 			properties: {},
-			widgets_values: [8566257, true, 20, 8, "euler", "normal", 1],
+			widgets_values: [8566257, "after generation", 20, 8, "euler", "normal", 1],
 		},
 		{
 			id: 8,


### PR DESCRIPTION
This PR adds the ability to generate a random seed *before* the workflow is queued.

- Converts the random value widget from a toggle to a combo with the following values:
  - after generation
  - before generation
  - off
- Sets the default value to `after generation` for backward compatibility.
- Adds a `beforeQueued` callback.
- Updates the default graph to use `after generation`.
- Supports the original value of `true` and `false` for backward compatibility with existing workflows.
  - I'd like to have the UI update the value to `after generation` when it sees `true` and `off` when it sees `false`, but I haven't figured that out yet.
- I'm not sure about running `graphToPrompt` twice. It feels hacky, so maybe there's a better way to implement that part.

**TODO**
- [x] When a workflow from before this PR is loaded, `true` values should be changed to `after generation`, and `false` values should be changed to `off`.
- [ ] Investigate whether `graphToPrompt` really needs to be called twice or if there is a better way to inspect and update the random widgets before generation.