### PR TITLE
Comfy menu text size

### DIFF
--- a/web/lib/litegraph.css
+++ b/web/lib/litegraph.css
@@ -56,7 +56,7 @@
 }
 
 .litegraph .litemenubar li {
-    font-size: 14px;
+    font-size: 16px;
     color: #999;
     display: inline-block;
     min-width: 50px;
@@ -87,7 +87,7 @@
 
 .litegraph .litemenu-entry,
 .litemenu-title {
-    font-size: 12px;
+    font-size: 16px;
     color: #aaa;
     padding: 0 0 0 4px;
     margin: 2px;


### PR DESCRIPTION
A menu size that's more supportive of high resolution displays.

Current text size is like sub-text on websites and such, and really small. And unfortunately, changing the page scale doesn't effect the menus. They just stay same size. 

![Screenshot_57](https://user-images.githubusercontent.com/1151589/234728381-f6dc7db6-d1a9-4046-a11b-765c0822dbe9.png)
![Screenshot_58](https://user-images.githubusercontent.com/1151589/234728441-5590f829-0050-401d-aaa7-3a1b2e3e4f60.png)

This could maybe be elaborated on as a CSS variable, that is defined by ComfyUI Config menu. 