### PR TITLE
Cached scanned filenames until next `object_info` call

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -139,12 +139,21 @@ def get_full_path(folder_name, filename):
             return full_path
 
 
+filename_list_cache = {}
+
+
+def clear_cache():
+    filename_list_cache = {}
+
+
 def get_filename_list(folder_name):
-    global folder_names_and_paths
-    output_list = set()
-    folders = folder_names_and_paths[folder_name]
-    for x in folders[0]:
-        output_list.update(filter_files_extensions(recursive_search(x), folders[1]))
-    return sorted(list(output_list))
+    global folder_names_and_paths, cache
 
+    if folder_name not in filename_list_cache:
+        output_list = set()
+        folders = folder_names_and_paths[folder_name]
+        for x in folders[0]:
+            output_list.update(filter_files_extensions(recursive_search(x), folders[1]))
+        filename_list_cache[folder_name] = sorted(list(output_list))
 
+    return filename_list_cache[folder_name]

--- a/server.py
+++ b/server.py
@@ -257,6 +257,7 @@ class PromptServer():
 
         @routes.get("/object_info")
         async def get_object_info(request):
+            folder_paths.clear_cache()
             out = {}
             for x in nodes.NODE_CLASS_MAPPINGS:
                 obj_class = nodes.NODE_CLASS_MAPPINGS[x]


### PR DESCRIPTION
It seems `validate_inputs` calls `INPUT_TYPES` a lot which ends up constantly rescanning the model folders if there are nodes which use models. This just caches those paths until the next time `object_info` is called, and fixes the performance issues for me