### PR TITLE
add prettier formatter config file

### DIFF
--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"trailingComma": "es5",
+	"tabWidth": 2,
+	"useTabs": true,
+	"printWidth": 100
+}


### PR DESCRIPTION
To run prettier on the `web` folder, the easiest way is to have [node](https://nodejs.org/en) installed on the system then to :
`npx prettier --config ./web/.prettierrc --write ./web`

It will format all `.js` `.html` `.json` and `.css` files.
I would recommend to run some tests after formatting a whole project (sometimes JavaScript syntax can be ambiguous).