### PR TITLE
Change in random seed execution order

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -285,7 +285,7 @@ app.registerExtension({
 				}
 
 				if (widget.type === "number") {
-					addRandomizeWidget(this, widget, "Random after every gen");
+					addRandomizeWidget(this, widget, "Random every gen");
 				}
 
 				// When our value changes, update other widgets to reflect our changes

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -17,7 +17,7 @@ export function addRandomizeWidget(node, targetWidget, name, defaultValue = fals
 		serialize: false, // Don't include this in prompt.
 	});
 
-	randomize.afterQueued = () => {
+	randomize.beforeQueued = () => {
 		if (randomize.value) {
 			const min = targetWidget.options?.min;
 			let max = targetWidget.options?.max;
@@ -32,12 +32,13 @@ export function addRandomizeWidget(node, targetWidget, name, defaultValue = fals
 			}
 		}
 	};
+
 	return randomize;
 }
 
 function seedWidget(node, inputName, inputData) {
 	const seed = ComfyWidgets.INT(node, inputName, inputData);
-	const randomize = addRandomizeWidget(node, seed.widget, "Random seed after every gen", true);
+	const randomize = addRandomizeWidget(node, seed.widget, "Random seed every gen", true);
 
 	seed.widget.linkedWidgets = [randomize];
 	return { widget: seed, randomize };


### PR DESCRIPTION
The idea is to make a random seed fixation and a rolling process more user friendly. 

What is happening now:

- we mark seed as random
- press execute
- image is generated
- new seed is generated after execution

As the result we have the problem that current seed value we do see in sampler widget doesn't correspond to the generated image and we can't fix the result. We need either store seed before execution or open history and restore the state, which is not user friendly.

What is the change:
- we mark seed as random
- press execute
- new seed is generated
- new image is generated

The situation now is different: the image does correspond to the seed, switching "off" the randomizer now freezes the current image.

