### PR TITLE
auto encoder from pt, clip from versions

### DIFF
--- a/comfy/ldm/models/autoencoder.py
+++ b/comfy/ldm/models/autoencoder.py
@@ -53,6 +53,8 @@ class AutoencoderKL(torch.nn.Module):
         if path.lower().endswith(".safetensors"):
             import safetensors.torch
             sd = safetensors.torch.load_file(path, device="cpu")
+        elif path.lower().endswith(".pth") or path.lower().endswith(".pt"):
+            sd = torch.load(path, map_location='cpu')
         else:
             sd = torch.load(path, map_location="cpu")["state_dict"]
         keys = list(sd.keys())

--- a/nodes.py
+++ b/nodes.py
@@ -373,6 +373,20 @@ class CLIPLoader:
         clip = comfy.sd.load_clip(ckpt_path=clip_path, embedding_directory=folder_paths.get_folder_paths("embeddings"))
         return (clip,)
 
+class CLIPVersionLoader:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": { "clip_version": (["openai/clip-vit-large-patch14"], ),
+                             }}
+    RETURN_TYPES = ("CLIP",)
+    FUNCTION = "load_clip"
+
+    CATEGORY = "loaders"
+
+    def load_clip(self, clip_version):
+        clip = comfy.sd.load_clip(ckpt_path=None, version=clip_version, embedding_directory=folder_paths.get_folder_paths("embeddings"))
+        return (clip,)
+
 class CLIPVisionLoader:
     @classmethod
     def INPUT_TYPES(s):
@@ -1065,6 +1079,7 @@ NODE_CLASS_MAPPINGS = {
     "LatentCrop": LatentCrop,
     "LoraLoader": LoraLoader,
     "CLIPLoader": CLIPLoader,
+    "CLIPVersionLoader": CLIPVersionLoader,
     "CLIPVisionEncode": CLIPVisionEncode,
     "StyleModelApply": StyleModelApply,
     "unCLIPConditioning": unCLIPConditioning,


### PR DESCRIPTION
I found it hard to load pt files with vae and clip(like direct from pretrained, load model from ~/.cache folder), so I add code support direct load pt file to load vae, and load clip for a specific version