### PR TITLE
support load A1111 prompt from txt file, fix a bug if "Step:" is not …

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1267,6 +1267,12 @@ export class ComfyApp {
 				this.loadGraphData(JSON.parse(reader.result));
 			};
 			reader.readAsText(file);
+		} else if (file.type === "text/plain" || file.name?.endsWith(".txt")) {
+			const reader = new FileReader();
+			reader.onload = () => {
+                importA1111(this.graph, reader.result);
+			};
+			reader.readAsText(file);
 		}
 	}
 

--- a/web/scripts/pnginfo.js
+++ b/web/scripts/pnginfo.js
@@ -48,7 +48,10 @@ export function getPngMetadata(file) {
 }
 
 export async function importA1111(graph, parameters) {
-	const p = parameters.lastIndexOf("\nSteps:");
+	var p = parameters.lastIndexOf("Steps:");
+    if (p > -1) {
+        p = parameters.substr(0, p).lastIndexOf("\n");
+    }
 	if (p > -1) {
 		const embeddings = await api.getEmbeddings();
 		const opts = parameters

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -465,7 +465,7 @@ export class ComfyUI {
 		const fileInput = $el("input", {
 			id: "comfy-file-input",
 			type: "file",
-			accept: ".json,image/png",
+			accept: ".json,.txt,image/png",
 			style: { display: "none" },
 			parent: document.body,
 			onchange: () => {


### PR DESCRIPTION
1. Support save A1111 prompt into a ".txt" file, and load the ".txt" file not from ".png" file
2. Parse A1111 prompt failed when the tag "Step:" is not the first one. Now fix it.