### PR TITLE
refactor: registerNodes

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1010,7 +1010,7 @@ export class ComfyApp {
 		const app = this;
 		// Load node definitions from the backend
 		const defs = await api.getNodeDefs();
-		this.registerNodesFromDefs(defs);
+		await this.registerNodesFromDefs(defs);
 		await this.#invokeExtensionsAsync("registerCustomNodes");
 	}
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1010,6 +1010,11 @@ export class ComfyApp {
 		const app = this;
 		// Load node definitions from the backend
 		const defs = await api.getNodeDefs();
+		this.registerNodesFromDefs(defs);
+		await this.#invokeExtensionsAsync("registerCustomNodes");
+	}
+
+    async registerNodesFromDefs(defs) {
 		await this.#invokeExtensionsAsync("addCustomNodeDefs", defs);
 
 		// Generate list of known widgets
@@ -1082,8 +1087,6 @@ export class ComfyApp {
 			LiteGraph.registerNodeType(nodeId, node);
 			node.category = nodeData.category;
 		}
-
-		await this.#invokeExtensionsAsync("registerCustomNodes");
 	}
 
 	/**


### PR DESCRIPTION
To support dynamic custom loading on frontend, separate the node registration process based on the defs in the registerNodes function.