### PR TITLE
Added wildcard node input support to back-end

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -409,7 +409,7 @@ def validate_inputs(prompt, item, validated):
             o_id = val[0]
             o_class_type = prompt[o_id]['class_type']
             r = nodes.NODE_CLASS_MAPPINGS[o_class_type].RETURN_TYPES
-            if r[val[1]] != type_input:
+            if r[val[1]] != type_input and type_input != "*":
                 received_type = r[val[1]]
                 details = f"{x}, {received_type} != {type_input}"
                 error = {


### PR DESCRIPTION
ComfyUI's front-end supports wildcard inputs but the back-end had no way to hand nodes with wildcard inputs.
This pull request changes a single line and allows a node to have an type_input of * that matches all other type inputs.