### PR TITLE
Safetensors Dependency Emergency Fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch
 torchsde
 einops
 transformers>=4.25.1
-safetensors>=0.3.2
+safetensors==0.3.2
 aiohttp
 accelerate
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch
 torchsde
 einops
 transformers>=4.25.1
-safetensors>=0.3.0
+safetensors>=0.3.2
 aiohttp
 accelerate
 pyyaml


### PR DESCRIPTION
A new version of safetensors (0.3.3) has been released but the wheels are not available and it's breaking the installation completely.

Fixing it to `safetensors==0.3.2` fixes this problem for now.