### PR TITLE
Fixes lack of support for multi configs

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -2,12 +2,12 @@ import argparse
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("--listen", nargs="?", const="0.0.0.0", default="127.0.0.1", type=str, help="Specify the IP address to listen on (default: 127.0.0.1). If --listen is provided without an argument, it defaults to 0.0.0.0. (listens on all)")
+parser.add_argument("--listen", type=str, default="127.0.0.1", metavar="IP", nargs="?", const="0.0.0.0", help="Specify the IP address to listen on (default: 127.0.0.1). If --listen is provided without an argument, it defaults to 0.0.0.0. (listens on all)")
 parser.add_argument("--port", type=int, default=8188, help="Set the listen port.")
-parser.add_argument("--enable-cors-header", default=None, nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
-parser.add_argument("--extra-model-paths-config", type=str, default=None, help="Load an extra_model_paths.yaml file.")
+parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
+parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
 parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory.")
-parser.add_argument("--cuda-device", type=int, default=None, help="Set the id of the cuda device this instance will use.")
+parser.add_argument("--cuda-device", type=int, default=None, metavar="DEVICE_ID", help="Set the id of the cuda device this instance will use.")
 parser.add_argument("--dont-upcast-attention", action="store_true", help="Disable upcasting of attention. Can boost speed but increase the chances of black images.")
 
 attn_group = parser.add_mutually_exclusive_group()

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import asyncio
+import itertools
 import os
 import shutil
 import threading
+
 from comfy.cli_args import args
 
 if os.name == "nt":
@@ -94,7 +96,8 @@ if __name__ == "__main__":
         load_extra_path_config(extra_model_paths_config_path)
 
     if args.extra_model_paths_config:
-        load_extra_path_config(args.extra_model_paths_config)
+        for config_path in itertools.chain(*args.extra_model_paths_config):
+            load_extra_path_config(config_path)
 
     if args.output_directory:
         output_dir = os.path.abspath(args.output_directory)


### PR DESCRIPTION
When converting to argparse, I forgot to correctly convert `--extra-model-paths-config` as it previously it supported

`python main.py --extra-model-paths-config extra_model_paths.yaml --extra-model-paths-config second_model_paths.yaml`

It now once again supports that. It also now supports

`python main.py --extra-model-paths-config extra_model_paths.yaml second_model_paths.yaml`

as well and yields the exact same results. Args can still be specified before and after it.

Edit: Adds some metavars to argparse which makes help message more informative. Previously `python main.py -h` shows

```
...
  --listen [LISTEN]     Specify the IP address to listen on (default: 127.0.0.1). If --listen is provided without an 
  --enable-cors-header [ENABLE_CORS_HEADER]
  --cuda-device CUDA_DEVICE
...
```

now it shows

```
  --listen [IP]         Specify the IP address to listen on (default: 127.0.0.1). If --listen is provided without an    
  --enable-cors-header [ORIGIN]
  --cuda-device DEVICE_ID
```