### PR TITLE
Custom API routes

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
     except:
         pass
 
+from nodes import init_custom_nodes
 import execution
 import server
 import folder_paths
@@ -98,6 +99,8 @@ if __name__ == "__main__":
     server = server.PromptServer(loop)
     q = execution.PromptQueue(server)
 
+    init_custom_nodes()
+    server.add_routes()
     hijack_progress(server)
 
     threading.Thread(target=prompt_worker, daemon=True, args=(q,server,)).start()
@@ -112,7 +115,6 @@ if __name__ == "__main__":
             pass
     except:
         address = '127.0.0.1'
-
 
     dont_print = False
     if '--dont-print-server' in sys.argv:

--- a/nodes.py
+++ b/nodes.py
@@ -1050,6 +1050,6 @@ def load_custom_nodes():
         if os.path.isfile(module_path) and os.path.splitext(module_path)[1] != ".py": continue
         load_custom_node(module_path)
 
-load_custom_nodes()
-
-load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_upscale_model.py"))
+def init_custom_nodes():
+    load_custom_nodes()
+    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_upscale_model.py"))

--- a/server.py
+++ b/server.py
@@ -42,6 +42,7 @@ class PromptServer():
         self.web_root = os.path.join(os.path.dirname(
             os.path.realpath(__file__)), "web")
         routes = web.RouteTableDef()
+        self.routes = routes
         self.last_node_id = None
         self.client_id = None
 
@@ -239,8 +240,9 @@ class PromptServer():
                     self.prompt_queue.delete_history_item(id_to_delete)
 
             return web.Response(status=200)
-
-        self.app.add_routes(routes)
+        
+    def add_routes(self):
+        self.app.add_routes(self.routes)
         self.app.add_routes([
             web.static('/', self.web_root),
         ])


### PR DESCRIPTION
This adds the ability for custom nodes to add routes to the server.
It moves the loading of custom nodes to after the initial creation of the server so additional routes can be added

---

Example:
```py
# Add using router
@PromptServer.instance.routes.get("/hello")
async def get_hello(request):
    return web.json_response("hello")
```
```py
# Add manually
async def get_world(request):
    return web.json_response("world")

PromptServer.instance.app.add_routes([
    web.get("/world", get_world)
])
```