### PR TITLE
Implement Synchronous API Hooks

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -435,7 +435,7 @@ def validate_inputs(prompt, item, validated):
             o_id = val[0]
             o_class_type = prompt[o_id]['class_type']
             r = nodes.NODE_CLASS_MAPPINGS[o_class_type].RETURN_TYPES
-            if r[val[1]] != type_input:
+            if type_input != "*" and r[val[1]] != "*" and r[val[1]] != type_input:
                 received_type = r[val[1]]
                 details = f"{x}, {received_type} != {type_input}"
                 error = {

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def prompt_worker(q, server):
         execution_start_time = time.perf_counter()
         prompt_id = item[1]
         e.execute(item[2], prompt_id, item[3], item[4])
-        q.task_done(item_id, e.outputs_ui)
+        q.task_done(item_id, e.outputs_ui, e.outputs_sync)
         if server.client_id is not None:
             server.send_sync("executing", { "node": None, "prompt_id": prompt_id }, server.client_id)
 

--- a/server.py
+++ b/server.py
@@ -367,6 +367,7 @@ class PromptServer():
             obj_class = nodes.NODE_CLASS_MAPPINGS[node_class]
             info = {}
             info['input'] = obj_class.INPUT_TYPES()
+            info['input_order'] = {key: list(value.keys()) for (key, value) in obj_class.INPUT_TYPES().items()}
             info['output'] = obj_class.RETURN_TYPES
             info['output_is_list'] = obj_class.OUTPUT_IS_LIST if hasattr(obj_class, 'OUTPUT_IS_LIST') else [False] * len(obj_class.RETURN_TYPES)
             info['output_name'] = obj_class.RETURN_NAMES if hasattr(obj_class, 'RETURN_NAMES') else info['output']

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -228,7 +228,7 @@ app.registerExtension({
 					const linkInfo = app.graph.links[l];
 					const node = this.graph.getNodeById(linkInfo.target_id);
 					const input = node.inputs[linkInfo.target_slot];
-					const widgetName = input.widget.name;
+					const widgetName = input.widget?.name;
 					if (widgetName) {
 						const widget = node.widgets.find((w) => w.name === widgetName);
 						if (widget) {


### PR DESCRIPTION
This PR allows ComfyUI to fulfill one of my last remaining uses for automatic1111's web UI -- easy integration with external tools.

The existing websocket-based API is ideal for interactive workflows, but is more complex than necessary for simple procedural uses (particularly those involving languages like C++ with sub-par support for websockets). This PR adds the necessary hooks for a custom node pack to add synchronous APIs.

Of note, this PR (along with the custom nodes at https://github.com/BadCafeCode/apitools-comfyui) allows ComfyUI to act as a drop-in replacement for the Automatic1111 API in tools like:
1. [oobabooga's Text WebUI](https://github.com/oobabooga/text-generation-webui) (with the sd_api_pictures extension)
2. Blender (with my fork of the dream-textures extension)
3. GIMP (via a plugin like https://github.com/thndrbrrr/gimp-stable-boy)

New endpoints can also be easily prototyped and used with the apitools nodes.

I've tried to strike a balance here between adding full HTTP API support to the base ComfyUI (which I think goes beyond the intended scope) and making no changes to the base ComfyUI (which would require overriding a lot of core functionality from custom nodes and cause frequent bugs when the overwritten code is changed).

I'll include some of my specific reasoning in inline comments on this PR.

Note that although these requests look synchronous to the client, they *do* still use async functions behind the scenes and will properly queue up if multiple requests are received at once. Each request will return a result once the associated workflow has completed. Standard browsers will generally wait up to 5 minutes if the request is simply performed via CORS, but HTTP client libraries can just about always be configured to wait longer. (More info on long-polling available [here](https://www.rfc-editor.org/rfc/rfc6202).)