### PR TITLE
Modify context menu styles

### DIFF
--- a/web/extensions/core/contextMenuOptions.js
+++ b/web/extensions/core/contextMenuOptions.js
@@ -1,0 +1,17 @@
+import {app} from "/scripts/app.js";
+
+app.registerExtension({
+    name: "Comfy.ContextMenuOptions",
+    init() {
+        const ctxMenu = LiteGraph.ContextMenu;
+
+        LiteGraph.ContextMenu = function (values, options) {
+            options.autoopen = true;
+			const ctx = ctxMenu.call(this, values, options);
+
+            return ctx;
+        }
+
+        LiteGraph.ContextMenu.prototype = ctxMenu.prototype;
+    }
+});

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -13792,7 +13792,7 @@ LGraphNode.prototype.executeAction = function(action)
         if (!disabled) {
             element.addEventListener("click", inner_onclick);
         }
-        if (options.autoopen) {
+        if (options.autoopen && !disabled) {
 			LiteGraph.pointerListenerAdd(element,"enter",inner_over);
         }
 

--- a/web/lib/litegraph.css
+++ b/web/lib/litegraph.css
@@ -38,7 +38,7 @@
 
 .litegraph.litecontextmenu .litemenu-entry {
     margin: 2px;
-    padding: 2px;
+    padding: 10px;
 }
 
 .litegraph.litecontextmenu .litemenu-entry.submenu {
@@ -132,9 +132,9 @@
     cursor: default !important;
 }
 
-.litegraph .litemenu-entry.has_submenu {
+/* .litegraph .litemenu-entry.has_submenu {
     border-right: 2px solid cyan;
-}
+} */
 
 .litegraph .litemenu-title {
     color: #dde;

--- a/web/style.css
+++ b/web/style.css
@@ -368,14 +368,16 @@ dialog::backdrop {
 
 .litegraph .litemenu-entry.has_submenu {
 	position: relative;
-	padding-right: 20px;
+	padding-right: 30px;
 }
 
 .litemenu-entry.has_submenu::after {
-	content: ">";
+	content: "〉";
+	font-weight:bold;
 	position: absolute;
-	top: 0;
-	right: 2px;
+	top: auto;
+	right: 10px;
+	margin-top:-1px;
 }
 
 .litegraph.litecontextmenu,


### PR DESCRIPTION
I am uncomfortable using the default context menu of litegraph, so I made a small modification to improve it.

Before:
![before](https://github.com/comfyanonymous/ComfyUI/assets/75435724/d75a13c2-4cc4-4b7c-99b5-a3875d396481)

After:
![after](https://github.com/comfyanonymous/ComfyUI/assets/75435724/84347598-67c2-4e3b-ab7d-1dc5098ecc4b)

Now, The button area is enlarged, which should help prevent some of the mis-selection with the auto-open.

https://github.com/comfyanonymous/ComfyUI/assets/75435724/16328804-10d5-4210-a8e5-eb86284c3d00



