### PR TITLE
Match comfy-menu style to litegraph

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -101,6 +101,12 @@ body {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	color: #999;
+	background-color: #353535;
+	font-family: sans-serif;
+	padding: 10px;
+	border-radius: 0 8px 8px 8px;
+	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.4);
 }
 
 .comfy-menu button {
@@ -115,6 +121,22 @@ body {
 .comfy-menu-btns button {
 	font-size: 10px;
 	width: 50%;
+	color: #999 !important;
+}
+
+.comfy-menu > button {
+	width: 100%;
+}
+
+.comfy-menu > button,
+.comfy-menu-btns button,
+.comfy-menu .comfy-list button {
+	color: #ddd;
+	background-color: #222;
+	border-radius: 8px;
+	border-color: #4e4e4e;
+	border-style: solid;
+	margin-top: 2px;
 }
 
 .comfy-menu span.drag-handle {
@@ -147,14 +169,18 @@ body {
 }
 
 .comfy-list {
-	background-color: rgb(225, 225, 225);
+	color: #999;
+	background-color: #333;
 	margin-bottom: 10px;
+	border-color: #4e4e4e;
+	border-style: solid;
 }
 
 .comfy-list-items {
 	overflow-y: scroll;
 	max-height: 100px;
-	background-color: #d0d0d0;
+	min-height: 25px;
+	background-color: #222;
 	padding: 5px;
 }
 
@@ -181,11 +207,16 @@ body {
 }
 
 button.comfy-settings-btn {
+	background-color: rgba(0, 0, 0, 0);
 	font-size: 12px;
 	padding: 0;
 	position: absolute;
 	right: 0;
 	border: none;
+}
+
+button.comfy-queue-btn {
+	margin: 6px 0 !important;
 }
 
 .comfy-modal.comfy-settings {


### PR DESCRIPTION
This is a quick CSS-only fix to make the `comfy-menu` element look like the litegraph nodes.

I also tried to fix the queue/history scrollbar overflowing when there aren't any items in the queue by adding a `min-height` to `.comfy-list-items`

I did **not** style the scrollbars or the popup `comfy-settings` window. 

![comfy](https://user-images.githubusercontent.com/125218114/228562201-5a205a0f-7b6d-4ba0-8842-c742282f0ae7.png)
