### PR TITLE
Add clipspace feature.

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -11,6 +11,7 @@ import torch
 import nodes
 
 import comfy.model_management
+import folder_paths
 
 def get_input_data(inputs, class_def, unique_id, outputs={}, prompt={}, extra_data={}):
     valid_inputs = class_def.INPUT_TYPES()
@@ -250,7 +251,12 @@ def validate_inputs(prompt, item):
                     return (False, "Value bigger than max. {}, {}".format(class_type, x))
 
             if isinstance(type_input, list):
-                if val not in type_input:
+                is_annotated_path = val.endswith("[temp]") or val.endswith("[input]") or val.endswith("[output]")
+                if is_annotated_path:
+                    if not folder_paths.exists_annotated_filepath(val):
+                        return (False, "Invalid file path. {}, {}: {}".format(class_type, x, val))
+
+                elif val not in type_input:
                     return (False, "Value not in list. {}, {}: {} not in {}".format(class_type, x, val, type_input))
     return (True, "")
 

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -70,7 +70,7 @@ def get_directory_by_type(type_name):
 
 # determine base_dir rely on annotation if name is 'filename.ext [annotation]' format
 # otherwise use default_path as base_dir
-def get_annotated_filepath(name, default_dir=None):
+def touch_annotated_filepath(name):
     if name.endswith("[output]"):
         base_dir = get_output_directory()
         name = name[:-9]
@@ -80,24 +80,29 @@ def get_annotated_filepath(name, default_dir=None):
     elif name.endswith("[temp]"):
         base_dir = get_temp_directory()
         name = name[:-7]
-    elif default_dir is not None:
-        base_dir = default_dir
     else:
-        base_dir = get_input_directory()  # fallback path
+        return name, None
+
+    return name, base_dir
+
+
+def get_annotated_filepath(name, default_dir=None):
+    name, base_dir = touch_annotated_filepath(name)
+
+    if base_dir is None:
+        if default_dir is not None:
+            base_dir = default_dir
+        else:
+            base_dir = get_input_directory()  # fallback path
 
     return os.path.join(base_dir, name)
 
 
 def exists_annotated_filepath(name):
-    if name.endswith("[output]"):
-        base_dir = get_output_directory()
-        name = name[:-9]
-    elif name.endswith("[temp]"):
-        base_dir = get_temp_directory()
-        name = name[:-7]
-    else:
-        base_dir = get_input_directory()
-        name = name[:-8]
+    name, base_dir = touch_annotated_filepath(name)
+
+    if base_dir is None:
+        base_dir = get_input_directory()  # fallback path
 
     filepath = os.path.join(base_dir, name)
     return os.path.exists(filepath)

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -68,6 +68,41 @@ def get_directory_by_type(type_name):
     return None
 
 
+# determine base_dir rely on annotation if name is 'filename.ext [annotation]' format
+# otherwise use default_path as base_dir
+def get_annotated_filepath(name, default_dir=None):
+    if name.endswith("[output]"):
+        base_dir = get_output_directory()
+        name = name[:-9]
+    elif name.endswith("[input]"):
+        base_dir = get_input_directory()
+        name = name[:-8]
+    elif name.endswith("[temp]"):
+        base_dir = get_temp_directory()
+        name = name[:-7]
+    elif default_dir is not None:
+        base_dir = default_dir
+    else:
+        base_dir = get_input_directory()  # fallback path
+
+    return os.path.join(base_dir, name)
+
+
+def exists_annotated_filepath(name):
+    if name.endswith("[output]"):
+        base_dir = get_output_directory()
+        name = name[:-9]
+    elif name.endswith("[temp]"):
+        base_dir = get_temp_directory()
+        name = name[:-7]
+    else:
+        base_dir = get_input_directory()
+        name = name[:-8]
+
+    filepath = os.path.join(base_dir, name)
+    return os.path.exists(filepath)
+
+
 def add_model_folder_path(folder_name, full_folder_path):
     global folder_names_and_paths
     if folder_name in folder_names_and_paths:

