### PR TITLE
make LoadImagesMask work with non RGBA images

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -915,6 +915,8 @@ class LoadImageMask:
         input_dir = folder_paths.get_input_directory()
         image_path = os.path.join(input_dir, image)
         i = Image.open(image_path)
+        if i.getbands() != ("R", "G", "B", "A"):
+            i = i.convert("RGBA")
         mask = None
         c = channel[0].upper()
         if c in i.getbands():


### PR DESCRIPTION
Checks, if input image is RGBA. If not, converts it.