### PR TITLE
clean state when loading another workflow

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -903,6 +903,13 @@ class ComfyApp {
 			}
 		}
 	}
+
+	/**
+	 * Clean current state
+	 */
+	clean() {
+		this.nodeOutputs = {};
+	}
 }
 
 export const app = new ComfyApp();

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -721,6 +721,8 @@ class ComfyApp {
 	 * @param {*} graphData A serialized graph object
 	 */
 	loadGraphData(graphData) {
+		this.clean();
+
 		if (!graphData) {
 			graphData = defaultGraph;
 		}

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -306,6 +306,7 @@ export class ComfyUI {
 			style: { display: "none" },
 			parent: document.body,
 			onchange: () => {
+				app.clean();
 				app.handleFile(fileInput.files[0]);
 			},
 		});
@@ -388,8 +389,14 @@ export class ComfyUI {
 			}),
 			$el("button", { textContent: "Load", onclick: () => fileInput.click() }),
 			$el("button", { textContent: "Refresh", onclick: () => app.refreshComboInNodes() }),
-			$el("button", { textContent: "Clear", onclick: () => app.graph.clear() }),
-			$el("button", { textContent: "Load Default", onclick: () => app.loadGraphData() }),
+			$el("button", { textContent: "Clear", onclick: () => {
+				app.clean();
+				app.graph.clear();
+			}}),
+			$el("button", { textContent: "Load Default", onclick: () => {
+				app.clean();
+				app.loadGraphData();
+			}}),
 		]);
 
 		dragElement(this.menuContainer);

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -306,7 +306,6 @@ export class ComfyUI {
 			style: { display: "none" },
 			parent: document.body,
 			onchange: () => {
-				app.clean();
 				app.handleFile(fileInput.files[0]);
 			},
 		});
@@ -393,10 +392,7 @@ export class ComfyUI {
 				app.clean();
 				app.graph.clear();
 			}}),
-			$el("button", { textContent: "Load Default", onclick: () => {
-				app.clean();
-				app.loadGraphData();
-			}}),
+			$el("button", { textContent: "Load Default", onclick: () => app.loadGraphData() }),
 		]);
 
 		dragElement(this.menuContainer);


### PR DESCRIPTION
![228307799-75b55c1c-288f-4c81-b3a0-d64e9c2cd643](https://user-images.githubusercontent.com/388375/228324470-f0f24a27-342f-4935-986e-302df7543c5f.png)

Clean `nodeOutputs` when loading another workflow to make sure previous images are not rendered anymore.