### PR TITLE
Prevent menu filter crashing if the widget cant be found

### DIFF
--- a/web/extensions/core/contextMenuFilter.js
+++ b/web/extensions/core/contextMenuFilter.js
@@ -30,6 +30,9 @@ const ext = {
 						?.value;
 
 					let selectedIndex = clickedComboValue ? values.findIndex(v => v === clickedComboValue) : 0;
+					if (selectedIndex < 0) {
+						selectedIndex = 0;
+					} 
 					let selectedItem = displayedItems[selectedIndex];
 					updateSelected();
 

--- a/web/extensions/core/contextMenuFilter.js
+++ b/web/extensions/core/contextMenuFilter.js
@@ -27,10 +27,10 @@ const ext = {
 					const clickedComboValue = currentNode.widgets
 						.filter(w => w.type === "combo" && w.options.values.length === values.length)
 						.find(w => w.options.values.every((v, i) => v === values[i]))
-						.value;
+						?.value;
 
-					let selectedIndex = values.findIndex(v => v === clickedComboValue);
-					let selectedItem = displayedItems?.[selectedIndex];
+					let selectedIndex = clickedComboValue ? values.findIndex(v => v === clickedComboValue) : 0;
+					let selectedItem = displayedItems[selectedIndex];
 					updateSelected();
 
 					// Apply highlighting to the selected item


### PR DESCRIPTION
I've seen this crash due to a couple of extensions and it ends up leaving behind a semi broken combo list.
It doesn't really matter if it cant find the matching widget as it's just used for setting the initial selected index, so better to default that to 0 than crash.