### PR TITLE
Fix loading history outputs

### DIFF
--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -225,10 +225,10 @@ class ComfyList {
 							$el("button", {
 								textContent: "Load",
 								onclick: () => {
+									app.loadGraphData(item.prompt[3].extra_pnginfo.workflow);
 									if (item.outputs) {
 										app.nodeOutputs = item.outputs;
 									}
-									app.loadGraphData(item.prompt[3].extra_pnginfo.workflow);
 								},
 							}),
 							$el("button", {


### PR DESCRIPTION
loadGraphData clears nodeOutputs
This swaps the order so it populates the outputs after loading