### PR TITLE
Add node for batching latent tensors

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -617,6 +617,20 @@ class LatentComposite:
         samples_out["samples"] = s
         return (samples_out,)
 
+class LatentBatch:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": { "samples": ("LATENT",),
+                              "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})}}
+
+    RETURN_TYPES = ("LATENT",)
+    FUNCTION = "batch"
+
+    CATEGORY = "latent"
+
+    def batch(self, samples, batch_size=1):
+        return ({"samples":samples["samples"].repeat(batch_size, 1, 1, 1)}, )
+
 class LatentCrop:
     @classmethod
     def INPUT_TYPES(s):
@@ -1086,6 +1100,7 @@ NODE_CLASS_MAPPINGS = {
     "LatentRotate": LatentRotate,
     "LatentFlip": LatentFlip,
     "LatentCrop": LatentCrop,
+    "LatentBatch": LatentBatch,
     "LoraLoader": LoraLoader,
     "CLIPLoader": CLIPLoader,
     "CLIPVisionEncode": CLIPVisionEncode,


### PR DESCRIPTION
When doing img2img work, it is useful to be able to batch generations. I couldn't find an easy way to do that with the existing nodes. `LatentBatch` is a trivial node that just repeats a given tensor so you can `LoadImage` -> `VAEEncode` -> `LatentBatch` -> `KSampler` and generate multiple at once.