### PR TITLE
Allow loading js extensions without copying to /web folder

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1673,6 +1673,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "VAEEncodeTiled": "VAE Encode (Tiled)",
 }
 
+EXTENSION_WEB_DIRS = {}
+
 def load_custom_node(module_path, ignore=set()):
     module_name = os.path.basename(module_path)
     if os.path.isfile(module_path):
@@ -1681,11 +1683,20 @@ def load_custom_node(module_path, ignore=set()):
     try:
         if os.path.isfile(module_path):
             module_spec = importlib.util.spec_from_file_location(module_name, module_path)
+            module_dir = os.path.split(module_path)[0]
         else:
             module_spec = importlib.util.spec_from_file_location(module_name, os.path.join(module_path, "__init__.py"))
+            module_dir = module_path
+
         module = importlib.util.module_from_spec(module_spec)
         sys.modules[module_name] = module
         module_spec.loader.exec_module(module)
+
+        if hasattr(module, "WEB_DIRECTORY") and getattr(module, "WEB_DIRECTORY") is not None:
+            web_dir = os.path.abspath(os.path.join(module_dir, getattr(module, "WEB_DIRECTORY")))
+            if os.path.isdir(web_dir):
+                EXTENSION_WEB_DIRS[module_name] = web_dir
+
         if hasattr(module, "NODE_CLASS_MAPPINGS") and getattr(module, "NODE_CLASS_MAPPINGS") is not None:
             for name in module.NODE_CLASS_MAPPINGS:
                 if name not in ignore:

--- a/server.py
+++ b/server.py
@@ -135,7 +135,6 @@ class PromptServer():
                 files = glob.glob(os.path.join(dir, '**/*.js'), recursive=True)
                 extensions.extend(list(map(lambda f: "/extensions/" + urllib.parse.quote(
                     name) + "/" + os.path.relpath(f, dir).replace("\\", "/"), files)))
-                print(extensions)
 
             return web.json_response(extensions)
 


### PR DESCRIPTION
Allows serving web content from the custom_nodes folder, meaning that custom nodes dont have to symlink/copy web files.
Also helps when people remove custom nodes, they often leave web files behind and have weird issues.

The `supports = ["custom_nodes_from_web"]` allows custom node authors to check if the current version of ComfyUI the user is running supports this feature or not, e.g. they couyld implement it something like this:
```py
def should_install_js():
    return not hasattr(PromptServer.instance, "supports") or "custom_nodes_from_web" not in PromptServer.instance.supports
```
If there is a better mechanism for this, open to suggestions.

A simple test for this:
```
NODE_CLASS_MAPPINGS = {
}

WEB_DIRECTORY = "./somejs"

__all__ = ['WEB_DIRECTORY']
```
Then create `somejs/hello.js` in the custom_nodes folder with `alert("hello")`