### PR TITLE
typo fix: field name in error message

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1316,7 +1316,7 @@ export class ComfyApp {
 		const nodeId = error.node_id
 		const nodeType = error.node_type
 
-		return `Error occurred when executing ${nodeType}:\n\n${error.message}\n\n${traceback}`
+		return `Error occurred when executing ${nodeType}:\n\n${error.exception_message}\n\n${traceback}`
 	}
 
 	async queuePrompt(number, batchCount = 1) {


### PR DESCRIPTION
Should be ```exception_message``` instead of ```message```

due to this:
https://github.com/comfyanonymous/ComfyUI/blob/a532888846809de7b8890e8beb10ea87edf39d7e/execution.py#L174
