### PR TITLE
Add .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ custom_nodes/
 !custom_nodes/example_node.py.example
 extra_model_paths.yaml
 /.vs
+.idea/


### PR DESCRIPTION
It is useful to add JetBrain's `.idea` folder to `.gitignore` because contributors to this project use different IDEs.