### PR TITLE
Improve error reporting

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -447,6 +447,7 @@ def validate_inputs(prompt, item, validated):
                     "extra_info": {
                         "input_name": x,
                         "input_config": info,
+                        "exception_message": str(ex),
                         "exception_type": exception_type,
                         "traceback": traceback.format_tb(tb),
                         "linked_node": val

--- a/execution.py
+++ b/execution.py
@@ -554,8 +554,8 @@ def validate_prompt(prompt):
         errors_list = "\n".join(errors_list)
 
         error = {
-            "type": "prompt_no_good_outputs",
-            "message": "Prompt has no properly connected outputs",
+            "type": "prompt_outputs_failed_validation",
+            "message": "Prompt outputs failed validation",
             "details": errors_list,
             "extra_info": {}
         }

--- a/execution.py
+++ b/execution.py
@@ -499,9 +499,7 @@ def validate_inputs(prompt, item, validated):
                     if r is not True:
                         details = f"{x}"
                         if r is not False:
-                            details += f": {str(r)}"
-                        else:
-                            details += "."
+                            details += f" - {str(r)}"
 
                         error = {
                             "type": "custom_validation_failed",

--- a/execution.py
+++ b/execution.py
@@ -171,7 +171,7 @@ def recursive_execute(server, prompt, outputs, current_item, extra_data, execute
 
         error_details = {
             "node_id": unique_id,
-            "message": str(ex),
+            "exception_message": str(ex),
             "exception_type": exception_type,
             "traceback": traceback.format_tb(tb),
             "current_inputs": input_data_formatted,
@@ -282,7 +282,7 @@ class PromptExecutor:
                     "node_type": class_type,
                     "executed": list(executed),
 
-                    "message": error["message"],
+                    "exception_message": error["exception_message"],
                     "exception_type": error["exception_type"],
                     "traceback": error["traceback"],
                     "current_inputs": error["current_inputs"],

--- a/execution.py
+++ b/execution.py
@@ -365,6 +365,8 @@ def validate_inputs(prompt, item, validated):
                     "message": "Exception when validating node",
                     "details": str(ex),
                     "extra_info": {
+                        "input_name": x,
+                        "input_config": info,
                         "error_type": error_type,
                         "traceback": traceback.format_tb(tb)
                     }

--- a/execution.py
+++ b/execution.py
@@ -103,7 +103,9 @@ def get_output_data(obj, input_data_all):
     return output, ui
 
 def format_value(x):
-    if isinstance(x, (int, float, bool, str)):
+    if x is None:
+        return None
+    elif isinstance(x, (int, float, bool, str)):
         return x
     else:
         return str(x)

--- a/execution.py
+++ b/execution.py
@@ -424,7 +424,8 @@ def validate_inputs(prompt, item, validated):
                     "extra_info": {
                         "input_name": x,
                         "input_config": info,
-                        "received_type": received_type
+                        "received_type": received_type,
+                        "linked_node": val
                     }
                 }
                 errors.append(error)
@@ -440,28 +441,44 @@ def validate_inputs(prompt, item, validated):
                 valid = False
                 exception_type = full_type_name(typ)
                 reasons = [{
-                    "type": "exception_during_validation",
-                    "message": "Exception when validating node",
+                    "type": "exception_during_inner_validation",
+                    "message": "Exception when validating inner node",
                     "details": str(ex),
                     "extra_info": {
                         "input_name": x,
                         "input_config": info,
                         "exception_type": exception_type,
-                        "traceback": traceback.format_tb(tb)
+                        "traceback": traceback.format_tb(tb),
+                        "linked_node": val
                     }
                 }]
                 validated[o_id] = (False, reasons, o_id)
                 continue
         else:
-            if type_input == "INT":
-                val = int(val)
-                inputs[x] = val
-            if type_input == "FLOAT":
-                val = float(val)
-                inputs[x] = val
-            if type_input == "STRING":
-                val = str(val)
-                inputs[x] = val
+            try:
+                if type_input == "INT":
+                    val = int(val)
+                    inputs[x] = val
+                if type_input == "FLOAT":
+                    val = float(val)
+                    inputs[x] = val
+                if type_input == "STRING":
+                    val = str(val)
+                    inputs[x] = val
+            except Exception as ex:
+                error = {
+                    "type": "invalid_input_type",
+                    "message": f"Failed to convert an input value to a {type_input} value",
+                    "details": f"{x}, {val}, {ex}",
+                    "extra_info": {
+                        "input_name": x,
+                        "input_config": info,
+                        "received_value": val,
+                        "exception_message": str(ex)
+                    }
+                }
+                errors.append(error)
+                continue
 
             if len(info) > 1:
                 if "min" in info[1] and val < info[1]["min"]:

--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -88,6 +88,12 @@ class ComfyApi extends EventTarget {
 					case "executed":
 						this.dispatchEvent(new CustomEvent("executed", { detail: msg.data }));
 						break;
+					case "execution_start":
+						this.dispatchEvent(new CustomEvent("execution_start", { detail: msg.data }));
+						break;
+					case "execution_error":
+						this.dispatchEvent(new CustomEvent("execution_error", { detail: msg.data }));
+						break;
 					default:
 						if (this.#registered.has(msg.type)) {
 							this.dispatchEvent(new CustomEvent(msg.type, { detail: msg.data }));

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -771,16 +771,25 @@ export class ComfyApp {
 		LGraphCanvas.prototype.drawNodeShape = function (node, ctx, size, fgcolor, bgcolor, selected, mouse_over) {
 			const res = origDrawNodeShape.apply(this, arguments);
 
+			const nodeErrors = self.lastPromptError?.node_errors[node.id];
+
 			let color = null;
+			let lineWidth = 1;
 			if (node.id === +self.runningNodeId) {
 				color = "#0f0";
 			} else if (self.dragOverNode && node.id === self.dragOverNode.id) {
 				color = "dodgerblue";
 			}
+			else if (self.lastPromptError != null && nodeErrors?.errors) {
+				color = "red";
+				lineWidth = 2;
+			}
+
+			self.graphTime = Date.now()
 
 			if (color) {
 				const shape = node._shape || node.constructor.shape || LiteGraph.ROUND_SHAPE;
-				ctx.lineWidth = 1;
+				ctx.lineWidth = lineWidth;
 				ctx.globalAlpha = 0.8;
 				ctx.beginPath();
 				if (shape == LiteGraph.BOX_SHAPE)
@@ -807,11 +816,28 @@ export class ComfyApp {
 				ctx.stroke();
 				ctx.strokeStyle = fgcolor;
 				ctx.globalAlpha = 1;
+			}
 
-				if (self.progress) {
-					ctx.fillStyle = "green";
-					ctx.fillRect(0, 0, size[0] * (self.progress.value / self.progress.max), 6);
-					ctx.fillStyle = bgcolor;
+			if (self.progress && node.id === +self.runningNodeId) {
+				ctx.fillStyle = "green";
+				ctx.fillRect(0, 0, size[0] * (self.progress.value / self.progress.max), 6);
+				ctx.fillStyle = bgcolor;
+			}
+
+			// Highlight inputs that failed validation
+			if (nodeErrors) {
+				ctx.lineWidth = 2;
+				ctx.strokeStyle = "red";
+				for (const error of nodeErrors.errors) {
+					if (error.extra_info && error.extra_info.input_name) {
+						const inputIndex = node.findInputSlot(error.extra_info.input_name)
+						if (inputIndex !== -1) {
+							let pos = node.getConnectionPos(true, inputIndex);
+							ctx.beginPath();
+							ctx.arc(pos[0] - node.pos[0], pos[1] - node.pos[1], 12, 0, 2 * Math.PI, false)
+							ctx.stroke();
+						}
+					}
 				}
 			}
 
@@ -1243,6 +1269,31 @@ export class ComfyApp {
 		return { workflow, output };
 	}
 
+	#formatError(error) {
+		if (error == null) {
+			return "(unknown error)"
+		}
+		else if (typeof error === "string") {
+			return error;
+		}
+		else if (error.stack && error.message) {
+			return error.toString()
+		}
+		else if (error.response) {
+			let message = error.response.error.message;
+			if (error.response.error.details)
+			message += ": " + error.response.error.details;
+			for (const [nodeID, nodeError] of Object.entries(error.response.node_errors)) {
+			message += "\n" + nodeError.class_type + ":"
+				for (const errorReason of nodeError.errors) {
+					message += "\n    - " + errorReason.message + ": " + errorReason.details
+				}
+			}
+			return message
+		}
+		return "(unknown error)"
+	}
+
 	async queuePrompt(number, batchCount = 1) {
 		this.#queueItems.push({ number, batchCount });
 
@@ -1250,8 +1301,10 @@ export class ComfyApp {
 		if (this.#processingQueue) {
 			return;
 		}
-	
+
 		this.#processingQueue = true;
+		this.lastPromptError = null;
+
 		try {
 			while (this.#queueItems.length) {
 				({ number, batchCount } = this.#queueItems.pop());
@@ -1262,7 +1315,12 @@ export class ComfyApp {
 					try {
 						await api.queuePrompt(number, p);
 					} catch (error) {
-						this.ui.dialog.show(error.response.error || error.toString());
+						const formattedError = this.#formatError(error)
+						this.ui.dialog.show(formattedError);
+						if (error.response) {
+							this.lastPromptError = error.response;
+							this.canvas.draw(true, true);
+						}
 						break;
 					}
 
@@ -1360,6 +1418,8 @@ export class ComfyApp {
 	 */
 	clean() {
 		this.nodeOutputs = {};
+		this.lastPromptError = null;
+		this.graphTime = null
 	}
 }
 


### PR DESCRIPTION
- Much more data sent back by `/prompt` if nodes fail validation
- There was a bug in the previous implementation where nodes other than the output were excluded from the `node_errors` hash, this fixes that
- Highlight nodes/inputs that failed validation in the frontend
<img width="310" alt="2023-05-25 11_49_19-ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/0a1a3b01-2d0a-409a-9e7e-74b7ca32ab7f">

- Send back more information about exceptions raised during prompt execution
- Highlight nodes that raised exceptions in the frontend and show a message
<img width="643" alt="2023-05-25 13_03_20-ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/5ed5d7af-e53b-44cb-a9bb-707e46e726b3">

Closes #681