### PR TITLE
Changed default name to be the node type not title

### DIFF
--- a/web/extensions/core/saveImageExtraOutput.js
+++ b/web/extensions/core/saveImageExtraOutput.js
@@ -90,7 +90,7 @@ app.registerExtension({
 				const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined;
 
 				if (!this.properties || !("Node name for S&R" in this.properties)) {
-					this.addProperty("Node name for S&R", this.title, "string");
+					this.addProperty("Node name for S&R", this.constructor.type, "string");
 				}
 
 				return r;


### PR DESCRIPTION
Search and replace values still support searching by the node title, but the property will now default to the node class name.