### PR TITLE
Initial mobile support

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<link rel="stylesheet" type="text/css" href="lib/litegraph.css" />
 		<link rel="stylesheet" type="text/css" href="style.css" />
 		<script type="text/javascript" src="lib/litegraph.core.js"></script>
-
 		<script type="module">
 			import { app } from "/scripts/app.js";
 			await app.setup();

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 		<link rel="stylesheet" type="text/css" href="lib/litegraph.css" />
 		<link rel="stylesheet" type="text/css" href="style.css" />
 		<script type="text/javascript" src="lib/litegraph.core.js"></script>

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -108,7 +108,7 @@
 		node_box_coloured_when_on: false, // [true!] this make the nodes box (top left circle) coloured when triggered (execute/action), visual feedback
         node_box_coloured_by_mode: false, // [true!] nodebox based on node mode, visual feedback
         
-        dialog_close_on_mouse_leave: true, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
+        dialog_close_on_mouse_leave: false, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
         dialog_close_on_mouse_leave_delay: 500,
         
         shift_click_do_break_link_from: false, // [false!] prefer false if results too easy to break links - implement with ALT or TODO custom keys

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -5801,7 +5801,7 @@ LGraphNode.prototype.executeAction = function(action)
         var skip_action = false;
         var now = LiteGraph.getTime();
 		var is_primary = (e.isPrimary === undefined || !e.isPrimary);
-        var is_double_click = (now - this.last_mouseclick < 300) && is_primary;
+        var is_double_click = (now - this.last_mouseclick < 300);
 		this.mouse[0] = e.clientX;
 		this.mouse[1] = e.clientY;
         this.graph_mouse[0] = e.canvasX;

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -138,7 +138,7 @@
 		
 		release_link_on_empty_shows_menu: false, //[true!] dragging a link to empty space will open a menu, add from list, search or defaults
 		
-        pointerevents_method: "mouse", // "mouse"|"pointer" use mouse for retrocompatibility issues? (none found @ now)
+        pointerevents_method: "pointer", // "mouse"|"pointer" use mouse for retrocompatibility issues? (none found @ now)
         // TODO implement pointercancel, gotpointercapture, lostpointercapture, (pointerover, pointerout if necessary)
 
         /**


### PR DESCRIPTION
- Added correct meta tags to index.html - head
- Changed litegraph.core.js - pointerevents_method: "pointer"  
  This should not negatively affect desktop browsers, since pointer events are supported in most modern browsers. https://caniuse.com/pointer
- Litegraph's double click events are handled even using non-primary pointer.
- Changed setting to not close dialogs on mouseleave.

Current state:

- Can move around canvas
- Right click by tapping with two fingers  
  (Hint: can tap with the second finger later.)
- Can type in conditions
- Double tap to bring search box up  
  (Hint: tap somewhere around top-right on the screen so it will be shown while typing.)
- Tapping input fields opens them like normal, can type in them.

Further work:

- Zooming is not implemented yet, maybe some touch gesture would work...  
  (Zoom by mousewheel still works as usual.)
- Menu is not collapsible, might be in the way