### PR TITLE
Adds middle click for default node creation and enable features

### DIFF
--- a/web/extensions/core/slotDefaults.js
+++ b/web/extensions/core/slotDefaults.js
@@ -1,0 +1,21 @@
+import { app } from "/scripts/app.js";
+
+// Adds defaults for quickly adding nodes with middle click on the input/output
+
+app.registerExtension({
+	name: "Comfy.SlotDefaults",
+	init() {
+		LiteGraph.middle_click_slot_add_default_node = true;
+		LiteGraph.slot_types_default_in = {
+			MODEL: "CheckpointLoaderSimple",
+			LATENT: "EmptyLatentImage",
+			VAE: "VAELoader",
+		};
+
+		LiteGraph.slot_types_default_out = {
+			LATENT: "VAEDecode",
+			IMAGE: "SaveImage",
+			CLIP: "CLIPTextEncode",
+		};
+	},
+});

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -676,6 +676,9 @@ class ComfyApp {
 		const canvas = (this.canvas = new LGraphCanvas(canvasEl, this.graph));
 		this.ctx = canvasEl.getContext("2d");
 
+		LiteGraph.release_link_on_empty_shows_menu = true;
+		LiteGraph.alt_drag_do_clone_nodes = true;
+
 		this.graph.start();
 
 		function resizeCanvas() {


### PR DESCRIPTION
Adds simple basics for slot default node types that you can quickly create using middle click on the node input/output.
This can be configured on a per-node basis, but for starters I think these are a few OK defaults and can be refined over time

Enables `release_link_on_empty_shows_menu` - when you drag a link to an empty space it allows you to add a node
`alt_drag_do_clone_nodes` - alt+drag clones the node