### PR TITLE
SaveLatent should report its outputs so they are visible to API

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -362,6 +362,14 @@ class SaveLatent:
                     metadata[x] = json.dumps(extra_pnginfo[x])
 
         file = f"{filename}_{counter:05}_.latent"
+
+        results = list()
+        results.append({
+            "filename": file,
+            "subfolder": subfolder,
+            "type": "output"
+        })
+
         file = os.path.join(full_output_folder, file)
 
         output = {}
@@ -369,7 +377,7 @@ class SaveLatent:
         output["latent_format_version_0"] = torch.tensor([])
 
         comfy.utils.save_torch_file(output, file, metadata=metadata)
-        return {}
+        return { "ui": { "latents": results } }
 
 
 class LoadLatent:


### PR DESCRIPTION
When using SaveLatent from the API there is no indication of where its file was saved, I looked at how SaveImage worked, and basically mirrored the logic to SaveLatent, in my testing this worked.

That said, I'm not sure if this is the best way to do this, or if this might cause issues with something else, I'm new to ComfyUI and know almost nothing about Python.

Hopefully this is good, and will save you a few minutes.