### PR TITLE
Allow output folder to be a symbolic link

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -752,7 +752,7 @@ class SaveImage:
 
         full_output_folder = os.path.join(self.output_dir, subfolder)
 
-        if os.path.commonpath((self.output_dir, os.path.realpath(full_output_folder))) != self.output_dir:
+        if os.path.commonpath((self.output_dir, os.path.abspath(full_output_folder))) != self.output_dir:
             print("Saving image outside the output folder is not allowed.")
             return {}
 

--- a/server.py
+++ b/server.py
@@ -125,7 +125,7 @@ class PromptServer():
                 output_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), type)
                 if "subfolder" in request.rel_url.query:
                     full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
-                    if os.path.commonpath((os.path.realpath(full_output_dir), output_dir)) != output_dir:
+                    if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
                         return web.Response(status=403)
                     output_dir = full_output_dir
 


### PR DESCRIPTION
The `realpath()` expands symbolic links, this PR changes it to `abspath()`, because it preserves the symbolic links, allowing the output folder to be a symbolic link pointing to a folder outside the ComfyUI folder.