### PR TITLE
Use a constant (signed int) as seed input field maximum value

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -431,7 +431,7 @@ def validate_inputs(prompt, item, validated):
             o_id = val[0]
             o_class_type = prompt[o_id]['class_type']
             r = nodes.NODE_CLASS_MAPPINGS[o_class_type].RETURN_TYPES
-            if r[val[1]] != type_input:
+            if r[val[1]] != type_input and type_input != "*":
                 received_type = r[val[1]]
                 details = f"{x}, {received_type} != {type_input}"
                 error = {

--- a/nodes.py
+++ b/nodes.py
@@ -1185,7 +1185,7 @@ class KSampler:
     def INPUT_TYPES(s):
         return {"required":
                     {"model": ("MODEL",),
-                    "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                    "seed": ("INT", {"default": 0, "min": 0, "max": sys.maxsize}),
                     "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                     "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0}),
                     "sampler_name": (comfy.samplers.KSampler.SAMPLERS, ),
@@ -1211,7 +1211,7 @@ class KSamplerAdvanced:
         return {"required":
                     {"model": ("MODEL",),
                     "add_noise": (["enable", "disable"], ),
-                    "noise_seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                    "noise_seed": ("INT", {"default": 0, "min": 0, "max": sys.maxsize}),
                     "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                     "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0}),
                     "sampler_name": (comfy.samplers.KSampler.SAMPLERS, ),

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -375,7 +375,11 @@ app.registerExtension({
 
 				for (const k in config1[1]) {
 					if (k !== "default") {
-						if (config1[1][k] !== config2[1][k]) {
+						if(k == "min") {
+							if(config1[1][k] < config2[1][k]) return false;
+						} else if(k == "max") {
+							if(config1[1][k] > config2[1][k]) return false;
+						} else if (config1[1][k] !== config2[1][k]) {
 							return false;
 						}
 					}

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -260,6 +260,9 @@ app.registerExtension({
 
 			onConnectOutput(slot, type, input, target_node, target_slot) {
 				// Fires before the link is made allowing us to reject it if it isn't valid
+				if (input.type == "*") {
+					return true;
+				}
 
 				// No widget, we cant connect
 				if (!input.widget) {

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -2,7 +2,7 @@ import { ComfyWidgets, addValueControlWidget } from "../../scripts/widgets.js";
 import { app } from "../../scripts/app.js";
 
 const CONVERTED_TYPE = "converted-widget";
-const VALID_TYPES = ["STRING", "combo", "number", "BOOLEAN"];
+const VALID_TYPES = ["STRING", "combo", "number", "BOOLEAN", "*"];
 
 function isConvertableWidget(widget, config) {
 	return VALID_TYPES.includes(widget.type) || VALID_TYPES.includes(config[0]);
@@ -169,8 +169,8 @@ app.registerExtension({
 			const input = this.inputs[slot];
 			if (!input.widget || !input[ignoreDblClick]) {
 				// Not a widget input or already handled input
-				if (!(input.type in ComfyWidgets) && !(input.widget.config?.[0] instanceof Array)) {
-					return r; //also Not a ComfyWidgets input or combo (do nothing)
+				if (!(input.type in ComfyWidgets) && input.type != "*" && !(input.widget.config?.[0] instanceof Array)) {
+					return r; //also Not a ComfyWidgets input, 'ANY' or combo (do nothing)
 				}
 			}
 
@@ -287,7 +287,7 @@ app.registerExtension({
 				if (!input) return;
 
 
-				var _widget;
+				let _widget;
 				if (!input.widget) {
 					if (!(input.type in ComfyWidgets)) return;
 					_widget = { "name": input.name, "config": [input.type, {}] }//fake widget
@@ -315,6 +315,8 @@ app.registerExtension({
 				let widget;
 				if (type in ComfyWidgets) {
 					widget = (ComfyWidgets[type](this, "value", inputData, app) || {}).widget;
+				} else if (type == "*") {
+					widget = (ComfyWidgets.STRING(this, "value", ["STRING", {"default": ""}], app) || {}).widget;
 				} else {
 					widget = this.addWidget(type, "value", null, () => { }, {});
 				}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1155,6 +1155,9 @@ export class ComfyApp {
 							} else if (type in widgets) {
 								// Standard type widgets
 								Object.assign(config, widgets[type](this, inputName, inputData, app) || {});
+							} else if (type == "*") {
+								// 'ANY' type widgets
+								Object.assign(config, widgets.STRING(this, inputName, ["STRING", {}], app) || {});
 							} else {
 								// Node connection inputs
 								this.addInput(inputName, type);


### PR DESCRIPTION
Using this constant would make the code more compliant with computing standards. A Bit less doesn't hurt, as seeds aren't required to be that big anyways.
Also this would restore compatibility with depending plugins, that adhere do this standard:
https://github.com/Derfuu/Derfuu_ComfyUI_ModdedNodes/blob/2ace4c463d5b2063de35e46ebb9bd3f10e2d34b4/components/fields.py#L10