### PR TITLE
Fix litegraph dialog CSS

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -14,5 +14,5 @@
 			window.graph = app.graph;
 		</script>
 	</head>
-	<body></body>
+	<body class="litegraph"></body>
 </html>

--- a/web/style.css
+++ b/web/style.css
@@ -289,6 +289,11 @@ button.comfy-queue-btn {
 
 /* Context menu */
 
+.litegraph .dialog {
+	 z-index: 1;
+	 font-family: Arial;
+}
+
 .litegraph .litemenu-entry.has_submenu {
 	position: relative;
 	padding-right: 20px;


### PR DESCRIPTION
The built-in dialog menus for litegraph require a container element with the `litegraph` class, so I added the class to the body. Now the properties dialog/dialogs added by extensions will work correctly