### PR TITLE
Fix unhandled message "execution_cached"

### DIFF
--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -120,6 +120,9 @@ class ComfyApi extends EventTarget {
 					    case "execution_error":
 						    this.dispatchEvent(new CustomEvent("execution_error", { detail: msg.data }));
 						    break;
+					    case "execution_cached":
+						    this.dispatchEvent(new CustomEvent("execution_cached", { detail: msg.data }));
+						    break;
 					    default:
 						    if (this.#registered.has(msg.type)) {
 							    this.dispatchEvent(new CustomEvent(msg.type, { detail: msg.data }));


### PR DESCRIPTION
Fix for the unhandled message that appears in the console: 
```
Unhandled message: {"type": "execution_cached", "data": {"nodes": ["7", "15", "5", "10", "17", "13", "6", "12", "4", "16", "8", "18"], "prompt_id": "cd24e0bf-ca8d-46cf-b48c-354f311747f3"}} Error: Unknown message type execution_cached
    at WebSocket.<anonymous> (api.js:130:18)
(anonymous) @ api.js:135
```