### PR TITLE
Fix `None` values in folder lists

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -154,7 +154,8 @@ def get_filename_list_(folder_name):
         output_list.update(filter_files_extensions(files, folders[1]))
         output_folders = {**output_folders, **folders_all}
 
-    return (sorted(list(output_list)), output_folders)
+    result = [x for x in output_list if x is not None]
+    return (sorted(result), output_folders)
 
 def cached_filename_list_(folder_name):
     global filename_list_cache

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -182,7 +182,7 @@ def get_filename_list(folder_name):
         out = get_filename_list_(folder_name)
         global filename_list_cache
         filename_list_cache[folder_name] = out
-    return out[0]
+    return list(out[0])
 
 def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height=0):
     def map_filename(filename):


### PR DESCRIPTION
Two issues

- Caching for paths returned `None` values but these weren't filtered out afterwards
- Something is mutating the folder lists after they've been sent, so instead copy them when they're asked for

Closes #719 