### PR TITLE
Improve UI render quality at higher pixel ratios

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -921,8 +921,9 @@ export class ComfyApp {
 		this.graph.start();
 
 		function resizeCanvas() {
-			canvasEl.width = canvasEl.offsetWidth;
-			canvasEl.height = canvasEl.offsetHeight;
+			canvasEl.width = canvasEl.offsetWidth * window.devicePixelRatio;
+			canvasEl.height = canvasEl.offsetHeight * window.devicePixelRatio;
+			canvasEl.getContext("2d").scale(window.devicePixelRatio, window.devicePixelRatio);
 			canvas.draw(true, true);
 		}
 

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -155,18 +155,24 @@ function addMultilineWidget(node, name, opts, app) {
 				computeSize(node.size);
 			}
 			const visible = app.canvas.ds.scale > 0.5 && this.type === "customtext";
-			const t = ctx.getTransform();
 			const margin = 10;
+			const elRect = ctx.canvas.getBoundingClientRect();
+			const transform = new DOMMatrix()
+				.scaleSelf(elRect.width / ctx.canvas.width, elRect.height / ctx.canvas.height)
+				.multiplySelf(ctx.getTransform())
+				.translateSelf(margin, margin + y);
+
 			Object.assign(this.inputEl.style, {
-				left: `${t.a * margin + t.e}px`,
-				top: `${t.d * (y + widgetHeight - margin - 3) + t.f}px`,
-				width: `${(widgetWidth - margin * 2 - 3) * t.a}px`,
-				background: (!node.color)?'':node.color,
-				height: `${(this.parent.inputHeight - margin * 2 - 4) * t.d}px`,
+				transformOrigin: "0 0",
+				transform: transform,
+				left: "0px",
+				top: "0px",
+				width: `${widgetWidth - (margin * 2)}px`,
+				height: `${this.parent.inputHeight - (margin * 2)}px`,
 				position: "absolute",
+				background: (!node.color)?'':node.color,
 				color: (!node.color)?'':'white',
 				zIndex: app.graph._nodes.indexOf(node),
-				fontSize: `${t.d * 10.0}px`,
 			});
 			this.inputEl.hidden = !visible;
 		},

--- a/web/style.css
+++ b/web/style.css
@@ -39,6 +39,8 @@ body {
 	padding: 2px;
 	resize: none;
 	border: none;
+	box-sizing: border-box;
+	font-size: 10px;
 }
 
 .comfy-modal {


### PR DESCRIPTION
This PR increases the canvas resolution to match the actual number of pixels of the display. This results in a less blurry UI for people with HiDPI monitors, or people who are using their browsers page zoom feature.

Here's an example when `window.devicePixelRatio` is 1.875

**Before**
![before](https://github.com/comfyanonymous/ComfyUI/assets/701073/627d2369-f09d-445b-b54c-54f3edd8faf0)
**After**
![after](https://github.com/comfyanonymous/ComfyUI/assets/701073/5e456f51-3d49-4ccb-a436-a66f71f0fd9b)

I've also updated the multiline text widget so it correctly positions the textarea element at the higher resolution.

