### PR TITLE
Extra formatting values on SaveImage

### DIFF
--- a/web/extensions/core/saveImageExtraOutput.js
+++ b/web/extensions/core/saveImageExtraOutput.js
@@ -1,0 +1,100 @@
+import { app } from "/scripts/app.js";
+
+// Use widget values and dates in output filenames
+
+app.registerExtension({
+	name: "Comfy.SaveImageExtraOutput",
+	async beforeRegisterNodeDef(nodeType, nodeData, app) {
+		if (nodeData.name === "SaveImage") {
+			const onNodeCreated = nodeType.prototype.onNodeCreated;
+
+         // Simple date formatter
+			const parts = {
+				d: (d) => d.getDate(),
+				M: (d) => d.getMonth() + 1,
+				h: (d) => d.getHours(),
+				m: (d) => d.getMinutes(),
+				s: (d) => d.getSeconds(),
+			};
+			const format =
+				Object.keys(parts)
+					.map((k) => k + k + "?")
+					.join("|") + "|yyy?y?";
+
+			function formatDate(text, date) {
+				return text.replace(new RegExp(format, "g"), function (text) {
+					if (text === "yy") return (date.getFullYear() + "").substring(2);
+					if (text === "yyyy") return date.getFullYear();
+					if (text[0] in parts) {
+						const p = parts[text[0]](date);
+						return (p + "").padStart(text.length, "0");
+					}
+					return text;
+				});
+			}
+
+         // When the SaveImage node is created we want to override the serialization of the output name widget to run our S&R
+			nodeType.prototype.onNodeCreated = function () {
+				const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined;
+
+				const widget = this.widgets.find((w) => w.name === "filename_prefix");
+				widget.serializeValue = () => {
+					return widget.value.replace(/%([^%]+)%/g, function (match, text) {
+						const split = text.split(".");
+						if (split.length !== 2) {
+                     // Special handling for dates
+							if (split[0].startsWith("date:")) {
+								return formatDate(split[0].substring(5), new Date());
+							}
+
+							if (text !== "width" && text !== "height") {
+								// Dont warn on standard replacements
+								console.warn("Invalid replacement pattern", text);
+							}
+							return match;
+						}
+
+						// Find node with matching S&R property name
+						let nodes = app.graph._nodes.filter((n) => n.properties?.["Node name for S&R"] === split[0]);
+						// If we cant, see if there is a node with that title
+						if (!nodes.length) {
+							nodes = app.graph._nodes.filter((n) => n.title === split[0]);
+						}
+						if (!nodes.length) {
+							console.warn("Unable to find node", split[0]);
+							return match;
+						}
+
+						if (nodes.length > 1) {
+							console.warn("Multiple nodes matched", split[0], "using first match");
+						}
+
+						const node = nodes[0];
+
+						const widget = node.widgets?.find((w) => w.name === split[1]);
+						if (!widget) {
+							console.warn("Unable to find widget", split[1], "on node", split[0], node);
+							return match;
+						}
+
+						return ((widget.value ?? "") + "").replaceAll(/\/|\\/g, "_");
+					});
+				};
+
+				return r;
+			};
+		} else {
+         // When any other node is created add a property to alias the node
+			const onNodeCreated = nodeType.prototype.onNodeCreated;
+			nodeType.prototype.onNodeCreated = function () {
+				const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined;
+
+				if (!this.properties || !("Node name for S&R" in this.properties)) {
+					this.addProperty("Node name for S&R", this.title, "string");
+				}
+
+				return r;
+			};
+		}
+	},
+});


### PR DESCRIPTION
This allows you to use any widget value as a replacement in the SaveImage output name

Search and replace is done in the format `%node.widgetname%`  
where `node` is a node S&R property name or a node title  
e.g. to output the model name: `%CheckpointLoaderSimple.ckpt_name%`  

To allow for shorter names or duplicates, you can either use the change node title and use that or right click any node -> Properties -> Node name for S&R  
![image](https://user-images.githubusercontent.com/125205205/228668327-d91101b6-b616-4250-a76a-20f60546ec8c.png)

Dates are usable by using `%date:FORMAT%`, it handles
`d` and `dd` for day of month (dd with leading zero)
`M` and `MM` for month of year
`yy` and `yyyy` for year
`h` and `hh` for hour
`m` and `mm` for minute
`s` and `ss` for second

e.g. `%date:yyyy-MM-ddThh-mm-ss%` -> `2023-03-29T01-02-03`