### PR TITLE
improve: allows option name for toggle

### DIFF
--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -287,6 +287,7 @@ export const ComfyWidgets = {
 				inputName,
 				defaultVal,
 				() => {},
+				inputData[1].options
 				)
 		};
 	},


### PR DESCRIPTION
This patch allows this.

```
"sw": ("TOGGLE", {"default": False, "options": { 'on': 'enable', 'off': 'disable' }})
```

![toggle](https://github.com/comfyanonymous/ComfyUI/assets/128333288/be63b25a-6534-45a9-b996-ba55fcafbe36)

you can ommit 'options' then it will display `true`, `false` such as before.