### PR TITLE
Clone default graph before using

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -802,7 +802,7 @@ class ComfyApp {
 		this.clean();
 
 		if (!graphData) {
-			graphData = defaultGraph;
+			graphData = structuredClone(defaultGraph);
 		}
 
 		// Patch T2IAdapterLoader to ControlNetLoader since they are the same node now


### PR DESCRIPTION
When the default graph is changed in UI, it is also mutating the defaultGraph object so if you reload it it doesnt undo all of the changes 