### PR TITLE
Fix "extra filename replacements in SaveImage is not done when prefix is supplied by Primitive".

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -20,7 +20,7 @@ function hideWidget(node, widget, suffix = "") {
 		if (link == null) {
 			return undefined;
 		}
-		return widget.value;
+		return widget.origSerializeValue ? widget.origSerializeValue() : widget.value;
 	};
 
 	// Hide any linked widgets, e.g. seed+randomize


### PR DESCRIPTION
![pr](https://user-images.githubusercontent.com/416194/229362138-e6516862-16eb-4969-9921-45ef51d619b4.png)

If "filename_prefix" widget is converted to an input, SaveImage's `widget.serializeValue()` is ignored and the extra replacements (`%node.widget%` and `%date:format%`) is not done.  This PR fixes it.