### PR TITLE
refactor/fix: Treat forceInput widgets as standard widgets

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1151,22 +1151,21 @@ export class ComfyApp {
 						const inputData = inputs[inputName];
 						const type = inputData[0];
 
-						if(inputData[1]?.forceInput) {
-							this.addInput(inputName, type);
+						if (Array.isArray(type)) {
+							// Enums
+							Object.assign(config, widgets.COMBO(this, inputName, inputData, app) || {});
+						} else if (`${type}:${inputName}` in widgets) {
+							// Support custom widgets by Type:Name
+							Object.assign(config, widgets[`${type}:${inputName}`](this, inputName, inputData, app) || {});
+						} else if (type in widgets) {
+							// Standard type widgets
+							Object.assign(config, widgets[type](this, inputName, inputData, app) || {});
 						} else {
-							if (Array.isArray(type)) {
-								// Enums
-								Object.assign(config, widgets.COMBO(this, inputName, inputData, app) || {});
-							} else if (`${type}:${inputName}` in widgets) {
-								// Support custom widgets by Type:Name
-								Object.assign(config, widgets[`${type}:${inputName}`](this, inputName, inputData, app) || {});
-							} else if (type in widgets) {
-								// Standard type widgets
-								Object.assign(config, widgets[type](this, inputName, inputData, app) || {});
-							} else {
-								// Node connection inputs
-								this.addInput(inputName, type);
-							}
+							// Node connection inputs
+							this.addInput(inputName, type);
+						}
+						if(inputData[1]?.forceInput && config?.widget) {
+							config.widget.options.forceInput = inputData[1].forceInput;
 						}
 					}
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1165,6 +1165,7 @@ export class ComfyApp {
 							this.addInput(inputName, type);
 						}
 						if(inputData[1]?.forceInput && config?.widget) {
+							if (!config.widget.options) config.widget.options = {};
 							config.widget.options.forceInput = inputData[1].forceInput;
 						}
 					}


### PR DESCRIPTION
Updates the way widgets with `forceInput: True` are handled.

Pre-Change:
- Standard Widget
    - Load Node Def -> Create Widget -> Convert to Input option in menu
- Forced Input
    - Load Node Def -> Create Input

Post-Change
- Standard Widget(No Change)
    - Load Node Def -> Create Widget -> Convert to Input option in menu
- Forced Input
    - Load Node Def -> Create Widget -> Force Convert to Input

Currently the Primitive node expects converted widgets to have a `widget` property on the input, but as "forced input" widgets are not converted to an input from a widget, they don't contain the property leading to errors.

This change treats "force input" widgets as widgets from the beginning, and then converts them to inputs. This way they should be identical to converted widgets. This also opens the door for adding support for additional configs such as "defaultToInput" in the future, if node developers want to allow users to convert the forcedInput back to a widget.