### PR TITLE
Optional RETURN_NAMES to set the output name

### DIFF
--- a/server.py
+++ b/server.py
@@ -152,6 +152,7 @@ class PromptServer():
                 info = {}
                 info['input'] = obj_class.INPUT_TYPES()
                 info['output'] = obj_class.RETURN_TYPES
+                info['output_name'] = obj_class.RETURN_NAMES if hasattr(obj_class, 'RETURN_NAMES') else info['output']
                 info['name'] = x #TODO
                 info['description'] = ''
                 info['category'] = 'sd'

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -611,8 +611,10 @@ class ComfyApp {
 						}
 					}
 
-					for (const output of nodeData["output"]) {
-						this.addOutput(output, output);
+					for (const o in nodeData["output"]) {
+						const output = nodeData["output"][o];
+						const outputName = nodeData["output_name"][o] || output;
+						this.addOutput(outputName, output);
 					}
 
 					const s = this.computeSize();


### PR DESCRIPTION
This PR adds a optional RETURN_NAMES attribute to return the outputs names.

It is needed for nodes that return multiple outputs with same type, or with primitive types (now that we have the widget to input) to set a better name instead of the type.