### PR TITLE
Changed --windows-standalone-build to --auto-launch

### DIFF
--- a/.ci/nightly/windows_base_files/run_nvidia_gpu.bat
+++ b/.ci/nightly/windows_base_files/run_nvidia_gpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --use-pytorch-cross-attention
+.\python_embeded\python.exe -s ComfyUI\main.py --auto-launch --use-pytorch-cross-attention
 pause

--- a/.ci/windows_base_files/run_cpu.bat
+++ b/.ci/windows_base_files/run_cpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --cpu --windows-standalone-build
+.\python_embeded\python.exe -s ComfyUI\main.py --cpu --auto-launch
 pause

--- a/.ci/windows_base_files/run_nvidia_gpu.bat
+++ b/.ci/windows_base_files/run_nvidia_gpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build
+.\python_embeded\python.exe -s ComfyUI\main.py --auto-launch
 pause


### PR DESCRIPTION
This goes along with https://github.com/comfyanonymous/ComfyUI/commit/a1f12e370dc694a26528c382e81b2e5e297934e0 and makes it so that --auto-launch is now the default. I spent a while trying to figure out how to stop the program from automatically opening in a browser before I discovered this parameter was the culprit. This change makes it a bit more obvious for future users.