### PR TITLE
Fix large workflow pnginfo import

### DIFF
--- a/web/scripts/pnginfo.js
+++ b/web/scripts/pnginfo.js
@@ -32,8 +32,9 @@ export function getPngMetadata(file) {
 					}
 					const keyword = String.fromCharCode(...pngData.slice(offset + 8, keyword_end));
 					// Get the text
-					const text = String.fromCharCode(...pngData.slice(keyword_end + 1, offset + 8 + length));
-					txt_chunks[keyword] = text;
+					const contentArraySegment = pngData.slice(keyword_end + 1, offset + 8 + length);
+					const contentJson = Array.from(contentArraySegment).map(s=>String.fromCharCode(s)).join('')
+					txt_chunks[keyword] = contentJson;
 				}
 
 				offset += 12 + length;


### PR DESCRIPTION
This PR fixes exception when importing large workflows from images. Example:


```
pnginfo.js:36 Uncaught RangeError: Maximum call stack size exceeded
```


![1680964505_1x_00001_](https://user-images.githubusercontent.com/10226292/230728769-976dbf25-b824-4583-aafa-e0d1daf8a6e5.png)


