### PR TITLE
Add Apple silicon installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,16 @@ After this you should have everything installed and can proceed to running Comfy
 
 [Intel Arc](https://github.com/comfyanonymous/ComfyUI/discussions/476)
 
-Mac/MPS: There is basic support in the code but until someone makes some install instruction you are on your own.
+You can install ComfyUI in Apple Mac silicon (M1 or M2) with any recent macOS version.
 
-Directml: ```pip install torch-directml``` Then you can launch ComfyUI with: ```python main.py --directml```
+According to the [DirectML page](https://github.com/microsoft/DirectML#hardware-requirements), `pytorch-directml` package is not avilable for Apple silicon computers. However, you can still run ComfyUI without `pytorch-directml`.
+
+1. Install pytorch. For instructions, read the [Accelerated PyTorch training on Mac](https://developer.apple.com/metal/pytorch/) Apple Developer guide.
+1. Follow the [ComfyUI manual installation](#manual-install-windows-linux) instructions for Windows and Linux.
+1. Install the ComfyUI [dependencies](#dependencies). If you have another UI to work with Stable Diffusion (such as Automatic1111), you can use the the packages for this installation. See [the instruction below](#i-already-have-another-ui-for-stable-diffusion-installed-do-i-really-have-to-install-all-of-these-dependencies).
+1. Launch ComfyUI by running `python main.py`.
+
+> **Note**: Remember to add your models, VAE, LoRAs etc. to the corresponding Comfy folders, as discussed in [ComfyUI manual installation](#manual-install-windows-linux).
 
 
 ### I already have another UI for Stable Diffusion installed do I really have to install all of these dependencies?


### PR DESCRIPTION
The current ComfyUI installation instructions for macOS include `pytorch-directml`, which it's not currently available in Apple silicon. However, it's possible to run ComfyUI in Apple silicon computers (M1 or M2) without `pytorch-directml`.

![Screenshot 2023-06-09 at 10 16 16@2x](https://github.com/comfyanonymous/ComfyUI/assets/62282406/7c5ec150-7036-4b48-b44e-910d3498d050)
