### PR TITLE
add a new custom property "defaultBehavior" = "widget" || "input"

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -152,10 +152,10 @@ app.registerExtension({
 			const r = originalOnNodeCreated ? originalOnNodeCreated.apply(this, arguments) : undefined;
 			if (this.widgets) {
 				for (const w of this.widgets) {
-					if (w.defaultBehavior === "input") {
+					if (w?.defaultBehavior === "input") {
 						const config = nodeData?.input?.required[w.name] || nodeData?.input?.optional?.[w.name] || [w.type, w.options || {}];
 						convertToInput(this, w, config);
-						w.defaultBehavior === "widget"
+						w?.defaultBehavior === "widget"
 					}
 				}
 			}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -830,7 +830,7 @@ class ComfyApp {
 							}
 
 							if (w != null) {
-								if(customProperties.defaultBehavior){
+								if(customProperties?.defaultBehavior){
 									w.widget.defaultBehavior = customProperties.defaultBehavior;
 								}else{
 									w.widget.defaultBehavior = "widget";


### PR DESCRIPTION
when create input in python you can add "defaultBehavior" = "input" or "widget" so the node input will start as input not widget

as examble 
   def INPUT_TYPES(s):
        return {"required": {
            "text": ("STRING", {"multiline": False, **_"defaultBehavior": "input"_**}),
            "terminology": (s.laodCategories(),),
            "separator": ("STRING", {"multiline": False, "default": ","}),
            "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
        }}