### PR TITLE
Fix double click on converted combo widget link

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -159,9 +159,11 @@ app.registerExtension({
 			const r = origOnInputDblClick ? origOnInputDblClick.apply(this, arguments) : undefined;
 
 			const input = this.inputs[slot];
-			if (!input.widget || !input[ignoreDblClick])// Not a widget input or already handled input
-			{
-				if (!(input.type in ComfyWidgets)) return r;//also Not a ComfyWidgets input (do nothing)
+			if (!input.widget || !input[ignoreDblClick]) {
+				// Not a widget input or already handled input
+				if (!(input.type in ComfyWidgets) && !(input.widget.config?.[0] instanceof Array)) {
+					return r; //also Not a ComfyWidgets input or combo (do nothing)
+				}
 			}
 
 			// Create a primitive node


### PR DESCRIPTION
Currently if you convert a combo to an input and double click the input to get a primitive node, it doesnt work
![image](https://user-images.githubusercontent.com/125205205/232238335-9e1f3f6e-65b4-4a04-8df8-a52b3eabb4e6.png)
This fixes that