### PR TITLE
Send back prompt number from `/prompt` endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -361,7 +361,7 @@ class PromptServer():
                     prompt_id = str(uuid.uuid4())
                     outputs_to_execute = valid[2]
                     self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute))
-                    return web.json_response({"prompt_id": prompt_id})
+                    return web.json_response({"prompt_id": prompt_id, "number": number})
                 else:
                     print("invalid prompt:", valid[1])
                     return web.json_response({"error": valid[1], "node_errors": valid[3]}, status=400)


### PR DESCRIPTION
I've wanted this so I can correctly order the queued prompts in the frontend, since the backend can change the number that was passed