### PR TITLE
Add arrow to menu items with submenus

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -257,3 +257,15 @@ button.comfy-queue-btn {
 	color: #ddd;
 	border-radius: 12px 0 0 12px;
 }
+
+.litegraph .litemenu-entry.has_submenu {
+	position: relative;
+	padding-right: 20px;
+ }
+ 
+ .litemenu-entry.has_submenu::after {
+	content: ">";
+	position: absolute;
+	top: 0;
+	right: 2px;
+ }

--- a/web/style.css
+++ b/web/style.css
@@ -262,10 +262,11 @@ button.comfy-queue-btn {
 	position: relative;
 	padding-right: 20px;
  }
- 
+
  .litemenu-entry.has_submenu::after {
 	content: ">";
 	position: absolute;
 	top: 0;
 	right: 2px;
  }
+ 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/125205205/230767724-8404736a-1b81-4e3c-a2d9-b5bc2cd869d5.png)
I know the blue border already indicates this, I just think adding an arrow is more standard makes it clearer which items have submenus
