### PR TITLE
Convert widget to input (and back)

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -149,6 +149,7 @@ app.registerExtension({
 				app.graph.add(node);
 				node.pos = [this.pos[0] - node.size[0] - 30, this.pos[1]];
 				node.connect(0, this, slot);
+				node.title = this.inputs[slot].name;
 			}
 
 			return r;

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -1,0 +1,315 @@
+import { ComfyWidgets, addRandomizeWidget } from "/scripts/widgets.js";
+import { app } from "/scripts/app.js";
+
+const CONVERTED_TYPE = "converted-widget";
+const VALID_TYPES = ["STRING", "combo", "number"];
+
+function isConvertableWidget(widget, config) {
+	return VALID_TYPES.includes(widget.type) || VALID_TYPES.includes(config[0]);
+}
+
+function hideWidget(node, widget, suffix = "") {
+	widget.origType = widget.type;
+	widget.origComputeSize = widget.computeSize;
+	widget.origSerializeValue = widget.serializeValue;
+	widget.computeSize = () => [0, -4]; // -4 is due to the gap litegraph adds between widgets automatically
+	widget.type = CONVERTED_TYPE + suffix;
+	widget.serializeValue = () => {
+		// Prevent serializing the widget if we have no input linked
+		const { link } = node.inputs.find((i) => i.widget?.name === widget.name);
+		if (link == null) {
+			return undefined;
+		}
+		return widget.value;
+	};
+
+	// Hide any linked widgets, e.g. seed+randomize
+	if (widget.linkedWidgets) {
+		for (const w of widget.linkedWidgets) {
+			hideWidget(node, w, ":" + widget.name);
+		}
+	}
+}
+
+function showWidget(widget) {
+	widget.type = widget.origType;
+	widget.computeSize = widget.origComputeSize;
+	widget.serializeValue = widget.origSerializeValue;
+
+	delete widget.origType;
+	delete widget.origComputeSize;
+	delete widget.origSerializeValue;
+
+	// Hide any linked widgets, e.g. seed+randomize
+	if (widget.linkedWidgets) {
+		for (const w of widget.linkedWidgets) {
+			showWidget(w);
+		}
+	}
+}
+
+function convertToInput(node, widget, config) {
+	hideWidget(node, widget);
+
+	const { linkType } = getWidgetType(config);
+
+	// Add input and store widget config for creating on primitive node
+	node.addInput(widget.name, linkType, {
+		widget: { name: widget.name, config },
+	});
+}
+
+function convertToWidget(node, widget) {
+	showWidget(widget);
+	node.removeInput(node.inputs.findIndex((i) => i.widget?.name === widget.name));
+}
+
+function getWidgetType(config) {
+	// Special handling for COMBO so we restrict links based on the entries
+	let type = config[0];
+	let linkType = type;
+	if (type instanceof Array) {
+		type = "COMBO";
+		linkType = linkType.join(",");
+	}
+	return { type, linkType };
+}
+
+app.registerExtension({
+	name: "Comfy.WidgetInputs",
+	async beforeRegisterNodeDef(nodeType, nodeData, app) {
+		// Add menu options to conver to/from widgets
+		const origGetExtraMenuOptions = nodeType.prototype.getExtraMenuOptions;
+		nodeType.prototype.getExtraMenuOptions = function (_, options) {
+			const r = origGetExtraMenuOptions ? origGetExtraMenuOptions.apply(this, arguments) : undefined;
+
+			if (this.widgets) {
+				let toInput = [];
+				let toWidget = [];
+				for (const w of this.widgets) {
+					if (w.type === CONVERTED_TYPE) {
+						toWidget.push({
+							content: `Convert ${w.name} to widget`,
+							callback: () => convertToWidget(this, w),
+						});
+					} else {
+						const config = nodeData?.input?.required[w.name] || [w.type, w.options || {}];
+						if (isConvertableWidget(w, config)) {
+							toInput.push({
+								content: `Convert ${w.name} to input`,
+								callback: () => convertToInput(this, w, config),
+							});
+						}
+					}
+				}
+				if (toInput.length) {
+					options.push(...toInput, null);
+				}
+
+				if (toWidget.length) {
+					options.push(...toWidget, null);
+				}
+			}
+
+			return r;
+		};
+
+		// On initial configure of nodes hide all converted widgets
+		const origOnConfigure = nodeType.prototype.onConfigure;
+		nodeType.prototype.onConfigure = function () {
+			const r = origOnConfigure ? origOnConfigure.apply(this, arguments) : undefined;
+
+			if (this.inputs) {
+				for (const input of this.inputs) {
+					if (input.widget) {
+						const w = this.widgets.find((w) => w.name === input.widget.name);
+						hideWidget(this, w);
+					}
+				}
+			}
+
+			return r;
+		};
+
+		// Double click a widget input to automatically attach a primitive
+		const origOnInputDblClick = nodeType.prototype.onInputDblClick;
+		nodeType.prototype.onInputDblClick = function (slot) {
+			const r = origOnInputDblClick ? origOnInputDblClick.apply(this, arguments) : undefined;
+
+			if (this.inputs[slot].widget) {
+				const node = LiteGraph.createNode("PrimitiveNode");
+				app.graph.add(node);
+				node.pos = [this.pos[0] - node.size[0] - 30, this.pos[1]];
+				node.connect(0, this, slot);
+			}
+
+			return r;
+		};
+	},
+	registerCustomNodes() {
+		class PrimitiveNode {
+			constructor() {
+				this.addOutput("connect to widget input", "*");
+				this.serialize_widgets = true;
+				this.isVirtualNode = true;
+			}
+
+			applyToGraph() {
+				if (!this.outputs[0].links?.length) return;
+
+				// For each output link copy our value over the original widget value
+				for (const l of this.outputs[0].links) {
+					const linkInfo = app.graph.links[l];
+					const node = this.graph.getNodeById(linkInfo.target_id);
+					const input = node.inputs[linkInfo.target_slot];
+					const widgetName = input.widget.name;
+					if (widgetName) {
+						const widget = node.widgets.find((w) => w.name === widgetName);
+						if (widget) {
+							widget.value = this.widgets[0].value;
+							if (widget.callback) {
+								widget.callback(widget.value, app.canvas, node, app.canvas.graph_mouse, {});
+							}
+						}
+					}
+				}
+			}
+
+			onConnectionsChange(_, index, connected) {
+				if (connected) {
+					if (this.outputs[0].links?.length) {
+						if (!this.widgets?.length) {
+							this.#onFirstConnection();
+						}
+						if (!this.widgets?.length && this.outputs[0].widget) {
+							// On first load it often cant recreate the widget as the other node doesnt exist yet
+							// Manually recreate it from the output info
+							this.#createWidget(this.outputs[0].widget.config);
+						}
+					}
+				} else if (!this.outputs[0].links?.length) {
+					this.#onLastDisconnect();
+				}
+			}
+
+			onConnectOutput(slot, type, input, target_node, target_slot) {
+				// Fires before the link is made allowing us to reject it if it isn't valid
+
+				// No widget, we cant connect
+				if (!input.widget) return false;
+
+				if (this.outputs[slot].links?.length) {
+					return this.#isValidConnection(input);
+				}
+			}
+
+			#onFirstConnection() {
+				// First connection can fire before the graph is ready on initial load so random things can be missing
+				const linkId = this.outputs[0].links[0];
+				const link = this.graph.links[linkId];
+				if (!link) return;
+
+				const theirNode = this.graph.getNodeById(link.target_id);
+				if (!theirNode || !theirNode.inputs) return;
+
+				const input = theirNode.inputs[link.target_slot];
+				if (!input) return;
+
+				const widget = input.widget;
+				const { type, linkType } = getWidgetType(widget.config);
+
+				// Update our output to restrict to the widget type
+				this.outputs[0].type = linkType;
+				this.outputs[0].name = type;
+				this.outputs[0].widget = widget;
+
+				this.#createWidget(widget.config, theirNode, widget.name);
+			}
+
+			#createWidget(inputData, node, widgetName) {
+				let type = inputData[0];
+
+				if (type instanceof Array) {
+					type = "COMBO";
+				}
+
+				let widget;
+				if (type in ComfyWidgets) {
+					widget = (ComfyWidgets[type](this, "value", inputData, app) || {}).widget;
+				} else {
+					widget = this.addWidget(type, "value", null, () => {}, {});
+				}
+
+				if (node?.widgets && widget) {
+					const theirWidget = node.widgets.find((w) => w.name === widgetName);
+					if (theirWidget) {
+						widget.value = theirWidget.value;
+					}
+				}
+
+				if (widget.type === "number") {
+					addRandomizeWidget(this, widget, "Random after every gen");
+				}
+
+				// Grow our node if required
+				const sz = this.computeSize();
+				if (this.size[0] < sz[0]) {
+					this.size[0] = sz[0];
+				}
+				if (this.size[1] < sz[1]) {
+					this.size[1] = sz[1];
+				}
+
+				requestAnimationFrame(() => {
+					if (this.onResize) {
+						this.onResize(this.size);
+					}
+				});
+			}
+
+			#isValidConnection(input) {
+				// Only allow connections where the configs match
+				const config1 = this.outputs[0].widget.config;
+				const config2 = input.widget.config;
+
+				if (config1[0] !== config2[0]) return false;
+
+				for (const k in config1[1]) {
+					if (k !== "default") {
+						if (config1[1][k] !== config2[1][k]) {
+							return false;
+						}
+					}
+				}
+
+				return true;
+			}
+
+			#onLastDisconnect() {
+				// We cant remove + re-add the output here as if you drag a link over the same link
+				// it removes, then re-adds, causing it to break
+				this.outputs[0].type = "*";
+				this.outputs[0].name = "connect to widget input";
+				delete this.outputs[0].widget;
+
+				if (this.widgets) {
+					// Allow widgets to cleanup
+					for (const w of this.widgets) {
+						if (w.onRemove) {
+							w.onRemove();
+						}
+					}
+					this.widgets.length = 0;
+				}
+			}
+		}
+
+		LiteGraph.registerNodeType(
+			"PrimitiveNode",
+			Object.assign(PrimitiveNode, {
+				title: "Primitive",
+			})
+		);
+		PrimitiveNode.category = "utils";
+	},
+});

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -251,6 +251,16 @@ app.registerExtension({
 					addRandomizeWidget(this, widget, "Random after every gen");
 				}
 
+				// When our value changes, update other widgets to reflect our changes
+				// e.g. so LoadImage shows correct image
+				const callback = widget.callback;
+				const self = this;
+				widget.callback = function () {
+					const r = callback ? callback.apply(this, arguments) : undefined;
+					self.applyToGraph();
+					return r;
+				};
+
 				// Grow our node if required
 				const sz = this.computeSize();
 				if (this.size[0] < sz[0]) {

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -54,14 +54,22 @@ function convertToInput(node, widget, config) {
 	const { linkType } = getWidgetType(config);
 
 	// Add input and store widget config for creating on primitive node
+	const sz = node.size;
 	node.addInput(widget.name, linkType, {
 		widget: { name: widget.name, config },
 	});
+
+	// Restore original size but grow if needed
+	node.setSize([Math.max(sz[0], node.size[0]), Math.max(sz[1], node.size[1])]);
 }
 
 function convertToWidget(node, widget) {
 	showWidget(widget);
+	const sz = node.size;
 	node.removeInput(node.inputs.findIndex((i) => i.widget?.name === widget.name));
+
+	// Restore original size but grow if needed
+	node.setSize([Math.max(sz[0], node.size[0]), Math.max(sz[1], node.size[1])]);
 }
 
 function getWidgetType(config) {

--- a/web/jsconfig.json
+++ b/web/jsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"/*": ["./*"]
+		}
+	},
+	"include": ["."]
+}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -527,7 +527,6 @@ class ComfyApp {
 			}
 		} catch (err) {
 			console.error("Error loading previous workflow", err);
-			debugger;
 		}
 
 		// We failed to restore a workflow so load the default

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -494,7 +494,7 @@ class ComfyApp {
 
 		// Create and mount the LiteGraph in the DOM
 		const canvasEl = (this.canvasEl = Object.assign(document.createElement("canvas"), { id: "graph-canvas" }));
-		canvasEl.tabIndex = "1"
+		canvasEl.tabIndex = "1";
 		document.body.prepend(canvasEl);
 
 		this.graph = new LGraph();
@@ -525,7 +525,10 @@ class ComfyApp {
 				this.loadGraphData(workflow);
 				restored = true;
 			}
-		} catch (err) {}
+		} catch (err) {
+			console.error("Error loading previous workflow", err);
+			debugger;
+		}
 
 		// We failed to restore a workflow so load the default
 		if (!restored) {
@@ -572,12 +575,8 @@ class ComfyApp {
 						const type = inputData[0];
 
 						if (Array.isArray(type)) {
-							// Enums e.g. latent rotation
-							let defaultValue = type[0];
-							if (inputData[1] && inputData[1].default) {
-								defaultValue = inputData[1].default;
-							}
-							this.addWidget("combo", inputName, defaultValue, () => {}, { values: type });
+							// Enums
+							Object.assign(config, widgets.COMBO(this, inputName, inputData, app) || {});
 						} else if (`${type}:${inputName}` in widgets) {
 							// Support custom widgets by Type:Name
 							Object.assign(config, widgets[`${type}:${inputName}`](this, inputName, inputData, app) || {});
@@ -667,11 +666,15 @@ class ComfyApp {
 	async graphToPrompt() {
 		const workflow = this.graph.serialize();
 		const output = {};
-		for (const n of workflow.nodes) {
-			const node = this.graph.getNodeById(n.id);
+		// Process nodes in order of execution
+		for (const node of this.graph.computeExecutionOrder(false)) {
+			const n = workflow.nodes.find((n) => n.id === node.id);
 
 			if (node.isVirtualNode) {
-				// Don't serialize frontend only nodes
+				// Don't serialize frontend only nodes but let them make changes
+				if (node.applyToGraph) {
+					node.applyToGraph(workflow);
+				}
 				continue;
 			}
 
@@ -695,7 +698,11 @@ class ComfyApp {
 					let link = node.getInputLink(i);
 					while (parent && parent.isVirtualNode) {
 						link = parent.getInputLink(link.origin_slot);
-						parent = parent.getInputNode(link.origin_slot);
+						if (link) {
+							parent = parent.getInputNode(link.origin_slot);
+						} else {
+							parent = null;
+						}
 					}
 
 					if (link) {


### PR DESCRIPTION
Adds convert options to the node menu
![image](https://user-images.githubusercontent.com/125205205/227503375-cd3a973d-04aa-49d2-9277-9b2df68725ef.png)

And once converted, convert back
![image](https://user-images.githubusercontent.com/125205205/227503465-495032af-ada5-40d8-9605-955a7be21594.png)

New primitive node that can be connected to one of these inputs
![image](https://user-images.githubusercontent.com/125205205/227503739-9354101f-6698-4365-abc1-9919751db8e0.png)

When connected it will copy the current value, numbers will be given a random toggle so it can be used for seeds
![image](https://user-images.githubusercontent.com/125205205/227503942-e6470bf1-02f2-4e91-ade6-ebb9de99b75d.png)

Links are restricted by type + widget configuration (e.g. you cant connect the same Primitive to seed and width, as width is restricted to steps of 64)

Primitives can be linked to multiple nodes to allow sharing of values

Values are sync'd to the source node, meaning things like LoadImage display the correct value
![image](https://user-images.githubusercontent.com/125205205/227504441-d1ea1034-93bd-4b89-b951-0033c14b6171.png)

For now it supports text, numbers and combos but can easily be updated to support anything else
![image](https://user-images.githubusercontent.com/125205205/227504867-42f56b65-cdd1-4474-aac2-4829a9681d4e.png)

To quickly add a primitive widget you can double click the input (the circle, not the label)

If anyone has any feedback / could give this some testing as it was quite fiddly to get working!

