### PR TITLE
Auto-launch cli arg

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -7,6 +7,7 @@ parser.add_argument("--port", type=int, default=8188, help="Set the listen port.
 parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
 parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
 parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory.")
+parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")
 parser.add_argument("--cuda-device", type=int, default=None, metavar="DEVICE_ID", help="Set the id of the cuda device this instance will use.")
 parser.add_argument("--dont-upcast-attention", action="store_true", help="Disable upcasting of attention. Can boost speed but increase the chances of black images.")
 parser.add_argument("--force-fp32", action="store_true", help="Force fp32 (If this makes your GPU work better please report it).")
@@ -30,3 +31,6 @@ parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test
 parser.add_argument("--windows-standalone-build", action="store_true", help="Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup).")
 
 args = parser.parse_args()
+
+if args.windows_standalone_build:
+    args.auto_launch = True

--- a/main.py
+++ b/main.py
@@ -91,23 +91,16 @@ if __name__ == "__main__":
 
     threading.Thread(target=prompt_worker, daemon=True, args=(q,server,)).start()
 
-    address = args.listen
-
-    dont_print = args.dont_print_server
-
-
     if args.output_directory:
         output_dir = os.path.abspath(args.output_directory)
         print(f"Setting output directory to: {output_dir}")
         folder_paths.set_output_directory(output_dir)
 
-    port = args.port
-
     if args.quick_test_for_ci:
         exit(0)
 
     call_on_start = None
-    if args.windows_standalone_build:
+    if args.auto_launch:
         def startup_server(address, port):
             import webbrowser
             webbrowser.open("http://{}:{}".format(address, port))
@@ -115,10 +108,10 @@ if __name__ == "__main__":
 
     if os.name == "nt":
         try:
-            loop.run_until_complete(run(server, address=address, port=port, verbose=not dont_print, call_on_start=call_on_start))
+            loop.run_until_complete(run(server, address=args.listen, port=args.port, verbose=not args.dont_print_server, call_on_start=call_on_start))
         except KeyboardInterrupt:
             pass
     else:
-        loop.run_until_complete(run(server, address=address, port=port, verbose=not dont_print, call_on_start=call_on_start))
+        loop.run_until_complete(run(server, address=args.listen, port=args.port, verbose=not args.dont_print_server, call_on_start=call_on_start))
 
     cleanup_temp()


### PR DESCRIPTION
As mentioned in #613, imo `windows-standalone-build` is currently a bit confusing as it's only purpose is auto launching the tab. However, MacOS and linux users might not realise that the windows standalone build is just autostart since its description implies other effects, and may not enable it because of that. But even if they did realise windows standalone build is autostart, now because of that you can't actually add any specific features to the windows standalone build command as those users will be expecting it to be autostart and will be suprised once it breaks after that.

This adds an auto-launch option and windows standalone build command enables it if it isn't already. Now if you do actually want windows-standalone-build to do other things like windows specific optimizations or something, you could add that under the if statement and not interfere with anyone who just wants an autostart command.

Also removes some redundant variables in main.py