--- a/nodes.py
+++ b/nodes.py
@@ -975,7 +975,7 @@ class LoadImage:
     FUNCTION = "load_image"
     def load_image(self, image):
         input_dir = folder_paths.get_input_directory()
-        image_path = os.path.join(input_dir, image)
+        image_path = folder_paths.get_annotated_filepath(image, input_dir)
         i = Image.open(image_path)
         image = i.convert("RGB")
         image = np.array(image).astype(np.float32) / 255.0
@@ -990,7 +990,7 @@ class LoadImage:
     @classmethod
     def IS_CHANGED(s, image):
         input_dir = folder_paths.get_input_directory()
-        image_path = os.path.join(input_dir, image)
+        image_path = folder_paths.get_annotated_filepath(image, input_dir)
         m = hashlib.sha256()
         with open(image_path, 'rb') as f:
             m.update(f.read())
@@ -1011,7 +1011,7 @@ class LoadImageMask:
     FUNCTION = "load_image"
     def load_image(self, image, channel):
         input_dir = folder_paths.get_input_directory()
-        image_path = os.path.join(input_dir, image)
+        image_path = folder_paths.get_annotated_filepath(image, input_dir)
         i = Image.open(image_path)
         if i.getbands() != ("R", "G", "B", "A"):
             i = i.convert("RGBA")
@@ -1029,7 +1029,7 @@ class LoadImageMask:
     @classmethod
     def IS_CHANGED(s, image, channel):
         input_dir = folder_paths.get_input_directory()
-        image_path = os.path.join(input_dir, image)
+        image_path = folder_paths.get_annotated_filepath(image, input_dir)
         m = hashlib.sha256()
         with open(image_path, 'rb') as f:
             m.update(f.read())

--- a/server.py
+++ b/server.py
@@ -112,13 +112,20 @@ class PromptServer():
 
         @routes.post("/upload/image")
         async def upload_image(request):
-            upload_dir = folder_paths.get_input_directory()
+            post = await request.post()
+            image = post.get("image")
+
+            if post.get("type") is None:
+                upload_dir = folder_paths.get_input_directory()
+            elif post.get("type") == "input":
+                upload_dir = folder_paths.get_input_directory()
+            elif post.get("type") == "temp":
+                upload_dir = folder_paths.get_temp_directory()
+            elif post.get("type") == "output":
+                upload_dir = folder_paths.get_output_directory()
 
             if not os.path.exists(upload_dir):
                 os.makedirs(upload_dir)
