### PR TITLE
Fix timestep ranges when batch_size > 1

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -19,11 +19,11 @@ def sampling_function(model_function, x, timestep, uncond, cond, cond_scale, con
             strength = 1.0
             if 'timestep_start' in cond[1]:
                 timestep_start = cond[1]['timestep_start']
-                if timestep_in > timestep_start:
+                if timestep_in[0] > timestep_start:
                     return None
             if 'timestep_end' in cond[1]:
                 timestep_end = cond[1]['timestep_end']
-                if timestep_in < timestep_end:
+                if timestep_in[0] < timestep_end:
                     return None
             if 'area' in cond[1]:
                 area = cond[1]['area']


### PR DESCRIPTION
ComfyUI complains about ambiguous boolean values when timestep ranges are used with batch sizes > 1 because `timestep_in` becomes multivalued.

The values in the tensor appear to all be the same, so just looking at the first index should be enough.