### PR TITLE
Make the extensions loads in parallel instead of waiting one by one

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1026,18 +1026,21 @@ export class ComfyApp {
 	}
 
 	/**
-	 * Loads all extensions from the API into the window
+	 * Loads all extensions from the API into the window in parallel
 	 */
 	async #loadExtensions() {
-		const extensions = await api.getExtensions();
-		this.logging.addEntry("Comfy.App", "debug", { Extensions: extensions });
-		for (const ext of extensions) {
-			try {
-				await import(api.apiURL(ext));
-			} catch (error) {
-				console.error("Error loading extension", ext, error);
-			}
-		}
+	    const extensions = await api.getExtensions();
+	    this.logging.addEntry("Comfy.App", "debug", { Extensions: extensions });
+	
+	    const extensionPromises = extensions.map(async ext => {
+	        try {
+	            await import(api.apiURL(ext));
+	        } catch (error) {
+	            console.error("Error loading extension", ext, error);
+	        }
+	    });
+	
+	    await Promise.all(extensionPromises);
 	}
 
 	/**


### PR DESCRIPTION
I don't know if there is any consequences of doing this, but the performance improvements is significant for everyone who have tons of extensions, especially for ppl who running comfyui from a remote server (e.g. Colab)

Before the change:
![chrome_23-08-19 173041](https://github.com/comfyanonymous/ComfyUI/assets/57245077/26afabad-28b5-42f0-b21d-a1f72b2f6bfa)

After the change:
![chrome_23-08-19 172818](https://github.com/comfyanonymous/ComfyUI/assets/57245077/04d0541f-d7fc-42a4-8a7a-a146ef0129a9)
