### PR TITLE
Allow saving workflows within the app

### DIFF
--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -310,9 +310,7 @@ class ComfyApi extends EventTarget {
 		// I'll just use client storage for now
 		try {
 			const r = load_saved();
-			console.log("r is", r);
 			return { Saved: Object.values(r).map((i) => {
-				console.log(i);
 				i['remove'] = {
                                         name: "Delete",
                                         cb: () => {

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -263,14 +263,18 @@ class ComfyList {
 
 	async show() {
 		this.element.style.display = "block";
-		this.button.textContent = "Close";
+                if (this.button) {
+			this.button.textContent = "Close";
+                }
 
 		await this.load();
 	}
 
 	hide() {
 		this.element.style.display = "none";
-		this.button.textContent = "View " + this.#text;
+		if (this.button) {
+			this.button.textContent = "View " + this.#text;
+		}
 	}
 
 	toggle() {
@@ -545,6 +549,7 @@ export class ComfyUI {
                                         };
                                         list[name] = new_item;
                                         save_saved(list);
+                                        this.saved.update();
                                 },
                         }),
 			$el("button", {
@@ -632,6 +637,7 @@ export class ComfyUI {
 			}),
 		]);
                 this.saved.show();
+                this.saved.update();
 
 		const devMode = this.settings.addSetting({
 			id: "Comfy.DevMode",


### PR DESCRIPTION
Note that this code is not yet ready or polished. I'm opening this PR now just to get feedback on the basic concept.

I'd like to be able to save and load workflows within the app, in a self-contained way, rather than download them to an external JSON file and have them cluttering up my downloads folder mixed up with a bunch of other files. This patch is an initial version of code to do that. It saves a workflow and its outputs (if applicable) to localStorage, and allows loading them back again from the sidebar.

It would be possible, and maybe preferable, to persist these workflows server-side rather than client-side. This would just require adding another API endpoint with semantics similar to `/history`. However, it would need to be persisted on disk, not just to memory as the history is. Currently the server doesn't have any persistent state, so I used local storage for the moment rather than make a server-side design decision.

This still needs various UI tweaks, largely around making the `ComfyList` code handle its particular UI case better. There's also the question of how this coexists with the existing download-JSON UI. For the moment, I've used the word "Save" for this new code, and renamed the download-JSON button as "Download". Any comments on how best to handle this are welcome.