### PR TITLE
Resize thumbnails to preview size before sending

### DIFF
--- a/server.py
+++ b/server.py
@@ -229,6 +229,8 @@ class PromptServer():
                             if preview_info[-1].isdigit():
                                 quality = int(preview_info[-1])
 
+                            img.thumbnail((256, 256), Image.ANTIALIAS)
+
                             buffer = BytesIO()
                             if image_format in ['jpeg']:
                                 img = img.convert("RGB")


### PR DESCRIPTION
This prevents the requests from being backed up if a ton of previews are requested at once

It will help in the case where network is the bottleneck