### PR TITLE
Add slider input for settings

### DIFF
--- a/web/extensions/core/snapToGrid.js
+++ b/web/extensions/core/snapToGrid.js
@@ -9,7 +9,7 @@ app.registerExtension({
 		app.ui.settings.addSetting({
 			id: "Comfy.SnapToGrid.GridSize",
 			name: "Grid Size",
-			type: "number",
+			type: "slider",
 			attrs: {
 				min: 1,
 				max: 500,

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -270,7 +270,7 @@ class ComfySettingsDialog extends ComfyDialog {
 								]),
 							]);
 							break;
-                        case "slider":
+						case "slider":
 							element = $el("div", [
 								$el("label", { textContent: name }, [
 									$el("input", {
@@ -278,16 +278,16 @@ class ComfySettingsDialog extends ComfyDialog {
 										value,
 										oninput: (e) => {
 											setter(e.target.value);
-                                            e.target.nextElementSibling.value = e.target.value;
+											e.target.nextElementSibling.value = e.target.value;
 										},
 										...attrs
 									}),
-                                    $el("input", {
+									$el("input", {
 										type: "number",
 										value,
 										oninput: (e) => {
 											setter(e.target.value);
-                                            e.target.previousElementSibling.value = e.target.value;
+											e.target.previousElementSibling.value = e.target.value;
 										},
 										...attrs
 									}),

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -270,6 +270,30 @@ class ComfySettingsDialog extends ComfyDialog {
 								]),
 							]);
 							break;
+                        case "slider":
+							element = $el("div", [
+								$el("label", { textContent: name }, [
+									$el("input", {
+										type: "range",
+										value,
+										oninput: (e) => {
+											setter(e.target.value);
+                                            e.target.nextElementSibling.value = e.target.value;
+										},
+										...attrs
+									}),
+                                    $el("input", {
+										type: "number",
+										value,
+										oninput: (e) => {
+											setter(e.target.value);
+                                            e.target.previousElementSibling.value = e.target.value;
+										},
+										...attrs
+									}),
+								]),
+							]);
+							break;
 						default:
 							console.warn("Unsupported setting type, defaulting to text");
 							element = $el("div", [

--- a/web/style.css
+++ b/web/style.css
@@ -217,6 +217,14 @@ button.comfy-queue-btn {
 	z-index: 99;
 }
 
+.comfy-modal.comfy-settings input[type="range"] {
+	vertical-align: middle;
+}
+
+.comfy-modal.comfy-settings input[type="range"] + input[type="number"] {
+	width: 3.5em;
+}
+
 .comfy-modal input,
 .comfy-modal select {
 	color: var(--input-text);


### PR DESCRIPTION
Allows creating settings with `type: "slider"`

![Untitled](https://user-images.githubusercontent.com/4073789/231638366-3f8e70a6-a9b0-4008-81e7-3124fb1352ba.png)
