### PR TITLE
Add noisy latent image node in comfy extras

### DIFF
--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -2,7 +2,7 @@ import torch
 from nodes import MAX_RESOLUTION
 
 # diffusers library scale the random noise
-vae_scaling_factor = 0.18215
+vae_scaling_factor = 0.18215 # doesn't work
 
 class NoisyLatentImage:
     def __init__(self, device="cpu"):
@@ -22,7 +22,7 @@ class NoisyLatentImage:
 
     def generate(self, seed, width, height, batch_size=1):
         generator = torch.manual_seed(seed)
-        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device) * vae_scaling_factor
+        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device)
         return ({"samples":latent}, )
 
 

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -22,7 +22,7 @@ class NoisyLatentImage:
 
     def generate(self, seed, width, height, batch_size=1):
         generator = torch.manual_seed(seed)
-        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device)
+        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device) / vae_scaling_factor
         return ({"samples":latent}, )
 
 

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -22,7 +22,7 @@ class NoisyLatentImage:
 
     def generate(self, seed, width, height, batch_size=1):
         generator = torch.manual_seed(seed)
-        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device) / vae_scaling_factor
+        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device) * vae_scaling_factor
         return ({"samples":latent}, )
 
 

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -2,7 +2,7 @@ import torch
 from nodes import MAX_RESOLUTION
 
 # diffusers library scale the random noise
-default_vae_scaling_factor = 0.18215 
+default_vae_scaling_factor = 1.0/0.18215 
 
 class NoisyLatentImage:
     def __init__(self, device="cpu"):
@@ -12,7 +12,7 @@ class NoisyLatentImage:
     def INPUT_TYPES(s):
         return {"required": { 
                               "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
-                              "vae_scaling_factor": ("FLOAT", {"default": default_vae_scaling_factor, "min": 0.01, "max": 1.1, "step": 0.01}),
+                              "vae_scaling_factor": ("FLOAT", {"default": default_vae_scaling_factor, "min": 0.0, "max": 10, "step": 0.01}),
                               "width": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
                               "height": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
                               "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})}}
@@ -23,7 +23,7 @@ class NoisyLatentImage:
 
     def generate(self, seed, vae_scaling_factor, width, height, batch_size=1):
         generator = torch.manual_seed(seed)
-        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device) / vae_scaling_factor
+        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device) * vae_scaling_factor
         return ({"samples":latent}, )
 
 

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -1,4 +1,5 @@
 import torch
+from nodes import MAX_RESOLUTION
 
 class NoisyLatentImage:
     def __init__(self, device="cpu"):

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -2,7 +2,7 @@ import torch
 from nodes import MAX_RESOLUTION
 
 # diffusers library scale the random noise
-vae_scaling_factor = 0.18215 # doesn't work
+default_vae_scaling_factor = 0.18215 
 
 class NoisyLatentImage:
     def __init__(self, device="cpu"):
@@ -12,6 +12,7 @@ class NoisyLatentImage:
     def INPUT_TYPES(s):
         return {"required": { 
                               "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                              "vae_scaling_factor": ("FLOAT", {"default": default_vae_scaling_factor, "min": 0.01, "max": 1.1, "step": 0.01})
                               "width": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
                               "height": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
                               "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})}}
@@ -20,7 +21,7 @@ class NoisyLatentImage:
 
     CATEGORY = "latent"
 
-    def generate(self, seed, width, height, batch_size=1):
+    def generate(self, seed, vae_scaling_factor, width, height, batch_size=1):
         generator = torch.manual_seed(seed)
         latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device) / vae_scaling_factor
         return ({"samples":latent}, )

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -28,7 +28,7 @@ class NoisyLatentImage:
 
 
 NODE_CLASS_MAPPINGS = {
-    "Noisy Latent Image": NoisyLatentImage,
+    "NoisyLatentImage": NoisyLatentImage,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -1,0 +1,31 @@
+import torch
+
+class NoisyLatentImage:
+    def __init__(self, device="cpu"):
+        self.device = device
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": { 
+                              "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                              "width": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
+                              "height": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
+                              "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})}}
+    RETURN_TYPES = ("LATENT",)
+    FUNCTION = "generate"
+
+    CATEGORY = "latent"
+
+    def generate(self, seed, width, height, batch_size=1):
+        generator = torch.manual_seed(seed)
+        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device)
+        return ({"samples":latent}, )
+
+
+NODE_CLASS_MAPPINGS = {
+    "Noisy Latent Image": NoisyLatentImage,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "NoisyLatentImage": "Noisy Latent Image"
+}

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -12,7 +12,7 @@ class NoisyLatentImage:
     def INPUT_TYPES(s):
         return {"required": { 
                               "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
-                              "vae_scaling_factor": ("FLOAT", {"default": default_vae_scaling_factor, "min": 0.01, "max": 1.1, "step": 0.01})
+                              "vae_scaling_factor": ("FLOAT", {"default": default_vae_scaling_factor, "min": 0.01, "max": 1.1, "step": 0.01}),
                               "width": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
                               "height": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
                               "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})}}

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -1,6 +1,9 @@
 import torch
 from nodes import MAX_RESOLUTION
 
+# diffusers library scale the random noise
+vae_scaling_factor = 0.18215
+
 class NoisyLatentImage:
     def __init__(self, device="cpu"):
         self.device = device
@@ -19,7 +22,7 @@ class NoisyLatentImage:
 
     def generate(self, seed, width, height, batch_size=1):
         generator = torch.manual_seed(seed)
-        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device)
+        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device) / vae_scaling_factor
         return ({"samples":latent}, )
 
 

--- a/nodes.py
+++ b/nodes.py
@@ -1653,4 +1653,5 @@ def init_custom_nodes():
     load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_tomesd.py"))
     load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_clip_sdxl.py"))
     load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_canny.py"))
+    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_latent.py"))
     load_custom_nodes()

--- a/nodes.py
+++ b/nodes.py
@@ -871,6 +871,27 @@ class EmptyLatentImage:
         latent = torch.zeros([batch_size, 4, height // 8, width // 8])
         return ({"samples":latent}, )
 
+class NoisyLatentImage:
+    def __init__(self, device="cpu"):
+        self.device = device
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": { 
+                              "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                              "width": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
+                              "height": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
+                              "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})}}
+    RETURN_TYPES = ("LATENT",)
+    FUNCTION = "generate"
+
+    CATEGORY = "latent"
+
+    def generate(self, seed, width, height, batch_size=1):
+        generator = torch.manual_seed(seed)
+        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device)
+        return ({"samples":latent}, )
+
 
 class LatentFromBatch:
     @classmethod

--- a/nodes.py
+++ b/nodes.py
@@ -871,28 +871,6 @@ class EmptyLatentImage:
         latent = torch.zeros([batch_size, 4, height // 8, width // 8])
         return ({"samples":latent}, )
 
-class NoisyLatentImage:
-    def __init__(self, device="cpu"):
-        self.device = device
-
-    @classmethod
-    def INPUT_TYPES(s):
-        return {"required": { 
-                              "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
-                              "width": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
-                              "height": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
-                              "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})}}
-    RETURN_TYPES = ("LATENT",)
-    FUNCTION = "generate"
-
-    CATEGORY = "latent"
-
-    def generate(self, seed, width, height, batch_size=1):
-        generator = torch.manual_seed(seed)
-        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device)
-        return ({"samples":latent}, )
-
-
 class LatentFromBatch:
     @classmethod
     def INPUT_TYPES(s):


### PR DESCRIPTION
In diffusers and WebUI, initial latent image is a random noise, rather than an empty latent tensor initialised with zero.