### PR TITLE
Add setting to change link render mode

### DIFF
--- a/web/extensions/core/linkRenderMode.js
+++ b/web/extensions/core/linkRenderMode.js
@@ -1,0 +1,25 @@
+import { app } from "/scripts/app.js";
+
+const id = "Comfy.LinkRenderMode";
+const ext = {
+	name: id,
+	async setup(app) {
+		app.ui.settings.addSetting({
+			id,
+			name: "Link Render Mode",
+			defaultValue: 2,
+			type: "combo",
+			options: LiteGraph.LINK_RENDER_MODES.map((m, i) => ({
+				value: i,
+				text: m,
+				selected: i == app.canvas.links_render_mode,
+			})),
+			onChange(value) {
+				app.canvas.links_render_mode = +value;
+				app.graph.setDirtyCanvas(true);
+			},
+		});
+	},
+};
+
+app.registerExtension(ext);

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -234,7 +234,7 @@ class ComfySettingsDialog extends ComfyDialog {
 		localStorage[settingId] = JSON.stringify(value);
 	}
 
-	addSetting({id, name, type, defaultValue, onChange, attrs = {}, tooltip = "",}) {
+	addSetting({id, name, type, defaultValue, onChange, attrs = {}, tooltip = "", options = undefined}) {
 		if (!id) {
 			throw new Error("Settings must have an ID");
 		}
@@ -344,6 +344,32 @@ class ComfySettingsDialog extends ComfyDialog {
 											},
 										}),
 									]),
+								]),
+							]);
+							break;
+						case "combo":
+							element = $el("tr", [
+								labelCell,
+								$el("td", [
+									$el(
+										"select",
+										{
+											oninput: (e) => {
+												setter(e.target.value);
+											},
+										},
+										(typeof options === "function" ? options(value) : options || []).map((opt) => {
+											if (typeof opt === "string") {
+												opt = { text: opt };
+											}
+											const v = opt.value ?? opt.text;
+											return $el("option", {
+												value: v,
+												textContent: opt.text,
+												selected: value + "" === v + "",
+											});
+										})
+									),
 								]),
 							]);
 							break;


### PR DESCRIPTION
Add support for combo settings and changing the link render mode, which is a surprisingly popular script.
![image](https://github.com/comfyanonymous/ComfyUI/assets/125205205/66a195f9-5d0f-43f5-bd19-2caa297d3a6e)
Defaults to spline which is the existing mode.


![workflow(1)](https://github.com/comfyanonymous/ComfyUI/assets/125205205/76920a4d-925b-48f1-b0ba-d20d5173e896)
![workflow(2)](https://github.com/comfyanonymous/ComfyUI/assets/125205205/7cb53a99-6fe5-4713-b8fd-df3b68edc728)
![workflow(3)](https://github.com/comfyanonymous/ComfyUI/assets/125205205/9f92e846-9d2b-4611-a35b-07c0f59ef56a)

