### PR TITLE
Improve current word selection

### DIFF
--- a/web/extensions/core/editAttention.js
+++ b/web/extensions/core/editAttention.js
@@ -89,24 +89,17 @@ app.registerExtension({
                     end = nearestEnclosure.end;
                     selectedText = inputField.value.substring(start, end);
                 } else {
-                    // Select the current word, find the start and end of the word (first space before and after)
-                    const wordStart = inputField.value.substring(0, start).lastIndexOf(" ") + 1;
-                    const wordEnd = inputField.value.substring(end).indexOf(" ");
-                    // If there is no space after the word, select to the end of the string
-                    if (wordEnd === -1) {
-                        end = inputField.value.length;
-                    } else {
-                        end += wordEnd;
+                    // Select the current word, find the start and end of the word
+                    const delimiters = " .,\\/!?%^*;:{}=-_`~()\r\n\t";
+                    
+                    while (!delimiters.includes(inputField.value[start - 1]) && start > 0) {
+                        start--;
                     }
-                    start = wordStart;
+                    
+                    while (!delimiters.includes(inputField.value[end]) && end < inputField.value.length) {
+                        end++;
+                    }
 
-                    // Remove all punctuation at the end and beginning of the word
-                    while (inputField.value[start].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
-                        start++;
-                    }
-                    while (inputField.value[end - 1].match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/)) {
-                        end--;
-                    }
                     selectedText = inputField.value.substring(start, end);
                     if (!selectedText) return;
                 }


### PR DESCRIPTION
It currently assumes that words are always separated by spaces, but that's not necessarily the case. For instance, I'm sure you've seen prompts with `commas,but not spaces,like this`, in which case `commas,but` and `spaces,like` each are treated as one word.

This way simply seeks forwards and backwards until it finds a delimiter.