### PR TITLE
A small fix to allow "multiline" input nodes to opt out of `dynamicPrompts` behaviour.

### DIFF
--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -190,6 +190,7 @@ function addMultilineWidget(node, name, opts, app) {
 			widget.inputEl.blur();
 		}
 	});
+	widget.dynamicPrompts = opts.dynamicPrompts;
 	widget.parent = node;
 	document.body.appendChild(widget.inputEl);
 


### PR DESCRIPTION
While I believe it would be better to make `dynamicPrompts` an opt-in behaviour for multiline text inputs, this at least makes it possible for nodes to opt out.

Example usage in a Node:

```python
class TextDebug:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {
                "label": ("STRING", {"default": "Text Value"}),
                "text": ("STRING", {"multiline": True, "dynamicPrompts": False}),
            }
        }

    RETURN_TYPES = ("STRING",)
    OUTPUT_NODE = True
    FUNCTION = "debug"
    CATEGORY = "Debug"

    def debug(self, label, text):
        print(f"{label}: {text}")
        return (text, )
```

Without specifying `"dynamicPrompts": False`, any text inside `{...}` blocks will strip the brackets, which is frankly quite surprising behaviour from a developer point of view.

I would prefer that dynamicPrompts was opt-in, but that would require a larger change across multiple nodes. No big deal for built-in nodes, but might be a bit of a pain for custom_nodes.

That said, happy to make it that way, and/or create a separate branch to make it opt-in.