### PR TITLE
Patch deletion of self.loaded_lora

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -497,7 +497,7 @@ class LoraLoader:
             if self.loaded_lora[0] == lora_path:
                 lora = self.loaded_lora[1]
             else:
-                del self.loaded_lora
+                self.loaded_lora = None
 
         if lora is None:
             lora = comfy.utils.load_torch_file(lora_path, safe_load=True)


### PR DESCRIPTION
self.loaded_lora is a required attribute of load_lora method when persistent. This returns self.loaded_lora to None when the loaded lora path is not the same as the requested lora path.