### PR TITLE
Style searchbox and context menu

### DIFF
--- a/web/extensions/core/colorPalette.js
+++ b/web/extensions/core/colorPalette.js
@@ -232,9 +232,26 @@ app.registerExtension({
 				"name": "My Color Palette",
 				"colors": {
 					"node_slot": {
+					},
+					"litegraph_base": {
+					},
+					"comfy_base": {
 					}
 				}
 			};
+
+			// Copy over missing keys from default color palette
+			const defaultColorPalette = colorPalettes[defaultColorPaletteId];
+			for (const key in defaultColorPalette.colors.litegraph_base) {
+				if (!colorPalette.colors.litegraph_base[key]) {
+					colorPalette.colors.litegraph_base[key] = "";
+				}
+			}
+			for (const key in defaultColorPalette.colors.comfy_base) {
+				if (!colorPalette.colors.comfy_base[key]) {
+					colorPalette.colors.comfy_base[key] = "";
+				}
+			}
 
 			return completeColorPalette(colorPalette);
 		};

--- a/web/style.css
+++ b/web/style.css
@@ -299,23 +299,52 @@ button.comfy-queue-btn {
 	right: 2px;
 }
 
-.litecontextmenu {
+.litegraph.litecontextmenu,
+.litegraph.litecontextmenu.dark {
 	z-index: 9999 !important;
-}
-
-.litegraph.litecontextmenu {
 	background-color: var(--comfy-menu-bg) !important;
 	filter: brightness(95%);
-	color: var(--input-text) !important;
 }
 
 .litegraph.litecontextmenu .litemenu-entry:hover:not(.disabled):not(.separator) {
 	background-color: var(--comfy-menu-bg) !important;
 	filter: brightness(155%);
+	color: var(--input-text);
+}
+
+.litegraph.litecontextmenu .litemenu-entry.submenu,
+.litegraph.litecontextmenu.dark .litemenu-entry.submenu {
+	background-color: var(--comfy-menu-bg) !important;
+	color: var(--input-text);
+}
+
+.litegraph.litecontextmenu input {
+	background-color: var(--comfy-input-bg) !important;
 	color: var(--input-text) !important;
 }
 
-.litegraph.litecontextmenu .litemenu-entry.submenu {
+/* Search box */
+
+.litegraph.litesearchbox {
+	z-index: 9999 !important;
 	background-color: var(--comfy-menu-bg) !important;
-	color: var(--input-text) !important;
+	overflow: hidden;
+}
+
+.litegraph.litesearchbox input,
+.litegraph.litesearchbox select {
+	background-color: var(--comfy-input-bg) !important;
+	color: var(--input-text);
+}
+
+.litegraph.lite-search-item {
+	color: var(--input-text);
+	background-color: var(--comfy-input-bg);
+	filter: brightness(80%);
+	padding-left: 0.2em;
+}
+
+.litegraph.lite-search-item.generic_type {
+	color: var(--input-text);
+	filter: brightness(50%);
 }

--- a/web/style.css
+++ b/web/style.css
@@ -257,8 +257,11 @@ button.comfy-queue-btn {
 	}
 }
 
+/* Input popup */
+
 .graphdialog {
 	min-height: 1em;
+	background-color: var(--comfy-menu-bg);
 }
 
 .graphdialog .name {
@@ -282,18 +285,37 @@ button.comfy-queue-btn {
 	border-radius: 12px 0 0 12px;
 }
 
+/* Context menu */
+
 .litegraph .litemenu-entry.has_submenu {
 	position: relative;
 	padding-right: 20px;
- }
+}
 
- .litemenu-entry.has_submenu::after {
+.litemenu-entry.has_submenu::after {
 	content: ">";
 	position: absolute;
 	top: 0;
 	right: 2px;
- }
- 
- .litecontextmenu {
+}
+
+.litecontextmenu {
 	z-index: 9999 !important;
+}
+
+.litegraph.litecontextmenu {
+	background-color: var(--comfy-menu-bg) !important;
+	filter: brightness(95%);
+	color: var(--input-text) !important;
+}
+
+.litegraph.litecontextmenu .litemenu-entry:hover:not(.disabled):not(.separator) {
+	background-color: var(--comfy-menu-bg) !important;
+	filter: brightness(155%);
+	color: var(--input-text) !important;
+}
+
+.litegraph.litecontextmenu .litemenu-entry.submenu {
+	background-color: var(--comfy-menu-bg) !important;
+	color: var(--input-text) !important;
 }


### PR DESCRIPTION
After this everything should be styled. The last two were the searchbox and the context menu which were not styled at all.

| Previous | Dark| Solarized | Light |
| - | - | - | - |
| ![image](https://user-images.githubusercontent.com/23466035/235504150-c57a1d05-51f3-4610-8e39-ed08bd507f92.png) | ![image](https://user-images.githubusercontent.com/23466035/235504032-f9c6d0c4-183f-4733-bb94-765dd0b2040e.png) | ![image](https://user-images.githubusercontent.com/23466035/235503811-96c55d92-6d37-4377-808c-d24df0ff71a2.png) | ![image](https://user-images.githubusercontent.com/23466035/235503922-85996b27-0ea0-466c-902b-d1c3e8a96c4d.png) |
| ![image](https://user-images.githubusercontent.com/23466035/235503563-41d5f408-e137-43b4-a263-91d3141de2ad.png) | ![image](https://user-images.githubusercontent.com/23466035/235502965-6b4a94de-be47-468b-8de7-65defe51309c.png) | ![image](https://user-images.githubusercontent.com/23466035/235503404-a51bb9b6-3974-4baa-b3c6-dd0a3933938a.png) | ![image](https://user-images.githubusercontent.com/23466035/235503105-cbfd753f-9b7b-49bf-b5b1-92bdd3a819a7.png) |

Also, fixed the graph dialog which is the input popup when you click on widget. It previously was not attached to a background color variable. Also updated the template for the color palette to be the full template.

Also now styles list widgets for stuff like lora and checkpoint loader.

Side note, can we make the searchbox stay up longer? Especially now when we are trying to click one of the type drop downs it just disappears for me.