### PR TITLE
Preview sampled images with TAESD

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This ui will let you design and execute advanced stable diffusion pipelines usin
 - [Upscale Models (ESRGAN, ESRGAN variants, SwinIR, Swin2SR, etc...)](https://comfyanonymous.github.io/ComfyUI_examples/upscale_models/)
 - [unCLIP Models](https://comfyanonymous.github.io/ComfyUI_examples/unclip/)
 - [GLIGEN](https://comfyanonymous.github.io/ComfyUI_examples/gligen/)
+- Latent previews with [TAESD](https://github.com/madebyollin/taesd)
 - Starts up very fast.
 - Works fully offline: will never download anything.
 - [Config file](extra_model_paths.yaml.example) to set the search paths for models.
@@ -180,6 +181,10 @@ Make sure you use the regular loaders/Load Checkpoint node to load checkpoints. 
 You can set this command line setting to disable the upcasting to fp32 in some cross attention operations which will increase your speed. Note that this will very likely give you black images on SD2.x models. If you use xformers this option does not do anything.
 
 ```--dont-upcast-attention```
+
+## How to show high-quality previews?
+
+The default installation includes a fast latent preview method that's low-resolution. To enable higher-quality previews with [TAESD](https://github.com/madebyollin/taesd), download the [taesd_encoder.pth](https://github.com/madebyollin/taesd/raw/main/taesd_encoder.pth) and [taesd_decoder.pth](https://github.com/madebyollin/taesd/raw/main/taesd_decoder.pth) models and place them in the `models/taesd` folder. Once they're installed, restart ComfyUI to enable high-quality previews.
 
 ## Support and dev channel
 

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -44,10 +44,11 @@ parser.add_argument("--dont-upcast-attention", action="store_true", help="Disabl
 parser.add_argument("--force-fp32", action="store_true", help="Force fp32 (If this makes your GPU work better please report it).")
 parser.add_argument("--directml", type=int, nargs="?", metavar="DIRECTML_DEVICE", const=-1, help="Use torch-directml.")
 
-class PreviewType(enum.Enum):
+class LatentPreviewType(enum.Enum):
+    Latent2RGB = "latent2rgb"
     TAESD = "taesd"
 parser.add_argument("--disable-previews", action="store_true", help="Disable showing node previews.")
-parser.add_argument("--default-preview-method", type=str, default=PreviewType.TAESD, metavar="PREVIEW_TYPE", help="Default preview method for sampler nodes.")
+parser.add_argument("--default-preview-method", type=str, default=LatentPreviewType.Latent2RGB, metavar="PREVIEW_TYPE", help="Default preview method for sampler nodes.")
 
 attn_group = parser.add_mutually_exclusive_group()
 attn_group.add_argument("--use-split-cross-attention", action="store_true", help="Use the split cross attention optimization instead of the sub-quadratic one. Ignored when xformers is used.")

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -44,11 +44,12 @@ parser.add_argument("--dont-upcast-attention", action="store_true", help="Disabl
 parser.add_argument("--force-fp32", action="store_true", help="Force fp32 (If this makes your GPU work better please report it).")
 parser.add_argument("--directml", type=int, nargs="?", metavar="DIRECTML_DEVICE", const=-1, help="Use torch-directml.")
 
-class LatentPreviewType(enum.Enum):
+class LatentPreviewMethod(enum.Enum):
+    Auto = "auto"
     Latent2RGB = "latent2rgb"
     TAESD = "taesd"
 parser.add_argument("--disable-previews", action="store_true", help="Disable showing node previews.")
-parser.add_argument("--default-preview-method", type=str, default=LatentPreviewType.Latent2RGB, metavar="PREVIEW_TYPE", help="Default preview method for sampler nodes.")
+parser.add_argument("--default-preview-method", type=str, default=LatentPreviewMethod.Auto, metavar="PREVIEW_METHOD", help="Default preview method for sampler nodes.")
 
 attn_group = parser.add_mutually_exclusive_group()
 attn_group.add_argument("--use-split-cross-attention", action="store_true", help="Use the split cross attention optimization instead of the sub-quadratic one. Ignored when xformers is used.")

--- a/comfy/taesd/taesd.py
+++ b/comfy/taesd/taesd.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Tiny AutoEncoder for Stable Diffusion
+(DNN for encoding / decoding SD's latent space)
+"""
+import torch
+import torch.nn as nn
+
+def conv(n_in, n_out, **kwargs):
+    return nn.Conv2d(n_in, n_out, 3, padding=1, **kwargs)
+
+class Clamp(nn.Module):
+    def forward(self, x):
+        return torch.tanh(x / 3) * 3
+
+class Block(nn.Module):
+    def __init__(self, n_in, n_out):
+        super().__init__()
+        self.conv = nn.Sequential(conv(n_in, n_out), nn.ReLU(), conv(n_out, n_out), nn.ReLU(), conv(n_out, n_out))
+        self.skip = nn.Conv2d(n_in, n_out, 1, bias=False) if n_in != n_out else nn.Identity()
+        self.fuse = nn.ReLU()
+    def forward(self, x):
+        return self.fuse(self.conv(x) + self.skip(x))
+
+def Encoder():
+    return nn.Sequential(
+        conv(3, 64), Block(64, 64),
+        conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64),
+        conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64),
+        conv(64, 64, stride=2, bias=False), Block(64, 64), Block(64, 64), Block(64, 64),
+        conv(64, 4),
+    )
+
+def Decoder():
+    return nn.Sequential(
+        Clamp(), conv(4, 64), nn.ReLU(),
+        Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False),
+        Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False),
+        Block(64, 64), Block(64, 64), Block(64, 64), nn.Upsample(scale_factor=2), conv(64, 64, bias=False),
+        Block(64, 64), conv(64, 3),
+    )
+
+class TAESD(nn.Module):
+    latent_magnitude = 3
+    latent_shift = 0.5
+
+    def __init__(self, encoder_path="taesd_encoder.pth", decoder_path="taesd_decoder.pth"):
+        """Initialize pretrained TAESD on the given device from the given checkpoints."""
+        super().__init__()
+        self.encoder = Encoder()
+        self.decoder = Decoder()
+        if encoder_path is not None:
+            self.encoder.load_state_dict(torch.load(encoder_path, map_location="cpu"))
+        if decoder_path is not None:
+            self.decoder.load_state_dict(torch.load(decoder_path, map_location="cpu"))
+
+    @staticmethod
+    def scale_latents(x):
+        """raw latents -> [0, 1]"""
+        return x.div(2 * TAESD.latent_magnitude).add(TAESD.latent_shift).clamp(0, 1)
+
+    @staticmethod
+    def unscale_latents(x):
+        """[0, 1] -> raw latents"""
+        return x.sub(TAESD.latent_shift).mul(2 * TAESD.latent_magnitude)

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -197,14 +197,14 @@ class ProgressBar:
         self.current = 0
         self.hook = PROGRESS_BAR_HOOK
 
-    def update_absolute(self, value, total=None):
+    def update_absolute(self, value, total=None, preview=None):
         if total is not None:
             self.total = total
         if value > self.total:
             value = self.total
         self.current = value
         if self.hook is not None:
-            self.hook(self.current, self.total)
+            self.hook(self.current, self.total, preview)
 
     def update(self, value):
         self.update_absolute(self.current + value)

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -1,6 +1,7 @@
 import torch
 import math
 import struct
+import comfy.model_management
 
 def load_torch_file(ckpt, safe_load=False):
     if ckpt.lower().endswith(".safetensors"):
@@ -166,6 +167,8 @@ def tiled_scale(samples, function, tile_x=64, tile_y=64, overlap = 8, upscale_am
         out_div = torch.zeros((s.shape[0], out_channels, round(s.shape[2] * upscale_amount), round(s.shape[3] * upscale_amount)), device="cpu")
         for y in range(0, s.shape[2], tile_y - overlap):
             for x in range(0, s.shape[3], tile_x - overlap):
+                comfy.model_management.throw_exception_if_processing_interrupted()
+
                 s_in = s[:,:,y:y+tile_y,x:x+tile_x]
 
                 ps = function(s_in).cpu()

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -18,6 +18,7 @@ folder_names_and_paths["clip_vision"] = ([os.path.join(models_dir, "clip_vision"
 folder_names_and_paths["style_models"] = ([os.path.join(models_dir, "style_models")], supported_pt_extensions)
 folder_names_and_paths["embeddings"] = ([os.path.join(models_dir, "embeddings")], supported_pt_extensions)
 folder_names_and_paths["diffusers"] = ([os.path.join(models_dir, "diffusers")], ["folder"])
+folder_names_and_paths["taesd"] = ([os.path.join(models_dir, "taesd")], supported_pt_extensions)
 
 folder_names_and_paths["controlnet"] = ([os.path.join(models_dir, "controlnet"), os.path.join(models_dir, "t2i_adapter")], supported_pt_extensions)
 folder_names_and_paths["gligen"] = ([os.path.join(models_dir, "gligen")], supported_pt_extensions)

--- a/main.py
+++ b/main.py
@@ -41,10 +41,10 @@ async def run(server, address='', port=8188, verbose=True, call_on_start=None):
     await asyncio.gather(server.start(address, port, verbose, call_on_start), server.publish_loop())
 
 def hijack_progress(server):
-    def hook(value, total, preview_bytes_jpeg):
+    def hook(value, total, preview_image_bytes):
         server.send_sync("progress", { "value": value, "max": total}, server.client_id)
-        if preview_bytes_jpeg is not None:
-            server.send_sync(BinaryEventTypes.PREVIEW_IMAGE, preview_bytes_jpeg, server.client_id)
+        if preview_image_bytes is not None:
+            server.send_sync(BinaryEventTypes.PREVIEW_IMAGE, preview_image_bytes, server.client_id)
             pass
     comfy.utils.set_progress_bar_global_hook(hook)
 

--- a/main.py
+++ b/main.py
@@ -45,7 +45,6 @@ def hijack_progress(server):
         server.send_sync("progress", { "value": value, "max": total}, server.client_id)
         if preview_image_bytes is not None:
             server.send_sync(BinaryEventTypes.PREVIEW_IMAGE, preview_image_bytes, server.client_id)
-            pass
     comfy.utils.set_progress_bar_global_hook(hook)
 
 def cleanup_temp():

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ import yaml
 import execution
 import folder_paths
 import server
+from server import BinaryEventTypes
 from nodes import init_custom_nodes
 
 
@@ -40,8 +41,11 @@ async def run(server, address='', port=8188, verbose=True, call_on_start=None):
     await asyncio.gather(server.start(address, port, verbose, call_on_start), server.publish_loop())
 
 def hijack_progress(server):
-    def hook(value, total):
+    def hook(value, total, preview_bytes_jpeg):
         server.send_sync("progress", { "value": value, "max": total}, server.client_id)
+        if preview_bytes_jpeg is not None:
+            server.send_sync(BinaryEventTypes.PREVIEW_IMAGE, preview_bytes_jpeg, server.client_id)
+            pass
     comfy.utils.set_progress_bar_global_hook(hook)
 
 def cleanup_temp():

--- a/nodes.py
+++ b/nodes.py
@@ -1023,7 +1023,7 @@ def common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, 
 
         method = args.default_preview_method
 
-        if args.default_preview_method == LatentPreviewMethod.AUTO:
+        if method == LatentPreviewMethod.Auto:
             method = LatentPreviewMethod.Latent2RGB
             if taesd_encoder_path and taesd_encoder_path:
                 method = LatentPreviewMethod.TAESD

--- a/nodes.py
+++ b/nodes.py
@@ -264,8 +264,8 @@ class TAESDPreviewerImpl(LatentPreviewer):
 
     def decode_latent_to_preview(self, device, x0):
         x_sample = self.taesd.decoder(x0.to(device))[0].detach()
-        x_sample = self.taesd.unscale_latents(x_sample)  # returns value in [-2, 2]
-        x_sample = x_sample * 0.5
+        # x_sample = self.taesd.unscale_latents(x_sample).div(4).add(0.5)  # returns value in [-2, 2]
+        x_sample = x_sample.sub(0.5).mul(2)
         return x_sample
 
 class SaveLatent:

--- a/nodes.py
+++ b/nodes.py
@@ -24,7 +24,7 @@ import comfy.samplers
 import comfy.sample
 import comfy.sd
 import comfy.utils
-from comfy.cli_args import args, LatentPreviewType
+from comfy.cli_args import args, LatentPreviewMethod
 from comfy.taesd.taesd import TAESD
 
 import comfy.clip_vision
@@ -1018,11 +1018,19 @@ def common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, 
     previewer = None
     if not args.disable_previews:
         # TODO previewer methods
-        if args.default_preview_method == LatentPreviewType.TAESD:
-            encoder_path = folder_paths.get_full_path("taesd", "taesd_encoder.pth")
-            decoder_path = folder_paths.get_full_path("taesd", "taesd_decoder.pth")
-            if encoder_path and decoder_path:
-                taesd = TAESD(encoder_path, decoder_path).to(device)
+        taesd_encoder_path = folder_paths.get_full_path("taesd", "taesd_encoder.pth")
+        taesd_decoder_path = folder_paths.get_full_path("taesd", "taesd_decoder.pth")
+
+        method = args.default_preview_method
+
+        if args.default_preview_method == LatentPreviewMethod.AUTO:
+            method = LatentPreviewMethod.Latent2RGB
+            if taesd_encoder_path and taesd_encoder_path:
+                method = LatentPreviewMethod.TAESD
+
+        if method == LatentPreviewMethod.TAESD:
+            if taesd_encoder_path and taesd_encoder_path:
+                taesd = TAESD(taesd_encoder_path, taesd_decoder_path).to(device)
                 previewer = TAESDPreviewerImpl(taesd)
             else:
                 print("Warning: TAESD previews enabled, but could not find models/taesd/taesd_encoder.pth and models/taesd/taesd_decoder.pth")

--- a/web/extensions/core/colorPalette.js
+++ b/web/extensions/core/colorPalette.js
@@ -21,6 +21,7 @@ const colorPalettes = {
 				"MODEL": "#B39DDB", // light lavender-purple
 				"STYLE_MODEL": "#C2FFAE", // light green-yellow
 				"VAE": "#FF6E6E", // bright red
+				"TAESD": "#DCC274", // cheesecake
 			},
 			"litegraph_base": {
 				"NODE_TITLE_COLOR": "#999",

--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -75,7 +75,6 @@ class ComfyApi extends EventTarget {
 					const view = new DataView(event.data);
 					const eventType = view.getUint32(0);
 					const buffer = event.data.slice(4);
-					console.error("BINARY", eventType);
 					switch (eventType) {
 					case 1:
 						const view2 = new DataView(event.data);
@@ -89,8 +88,8 @@ class ComfyApi extends EventTarget {
 							case 2:
 								imageMime = "image/png"
 						}
-						const jpegBlob = new Blob([buffer.slice(4)], { type: imageMime });
-						this.dispatchEvent(new CustomEvent("b_preview", { detail: jpegBlob }));
+						const imageBlob = new Blob([buffer.slice(4)], { type: imageMime });
+						this.dispatchEvent(new CustomEvent("b_preview", { detail: imageBlob }));
 						break;
 					default:
 						throw new Error(`Unknown binary websocket message of type ${eventType}`);

--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -42,6 +42,7 @@ class ComfyApi extends EventTarget {
 		this.socket = new WebSocket(
 			`ws${window.location.protocol === "https:" ? "s" : ""}://${location.host}/ws${existingSession}`
 		);
+		this.socket.binaryType = "arraybuffer";
 
 		this.socket.addEventListener("open", () => {
 			opened = true;
@@ -70,39 +71,66 @@ class ComfyApi extends EventTarget {
 
 		this.socket.addEventListener("message", (event) => {
 			try {
-				const msg = JSON.parse(event.data);
-				switch (msg.type) {
-					case "status":
-						if (msg.data.sid) {
-							this.clientId = msg.data.sid;
-							window.name = this.clientId;
+				if (event.data instanceof ArrayBuffer) {
+					const view = new DataView(event.data);
+					const eventType = view.getUint32(0);
+					const buffer = event.data.slice(4);
+					console.error("BINARY", eventType);
+					switch (eventType) {
+					case 1:
+						const view2 = new DataView(event.data);
+						const imageType = view2.getUint32(0)
+						let imageMime
+						switch (imageType) {
+							case 1:
+							default:
+								imageMime = "image/jpeg";
+								break;
+							case 2:
+								imageMime = "image/png"
 						}
-						this.dispatchEvent(new CustomEvent("status", { detail: msg.data.status }));
-						break;
-					case "progress":
-						this.dispatchEvent(new CustomEvent("progress", { detail: msg.data }));
-						break;
-					case "executing":
-						this.dispatchEvent(new CustomEvent("executing", { detail: msg.data.node }));
-						break;
-					case "executed":
-						this.dispatchEvent(new CustomEvent("executed", { detail: msg.data }));
-						break;
-					case "execution_start":
-						this.dispatchEvent(new CustomEvent("execution_start", { detail: msg.data }));
-						break;
-					case "execution_error":
-						this.dispatchEvent(new CustomEvent("execution_error", { detail: msg.data }));
+						const jpegBlob = new Blob([buffer.slice(4)], { type: imageMime });
+						this.dispatchEvent(new CustomEvent("b_preview", { detail: jpegBlob }));
 						break;
 					default:
-						if (this.#registered.has(msg.type)) {
-							this.dispatchEvent(new CustomEvent(msg.type, { detail: msg.data }));
-						} else {
-							throw new Error("Unknown message type");
-						}
+						throw new Error(`Unknown binary websocket message of type ${eventType}`);
+					}
+				}
+				else {
+				    const msg = JSON.parse(event.data);
+				    switch (msg.type) {
+					    case "status":
+						    if (msg.data.sid) {
+							    this.clientId = msg.data.sid;
+							    window.name = this.clientId;
+						    }
+						    this.dispatchEvent(new CustomEvent("status", { detail: msg.data.status }));
+						    break;
+					    case "progress":
+						    this.dispatchEvent(new CustomEvent("progress", { detail: msg.data }));
+						    break;
+					    case "executing":
+						    this.dispatchEvent(new CustomEvent("executing", { detail: msg.data.node }));
+						    break;
+					    case "executed":
+						    this.dispatchEvent(new CustomEvent("executed", { detail: msg.data }));
+						    break;
+					    case "execution_start":
+						    this.dispatchEvent(new CustomEvent("execution_start", { detail: msg.data }));
+						    break;
+					    case "execution_error":
+						    this.dispatchEvent(new CustomEvent("execution_error", { detail: msg.data }));
+						    break;
+					    default:
+						    if (this.#registered.has(msg.type)) {
+							    this.dispatchEvent(new CustomEvent(msg.type, { detail: msg.data }));
+						    } else {
+							    throw new Error(`Unknown message type ${msg.type}`);
+						    }
+				    }
 				}
 			} catch (error) {
-				console.warn("Unhandled message:", event.data);
+				console.warn("Unhandled message:", event.data, error);
 			}
 		});
 	}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -382,7 +382,7 @@ export class ComfyApp {
 						this.images = output.images;
 						imagesChanged = true;
 						imgURLs = imgURLs.concat(output.images.map(params => {
-							return "/view?" + new URLSearchParams(src).toString() + app.getPreviewFormatParam();
+							return "/view?" + new URLSearchParams(params).toString() + app.getPreviewFormatParam();
 						}))
 					}
 				}


### PR DESCRIPTION
Lets KSampler show previews with [taesd](https://github.com/madebyollin/taesd)

Download the `.pth` models from https://github.com/madebyollin/taesd and stick them in `models/taesd` first

Previews are encoded to JPEG bytes first then sent over websockets, they're resized to 512 pixels first so the network load shouldn't be too much (~50kb per frame for 2048x2048 resolution)

Also adds taesd-related nodes, they're functionally equivalent to VAE loader/encoder/decoder nodes

[output2.webm](https://github.com/comfyanonymous/ComfyUI/assets/24979496/f8cfc538-55d8-4d6f-b817-0db743d4f885)

<img width="938" alt="2023-05-30 20_47_37-ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/69cb60e2-087a-4756-8408-541309f1706c">
