### PR TITLE
Grids & combinatorial outputs

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -135,15 +135,10 @@ def get_input_data_batches(input_data_all):
     if not inherit_id or axis_id is None:
         axis_id = str(uuid.uuid4())
 
-    pp(input_to_index)
-    pp(input_to_values)
-    pp(index_to_values)
-
     indices = list(itertools.product(*index_to_coords))
     combinations = list(itertools.product(*index_to_values))
 
     pp(indices)
-    pp(combinations)
 
     for i, indices_set in enumerate(indices):
         combination = combinations[i]

--- a/execution.py
+++ b/execution.py
@@ -87,38 +87,7 @@ def get_input_data_batches(input_data_all):
                 batch[input_name] = value
         batches.append(batch)
 
-    print("------------------=+++++++++++++++++")
-    for batch in batches:
-        print(format_dict(batch))
-    print(format_dict(input_to_index))
-    print(format_dict({ "v": index_to_values }))
-    print(index_to_coords)
-    print("------------------=+++++++++++++++++")
-
     return CombinatorialBatches(batches, input_to_index, index_to_values, indices, combinations)
-
-
-def format_dict(d):
-    s = []
-    for k,v in d.items():
-        st = f"{k}: "
-        if isinstance(v, list):
-            st += f"list[len: {len(v)}]["
-            i = []
-            for v2 in v:
-                if isinstance(v2, (int, float, bool)):
-                    i.append(str(v2))
-                else:
-                    i.append(v2.__class__.__name__)
-            st += ",".join(i) + "]"
-        else:
-            if isinstance(v, (int, float, bool)):
-                st += str(v)
-            else:
-                st += str(type(v))
-        s.append(st)
-    return "( " + ", ".join(s) + " )"
-
 
 def get_input_data(inputs, class_def, unique_id, outputs={}, prompt={}, extra_data={}):
     """Given input data from the prompt, returns a list of input data dicts for
@@ -148,15 +117,7 @@ def get_input_data(inputs, class_def, unique_id, outputs={}, prompt={}, extra_da
                 # Make the outputs into a list for map-over-list use
                 # (they are themselves lists so flatten them afterwards)
                 input_values = [batch_output[output_index] for batch_output in outputs_for_all_batches]
-                print("COMB")
-                print(str(input_unique_id))
-                print(str(output_index))
-                print(format_dict({ "values": input_values }))
-                input_values = {
-                    "combinatorial": True,
-                    "values": flatten(input_values),
-                    "axis_id": prompt[input_unique_id].get("axis_id")
-                }
+                input_values = { "combinatorial": True, "values": flatten(input_values) }
                 input_data_all[x] = input_values
         elif is_combinatorial_input(input_data):
             if required_or_optional:
@@ -181,6 +142,22 @@ def get_input_data(inputs, class_def, unique_id, outputs={}, prompt={}, extra_da
                 input_data_all[x] = [unique_id]
 
     input_data_all_batches = get_input_data_batches(input_data_all)
+
+    def format_dict(d):
+        s = []
+        for k,v in d.items():
+            st = f"{k}: "
+            if isinstance(v, list):
+                st += f"list[len: {len(v)}]["
+                i = []
+                for v2 in v:
+                    i.append(v2.__class__.__name__)
+                st += ",".join(i) + "]"
+            else:
+                st += str(type(v))
+            s.append(st)
+        return "( " + ", ".join(s) + " )"
+
 
     print("---------------------------------")
     from pprint import pp
@@ -297,7 +274,7 @@ def get_output_data(obj, input_data_all_batches, server, unique_id, prompt_id):
                 "output": outputs_ui_to_send,
                 "prompt_id": prompt_id,
                 "batch_num": inner_totals,
-                "total_batches": total_inner_batches,
+                "total_batches": total_inner_batches
             }
             if input_data_all_batches.indices:
                 message["indices"] = input_data_all_batches.indices[batch_num]
@@ -434,7 +411,7 @@ def recursive_output_delete_if_changed(prompt, old_prompt, outputs, current_item
         if unique_id in old_prompt and 'is_changed' in old_prompt[unique_id]:
             is_changed_old = old_prompt[unique_id]['is_changed']
         if 'is_changed' not in prompt[unique_id]:
-            input_data_all_batches = get_input_data(inputs, class_def, unique_id, outputs, prompt)
+            input_data_all_batches = get_input_data(inputs, class_def, unique_id, outputs)
             if input_data_all_batches is not None:
                  try:
                     #is_changed = class_def.IS_CHANGED(**input_data_all)
@@ -777,7 +754,7 @@ def validate_inputs(prompt, item, validated):
                 inputs[x] = r[1]
 
             if hasattr(obj_class, "VALIDATE_INPUTS"):
-                input_data_all_batches = get_input_data(inputs, obj_class, unique_id, {}, prompt)
+                input_data_all_batches = get_input_data(inputs, obj_class, unique_id)
                 #ret = obj_class.VALIDATE_INPUTS(**input_data_all)
                 for batch in input_data_all_batches.batches:
                     ret = map_node_over_list(obj_class, batch, "VALIDATE_INPUTS")

--- a/web/extensions/core/showGrid.js
+++ b/web/extensions/core/showGrid.js
@@ -23,7 +23,7 @@ app.registerExtension({
 		nodeType.prototype.onNodeCreated = function () {
 			const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined;
 
-			this.addWidget("button", "Show Grid", "Show Grid", () => {
+			this.showGridWidget = this.addWidget("button", "Show Grid", "Show Grid", () => {
 				const grid = app.nodeGrids[this.id];
 				if (grid == null) {
 					console.warn("No grid to show!");
@@ -282,6 +282,14 @@ app.registerExtension({
 
 				document.body.appendChild(this._gridPanel);
 			})
+
+			this.showGridWidget.disabled = true;
+		}
+
+		const onExecuted = nodeType.prototype.onExecuted;
+		nodeType.prototype.onExecuted = function (output) {
+			const r = onExecuted ? onExecuted.apply(this, arguments) : undefined;
+			this.showGridWidget.disabled = app.nodeGrids[this.id] == null;
 		}
 	}
 })

--- a/web/extensions/core/showGrid.js
+++ b/web/extensions/core/showGrid.js
@@ -23,7 +23,7 @@ app.registerExtension({
 		nodeType.prototype.onNodeCreated = function () {
 			const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined;
 
-			this.showGridWidget = this.addWidget("button", "Show Grid", "Show Grid", () => {
+			this.addWidget("button", "Show Grid", "Show Grid", () => {
 				const grid = app.nodeGrids[this.id];
 				if (grid == null) {
 					console.warn("No grid to show!");
@@ -282,14 +282,6 @@ app.registerExtension({
 
 				document.body.appendChild(this._gridPanel);
 			})
-
-			this.showGridWidget.disabled = true;
-		}
-
-		const onExecuted = nodeType.prototype.onExecuted;
-		nodeType.prototype.onExecuted = function (output) {
-			const r = onExecuted ? onExecuted.apply(this, arguments) : undefined;
-			this.showGridWidget.disabled = app.nodeGrids[this.id] == null;
 		}
 	}
 })

--- a/web/extensions/core/showGrid.js
+++ b/web/extensions/core/showGrid.js
@@ -266,7 +266,7 @@ app.registerExtension({
 				imageSizeInput.addEventListener("input", () => {
 					this.imageSize = parseInt(imageSizeInput.value);
 
-					const ratio = Math.min(this.imageSize / natWidth, this.imageSize / natHeight);
+					const ratio = Math.min(this.imageSize / this.naturalWidth, this.imageSize / this.naturalHeight);
 					const newWidth = this.naturalWidth * ratio;
 					const newHeight = this.naturalHeight * ratio;
 					this.imageWidth = newWidth;

--- a/web/extensions/core/showGrid.js
+++ b/web/extensions/core/showGrid.js
@@ -1,0 +1,247 @@
+import { app } from "/scripts/app.js";
+
+// Show grids from combinatorial outputs
+
+app.registerExtension({
+	name: "Comfy.ShowGrid",
+	async beforeRegisterNodeDef(nodeType, nodeData, app) {
+		if (!(nodeData.name === "SaveImage" || nodeData.name === "PreviewImage")) {
+			return
+		}
+
+		const onNodeCreated = nodeType.prototype.onNodeCreated;
+		nodeType.prototype.onNodeCreated = function () {
+			const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined;
+
+			this.addWidget("button", "Show Grid", "Show Grid", () => {
+				const grid = app.nodeGrids[this.id];
+				if (grid == null) {
+					console.warn("No grid to show!");
+					return;
+				}
+
+				const graphCanvas = LiteGraph.LGraphCanvas.active_canvas
+				if (graphCanvas == null)
+					return;
+
+				if (this._gridPanel != null)
+					return
+
+				this._gridPanel = graphCanvas.createPanel("Grid", { closable: true });
+				this._gridPanel.onClose = () => {
+					this._gridPanel = null;
+				}
+				this._gridPanel.node = this;
+				this._gridPanel.classList.add("grid_dialog");
+
+				const rootHtml = `
+<div class="axis-selectors">
+</div>
+<table class="image-table">
+</table>
+`;
+				const rootElem = this._gridPanel.addHTML(rootHtml, "grid-root");
+				const axisSelectors = rootElem.querySelector(".axis-selectors");
+				const imageTable = rootElem.querySelector(".image-table");
+
+				const footerHtml = `
+<label for="image-size">Image size</label>
+<input class="image-size" id="image-size" type="range" min="64" max="1024" step="1" value="512">
+</input>
+`
+				const footerElem = this._gridPanel.addHTML(footerHtml, "grid-footer", true);
+				const imageSizeInput = footerElem.querySelector(".image-size");
+
+				const frozenCoords = Array.from({length: grid.axes.length}, (v, i) => 0)
+
+				const getAxisData = (index) => {
+					let data = grid.axes[index];
+					if (data == null) {
+						data = {
+							nodeID: null,
+							id: "none",
+							label: "(Nothing)",
+							values: ["(None)"]
+						}
+					}
+					return data;
+				}
+
+				const selectAxis = (isY, axisID, change) => {
+					const axisName = isY ? "y" : "x";
+					const group = axisSelectors.querySelector(`.${axisName}-axis-selector`);
+
+					for (const input of group.querySelectorAll(`input#${axisName}-${axisID}`)) {
+						input.checked = true;
+						if (change) {
+							input.dispatchEvent(new Event('change'));
+						}
+					}
+				}
+
+				const getImagesAt = (x, y) => {
+					return grid.images.filter(image => {
+						for (let i = 0; i < grid.axes.length; i++) {
+							if (i === this.xAxis) {
+								if (image.coords[this.xAxis] !== x)
+									return false;
+							}
+							else if (i === this.yAxis) {
+								if (image.coords[this.yAxis] !== y)
+									return false;
+							}
+							else {
+								if (image.coords[i] !== frozenCoords[i])
+									return false;
+							}
+						}
+						return true;
+					});
+				}
+
+				const refreshGrid = (xAxis, yAxis) => {
+					this.xAxis = xAxis;
+					this.yAxis = yAxis;
+					this.xAxisData = getAxisData(this.xAxis);
+					this.yAxisData = getAxisData(this.yAxis);
+
+					selectAxis(false, this.xAxisData.id)
+					selectAxis(true, this.yAxisData.id)
+
+					if (xAxis === yAxis) {
+						this.yAxisData = getAxisData(-1);
+					}
+
+					imageTable.innerHTML = "";
+
+					const thead = document.createElement("thead")
+
+					const trXAxisLabel = document.createElement("tr");
+					const thXAxisLabel = document.createElement("th");
+					thXAxisLabel.setAttribute("colspan", String(this.xAxisData.values.length + 2))
+					thXAxisLabel.classList.add("axis", "x-axis")
+					thXAxisLabel.innerHTML = "<span>" + this.xAxisData.label + "</span>";
+					trXAxisLabel.appendChild(thXAxisLabel);
+					thead.appendChild(trXAxisLabel);
+
+					const trLabel = document.createElement("tr");
+					trLabel.appendChild(document.createElement("th")) // blank
+					trLabel.appendChild(document.createElement("th")) // blank
+					for (const xValue of this.xAxisData.values) {
+						const th = document.createElement("th");
+						th.classList.add("label", "x-label");
+						th.innerHTML = "<span>" + String(xValue) + "</span>";
+						trLabel.appendChild(th);
+					}
+					thead.appendChild(trLabel)
+
+					imageTable.appendChild(thead)
+
+					const tableBody = document.createElement("tbody");
+					imageTable.appendChild(tableBody);
+
+					const trYAxisLabel = document.createElement("tr");
+					const thYAxisLabel = document.createElement("th");
+					thYAxisLabel.setAttribute("rowspan", String(this.yAxisData.values.length + 1))
+					thYAxisLabel.classList.add("axis", "y-axis")
+					thYAxisLabel.style.textAlign = "center"
+					thYAxisLabel.style.textAlign = "center"
+					thYAxisLabel.innerHTML = "<span>" + this.yAxisData.label + "</span>";
+					trYAxisLabel.appendChild(thYAxisLabel);
+					tableBody.appendChild(trYAxisLabel);
+
+					for (const [y, yValue] of this.yAxisData.values.entries()) {
+						const tr = document.createElement("tr");
+
+						const tdLabel = document.createElement("td");
+						tdLabel.innerHTML = "<span>" + String(yValue) + "</span>";
+						tdLabel.classList.add("label", "y-label")
+						tr.append(tdLabel);
+
+						for (const [x, xValue] of this.xAxisData.values.entries()) {
+							const td = document.createElement("td");
+
+							const img = document.createElement("img");
+							img.style.width = `${this.imageSize}px`
+							img.style.height = `${this.imageSize}px`
+							const gridImages = getImagesAt(x, y);
+							if (gridImages.length > 0) {
+								img.src = "/view?" + new URLSearchParams(gridImages[0].image).toString() + app.getPreviewFormatParam();
+							}
+							td.append(img);
+
+							tr.append(td);
+						}
+						tableBody.appendChild(tr);
+					}
+				}
+
+				for (let i = 0; i < 2; i++) {
+					const axisName = i === 0 ? "x" : "y";
+					const isY = i === 1;
+
+					const group = document.createElement("div")
+					group.setAttribute("role", "group");
+					group.classList.add("axis-selector", `${axisName}-axis-selector`)
+
+					group.innerHTML = `${axisName.toUpperCase()} Axis:&nbsp `;
+
+					const addAxis = (index, axis) => {
+						const axisID = `${axisName}-${axis.id}`;
+
+						const input = document.createElement("input")
+						input.setAttribute("type", "radio")
+						input.setAttribute("name", `${axisName}-axis-selector`)
+						input.setAttribute("id", axisID)
+						input.classList.add("axis-radio")
+						input.addEventListener("change", () => {
+							if (input.checked) {
+								if (isY)
+									this.yAxis = index;
+								else
+									this.xAxis = index;
+							}
+
+							refreshGrid(this.xAxis, this.yAxis);
+						})
+
+						const label = document.createElement("label")
+						label.setAttribute("for", axisID)
+						label.classList.add("axis-label")
+						label.innerHTML = String(axis.label);
+						label.addEventListener("click", () => {
+							console.warn("SETAXIS", axis);
+							selectAxis(isY, axis.id, true);
+						})
+
+						group.appendChild(input)
+						group.appendChild(label)
+					}
+
+					// Add "None" entry
+					addAxis(-1, getAxisData(-1));
+
+					for (const [index, axis] of grid.axes.entries()) {
+						addAxis(index, axis);
+					}
+
+					axisSelectors.appendChild(group);
+				}
+
+				this.imageSize = 256;
+
+				imageSizeInput.addEventListener("input", () => {
+					this.imageSize = parseInt(imageSizeInput.value);
+					for (const img of imageTable.querySelectorAll("img")) {
+						img.style.width = `${this.imageSize}px`
+						img.style.height = `${this.imageSize}px`
+					}
+				})
+
+				refreshGrid(1, 2);
+
+				document.body.appendChild(this._gridPanel);
+			})
+		}
+	}
+})

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -197,6 +197,7 @@ app.registerExtension({
 				this.isVirtualNode = true;
 				this.properties ||= {}
 				this.properties.valuesType = "single";
+				this.properties.axisName = "";
 				this.properties.listValue = "";
 				this.properties.rangeStepBy = 64;
 				this.properties.rangeSteps = 2;
@@ -228,6 +229,12 @@ app.registerExtension({
 							}
 
 							let values;
+							let axisID = null;
+							let axisName = null;
+							if (this.properties.axisName != "") {
+								axisID = this.id;
+								axisName = this.properties.axisName
+							}
 
 							switch (this.properties.valuesType) {
 							case "list":
@@ -239,13 +246,13 @@ app.registerExtension({
 								else if (inputType === "FLOAT") {
 									values = values.map(v => parseFloat(v))
 								}
-								widget.value = { __inputType__: "combinatorial", values: values }
+								widget.value = { __inputType__: "combinatorial", values: values, axis_id: axisID, axis_name: axisName }
 								break;
 							case "range":
 								const isNumberWidget = widget.type === "number" || widget.origType === "number";
 								if (isNumberWidget) {
 									values = this.getRange(widget.value, this.properties.rangeStepBy, this.properties.rangeSteps);
-									widget.value = { __inputType__: "combinatorial", values: values }
+									widget.value = { __inputType__: "combinatorial", values: values, axis_id: axisID, axis_name: axisName }
 									break;
 								}
 							case "single":
@@ -259,6 +266,10 @@ app.registerExtension({
 
 			onPropertyChanged(property, value) {
 				if (property === "valuesType") {
+					const isSingle = value === "single"
+					if (this.axisNameWidget)
+						this.axisNameWidget.disabled = isSingle
+
 					const isList = value === "list"
 					if (this.mainWidget)
 						this.mainWidget.disabled = isList
@@ -365,6 +376,9 @@ app.registerExtension({
 				}
 
 				this.valuesTypeWidget = this.addWidget("combo", "Values type", this.properties.valuesType, "valuesType", { values: valuesTypeChoices });
+
+				this.axisNameWidget = this.addWidget("text", "Axis Name", this.properties.axisName, "axisName");
+				this.axisNameWidget.disabled = this.properties.valuesType === "single";
 
 				this.listWidget = this.addWidget("text", "Choices", this.properties.listValue, "listValue");
 				this.listWidget.disabled = this.properties.valuesType !== "list";

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -260,6 +260,8 @@ app.registerExtension({
 			onPropertyChanged(property, value) {
 				if (property === "valuesType") {
 					const isList = value === "list"
+					if (this.mainWidget)
+						this.mainWidget.disabled = isList
 					if (this.listWidget)
 						this.listWidget.disabled = !isList
 

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -229,10 +229,9 @@ app.registerExtension({
 							}
 
 							let values;
-							let axisID = null;
-							let axisName = null;
+							let axisID = this.id;
+							let axisName = `${node.id}_${node.type}: ${widget.name}`;
 							if (this.properties.axisName != "") {
-								axisID = this.id;
 								axisName = this.properties.axisName
 							}
 
@@ -251,7 +250,7 @@ app.registerExtension({
 									values: values,
 									axis_id: axisID,
 									axis_name: axisName,
-									join_axis: Boolean(axisName)
+									join_axis: true
 								}
 								break;
 							case "range":
@@ -263,7 +262,7 @@ app.registerExtension({
 										values: values,
 										axis_id: axisID,
 										axis_name: axisName,
-										join_axis: Boolean(axisName)
+										join_axis: true
 									}
 									break;
 								}

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -246,13 +246,25 @@ app.registerExtension({
 								else if (inputType === "FLOAT") {
 									values = values.map(v => parseFloat(v))
 								}
-								widget.value = { __inputType__: "combinatorial", values: values, axis_id: axisID, axis_name: axisName }
+								widget.value = {
+									__inputType__: "combinatorial",
+									values: values,
+									axis_id: axisID,
+									axis_name: axisName,
+									join_axis: Boolean(axisName)
+								}
 								break;
 							case "range":
 								const isNumberWidget = widget.type === "number" || widget.origType === "number";
 								if (isNumberWidget) {
 									values = this.getRange(widget.value, this.properties.rangeStepBy, this.properties.rangeSteps);
-									widget.value = { __inputType__: "combinatorial", values: values, axis_id: axisID, axis_name: axisName }
+									widget.value = {
+										__inputType__: "combinatorial",
+										values: values,
+										axis_id: axisID,
+										axis_name: axisName,
+										join_axis: Boolean(axisName)
+									}
 									break;
 								}
 							case "single":

--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -109,7 +109,7 @@ class ComfyApi extends EventTarget {
 						    this.dispatchEvent(new CustomEvent("progress", { detail: msg.data }));
 						    break;
 					    case "executing":
-						    this.dispatchEvent(new CustomEvent("executing", { detail: msg.data.node }));
+						    this.dispatchEvent(new CustomEvent("executing", { detail: msg.data }));
 						    break;
 					    case "executed":
 						    this.dispatchEvent(new CustomEvent("executed", { detail: msg.data }));

--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -108,6 +108,9 @@ class ComfyApi extends EventTarget {
 					    case "progress":
 						    this.dispatchEvent(new CustomEvent("progress", { detail: msg.data }));
 						    break;
+					    case "batch_progress":
+						    this.dispatchEvent(new CustomEvent("batch_progress", { detail: msg.data }));
+						    break;
 					    case "executing":
 						    this.dispatchEvent(new CustomEvent("executing", { detail: msg.data }));
 						    break;

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -890,23 +890,28 @@ export class ComfyApp {
 				ctx.globalAlpha = 1;
 			}
 
-			if (self.progress && node.id === +self.runningNodeId) {
-				let offset = 0
-				let height = 6;
+			if (node.id === +self.runningNodeId) {
+				if (self.progress) {
+					let offset = 0
+					let height = 6;
 
-				if (self.batchProgress) {
-					offset = 4;
-					height = 4;
+					if (self.batchProgress) {
+						offset = 4;
+						height = 4;
+					}
+
+					ctx.fillStyle = "green";
+					ctx.fillRect(0, offset, size[0] * (self.progress.value / self.progress.max), height);
+
+					if (self.batchProgress) {
+						ctx.fillStyle = "#3ca2c3";
+						ctx.fillRect(0, 0, size[0] * (self.batchProgress.value / self.batchProgress.max), height);
+					}
 				}
-
-				ctx.fillStyle = "green";
-				ctx.fillRect(0, offset, size[0] * (self.progress.value / self.progress.max), height);
-
-				if (self.batchProgress) {
+				else if (self.batchProgress) {
 					ctx.fillStyle = "#3ca2c3";
-					ctx.fillRect(0, 0, size[0] * (self.batchProgress.value / self.batchProgress.max), height);
+					ctx.fillRect(0, 0, size[0] * (self.batchProgress.value / self.batchProgress.max), 6);
 				}
-
 				ctx.fillStyle = bgcolor;
 			}
 
@@ -1082,14 +1087,18 @@ export class ComfyApp {
 			for (const inputName of sortedKeys) {
 				const input = promptInput.inputs[inputName];
 				if (typeof input === "object" && "__inputType__" in input) {
-					axes.push({
-						nodeID,
-						nodeClass,
-						id: `${nodeID}-${inputName}`.replace(" ", "-"),
-						label: `${nodeClass}: ${inputName}`,
-						inputName,
-						values: input.values
-					})
+					if (input.axis_id == null || !axes.some(a => a.id != null && a.id === input.axis_id)) {
+						let label = input.axis_name || `${nodeClass}: ${inputName}`;
+						axes.push({
+							id: input.axis_id,
+							nodeID,
+							nodeClass,
+							selectorID: `${nodeID}-${inputName}`.replace(" ", "-"),
+							label,
+							inputName,
+							values: input.values
+						})
+					}
 				}
 				else if (isInputLink(input)) {
 					const inputNodeID = input[0]

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -450,8 +450,6 @@ export class ComfyApp {
 						this.pointerDown = null;
 					}
 
-					let w = this.imgs[0].naturalWidth;
-					let h = this.imgs[0].naturalHeight;
 					let imageIndex = this.imageIndex;
 					const numImages = this.imgs.length;
 					if (numImages === 1 && !imageIndex) {
@@ -465,6 +463,8 @@ export class ComfyApp {
 					dh -= shiftY;
 
 					if (imageIndex == null) {
+						let w = this.imgs[0].naturalWidth;
+						let h = this.imgs[0].naturalHeight;
 						let best = 0;
 						let cellWidth;
 						let cellHeight;

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1083,10 +1083,6 @@ export class ComfyApp {
 			let sortedKeys = Object.keys(promptInput.inputs);
 			sortedKeys.sort((a, b) => a.localeCompare(b));
 
-			// Then reverse the order since we're traversing the graph upstream,
-			// so application order of the inputs comes out backwards
-			sortedKeys = sortedKeys.reverse();
-
 			for (const inputName of sortedKeys) {
 				const input = promptInput.inputs[inputName];
 				if (typeof input === "object" && "__inputType__" in input) {
@@ -1406,7 +1402,7 @@ export class ComfyApp {
 				for (let widget of node.widgets) {
 					if (node.type == "KSampler" || node.type == "KSamplerAdvanced") {
 						if (widget.name == "sampler_name") {
-							if (widget.value.startsWith("sample_")) {
+							if (typeof widget.value === "string" && widget.value.startsWith("sample_")) {
 								widget.value = widget.value.slice(7);
 							}
 						}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -999,14 +999,16 @@ export class ComfyApp {
 		});
 
 		api.addEventListener("executed", ({ detail }) => {
-			this.nodeOutputs[detail.node] = detail.output;
-			if (detail.output != null) {
-				this.nodeGrids[detail.node] = this.#resolveGrid(detail.node, detail.output, this.runningPrompt)
-			}
-			const node = this.graph.getNodeById(detail.node);
-			if (node) {
-				if (node.onExecuted)
-					node.onExecuted(detail.output);
+			if (detail.batch_num === detail.total_batches) {
+				this.nodeOutputs[detail.node] = detail.output;
+				if (detail.output != null) {
+					this.nodeGrids[detail.node] = this.#resolveGrid(detail.node, detail.output, this.runningPrompt)
+				}
+				const node = this.graph.getNodeById(detail.node);
+				if (node) {
+					if (node.onExecuted)
+						node.onExecuted(detail.output);
+				}
 			}
 			if (this.batchProgress != null) {
 				this.batchProgress.value = detail.batch_num

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1075,6 +1075,7 @@ export class ComfyApp {
 			seen.add(nodeID);
 			const promptInput = runningPrompt.output[nodeID];
 			const nodeClass = promptInput.class_type
+			console.warn("TRAVEL", nodeID, promptInput)
 
 			// Ensure input keys are sorted alphanumerically
 			// This is important for the plot to have the same order as
@@ -1083,7 +1084,7 @@ export class ComfyApp {
 			sortedKeys.sort((a, b) => a.localeCompare(b));
 
 			// Then reverse the order since we're traversing the graph upstream,
-			// so execution order comes out backwards
+			// so application order of the inputs comes out backwards
 			sortedKeys = sortedKeys.reverse();
 
 			for (const inputName of sortedKeys) {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -999,16 +999,14 @@ export class ComfyApp {
 		});
 
 		api.addEventListener("executed", ({ detail }) => {
-			if (detail.batch_num === detail.total_batches) {
-				this.nodeOutputs[detail.node] = detail.output;
-				if (detail.output != null) {
-					this.nodeGrids[detail.node] = this.#resolveGrid(detail.node, detail.output, this.runningPrompt)
-				}
-				const node = this.graph.getNodeById(detail.node);
-				if (node) {
-					if (node.onExecuted)
-						node.onExecuted(detail.output);
-				}
+			this.nodeOutputs[detail.node] = detail.output;
+			if (detail.output != null) {
+				this.nodeGrids[detail.node] = this.#resolveGrid(detail.node, detail.output, this.runningPrompt)
+			}
+			const node = this.graph.getNodeById(detail.node);
+			if (node) {
+				if (node.onExecuted)
+					node.onExecuted(detail.output);
 			}
 			if (this.batchProgress != null) {
 				this.batchProgress.value = detail.batch_num
@@ -1475,7 +1473,6 @@ export class ComfyApp {
 
 			const inputs = {};
 			const widgets = node.widgets;
-			let axis_id = null;
 
 			// Store all widget values
 			if (widgets) {
@@ -1487,13 +1484,6 @@ export class ComfyApp {
 						if (typeof widgetValue === "object" && widgetValue.__inputType__) {
 							totalCombinatorialNodes += 1;
 							executionFactor *= widgetValue.values.length;
-
-							if (widgetValue.axis_id != null) {
-								if (axis_id != null && axis_id != widgetValue.axis_id) {
-									throw new RuntimeError("Each node's outputs can only belong to one axis at a time");
-								}
-								axis_id = widgetValue.axis_id;
-							}
 						}
 						totalExecuted += executionFactor;
 					}
@@ -1523,7 +1513,6 @@ export class ComfyApp {
 			output[String(node.id)] = {
 				inputs,
 				class_type: node.comfyClass,
-				axis_id,
 			};
 		}
 

--- a/web/style.css
+++ b/web/style.css
@@ -356,3 +356,123 @@ button.comfy-queue-btn {
 	color: var(--input-text);
 	filter: brightness(50%);
 }
+
+.litegraph .dialog.grid_dialog {
+    display: inline-block;
+    text-align: right;
+	color: #AAA;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    max-width: initial;
+    min-width: 200px;
+	max-height: initial;
+    min-height: 20px;
+    padding: 4px;
+    margin: auto;
+	overflow: hidden;
+	border-radius: 3px;
+    z-index: 200;
+}
+
+.litegraph .dialog.grid_dialog .grid-root {
+    margin: auto;
+    width: fit-content;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .axis-selectors {
+    text-align: right;
+    margin: auto;
+    width: fit-content;
+    display: flex;
+    flex-direction: column;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .axis-selector {
+    position: relative;
+    display: inline-flex;
+    vertical-align: middle;
+
+}
+
+.litegraph .dialog.grid_dialog .grid-root .axis-label {
+    position: relative;
+    flex: 1 1 auto;
+    display: inline-block;
+    padding: 0.5rem;
+    font-size: 14pt;
+    color: #ccc;
+    text-align: center;
+    text-decoration: none;
+    vertical-align: middle;
+    cursor: pointer;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .axis-radio:checked + .axis-label {
+    color: black;
+    background-color: #aaa;
+    border-color: black;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .axis-radio {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    pointer-events: none;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .axis-label {
+}
+
+.litegraph .dialog.grid_dialog .grid-root img {
+    width: 512px;
+    height: 512px;
+    display: block;
+    margin: auto;
+    object-fit: contain;
+}
+
+.litegraph .dialog.grid_dialog .grid-root table {
+    border-spacing: 0;
+    border-collapse: collapse;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .axis {
+    text-align: center;
+    font-size: 20pt;
+    padding: 1rem;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .label {
+    text-align: center;
+    font-weight: bold;
+    font-size: 16pt;
+    padding: 0.5rem;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .y-label {
+    vertical-align: middle;
+}
+
+.litegraph .dialog.grid_dialog .grid-root .y-axis {
+    writing-mode: tb-rl;
+    text-orientation: mixed;
+    transform: rotate(180deg);
+}
+
+.litegraph .dialog.grid_dialog table {
+    margin: auto;
+}
+
+.litegraph .dialog.grid_dialog .grid-footer {
+    display: flex;
+}
+
+.litegraph .dialog.grid_dialog .image-size {
+    width: 400px;
+}
+
+.litegraph .dialog.grid_dialog table tr td, .litegraph .dialog.grid_dialog table tr th {
+    border: 1px solid #ccc;
+    vertical-align: top;
+}


### PR DESCRIPTION
Adds a grids feature similar to XYZ-plots in webui, supporting an arbitrary number of axes

<img width="979" alt="2023-06-09 21_50_54-ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/5fc111ba-1727-4b98-979d-f7218cfbb059">

<img width="992" alt="2023-06-09 21_51_09-ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/1e2af562-fc3a-4f0a-967e-bef265dd767c">

**NOTE:** It's still *extremely WIP* and assumes a uniform batch size, nodes that change the batch size partway or rebatch latents will almost certainly break it. Also I need to make sure the new `PrimitiveNode` widgets don't break existing workflows

## Test workflow

Sets up a 5-axis grid from various parameters

https://files.catbox.moe/tym26a.json

## Features added

- The executor now supports combinatorial inputs. This means it will generate a new prompt for every combination of one or more list of input values for each node, and pass each one of those prompts further down the graph combinatorially as well

- All nodes now show batch progress in addition to individual progress if they're being mapped over combinatorially

<img width="475" alt="2023-06-09 22_10_16-(1) ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/92c71ad2-5d87-458b-85ff-17157bd1f5c1">

- `PrimitiveNode` gets new options for defining grid axis options, `list` for a comma separated list and `range` for numeric ranges (in supported input types). Each one of the two new value types will add a new grid axis to the output

<img width="575" alt="2023-06-09 21_57_31-ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/585a077d-bc19-4c37-80bd-0ba9fd28ff17">

(*NOTE*: The `list` type needs to change from comma-separated lists to support lists of text prompts, which almost always contain commas internally. Also I may just split this functionality into its own `GridAxis` node instead)

- `PrimitiveNode` can combine more than one attached input into a single axis, for example to treat both LoRA weights as one axis. And this works (or at least is supposed to) for more than one node attached

<img width="676" alt="2023-06-09 22_02_04-ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/0623e1f8-8bc8-4b3e-aec1-71b842cbb30d">

- `SaveImage` and `PreviewImage` can now show grids if combinatorial outputs were used

<img width="340" alt="2023-06-09 21_54_26-ComfyUI - Chromium" src="https://github.com/comfyanonymous/ComfyUI/assets/24979496/6c93f861-a8c7-4f1d-b68b-ab38794adb9d">

## Implementation
Internally some new state was added to inputs and outputs in the partially executed graph to keep track of which grid axis they came from. Nodes with more than one output like `LoraLoader` treat all of their outputs as having originated from the same axis, such that both outputs (`CLIP` and `MODEL`) are treated as one axis instead of two separate axes. Otherwise the `CLIP` from one batch could be combined with the `MODEL` from another batch, which never happens during normal usage of `LoraLoader`, so it's an invalid state

`PrimitiveNode` internally "joins" all the inputs it's connected to into one axis as well, by associating each connection with a unique axis ID (which is the `PrimitiveNode`'s ID for now). This ID is attached to the node's outputs and propagated downstream so long as those outputs have the only unique combinatorial axis ID across the inputs the other nodes receive, else the axis ID is reset so a new combination can be created

The frontend relies on the sorting of the nodes' inputs based on some criteria to correctly associate the final output images with their coordinates in the graph. New combinatorial inputs will be prepended to the set of combinations, such that *earlier* axes will be changed more frequently. As an example, if A is connected to B, and each has a `weight` axis with two values, then the order in the grid will be

```
(B1, A1)
(B1, A2)
(B2, A1)
(B2, A2)
```

If there is more than one axis attached to a node then they will be applied in the alphabetical order of the input names

This order is recreated in the frontend by traversing the graph backwards from the output image nodes, instead of the backend explicitly sending the mapping from output to grid coordinates, as it gets pretty arduous to keep track of. I'm not even sure it can be tracked in the general case if the batch size changes since there's no universal way to correlate a number of inputs to outputs in a given backend node

Basically while there are a lot of use cases that this built-in grid feature can support, there are bound to be many it *can't* support, and it's a matter of throwing as many prompts as possible at it until it breaks so that those edge cases can be uncovered