### PR TITLE
bugfix: size calculation conflict between text widget, img widget

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -365,6 +365,10 @@ export class ComfyApp {
 		}
 
 		node.prototype.setSizeForImage = function () {
+			if (this.inputHeight) {
+				this.setSize(this.size);
+				return;
+			}
 			const minHeight = getImageTop(this) + 220;
 			if (this.size[1] < minHeight) {
 				this.setSize([this.size[0], minHeight]);

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -115,12 +115,12 @@ function addMultilineWidget(node, name, opts, app) {
 
 		// See how large each text input can be
 		freeSpace -= widgetHeight;
-		freeSpace /= multi.length;
+		freeSpace /= multi.length + (!!node.imgs?.length);
 
 		if (freeSpace < MIN_SIZE) {
 			// There isnt enough space for all the widgets, increase the size of the node
 			freeSpace = MIN_SIZE;
-			node.size[1] = y + widgetHeight + freeSpace * multi.length;
+			node.size[1] = y + widgetHeight + freeSpace * (multi.length + (!!node.imgs?.length));
 			node.graph.setDirtyCanvas(true);
 		}
 


### PR DESCRIPTION
* Fixing the calculation issue when an image widget is added to he size calculation of the text widget.
* This issue occurs when there is already a text widget in a node, but an image widget is added through the preview functionality.