### PR TITLE
[DRAFT] Support adding multiple outputs to a primitive widget

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -221,7 +221,10 @@ app.registerExtension({
 						if (widgetName) {
 							const widget = node.widgets.find((w) => w.name === widgetName);
 							if (widget) {
-								widget.value = this.widgets[linkInfo.origin_slot].value;
+								// the first widget matching a slot in the primitive should hold the value, as they're kept
+								// sorted. If this is undefined, something weird is going on.
+								const sourcewidget = this.widgets.find((w) => w.primitiveSlot === linkInfo.origin_slot);
+								widget.value = sourcewidget.value;
 								if (widget.callback) {
 									widget.callback(widget.value, app.canvas, node, app.canvas.graph_mouse, {});
 								}

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -206,21 +206,25 @@ app.registerExtension({
 				this.widgets?.sort((a, b) => (a.primitiveSlot || 0) - (a.primitiveSlot || 0));
 			}
 
-			applyToGraph(slot) {
-				if (!this.outputs[slot].links?.length) return;
+			applyToGraph() {
+				for (const o of this.outputs) {
+					if (!o.links?.length) {
+						continue;
+					}
 
-				// For each output link copy our value over the original widget value
-				for (const l of this.outputs[slot].links) {
-					const linkInfo = app.graph.links[l];
-					const node = this.graph.getNodeById(linkInfo.target_id);
-					const input = node.inputs[linkInfo.target_slot];
-					const widgetName = input.widget.name;
-					if (widgetName) {
-						const widget = node.widgets.find((w) => w.name === widgetName);
-						if (widget) {
-							widget.value = this.widgets[slot].value;
-							if (widget.callback) {
-								widget.callback(widget.value, app.canvas, node, app.canvas.graph_mouse, {});
+					// For each output link copy our value over the original widget value
+					for (const l of o.links) {
+						const linkInfo = app.graph.links[l];
+						const node = this.graph.getNodeById(linkInfo.target_id);
+						const input = node.inputs[linkInfo.target_slot];
+						const widgetName = input.widget.name;
+						if (widgetName) {
+							const widget = node.widgets.find((w) => w.name === widgetName);
+							if (widget) {
+								widget.value = this.widgets[linkInfo.origin_slot].value;
+								if (widget.callback) {
+									widget.callback(widget.value, app.canvas, node, app.canvas.graph_mouse, {});
+								}
 							}
 						}
 					}
@@ -318,7 +322,7 @@ app.registerExtension({
 				const self = this;
 				widget.callback = function () {
 					const r = callback ? callback.apply(this, arguments) : undefined;
-					self.applyToGraph(slot);
+					self.applyToGraph();
 					return r;
 				};
 


### PR DESCRIPTION
This generalizes the Primitive widget to support an arbitrary number of outputs.

It still defaults to one, but you can right-click and add outputs as needed. I didn't implement removal of slots, as you might as well just recreate the widget in that case.

There's something weird going on with size calculations though. Adding an output when something is connected causes the new slot to go under an existing widget until refresh.

I couldn't figure out why this happens, or how to get LiteGraph to recalculate the node size.