### PR TITLE
added slider and toggle widget

### DIFF
--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -250,19 +250,25 @@ function addMultilineWidget(node, name, opts, app) {
 	return { minWidth: 400, minHeight: 200, widget };
 }
 
+function isSlider(display_as) {
+	return (display_as==="slider") ? "slider" : "number"
+}
+
 export const ComfyWidgets = {
 	"INT:seed": seedWidget,
 	"INT:noise_seed": seedWidget,
 	FLOAT(node, inputName, inputData) {
+		let widgetType = isSlider(inputData[1]["display_as"]);
 		const { val, config } = getNumberDefaults(inputData, 0.5);
-		return { widget: node.addWidget("number", inputName, val, () => {}, config) };
+		return { widget: node.addWidget(widgetType, inputName, val, () => {}, config) };
 	},
 	INT(node, inputName, inputData) {
+		let widgetType = isSlider(inputData[1]["display_as"]);
 		const { val, config } = getNumberDefaults(inputData, 1);
 		Object.assign(config, { precision: 0 });
 		return {
 			widget: node.addWidget(
-				"number",
+				widgetType,
 				inputName,
 				val,
 				function (v) {
@@ -270,23 +276,7 @@ export const ComfyWidgets = {
 					this.value = Math.round(v / s) * s;
 				},
 				config
-			),
-		};
-	},
-	SLIDER(node, inputName, inputData) {
-		const { val, config } = getNumberDefaults(inputData, 1);
-		Object.assign(config, { precision: 0 });
-		return {
-			widget: node.addWidget(
-				"slider",
-				inputName,
-				val,
-				function (v) {
-					const s = this.options.step / 10;
-					this.value = Math.round(v / s) * s;
-				},
-				config
-			),
+			),	
 		};
 	},
 	TOGGLE(node, inputName, inputData) {

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -273,6 +273,33 @@ export const ComfyWidgets = {
 			),
 		};
 	},
+	SLIDER(node, inputName, inputData) {
+		const { val, config } = getNumberDefaults(inputData, 1);
+		Object.assign(config, { precision: 0 });
+		return {
+			widget: node.addWidget(
+				"slider",
+				inputName,
+				val,
+				function (v) {
+					const s = this.options.step / 10;
+					this.value = Math.round(v / s) * s;
+				},
+				config
+			),
+		};
+	},
+	TOGGLE(node, inputName, inputData) {
+		let defaultVal = inputData[1]["default"];
+		return {
+			widget: node.addWidget(
+				"toggle",
+				inputName,
+				defaultVal,
+				() => {},
+				)
+		};
+	},
 	STRING(node, inputName, inputData, app) {
 		const defaultVal = inputData[1].default || "";
 		const multiline = !!inputData[1].multiline;


### PR DESCRIPTION
I have added slider and toggle widgets from `litegraph.js`. It improves usability compare to an input number where you have to type the value each time.

For example, it is possible to create an image_resolution node with an increment of 64 and an invert toggle button to easily change the desired resolution of an output image:

![Untitled](https://github.com/comfyanonymous/ComfyUI/assets/66461774/011013f5-9ee2-441f-b6a8-8b0d139fbe5e)

the code used to create this custom node:

```py
class ImageResolution:
    @classmethod
    def INPUT_TYPES(s):
        return {
            "required": {
                "width": (
                    "SLIDER",
                    {
                        "default": 1024,
                        "min": 0,
                        "max": 6144,
                        "step": 64,
                    },
                ),
                "height": (
                    "SLIDER",
                    {
                        "default": 1024,
                        "min": 0,
                        "max": 6144,
                        "step": 64,
                    },
                ),
                "invert": (
                    "TOGGLE",
                    {
                        "default": False,
                    },
                ),
            },
        }

    RETURN_TYPES = ("INT", "INT")
    RETURN_NAMES = ("width", "height")
    FUNCTION = "inverse_values"

    CATEGORY = "image"

    def inverse_values(self, width, height, invert):
        return (height, width) if invert else (width, height)
```