### PR TITLE
Basic support for Intel XPU (Arc Graphics)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -22,11 +22,12 @@ set_vram_to = NORMAL_VRAM
 
 try:
     import torch
-    import intel_extension_for_pytorch as ipex
-    if torch.xpu.is_available():
-        xpu_available = True
-        total_vram = torch.xpu.get_device_properties(torch.xpu.current_device()).total_memory / (1024 * 1024)
-    else:
+    try:
+        import intel_extension_for_pytorch as ipex
+        if torch.xpu.is_available():
+            xpu_available = True
+            total_vram = torch.xpu.get_device_properties(torch.xpu.current_device()).total_memory / (1024 * 1024)
+    except:
         total_vram = torch.cuda.mem_get_info(torch.cuda.current_device())[1] / (1024 * 1024)
     total_ram = psutil.virtual_memory().total / (1024 * 1024)
     forced_normal_vram = "--normalvram" in sys.argv

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -87,7 +87,7 @@ except:
     pass
 
 try:
-    import intel_extension_for_pytorch
+    import intel_extension_for_pytorch as ipex
     if torch.xpu.is_available():
         vram_state = XPU
 except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torchsde
 einops
 open-clip-torch
 transformers>=4.25.1
-safetensors
+safetensors>=0.3.0
 pytorch_lightning
 aiohttp
 accelerate


### PR DESCRIPTION
closed #387 

## Note:

need to install the [oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html) first, on Arch Linux it is `paru -S intel-oneapi-basekit intel-compute-runtime-bin`

> Use AUR's `intel-compute-runtime-bin` instead of `intel-compute-runtime` to avoid the `Assertion '__n < this->size()' failed.` error

Maybe it also depends on the [oneAPI AI Analytics Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/ai-analytics-toolkit.html), I'm not sure

Then run:

```bash
# setvars
source /opt/intel/oneapi/setvars.sh
# install dependencies
pip install torch==1.13.0a0 torchvision==0.14.1a0 intel_extension_for_pytorch==1.13.10+xpu -f https://developer.intel.com/ipex-whl-stable-xpu
pip install -r requirements.txt
# run
python main.py --use-split-cross-attention
```

If `--use-split-cross-attention` is not used, output is noise.

Verify XPU availability under the ComfyUI folder where dependencies have been installed:

```bash
[user@host ComfyUI]$ python
>>> import torch
>>> import intel_extension_for_pytorch
>>> torch.xpu.is_available()
True
>>> torch.xpu.get_device_properties('xpu')
_DeviceProperties(name='Intel(R) Arc(TM) A770 Graphics', platform_name='Intel(R) Level-Zero', dev_type='gpu, support_fp64=0, total_memory=15473MB, max_compute_units=512)
```

## Known issues:

- ~~Noise occurs when batch is larger than one, even with `--use-split-cross-attention`~~
  - There is always about a 50% probability of noise generation
  - If `--use-split-cross-attention` is not used, it is 100%
- Some samplers and schedulers cannot be used
