### PR TITLE
Catch configure errors

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -873,11 +873,11 @@ class ComfyApp {
 			this.graph.configure(graphData);
 		} catch (error) {
 			let errorHint = "";
-			// Try extracting filename to see if it was caused by an extension
-			const filename = error.fileName || (error.stack || "").match(/\/([\/\w-_\.]+\.js):(\d*):(\d*)/)?.[1];
+			// Try extracting filename to see if it was caused by an extension script
+			const filename = error.fileName || (error.stack || "").match(/(\/extensions\/.*\.js)/)?.[1];
 			const pos = (filename || "").indexOf("/extensions/");
 			if (pos > -1) {
-				errorHint = "This may be due to the following extension: " + filename.substring(pos + 12);
+				errorHint = "This may be due to the following script: " + filename.substring(pos + 12);
 			}
 
 			// Show dialog to let the user know something went wrong loading the data

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -872,12 +872,21 @@ class ComfyApp {
 		try {
 			this.graph.configure(graphData);
 		} catch (error) {
-			let errorHint = "";
+			let errorHint = [];
 			// Try extracting filename to see if it was caused by an extension script
 			const filename = error.fileName || (error.stack || "").match(/(\/extensions\/.*\.js)/)?.[1];
 			const pos = (filename || "").indexOf("/extensions/");
 			if (pos > -1) {
-				errorHint = "This may be due to the following script: " + filename.substring(pos + 12);
+				errorHint.push(
+					$el("span", { textContent: "This may be due to the following script:" }),
+					$el("br"),
+					$el("span", {
+						style: {
+							fontWeight: "bold",
+						},
+						textContent: filename.substring(pos),
+					})
+				);
 			}
 
 			// Show dialog to let the user know something went wrong loading the data
@@ -895,14 +904,14 @@ class ComfyApp {
 							fontSize: "10px",
 							maxHeight: "50vh",
 							overflow: "auto",
-							backgroundColor: "rgba(255,0,0,0.2)",
+							backgroundColor: "rgba(0,0,0,0.2)",
 						},
 						textContent: error.stack || "No stacktrace available",
 					}),
-					$el("span", { textContent: errorHint, style: { fontWeight: "bold" } }),
+					...errorHint,
 				]).outerHTML
 			);
-			
+
 			return;
 		}
 


### PR DESCRIPTION
Add some error handling around the graph configure call
![image](https://user-images.githubusercontent.com/125205205/230730102-066dea1e-67d8-4831-81ca-a1d38ba002ff.png)

Tries to extract the filename from the error to give a hint of what the cause might be.

My test extension that just throws when reloaded:

```
import { app } from "/scripts/app.js";

app.registerExtension({
	name: "I.DoAnError",
	registerCustomNodes() {
		class DoAnError {
			onConfigure() {
				throw new Error("boom");
			}
		}

		LiteGraph.registerNodeType("DoAnError", DoAnError);
		DoAnError.category = "DoAnError";
	},
});
```