### PR TITLE
improve: lightweight preview to reduce network traffic

### DIFF
--- a/server.py
+++ b/server.py
@@ -219,12 +219,24 @@ class PromptServer():
                 if os.path.isfile(file):
                     if 'preview' in request.rel_url.query:
                         with Image.open(file) as img:
-                            img = img.convert("RGB")  # jpeg doesn't support RGBA
+                            preview_info = request.rel_url.query['preview'].split(';')
+
+                            if preview_info[0] == "L" or preview_info[0] == "l":
+                                img = img.convert("L")
+                                image_format = preview_info[1]
+                            else:
+                                img = img.convert("RGB")  # jpeg doesn't support RGBA
+                                image_format = preview_info[0]
+
+                            quality = 90
+                            if preview_info[-1].isdigit():
+                                quality = int(preview_info[-1])
+
                             buffer = BytesIO()
-                            img.save(buffer, format=request.rel_url.query['preview'], optimize=True, quality=90)
+                            img.save(buffer, format=image_format, optimize=True, quality=quality)
                             buffer.seek(0)
 
-                            return web.Response(body=buffer.read(), content_type=f'image/{request.rel_url.query}',
+                            return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
                                                 headers={"Content-Disposition": f"filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:

--- a/server.py
+++ b/server.py
@@ -217,6 +217,16 @@ class PromptServer():
                 file = os.path.join(output_dir, filename)
 
                 if os.path.isfile(file):
+                    if 'preview' in request.rel_url.query:
+                        with Image.open(file) as img:
+                            img = img.convert("RGB")  # jpeg doesn't support RGBA
+                            buffer = BytesIO()
+                            img.save(buffer, format=request.rel_url.query['preview'], optimize=True, quality=90)
+                            buffer.seek(0)
+
+                            return web.Response(body=buffer.read(), content_type=f'image/{request.rel_url.query}',
+                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
                     else:

--- a/web/extensions/core/maskeditor.js
+++ b/web/extensions/core/maskeditor.js
@@ -41,7 +41,7 @@ async function uploadMask(filepath, formData) {
 	});
 
 	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']] = new Image();
-	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src = "/view?" + new URLSearchParams(filepath).toString() + "&preview=jpeg";
+	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src = "/view?" + new URLSearchParams(filepath).toString() + "&preview="+app.preview_format;
 
 	if(ComfyApp.clipspace.images)
 		ComfyApp.clipspace.images[ComfyApp.clipspace['selectedIndex']] = filepath;

--- a/web/extensions/core/maskeditor.js
+++ b/web/extensions/core/maskeditor.js
@@ -41,7 +41,7 @@ async function uploadMask(filepath, formData) {
 	});
 
 	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']] = new Image();
-	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src = "/view?" + new URLSearchParams(filepath).toString();
+	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src = "/view?" + new URLSearchParams(filepath).toString() + "&preview=jpeg";
 
 	if(ComfyApp.clipspace.images)
 		ComfyApp.clipspace.images[ComfyApp.clipspace['selectedIndex']] = filepath;
@@ -335,6 +335,7 @@ class MaskEditorDialog extends ComfyDialog {
 
 		const alpha_url = new URL(ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src)
 		alpha_url.searchParams.delete('channel');
+		alpha_url.searchParams.delete('preview');
 		alpha_url.searchParams.set('channel', 'a');
 		touched_image.src = alpha_url;
 
@@ -345,6 +346,7 @@ class MaskEditorDialog extends ComfyDialog {
 
 		const rgb_url = new URL(ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src);
 		rgb_url.searchParams.delete('channel');
+		rgb_url.searchParams.delete('preview');
 		rgb_url.searchParams.set('channel', 'rgb');
 		orig_image.src = rgb_url;
 		this.image = orig_image;

--- a/web/extensions/core/maskeditor.js
+++ b/web/extensions/core/maskeditor.js
@@ -41,7 +41,7 @@ async function uploadMask(filepath, formData) {
 	});
 
 	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']] = new Image();
-	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src = "/view?" + new URLSearchParams(filepath).toString() + "&preview="+app.preview_format;
+	ComfyApp.clipspace.imgs[ComfyApp.clipspace['selectedIndex']].src = "/view?" + new URLSearchParams(filepath).toString() + app.getPreviewFormatParam();
 
 	if(ComfyApp.clipspace.images)
 		ComfyApp.clipspace.images[ComfyApp.clipspace['selectedIndex']] = filepath;

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -49,6 +49,12 @@ export class ComfyApp {
 		 * @type {boolean}
 		 */
 		this.shiftDown = false;
+
+		/**
+		 * file format for preview
+		 * @type {string}
+		 */
+		this.preview_format = "jpeg";
 	}
 
 	static isImageNode(node) {
@@ -371,7 +377,7 @@ export class ComfyApp {
 									const img = new Image();
 									img.onload = () => r(img);
 									img.onerror = () => r(null);
-									img.src = "/view?" + new URLSearchParams(src).toString() + "&preview=jpeg";
+									img.src = "/view?" + new URLSearchParams(src).toString() + "&preview="+app.preview_format;
 								});
 							})
 						).then((imgs) => {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -231,14 +231,20 @@ export class ComfyApp {
 					options.unshift(
 						{
 							content: "Open Image",
-							callback: () => window.open(img.src, "_blank"),
+							callback: () => {
+								let url = new URL(img.src);
+								url.searchParams.delete('preview');
+								window.open(url, "_blank")
+							},
 						},
 						{
 							content: "Save Image",
 							callback: () => {
 								const a = document.createElement("a");
-								a.href = img.src;
-								a.setAttribute("download", new URLSearchParams(new URL(img.src).search).get("filename"));
+								let url = new URL(img.src);
+								url.searchParams.delete('preview');
+								a.href = url;
+								a.setAttribute("download", new URLSearchParams(url.search).get("filename"));
 								document.body.append(a);
 								a.click();
 								requestAnimationFrame(() => a.remove());
@@ -365,7 +371,7 @@ export class ComfyApp {
 									const img = new Image();
 									img.onload = () => r(img);
 									img.onerror = () => r(null);
-									img.src = "/view?" + new URLSearchParams(src).toString();
+									img.src = "/view?" + new URLSearchParams(src).toString() + "&preview=jpeg";
 								});
 							})
 						).then((imgs) => {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -52,11 +52,17 @@ export class ComfyApp {
 
 		/**
 		 * file format for preview
+		 *
+		 * L?;format;quality
+		 *
+		 * ex)
+		 * L;webp;50 -> grayscale, webp, quality 50
+		 * jpeg;80 -> rgb, jpeg, quality 80
+		 * png -> rgb, png, default quality(=90)
+		 *
 		 * @type {string}
 		 */
-		this.preview_format = "webp";	// L;webp;50 -> grayscale, webp, quality 50
-										// jpeg;80 -> rgb, jpeg, quality 80
-										// png -> rgb, png, default quality(=90)
+		this.preview_format = "webp";
 	}
 
 	static isImageNode(node) {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -49,20 +49,14 @@ export class ComfyApp {
 		 * @type {boolean}
 		 */
 		this.shiftDown = false;
+	}
 
-		/**
-		 * file format for preview
-		 *
-		 * L?;format;quality
-		 *
-		 * ex)
-		 * L;webp;50 -> grayscale, webp, quality 50
-		 * jpeg;80 -> rgb, jpeg, quality 80
-		 * png -> rgb, png, default quality(=90)
-		 *
-		 * @type {string}
-		 */
-		this.preview_format = "webp";
+	getPreviewFormatParam() {
+		let preview_format = this.ui.settings.getSettingValue("Comfy.PreviewFormat");
+		if(preview_format)
+			return `&preview=${preview_format}`;
+		else
+			return "";
 	}
 
 	static isImageNode(node) {
@@ -385,7 +379,7 @@ export class ComfyApp {
 									const img = new Image();
 									img.onload = () => r(img);
 									img.onerror = () => r(null);
-									img.src = "/view?" + new URLSearchParams(src).toString() + "&preview="+app.preview_format;
+									img.src = "/view?" + new URLSearchParams(src).toString() + app.getPreviewFormatParam();
 								});
 							})
 						).then((imgs) => {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -54,7 +54,9 @@ export class ComfyApp {
 		 * file format for preview
 		 * @type {string}
 		 */
-		this.preview_format = "webp";
+		this.preview_format = "webp";	// L;webp;50 -> grayscale, webp, quality 50
+										// jpeg;80 -> rgb, jpeg, quality 80
+										// png -> rgb, png, default quality(=90)
 	}
 
 	static isImageNode(node) {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -54,7 +54,7 @@ export class ComfyApp {
 		 * file format for preview
 		 * @type {string}
 		 */
-		this.preview_format = "jpeg";
+		this.preview_format = "webp";
 	}
 
 	static isImageNode(node) {

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -462,6 +462,25 @@ export class ComfyUI {
 			defaultValue: true,
 		});
 
+		/**
+		 * file format for preview
+		 *
+		 * L?;format;quality
+		 *
+		 * ex)
+		 * L;webp;50 -> grayscale, webp, quality 50
+		 * jpeg;80 -> rgb, jpeg, quality 80
+		 * png -> rgb, png, default quality(=90)
+		 *
+		 * @type {string}
+		 */
+		const previewImage = this.settings.addSetting({
+			id: "Comfy.PreviewFormat",
+			name: "When displaying a preview in the image widget, convert it to a lightweight image. (webp, jpeg, webp;50, ...)",
+			type: "string",
+			defaultValue: "",
+		});
+
 		const fileInput = $el("input", {
 			id: "comfy-file-input",
 			type: "file",

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -303,7 +303,7 @@ export const ComfyWidgets = {
 				subfolder = name.substring(0, folder_separator);
 				name = name.substring(folder_separator + 1);
 			}
-			img.src = `/view?filename=${name}&type=input&subfolder=${subfolder}`;
+			img.src = `/view?filename=${name}&type=input&subfolder=${subfolder}&preview=jpeg`;
 			node.setSizeForImage?.();
 		}
 

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -303,7 +303,7 @@ export const ComfyWidgets = {
 				subfolder = name.substring(0, folder_separator);
 				name = name.substring(folder_separator + 1);
 			}
-			img.src = `/view?filename=${name}&type=input&subfolder=${subfolder}&preview=${app.preview_format}`;
+			img.src = `/view?filename=${name}&type=input&subfolder=${subfolder}${app.getPreviewFormatParam()}`;
 			node.setSizeForImage?.();
 		}
 

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -303,7 +303,7 @@ export const ComfyWidgets = {
 				subfolder = name.substring(0, folder_separator);
 				name = name.substring(folder_separator + 1);
 			}
-			img.src = `/view?filename=${name}&type=input&subfolder=${subfolder}&preview=jpeg`;
+			img.src = `/view?filename=${name}&type=input&subfolder=${subfolder}&preview=${app.preview_format}`;
 			node.setSizeForImage?.();
 		}
 


### PR DESCRIPTION
To reduce network traffic in a remote environment, a lossy compression-based preview mode is provided for displaying simple visualizations in node-based widgets.
    
    * Added 'preview=[image format]' option to the '/view' API.
    * Updated node to use preview for displaying images as widgets.
    * Excluded preview usage in the open image, save image, mask editor where the original data is required.