### PR TITLE
Draggable menu

### DIFF
--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -35,6 +35,47 @@ function $el(tag, propsOrChildren, children) {
 	return element;
 }
 
+function dragElement(dragEl) {
+	var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+	if (dragEl.getElementsByClassName('drag-handle')[0]) {
+		// if present, the handle is where you move the DIV from:
+		dragEl.getElementsByClassName('drag-handle')[0].onmousedown = dragMouseDown;
+	} else {
+		// otherwise, move the DIV from anywhere inside the DIV:
+		dragEl.onmousedown = dragMouseDown;
+	}
+
+	function dragMouseDown(e) {
+		e = e || window.event;
+		e.preventDefault();
+		// get the mouse cursor position at startup:
+		pos3 = e.clientX;
+		pos4 = e.clientY;
+		document.onmouseup = closeDragElement;
+		// call a function whenever the cursor moves:
+		document.onmousemove = elementDrag;
+	}
+
+	function elementDrag(e) {
+		e = e || window.event;
+		e.preventDefault();
+		// calculate the new cursor position:
+		pos1 = pos3 - e.clientX;
+		pos2 = pos4 - e.clientY;
+		pos3 = e.clientX;
+		pos4 = e.clientY;
+		// set the element's new position:
+		dragEl.style.top = (dragEl.offsetTop - pos2) + "px";
+		dragEl.style.left = (dragEl.offsetLeft - pos1) + "px";
+	}
+
+	function closeDragElement() {
+		// stop moving when mouse button is released:
+		document.onmouseup = null;
+		document.onmousemove = null;
+	}
+}
+
 class ComfyDialog {
 	constructor() {
 		this.element = $el("div.comfy-modal", { parent: document.body }, [
@@ -253,6 +294,7 @@ export class ComfyUI {
 
 		this.menuContainer = $el("div.comfy-menu", { parent: document.body }, [
 			$el("div", { style: { overflow: "hidden", position: "relative", width: "100%" } }, [
+				$el("span.drag-handle"),
 				$el("span", { $: (q) => (this.queueSize = q) }),
 				$el("button.comfy-settings-btn", { textContent: "⚙️", onclick: () => this.settings.show() }),
 			]),
@@ -330,6 +372,8 @@ export class ComfyUI {
 			$el("button", { textContent: "Clear", onclick: () => app.graph.clear() }),
 			$el("button", { textContent: "Load Default", onclick: () => app.loadGraphData() }),
 		]);
+
+		dragElement(this.menuContainer);
 
 		this.setStatus({ exec_info: { queue_remaining: "X" } });
 	}

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -36,7 +36,12 @@ function $el(tag, propsOrChildren, children) {
 }
 
 function dragElement(dragEl) {
-	var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+	var posDiffX = 0,
+		posDiffY = 0,
+		posStartX = 0,
+		posStartY = 0,
+		newPosX = 0,
+		newPosY = 0;
 	if (dragEl.getElementsByClassName('drag-handle')[0]) {
 		// if present, the handle is where you move the DIV from:
 		dragEl.getElementsByClassName('drag-handle')[0].onmousedown = dragMouseDown;
@@ -49,8 +54,8 @@ function dragElement(dragEl) {
 		e = e || window.event;
 		e.preventDefault();
 		// get the mouse cursor position at startup:
-		pos3 = e.clientX;
-		pos4 = e.clientY;
+		posStartX = e.clientX;
+		posStartY = e.clientY;
 		document.onmouseup = closeDragElement;
 		// call a function whenever the cursor moves:
 		document.onmousemove = elementDrag;
@@ -60,13 +65,15 @@ function dragElement(dragEl) {
 		e = e || window.event;
 		e.preventDefault();
 		// calculate the new cursor position:
-		pos1 = pos3 - e.clientX;
-		pos2 = pos4 - e.clientY;
-		pos3 = e.clientX;
-		pos4 = e.clientY;
+		posDiffX = e.clientX - posStartX;
+		posDiffY = e.clientY - posStartY;
+		posStartX = e.clientX;
+		posStartY = e.clientY;
+		newPosX = Math.min((document.body.clientWidth - dragEl.clientWidth), Math.max(0, (dragEl.offsetLeft + posDiffX)));
+		newPosY = Math.min((document.body.clientHeight - dragEl.clientHeight), Math.max(0, (dragEl.offsetTop + posDiffY)));
 		// set the element's new position:
-		dragEl.style.top = (dragEl.offsetTop - pos2) + "px";
-		dragEl.style.left = (dragEl.offsetLeft - pos1) + "px";
+		dragEl.style.top = newPosY + "px";
+		dragEl.style.left = newPosX + "px";
 	}
 
 	function closeDragElement() {

--- a/web/style.css
+++ b/web/style.css
@@ -111,6 +111,31 @@ body {
 	width: 50%;
 }
 
+.comfy-menu span.drag-handle {
+	width: 10px;
+	height: 20px;
+	display: inline-block;
+	overflow: hidden;
+	line-height: 5px;
+	padding: 3px 4px;
+	cursor: move;
+	vertical-align: middle;
+	margin-top: -.4em;
+	margin-left: -.2em;
+	font-size: 12px;
+	font-family: sans-serif;
+	letter-spacing: 2px;
+	color: #cccccc;
+	text-shadow: 1px 0 1px black;
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
+.comfy-menu span.drag-handle::after {
+	content: '.. .. ..';
+}
+
 .comfy-queue-btn {
 	width: 100%;
 }


### PR DESCRIPTION
This PR makes possible to drag the menu.

The menu starts in the original position and can be dragged by the handle on the top left corner.

The position is not saved, it is just to move the menu to see the node that is behind it, the position resets on page refresh.

![image](https://user-images.githubusercontent.com/5104869/227747192-53a36dbb-4a5a-4cf1-b489-dd275c155bef.png)
![image](https://user-images.githubusercontent.com/5104869/227747270-f68569a5-f282-49f2-b2f4-99ecfc9459e1.png)
