### PR TITLE
Update nodes.py to fix missing denoise lever on advanced KSampler

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1222,6 +1222,7 @@ class KSamplerAdvanced:
                     "start_at_step": ("INT", {"default": 0, "min": 0, "max": 10000}),
                     "end_at_step": ("INT", {"default": 10000, "min": 0, "max": 10000}),
                     "return_with_leftover_noise": (["disable", "enable"], ),
+                    "denoise": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
                      }
                 }
 


### PR DESCRIPTION
advanced KSampler was missing denoise lever making it impossible in any kind of img2img workflows