### PR TITLE
Custom_nodes Monitor Daemon (Automatic reloading of modified custom_nodes)

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -66,10 +66,11 @@ vram_group.add_argument("--lowvram", action="store_true", help="Split the unet i
 vram_group.add_argument("--novram", action="store_true", help="When lowvram isn't enough.")
 vram_group.add_argument("--cpu", action="store_true", help="To use the CPU for everything (slow).")
 
-
 parser.add_argument("--dont-print-server", action="store_true", help="Don't print server output.")
 parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test for CI.")
 parser.add_argument("--windows-standalone-build", action="store_true", help="Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup).")
+
+parser.add_argument("--monitor-nodes", action="store_true", help="Monitor custom_nodes for modifications, and reload them.")
 
 args = parser.parse_args()
 

--- a/nodes.py
+++ b/nodes.py
@@ -1411,7 +1411,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
 }
 
 def load_custom_node(module_path):
-
     def update_modified_times(module_path):
         if os.path.isdir(module_path):
             for root, _, files in os.walk(module_path):
@@ -1424,16 +1423,30 @@ def load_custom_node(module_path):
 
     if os.path.isfile(module_path):
         module_name = os.path.splitext(os.path.basename(module_path))[0]
+        loader = importlib.machinery.SourceFileLoader(module_name, module_path)
     else:
         module_name = os.path.basename(module_path)
-    if os.path.isfile(module_path):
-        sp = os.path.splitext(module_path)
-        module_name = sp[0]
-    try:
-        if os.path.isfile(module_path):
-            loader = importlib.machinery.SourceFileLoader(module_name, module_path)
+        init_file_path = os.path.join(module_path, "__init__.py")
+        if os.path.exists(init_file_path):
+            loader = importlib.machinery.SourceFileLoader(module_name, init_file_path)
         else:
-            loader = importlib.machinery.SourceFileLoader(module_name, os.path.join(module_path, "__init__.py"))
+            file_paths = [os.path.join(module_path, file_name) for file_name in os.listdir(module_path) if file_name.endswith(".py")]
+            for file_path in file_paths:
+                sub_module_name = os.path.splitext(os.path.basename(file_path))[0]
+                sub_loader = importlib.machinery.SourceFileLoader(sub_module_name, file_path)
+                sub_module = sub_loader.load_module()
+                sys.modules[sub_module_name] = sub_module
+
+                if hasattr(sub_module, "NODE_CLASS_MAPPINGS") and getattr(sub_module, "NODE_CLASS_MAPPINGS") is not None:
+                    NODE_CLASS_MAPPINGS.update(sub_module.NODE_CLASS_MAPPINGS)
+                    if hasattr(sub_module, "NODE_DISPLAY_NAME_MAPPINGS") and getattr(sub_module, "NODE_DISPLAY_NAME_MAPPINGS") is not None:
+                        NODE_DISPLAY_NAME_MAPPINGS.update(sub_module.NODE_DISPLAY_NAME_MAPPINGS)
+
+            # Update modified times for the main module path
+            update_modified_times(module_path)
+            return True
+
+    try:
         module = loader.load_module()
         sys.modules[module_name] = module
 
@@ -1445,13 +1458,12 @@ def load_custom_node(module_path):
         update_modified_times(module_path)
 
         return True
-        
+
     except Exception as e:
         print(traceback.format_exc())
         print(f"Cannot import {module_path} module for custom nodes:", e)
         update_modified_times(module_path)
-        
-        return False
+        return False 
 
 def load_custom_nodes():
     node_paths = folder_paths.get_folder_paths("custom_nodes")


### PR DESCRIPTION
When developing, closing and opening ComfyUI over and over is cumbersome, I'm also not sure it's particular "standard usage" of your hardware when it comes to life expectancy. This pull request adds a custom_nodes monitoring daemon which will monitor your custom_nodes `.py` files for changes, and then reload them. 

It is required to add the `--monitor-nodes` argument/flag to your `.bat` or other launcher when running ComfyUI.  