### PR TITLE
A few more postprocessing nodes

### DIFF
--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -395,6 +395,45 @@ class Split:
 
         return (result_r, result_g, result_b)
 
+class Merge:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "red": ("IMAGE",),
+                "green": ("IMAGE",),
+                "blue": ("IMAGE",),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "merge"
+
+    CATEGORY = "image/postprocessing"
+
+    def merge(self, red: torch.Tensor, green: torch.Tensor, blue: torch.Tensor):
+        batch_size, height, width, _ = red.shape
+        result = torch.zeros_like(red)
+
+        for b in range(batch_size):
+            img_r = (red[b] * 255).to(torch.uint8).numpy()
+            img_g = (green[b] * 255).to(torch.uint8).numpy()
+            img_b = (blue[b] * 255).to(torch.uint8).numpy()
+            pil_image_r = Image.fromarray(img_r, mode='RGB').convert("L")
+            pil_image_g = Image.fromarray(img_g, mode='RGB').convert("L")
+            pil_image_b = Image.fromarray(img_b, mode='RGB').convert("L")
+
+            output_image = Image.merge("RGB", (pil_image_r, pil_image_g, pil_image_b))
+
+            output_array = torch.tensor(np.array(output_image.convert("RGB"))).float() / 255
+            result[b] = output_array
+
+        return (result,)
+
+
 
 NODE_CLASS_MAPPINGS = {
     "ImageBlend": Blend,
@@ -405,4 +444,17 @@ NODE_CLASS_MAPPINGS = {
     "ImageRotate": Rotate,
     "ImageGetChannel": GetChannel,
     "ImageSplit": Split,
+    "ImageMerge": Merge,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS  = {
+    "ImageBlend": "Blend Images",
+    "ImageBlur": "Blur Image",
+    "ImageQuantize": "Quantize Image",
+    "ImageSharpen": "Sharpen Image",
+    "ImageTranspose": "Transpose",
+    "ImageRotate": "Rotate",
+    "ImageGetChannel": "Extract Channel",
+    "ImageSplit": "Split Channels",
+    "ImageMerge": "Merge Channels",
 }

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -236,24 +236,17 @@ class Transpose:
             result = torch.permute(result, (0, 2, 1, 3))
 
         methods = {
-            "Flip horizontal": Image.Transpose.FLIP_LEFT_RIGHT,
-            "Flip vertical": Image.Transpose.FLIP_TOP_BOTTOM,
-            "Rotate 90°": Image.Transpose.ROTATE_90,
-            "Rotate 180°": Image.Transpose.ROTATE_180,
-            "Rotate 270°": Image.Transpose.ROTATE_270,
-            "Transpose": Image.Transpose.TRANSPOSE,
-            "Transverse": Image.Transpose.TRANSVERSE,
+            "Flip horizontal": (lambda x: torch.fliplr(x)),
+            "Flip vertical": (lambda x: torch.flipud(x)),
+            "Rotate 90°": (lambda x: torch.rot90(x)),
+            "Rotate 180°": (lambda x: torch.rot90(x, 2)),
+            "Rotate 270°": (lambda x: torch.rot90(x, 3)),
+            "Transpose": (lambda x: torch.transpose(x, 0, 1)),
+            "Transverse": (lambda x: torch.rot90(torch.transpose(x, 0, 1), 2)),
         }
 
         for b in range(batch_size):
-            tensor_image = image[b]
-            img = (tensor_image * 255).to(torch.uint8).numpy()
-            pil_image = Image.fromarray(img, mode='RGB')
-
-            transposed_image = pil_image.transpose(methods[method])
-
-            transposed_array = torch.tensor(np.array(transposed_image.convert("RGB"))).float() / 255
-            result[b] = transposed_array
+            result[b] = methods[method](image[b])
 
         return (result,)
 

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -452,17 +452,18 @@ class Composite:
         result = torch.zeros_like(base_image)
 
         for b in range(batch_size):
-            if mask is None:
-                mask = torch.ones(overlay_image.shape[1:3])
-        
             img_a = (base_image[b] * 255).to(torch.uint8).numpy()
             img_b = (overlay_image[b] * 255).to(torch.uint8).numpy()
-            img_mask = (mask * 255).to(torch.uint8).numpy()
             pil_base_image = Image.fromarray(img_a, mode='RGB')
             pil_overlay_image = Image.fromarray(img_b, mode='RGB')
-            pil_image_mask = Image.fromarray(img_mask, mode='L')
-            if pil_image_mask.size != pil_overlay_image.size:
-                pil_image_mask = pil_image_mask.resize(pil_overlay_image.size, resamplers[resample])
+            
+            if mask is None:
+                pil_image_mask = mask
+            else:
+                img_mask = (mask * 255).to(torch.uint8).numpy()
+                pil_image_mask = Image.fromarray(img_mask, mode='L')
+                if pil_image_mask.size != pil_overlay_image.size:
+                    pil_image_mask = pil_image_mask.resize(pil_overlay_image.size, resamplers[resample])
 
             pil_base_image.paste(pil_overlay_image, (x, y), pil_image_mask)
 

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -320,6 +320,82 @@ class Rotate:
 
         return (result,)
 
+class GetChannel:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "channel": ([
+                    "Red",
+                    "Green",
+                    "Blue",
+                ],),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "getchannel"
+
+    CATEGORY = "image/postprocessing"
+
+    def getchannel(self, image: torch.Tensor, channel: str):
+        batch_size, height, width, _ = image.shape
+        result = torch.zeros_like(image)
+
+        for b in range(batch_size):
+            tensor_image = image[b]
+            img = (tensor_image * 255).to(torch.uint8).numpy()
+            pil_image = Image.fromarray(img, mode='RGB')
+
+            output_image = pil_image.getchannel(channel[0])
+
+            output_array = torch.tensor(np.array(output_image.convert("RGB"))).float() / 255
+            result[b] = output_array
+
+        return (result,)
+
+class Split:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE")
+    FUNCTION = "split"
+
+    CATEGORY = "image/postprocessing"
+
+    def split(self, image: torch.Tensor):
+        batch_size, height, width, _ = image.shape
+        result_r = torch.zeros_like(image)
+        result_g = torch.zeros_like(image)
+        result_b = torch.zeros_like(image)
+
+        for b in range(batch_size):
+            tensor_image = image[b]
+            img = (tensor_image * 255).to(torch.uint8).numpy()
+            pil_image = Image.fromarray(img, mode='RGB')
+
+            output_r, output_g, output_b = pil_image.split()
+
+            output_array_r = torch.tensor(np.array(output_r.convert("RGB"))).float() / 255
+            output_array_g = torch.tensor(np.array(output_g.convert("RGB"))).float() / 255
+            output_array_b = torch.tensor(np.array(output_b.convert("RGB"))).float() / 255
+            result_r[b], result_g[b], result_b[b] = output_array_r, output_array_g, output_array_b
+
+        return (result_r, result_g, result_b)
+
+
 NODE_CLASS_MAPPINGS = {
     "ImageBlend": Blend,
     "ImageBlur": Blur,
@@ -327,4 +403,6 @@ NODE_CLASS_MAPPINGS = {
     "ImageSharpen": Sharpen,
     "ImageTranspose": Transpose,
     "ImageRotate": Rotate,
+    "ImageGetChannel": GetChannel,
+    "ImageSplit": Split,
 }

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -320,8 +320,8 @@ class Rotate:
         color = fill_color.replace(" ", "")
         color = parse_palette(color)
         rotated_image = pil_image.rotate(angle=angle, resample=resamplers[resample], expand=expand, center=center, translate=translate, fillcolor=color)
-        height, width = rotated_image.size
-        result = torch.zeros(batch_size, width, height, 3)
+        width, height = rotated_image.size
+        result = torch.zeros(batch_size, height, width, 3)
         rotated_array = torch.tensor(np.array(rotated_image.convert("RGB"))).float() / 255
         result[0] = rotated_array
 

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -373,6 +373,8 @@ class Split:
         }
 
     RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE")
+    RETURN_NAMES = ("Red", "Green", "Blue")
+
     FUNCTION = "split"
 
     CATEGORY = "image/postprocessing"

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -232,6 +232,8 @@ class Transpose:
     def transpose(self, image: torch.Tensor, method: str):
         batch_size, height, width, _ = image.shape
         result = torch.zeros_like(image)
+        if height != width and method in ("Transpose", "Transverse", "Rotate 90°", "Rotate 270°"):
+            result = torch.permute(result, (0, 2, 1, 3))
 
         methods = {
             "Flip horizontal": Image.Transpose.FLIP_LEFT_RIGHT,

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -308,7 +308,7 @@ class Rotate:
             else:
                 raise ValueError(f"Invalid color format: {color_str}")
 
-        center = (center_x, center_y) if center_of_image == "disabled" else (width / 2, height / 2)  
+        center = (width / 2, height / 2) if center_of_image == "enabled" else (center_x, center_y)
         translate = (translate_x, translate_y)
 
         color = fill_color.replace(" ", "")

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -428,10 +428,12 @@ class Composite:
             "required": {
                 "image_a": ("IMAGE",),
                 "image_b": ("IMAGE",),
-                "mask": ("MASK",),
                 "x": ("INT", {"default": 0, "min": -MAX_RESOLUTION, "max": MAX_RESOLUTION}),
                 "y": ("INT", {"default": 0, "min": -MAX_RESOLUTION, "max": MAX_RESOLUTION}),
             },
+            "optional": {
+                "mask": ("MASK",),
+            }
         }
 
     RETURN_TYPES = ("IMAGE",)
@@ -439,11 +441,14 @@ class Composite:
 
     CATEGORY = "image/postprocessing"
 
-    def composite(self, image_a: torch.Tensor, image_b: torch.Tensor, mask: torch.Tensor, x: int, y: int):
+    def composite(self, image_a: torch.Tensor, image_b: torch.Tensor, x: int, y: int, mask: torch.Tensor = None):
         batch_size, height, width, _ = image_a.shape
         result = torch.zeros_like(image_a)
 
         for b in range(batch_size):
+            if mask is None:
+                mask = torch.ones(image_b.shape[1:3])
+        
             img_a = (image_a[b] * 255).to(torch.uint8).numpy()
             img_b = (image_b[b] * 255).to(torch.uint8).numpy()
             img_mask = (mask * 255).to(torch.uint8).numpy()

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -313,8 +313,6 @@ class Rotate:
                 raise ValueError(f"Invalid color format: {color_str}")
 
         center = (center_x, center_y) if center_of_image == "disabled" else (width / 2, height / 2)  
-        print(center_of_image)
-        print(center)
         translate = (translate_x, translate_y)
 
         color = fill_color.replace(" ", "")


### PR DESCRIPTION
Transpose: rotates, flips, and transposes images.
![image](https://user-images.githubusercontent.com/4073789/231026771-67637ad2-38e9-40ee-9964-e5d7988a3998.png)

Rotate: rotates images to arbitrary angles, with selectable background color (same syntax as #437), and optionally expand to fit.
![image](https://user-images.githubusercontent.com/4073789/231027022-2883bb1f-483d-4c19-b9b2-d26910cbac35.png)

Extract channel: extracts the selected color channel.
![image](https://user-images.githubusercontent.com/4073789/231027138-2e2be165-014a-4d50-a2ae-04902b0d9aaa.png)

Split channels: extracts all three color channels.
![Untitled](https://user-images.githubusercontent.com/4073789/231027219-d87ae721-7f38-427e-b614-3d0592a8d3a8.png)

Merge channels: The opposite of split channels, Merges channels back to an RGB image.
![Untitled0](https://user-images.githubusercontent.com/4073789/231027384-3709a3f5-5f93-4a94-b477-c0a0daf54f23.png)

Composite images: composites two images using a mask.
![image](https://user-images.githubusercontent.com/4073789/231027820-6fafb532-ed31-4287-b7bf-8207533fd5fa.png)
