### PR TITLE
Selects current word automatically

### DIFF
--- a/web/extensions/core/editAttention.js
+++ b/web/extensions/core/editAttention.js
@@ -79,8 +79,16 @@ name:id,
                     selectedText = inputField.value.substring(start, end);
                 } else {
                     // Select the current word, find the start and end of the word (first space before and after)
-                    start = inputField.value.substring(0, start).lastIndexOf(" ") + 1;
-                    end = inputField.value.substring(end).indexOf(" ") + end;
+                    const wordStart = inputField.value.substring(0, start).lastIndexOf(" ") + 1;
+                    const wordEnd = inputField.value.substring(end).indexOf(" ");
+                    // If there is no space after the word, select to the end of the string
+                    if (wordEnd === -1) {
+                        end = inputField.value.length;
+                    } else {
+                        end += wordEnd;
+                    }
+                    start = wordStart;
+
                     // Remove all punctuation at the end and beginning of the word
                     while (inputField.value[start].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
                         start++;

--- a/web/extensions/core/editAttention.js
+++ b/web/extensions/core/editAttention.js
@@ -70,7 +70,7 @@ name:id,
             let end = inputField.selectionEnd;
             let selectedText = inputField.value.substring(start, end);
 
-            // If there is no selection, attempt to find the nearest enclosure
+            // If there is no selection, attempt to find the nearest enclosure, or select the current word
             if (!selectedText) {
                 const nearestEnclosure = findNearestEnclosure(inputField.value, start);
                 if (nearestEnclosure) {
@@ -78,7 +78,18 @@ name:id,
                     end = nearestEnclosure.end;
                     selectedText = inputField.value.substring(start, end);
                 } else {
-                    return;
+                    // Select the current word, find the start and end of the word (first space before and after)
+                    start = inputField.value.substring(0, start).lastIndexOf(" ") + 1;
+                    end = inputField.value.substring(end).indexOf(" ") + end;
+                    // Remove all punctuation at the end and beginning of the word
+                    while (inputField.value[start].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
+                        start++;
+                    }
+                    while (inputField.value[end - 1].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
+                        end--;
+                    }
+                    selectedText = inputField.value.substring(start, end);
+                    if (!selectedText) return;
                 }
             }
 
@@ -97,7 +108,6 @@ name:id,
 
             // If the selection is not enclosed in parentheses, add them
             if (selectedText[0] !== "(" || selectedText[selectedText.length - 1] !== ")") {
-                console.log("adding parentheses", inputField.value[start], inputField.value[end], selectedText);
                 selectedText = `(${selectedText})`;
             }
 


### PR DESCRIPTION
Remove a console.log, my bad.

Also now, this is a new feature similar to how previously it finds the current enclosure if there is no selection, it also now attempts to find the current word.

![clip-edit-attention-fix](https://user-images.githubusercontent.com/23466035/232627433-663b70e6-985e-4e3c-8691-8ee133ea27b7.gif)

You don't even have to highlight a word anymore as previously you had to highlight a single word to give it the initial attention braces. Now it automatically tries to find the immediate word.