-            
-            post = await request.post()
-            image = post.get("image")
 
             if image and image.file:
                 filename = image.filename

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -146,7 +146,10 @@ export class ComfyApp {
 						if(this.widgets) {
 						    widgets = this.widgets.map(({ type, name, value }) => ({ type, name, value }));
 						}
-						ComfyApp.clipspace = { 'widgets': widgets, 'imgs': this.imgs, 'images': this.images };
+						
+						let img = new Image();
+						img.src = this.imgs[0].src;
+						ComfyApp.clipspace = { 'widgets': widgets, 'imgs': [img], 'images': this.images };
 					}
 				},
 				{

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -24,7 +24,7 @@ export class ComfyApp {
 	 * Content Clipboard
 	 * @type {serialized node object}
 	 */
-	static contentClipboard = null;
+	static clipspace = null;
 
 	constructor() {
 		this.ui = new ComfyUI(this);
@@ -146,16 +146,16 @@ export class ComfyApp {
 						if(this.widgets) {
 						    widgets = this.widgets.map(({ type, name, value }) => ({ type, name, value }));
 						}
-						ComfyApp.contentClipboard = { 'widgets': widgets, 'imgs': this.imgs, 'images': this.images };
+						ComfyApp.clipspace = { 'widgets': widgets, 'imgs': this.imgs, 'images': this.images };
 					}
 				},
 				{
 					content: "Paste (Clipspace)",
 					callback: () => {
-						if(ComfyApp.contentClipboard != null) {
-							console.log(ComfyApp.contentClipboard.widgets);
-							if(ComfyApp.contentClipboard.widgets != null) {
-								ComfyApp.contentClipboard.widgets.forEach(({ type, name, value }) => {
+						if(ComfyApp.clipspace != null) {
+							console.log(ComfyApp.clipspace.widgets);
+							if(ComfyApp.clipspace.widgets != null) {
+								ComfyApp.clipspace.widgets.forEach(({ type, name, value }) => {
 									const prop = Object.values(this.widgets).find(obj => obj.type === type && obj.name === name);
 										if (prop) {
 										prop.value = value;
@@ -163,9 +163,9 @@ export class ComfyApp {
 								});
 							}
 
-							if(ComfyApp.contentClipboard.imgs != undefined && this.imgs != undefined) {
-								this.imgs = ComfyApp.contentClipboard.imgs;
-								this.images = ComfyApp.contentClipboard.images;
+							if(ComfyApp.clipspace.imgs != undefined && this.imgs != undefined) {
+								this.imgs = ComfyApp.clipspace.imgs;
+								this.images = ComfyApp.clipspace.images;
 								const index = this.widgets.findIndex(obj => obj.name === 'image');
 								if(index >= 0) {
 									let filename = `${this.images[0].filename} [${this.images[0].type}]`;

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -160,51 +160,55 @@ export class ComfyApp {
 							'images': this.images
 							};
 					}
-				},
-				{
-					content: "Paste (Clipspace)",
-					callback: () => {
-						if(ComfyApp.clipspace != null) {
-							if(ComfyApp.clipspace.widgets != null && this.widgets != null) {
-								ComfyApp.clipspace.widgets.forEach(({ type, name, value }) => {
-									const prop = Object.values(this.widgets).find(obj => obj.type === type && obj.name === name);
-										if (prop) {
-										prop.value = value;
+				});
+
+			if(ComfyApp.clipspace != null) {
+				options.push(
+					{
+						content: "Paste (Clipspace)",
+						callback: () => {
+							if(ComfyApp.clipspace != null) {
+								if(ComfyApp.clipspace.widgets != null && this.widgets != null) {
+									ComfyApp.clipspace.widgets.forEach(({ type, name, value }) => {
+										const prop = Object.values(this.widgets).find(obj => obj.type === type && obj.name === name);
+											if (prop) {
+											prop.value = value;
+										}
+									});
+								}
+
+								// image paste
+								if(ComfyApp.clipspace.imgs != undefined && this.imgs != undefined && this.widgets != null) {
+									var filename = "";
+									if(this.images && ComfyApp.clipspace.images) {
+										this.images = ComfyApp.clipspace.images;
 									}
-								});
-							}
 
-							// image paste
-							if(ComfyApp.clipspace.imgs != undefined && this.imgs != undefined && this.widgets != null) {
-								var filename = "";
-								if(this.images && ComfyApp.clipspace.images) {
-									this.images = ComfyApp.clipspace.images;
-								}
-
-								if(ComfyApp.clipspace.images != undefined) {
-									filename = `${ComfyApp.clipspace.images[0].filename} [${ComfyApp.clipspace.images[0].type}]`;
-								}
-								else if(ComfyApp.clipspace.widgets != undefined) {
-									const index_in_clip = ComfyApp.clipspace.widgets.findIndex(obj => obj.name === 'image');
-									if(index_in_clip >= 0) {
-										filename = `${ComfyApp.clipspace.widgets[index_in_clip].value}`;
+									if(ComfyApp.clipspace.images != undefined) {
+										filename = `${ComfyApp.clipspace.images[0].filename} [${ComfyApp.clipspace.images[0].type}]`;
 									}
-								}
+									else if(ComfyApp.clipspace.widgets != undefined) {
+										const index_in_clip = ComfyApp.clipspace.widgets.findIndex(obj => obj.name === 'image');
+										if(index_in_clip >= 0) {
+											filename = `${ComfyApp.clipspace.widgets[index_in_clip].value}`;
+										}
+									}
 
-								const index = this.widgets.findIndex(obj => obj.name === 'image');
-								if(index >= 0 && filename != "" && ComfyApp.clipspace.imgs != undefined) {
-									this.imgs = ComfyApp.clipspace.imgs;
+									const index = this.widgets.findIndex(obj => obj.name === 'image');
+									if(index >= 0 && filename != "" && ComfyApp.clipspace.imgs != undefined) {
+										this.imgs = ComfyApp.clipspace.imgs;
 
-									this.widgets[index].value = filename;
-									if(this.widgets_values != undefined) {
-										this.widgets_values[index] = filename;
+										this.widgets[index].value = filename;
+										if(this.widgets_values != undefined) {
+											this.widgets_values[index] = filename;
+										}
 									}
 								}
 							}
 						}
 					}
-				}
-			);
+				);
+			}
 		};
 	}
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -149,7 +149,12 @@ export class ComfyApp {
 						
 						let img = new Image();
 						img.src = this.imgs[0].src;
-						ComfyApp.clipspace = { 'widgets': widgets, 'imgs': [img], 'images': this.images };
+						ComfyApp.clipspace = {
+							'widgets': widgets,
+							'imgs': [img],
+							'original_imgs': [img],
+							'images': this.images
+							};
 					}
 				},
 				{

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -20,6 +20,12 @@ export class ComfyApp {
 	 */
 	#processingQueue = false;
 
+	/**
+	 * Content Clipboard
+	 * @type {serialized node object}
+	 */
+	static contentClipboard = null;
+
 	constructor() {
 		this.ui = new ComfyUI(this);
 
@@ -130,6 +136,49 @@ export class ComfyApp {
 					);
 				}
 			}
+
+			options.push(
+				{
+					content: "Copy (Clipspace)",
+					callback: (obj) => {
+						console.log(this);
+						var widgets = null;
+						if(this.widgets) {
+						    widgets = this.widgets.map(({ type, name, value }) => ({ type, name, value }));
+						}
+						ComfyApp.contentClipboard = { 'widgets': widgets, 'imgs': this.imgs, 'images': this.images };
+					}
+				},
+				{
+					content: "Paste (Clipspace)",
+					callback: () => {
+						if(ComfyApp.contentClipboard != null) {
+							console.log(ComfyApp.contentClipboard.widgets);
+							if(ComfyApp.contentClipboard.widgets != null) {
+								ComfyApp.contentClipboard.widgets.forEach(({ type, name, value }) => {
+									const prop = Object.values(this.widgets).find(obj => obj.type === type && obj.name === name);
+										if (prop) {
+										prop.value = value;
+									}
+								});
+							}
+
+							if(ComfyApp.contentClipboard.imgs != undefined && this.imgs != undefined) {
+								this.imgs = ComfyApp.contentClipboard.imgs;
+								this.images = ComfyApp.contentClipboard.images;
+								const index = this.widgets.findIndex(obj => obj.name === 'image');
+								if(index >= 0) {
+									let filename = `${this.images[0].filename} [${this.images[0].type}]`;
+									this.widgets[index].value = filename;
+									if(this.widgets_values != undefined) {
+										this.widgets_values[index] = filename;
+									}
+								}
+							}
+						}
+					}
+				}
+			);
 		};
 	}
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -172,8 +172,8 @@ export class ComfyApp {
 									ComfyApp.clipspace.widgets.forEach(({ type, name, value }) => {
 										const prop = Object.values(this.widgets).find(obj => obj.type === type && obj.name === name);
 											if (prop) {
-											prop.value = value;
-										}
+												prop.value = value;
+											}
 									});
 								}
 
@@ -204,6 +204,7 @@ export class ComfyApp {
 										}
 									}
 								}
+								this.trigger('changed');
 							}
 						}
 					}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -185,7 +185,10 @@ export class ComfyApp {
 									}
 
 									if(ComfyApp.clipspace.images != undefined) {
-										filename = `${ComfyApp.clipspace.images[0].filename} [${ComfyApp.clipspace.images[0].type}]`;
+										const clip_image = ComfyApp.clipspace.images[0];
+										if(clip_image.subfolder != '')
+											filename = `${clip_image.subfolder}/`;
+										filename += `${clip_image.filename} [${clip_image.type}]`;
 									}
 									else if(ComfyApp.clipspace.widgets != undefined) {
 										const index_in_clip = ComfyApp.clipspace.widgets.findIndex(obj => obj.name === 'image');

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -141,18 +141,22 @@ export class ComfyApp {
 				{
 					content: "Copy (Clipspace)",
 					callback: (obj) => {
-						console.log(this);
 						var widgets = null;
 						if(this.widgets) {
 						    widgets = this.widgets.map(({ type, name, value }) => ({ type, name, value }));
 						}
 						
 						let img = new Image();
-						img.src = this.imgs[0].src;
+						var imgs = undefined;
+						if(this.imgs != undefined) {
+							img.src = this.imgs[0].src;
+							imgs = [img];
+						}
+
 						ComfyApp.clipspace = {
 							'widgets': widgets,
-							'imgs': [img],
-							'original_imgs': [img],
+							'imgs': imgs,
+							'original_imgs': imgs,
 							'images': this.images
 							};
 					}
@@ -161,8 +165,7 @@ export class ComfyApp {
 					content: "Paste (Clipspace)",
 					callback: () => {
 						if(ComfyApp.clipspace != null) {
-							console.log(ComfyApp.clipspace.widgets);
-							if(ComfyApp.clipspace.widgets != null) {
+							if(ComfyApp.clipspace.widgets != null && this.widgets != null) {
 								ComfyApp.clipspace.widgets.forEach(({ type, name, value }) => {
 									const prop = Object.values(this.widgets).find(obj => obj.type === type && obj.name === name);
 										if (prop) {
@@ -171,12 +174,27 @@ export class ComfyApp {
 								});
 							}
 
-							if(ComfyApp.clipspace.imgs != undefined && this.imgs != undefined) {
-								this.imgs = ComfyApp.clipspace.imgs;
-								this.images = ComfyApp.clipspace.images;
+							// image paste
+							if(ComfyApp.clipspace.imgs != undefined && this.imgs != undefined && this.widgets != null) {
+								var filename = "";
+								if(this.images && ComfyApp.clipspace.images) {
+									this.images = ComfyApp.clipspace.images;
+								}
+
+								if(ComfyApp.clipspace.images != undefined) {
+									filename = `${ComfyApp.clipspace.images[0].filename} [${ComfyApp.clipspace.images[0].type}]`;
+								}
+								else if(ComfyApp.clipspace.widgets != undefined) {
+									const index_in_clip = ComfyApp.clipspace.widgets.findIndex(obj => obj.name === 'image');
+									if(index_in_clip >= 0) {
+										filename = `${ComfyApp.clipspace.widgets[index_in_clip].value}`;
+									}
+								}
+
 								const index = this.widgets.findIndex(obj => obj.name === 'image');
-								if(index >= 0) {
-									let filename = `${this.images[0].filename} [${this.images[0].type}]`;
+								if(index >= 0 && filename != "" && ComfyApp.clipspace.imgs != undefined) {
+									this.imgs = ComfyApp.clipspace.imgs;
+
 									this.widgets[index].value = filename;
 									if(this.widgets_values != undefined) {
 										this.widgets_values[index] = filename;


### PR DESCRIPTION
* feat: copy content to clipspace (context menu on node)
* feat: paste content from clipspace (context menu on node)

Extend validation to allow for validating annotated_path in addition to other parameters.
Add support for annotated_filepath in folder_paths function.
Generalize the '/upload/image' API to allow for uploading images to the 'input', 'temp', or 'output' directories.

Explain:
I intentionally used a name that is similar to "clipboard" but distinct, as the clipboard is currently used for copying within the node. This provides a foundation for future development of features that allow for editing clipspace data (especially images) and reflecting them in the node.

The previously proposed feature/img-send pull request can be replaced with this feature if it is incorporated.

You can copy content from the context menu of a node and paste it into another node, and it will apply if the names and types are the same in the widgets. For images, both "images" and "img" are cloned, so they can be reflected in nodes such as 'Load Image'.

