### PR TITLE
Disable cuda malloc on Quadro M3000M, linux

### DIFF
--- a/cuda_malloc.py
+++ b/cuda_malloc.py
@@ -33,6 +33,12 @@ def get_gpu_names():
                 gpu_names.add(device_info.DeviceString.decode('utf-8'))
             return gpu_names
         return enum_display_devices()
+    elif os.name == 'posix':
+        import torch
+        gpu_names = set()
+        for i in range(torch.cuda.device_count()):
+            gpu_names.add(torch.cuda.get_device_properties(i).name)
+        return gpu_names
     else:
         return set()
 
@@ -40,7 +46,7 @@ def cuda_malloc_supported():
     blacklist = {"GeForce GTX TITAN X", "GeForce GTX 980", "GeForce GTX 970", "GeForce GTX 960", "GeForce GTX 950", "GeForce 945M",
                  "GeForce 940M", "GeForce 930M", "GeForce 920M", "GeForce 910M", "GeForce GTX 750", "GeForce GTX 745", "Quadro K620",
                  "Quadro K1200", "Quadro K2200", "Quadro M500", "Quadro M520", "Quadro M600", "Quadro M620", "Quadro M1000",
-                 "Quadro M1200", "Quadro M2000", "Quadro M2200", "Quadro M3000", "Quadro M4000", "Quadro M5000", "Quadro M5500", "Quadro M6000"}
+                 "Quadro M1200", "Quadro M2000", "Quadro M2200", "Quadro M3000", "Quadro M3000M", "Quadro M4000", "Quadro M5000", "Quadro M5500", "Quadro M6000"}
 
     try:
         names = get_gpu_names()


### PR DESCRIPTION
Add Quadro M3000**M** to the cuda malloc blacklist. Get the GPU names in posix (let the blacklist work in linux)

Only tested in Ubuntu 22.