### PR TITLE
docs(extra model paths): add LyCORIS path

### DIFF
--- a/extra_model_paths.yaml.example
+++ b/extra_model_paths.yaml.example
@@ -8,7 +8,9 @@ a111:
     checkpoints: models/Stable-diffusion
     configs: models/Stable-diffusion
     vae: models/VAE
-    loras: models/Lora
+    loras: |
+         models/Lora
+         models/LyCORIS
     upscale_models: |
                   models/ESRGAN
                   models/SwinIR
@@ -21,5 +23,3 @@ a111:
 #    checkpoints: models/checkpoints
 #    gligen: models/gligen
 #    custom_nodes: path/custom_nodes
-
-


### PR DESCRIPTION
Hi!

The majority of LyCORIS users from A1111 are using [KohakuBlueleaf/a1111-sd-webui-lycoris](https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris).

By default, it requires placing models in models/LyCORIS.
I think this patch is a sane example for most of the users.

Thank :)