### PR TITLE
added a cli argument that skips creating a new browser window or tab

### DIFF
--- a/.ci/windows_base_files/run_cpu.bat
+++ b/.ci/windows_base_files/run_cpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --cpu --windows-standalone-build
+.\python_embeded\python.exe -s ComfyUI\main.py --cpu --windows-standalone-build %*
 pause

--- a/.ci/windows_base_files/run_nvidia_gpu.bat
+++ b/.ci/windows_base_files/run_nvidia_gpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build
+.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build %*
 pause

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -11,6 +11,7 @@ parser.add_argument("--cuda-device", type=int, default=None, metavar="DEVICE_ID"
 parser.add_argument("--dont-upcast-attention", action="store_true", help="Disable upcasting of attention. Can boost speed but increase the chances of black images.")
 parser.add_argument("--force-fp32", action="store_true", help="Force fp32 (If this makes your GPU work better please report it).")
 parser.add_argument("--directml", type=int, nargs="?", metavar="DIRECTML_DEVICE", const=-1, help="Use torch-directml.")
+parser.add_argument("--disable-new-tab", type=bool, const = True, nargs="?", help="Disable creating a new browser window/tab when starting--reuse an existing browser tab.")
 
 attn_group = parser.add_mutually_exclusive_group()
 attn_group.add_argument("--use-split-cross-attention", action="store_true", help="Use the split cross attention optimization instead of the sub-quadratic one. Ignored when xformers is used.")

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
         exit(0)
 
     call_on_start = None
-    if args.windows_standalone_build:
+    if args.windows_standalone_build and not args.disable_new_tab:
         def startup_server(address, port):
             import webbrowser
             webbrowser.open("http://{}:{}".format(address, port))


### PR DESCRIPTION
Especially when developing on ComfyUI, but also when restarting after installing plugins, it can get tedious when new browser tabs open when restarting. This adds a new `--disable-new-tab` switch that prevents this. Additionally, I updated the .bat files for windows-standalone that passes *any* arguments on to python. Naming stuff is hard, so please update the parameter name if you don't like it.