### PR TITLE
Turn comfy-menu into a sidebar on small screens

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -227,6 +227,13 @@ button.comfy-queue-btn {
 
 @media only screen and (max-height: 850px) {
 	.comfy-menu {
-		margin-top: -70px;
+		top: 0 !important;
+		bottom: 0 !important;
+		left: auto !important;
+		right: 0 !important;
+		border-radius: 0px;
+	}
+	.comfy-menu span.drag-handle {
+		visibility:hidden
 	}
 }


### PR DESCRIPTION
The original `margin-top: -70px` rule would behave weirdly when resizing the window. The new rule turns the menu into a sidebar instead if the screen size is smaller than 850px in height (minimized window, laptop screen, etc).
As this is a media query rule, it doesn't break the position set on the element by the javascript. Maximizing the window should restore the original position automatically.

![comfy](https://user-images.githubusercontent.com/125218114/228692475-408efaa0-7fb5-438f-952d-7791efb16015.png)