### PR TITLE
Fix reroute node connecting different types

### DIFF
--- a/web/extensions/core/rerouteNode.js
+++ b/web/extensions/core/rerouteNode.js
@@ -24,9 +24,13 @@ app.registerExtension({
 						// Ignore wildcard nodes as these will be updated to real types
 						const types = new Set(this.outputs[0].links.map((l) => app.graph.links[l].type).filter((t) => t !== "*"));
 						if (types.size > 1) {
+							const linksToDisconnect = [];
 							for (let i = 0; i < this.outputs[0].links.length - 1; i++) {
 								const linkId = this.outputs[0].links[i];
 								const link = app.graph.links[linkId];
+								linksToDisconnect.push(link);
+							}
+							for (const link of linksToDisconnect) {
 								const node = app.graph.getNodeById(link.target_id);
 								node.disconnectInput(link.target_slot);
 							}


### PR DESCRIPTION
The links array changes during the loop when disconnecting inputs, invalidating the loop condition and the index counter. This caused links to be left over when they should have been disconnected.

![image](https://github.com/comfyanonymous/ComfyUI/assets/57548627/a35e25f0-d96e-4029-b2f0-49c8c52a207c)
