### PR TITLE
Allow static files to be symlinks

### DIFF
--- a/server.py
+++ b/server.py
@@ -362,7 +362,7 @@ class PromptServer():
     def add_routes(self):
         self.app.add_routes(self.routes)
         self.app.add_routes([
-            web.static('/', self.web_root),
+            web.static('/', self.web_root, follow_symlinks=True),
         ])
 
     def get_queue_info(self):


### PR DESCRIPTION
Allows the server to serve symlinks in the web folder

JS extensions can then be installed to the custom_nodes folder and the js then symlinked instead of needing to be copied on each startup or copied once and then being out of date on subsequent updates of the extension
