### PR TITLE
add canvas tab index so it recieves keydown events

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -494,6 +494,7 @@ class ComfyApp {
 
 		// Create and mount the LiteGraph in the DOM
 		const canvasEl = (this.canvasEl = Object.assign(document.createElement("canvas"), { id: "graph-canvas" }));
+		canvasEl.tabIndex = "1"
 		document.body.prepend(canvasEl);
 
 		this.graph = new LGraph();


### PR DESCRIPTION
This should fix #201 and clean up other broken keyboard shortcuts from the default litegraph.js implementation that require `keydown` events. Some browsers do not fire key events for elements without a tab index.