### PR TITLE
%width% and %height% wildcards for filepath

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -746,6 +746,13 @@ class SaveImage:
             except:
                 digits = 0
             return (digits, prefix)
+        
+        def compute_vars(input):
+            input = input.replace("%width%", str(images[0].shape[1]))
+            input = input.replace("%height%", str(images[0].shape[0]))
+            return input
+        
+        filename_prefix = compute_vars(filename_prefix)
 
         subfolder = os.path.dirname(os.path.normpath(filename_prefix))
         filename = os.path.basename(os.path.normpath(filename_prefix))


### PR DESCRIPTION
Allows users to set the filename prefix of the SaveImage node to something like this : `PR/%width%x%height%/ComfyUI`

![Screenshot_20230326_131615](https://user-images.githubusercontent.com/125697471/227772068-09b8e93b-cc5c-4f59-87d0-96bf7e9d4d6e.png)