### PR TITLE
Fixes comfy list not being styled

### DIFF
--- a/web/extensions/core/colorPalette.js
+++ b/web/extensions/core/colorPalette.js
@@ -107,7 +107,7 @@ const colorPalettes = {
 				"descrip-text": "#444",
 				"drag-text": "#555",
 				"error-text": "#F44336",
-				"border-color": "#CCC"
+				"border-color": "#888"
 			}
 		},
 	},

--- a/web/style.css
+++ b/web/style.css
@@ -160,9 +160,9 @@ body {
 
 .comfy-list {
 	color: var(--descrip-text);
-	background-color: #333;
+	background-color: var(--comfy-menu-bg);
 	margin-bottom: 10px;
-	border-color: #4e4e4e;
+	border-color: var(--border-color);
 	border-style: solid;
 }
 


### PR DESCRIPTION
Missed this in #481, comfy-list was not styled so history and queue were not. Also, Light theme has a bad border color as seen in the history image below since it blends with background.

Previous:
![image](https://user-images.githubusercontent.com/23466035/231731631-dadf79ef-f49e-438c-a183-dec2502f1574.png) ![image](https://user-images.githubusercontent.com/23466035/231733996-a6e1cc3d-a9ca-4d55-a9f0-83054f14601f.png)


Now:
![image](https://user-images.githubusercontent.com/23466035/231733124-b64fc98e-a025-473b-aab9-af52e1ff5b75.png) ![image](https://user-images.githubusercontent.com/23466035/231733527-602d0878-1d52-40fc-a623-28207d204c58.png)
