### PR TITLE
fix client freeze on connect reroutes in a circle

### DIFF
--- a/web/extensions/core/rerouteNode.js
+++ b/web/extensions/core/rerouteNode.js
@@ -43,8 +43,15 @@ app.registerExtension({
 							const node = app.graph.getNodeById(link.origin_id);
 							const type = node.constructor.type;
 							if (type === "Reroute") {
+								if (node === this) {
+									// We've found a circle
+									currentNode.disconnectInput(link.target_slot);
+									currentNode = null;
+								}
+								else {
 								// Move the previous node
-								currentNode = node;
+									currentNode = node;
+								}
 							} else {
 								// We've found the end
 								inputNode = currentNode;


### PR DESCRIPTION
ISSUE:
Currently, if one connects reroutes in a circle, the client will get stuck in an infinite loop, while trying to find the root input.

FIX:
Detect the circle and disconnecting the link.