### PR TITLE
Add quantize to palette node

### DIFF
--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -265,3 +265,11 @@ NODE_CLASS_MAPPINGS = {
     "ImageQuantizePalette": QuantizePalette,
     "ImageSharpen": Sharpen,
 }
+
+NODE_DISPLAY_NAME_MAPPINGS  = {
+    "ImageBlend": "Blend Images",
+    "ImageBlur": "Blur Image",
+    "ImageQuantize": "Quantize Image",
+    "ImageQuantizePalette": "Quantize Image (using Palette)",
+    "ImageSharpen": "Sharpen Image",
+}

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -163,7 +163,7 @@ class QuantizePalette:
         return {
             "required": {
                 "image": ("IMAGE",),
-                "palette": ("STRING", {"default": "#000000, #ffffff", "multiline": True}),
+                "palette": ("STRING", {"default": "black, white", "multiline": True}),
                 "dither": (["none", "floyd-steinberg"],),
             },
         }
@@ -186,7 +186,7 @@ class QuantizePalette:
                 raise ValueError("Palette is empty")
 
             def parse_palette(color_str):
-                if re.match(r'#[a-fA-F0-9]{6}', color_str)  or color_str.lower() in ImageColor.colormap:
+                if re.match(r'#[a-fA-F0-9]{6}', color_str) or color_str.lower() in ImageColor.colormap:
                     return ImageColor.getrgb(color_str)
 
                 color_rgb = re.match(r'\(?(\d{1,3}),(\d{1,3}),(\d{1,3})\)?', color_str)
@@ -197,7 +197,7 @@ class QuantizePalette:
 
             pal_img = Image.new('P', (1, 1))
             pal_colors = palette.replace(" ", "")
-            pal_colors = re.findall(fr'#[a-fA-F0-9]{{6}}|\(?\d{{1,3}},\d{{1,3}},\d{{1,3}}\)?|{"|".join(ImageColor.colormap.keys())}', pal_colors)
+            pal_colors = re.findall(fr'#[a-fA-F0-9]{{6}}|\(?\d{{1,3}},\d{{1,3}},\d{{1,3}}\)?|{"|".join(ImageColor.colormap.keys())}', pal_colors, re.IGNORECASE)
             pal_colors = list(itertools.chain.from_iterable(map(parse_palette, pal_colors)))
             pal_img.putpalette(pal_colors)
 

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -186,7 +186,7 @@ class QuantizePalette:
                 raise ValueError("Palette is empty")
 
             def parse_palette(color_str):
-                if re.match(r'#[a-fA-F0-9]{6}', color_str):
+                if re.match(r'#[a-fA-F0-9]{6}', color_str)  or color_str.lower() in ImageColor.colormap:
                     return ImageColor.getrgb(color_str)
 
                 color_rgb = re.match(r'\(?(\d{1,3}),(\d{1,3}),(\d{1,3})\)?', color_str)
@@ -197,7 +197,7 @@ class QuantizePalette:
 
             pal_img = Image.new('P', (1, 1))
             pal_colors = palette.replace(" ", "")
-            pal_colors = re.findall(r'#[a-fA-F0-9]{6}|\(?\d{1,3},\d{1,3},\d{1,3}\)?', pal_colors)
+            pal_colors = re.findall(fr'#[a-fA-F0-9]{{6}}|\(?\d{{1,3}},\d{{1,3}},\d{{1,3}}\)?|{"|".join(ImageColor.colormap.keys())}', pal_colors)
             pal_colors = list(itertools.chain.from_iterable(map(parse_palette, pal_colors)))
             pal_img.putpalette(pal_colors)
 


### PR DESCRIPTION
![Untitled](https://user-images.githubusercontent.com/4073789/230713980-b34d70a2-1ece-4eb9-a456-dda4094c6d42.png)
Does the same thing as the existing quantize node, using a user-defined palette instead of a number of colors. Colors can be RGB triplets, HTML color codes, or [color names](https://github.com/python-pillow/Pillow/blob/4ffbbe194c5a1b8840f809574017ab5f1333695f/src/PIL/ImageColor.py#L153-L305).

`red, green, blue`
`#ff0000, #00ff00, #0000ff`
`(255, 0, 0), (0, 255, 0), (0, 0, 255)`
Or any combination thereof.
