### PR TITLE
fix: cannot disable dynamicPrompts

### DIFF
--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -299,7 +299,7 @@ export const ComfyWidgets = {
 		const defaultVal = inputData[1].default || "";
 		const multiline = !!inputData[1].multiline;
 
-        let res;
+		let res;
 		if (multiline) {
 			res = addMultilineWidget(node, inputName, { defaultVal, ...inputData[1] }, app);
 		} else {
@@ -307,9 +307,9 @@ export const ComfyWidgets = {
 		}
 
 		if(inputData[1].dynamicPrompts != undefined)
-		    res.widget.dynamicPrompts = inputData[1].dynamicPrompts;
+			res.widget.dynamicPrompts = inputData[1].dynamicPrompts;
 
-        return res;
+		return res;
 	},
 	COMBO(node, inputName, inputData) {
 		const type = inputData[0];

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -299,11 +299,17 @@ export const ComfyWidgets = {
 		const defaultVal = inputData[1].default || "";
 		const multiline = !!inputData[1].multiline;
 
+        let res;
 		if (multiline) {
-			return addMultilineWidget(node, inputName, { defaultVal, ...inputData[1] }, app);
+			res = addMultilineWidget(node, inputName, { defaultVal, ...inputData[1] }, app);
 		} else {
-			return { widget: node.addWidget("text", inputName, defaultVal, () => {}, {}) };
+			res = { widget: node.addWidget("text", inputName, defaultVal, () => {}, {}) };
 		}
+
+		if(inputData[1].dynamicPrompts != undefined)
+		    res.widget.dynamicPrompts = inputData[1].dynamicPrompts;
+
+        return res;
 	},
 	COMBO(node, inputName, inputData) {
 		const type = inputData[0];


### PR DESCRIPTION
**Problem:**
In the situation where the `nodeCreated` of `dynamicPrompts.js` is being called before another extension's `nodeCreated`, it becomes impossible to disable using dynamicPrompts = false.

currently, this disable code is useless
https://github.com/comfyanonymous/ComfyUI/blob/30eb92c3cbe0e0dfa442d452b5f1187c654e572e/web/extensions/core/dynamicPrompts.js#L20

**Solution:**
Assigning the `dynamicPrompts` configured in the widget config of STRING to the text widget's creation ensures that the configuration is set before the `nodeCreated` of `dynamicPrompts` is executed.

```
return {"required": {"text": ("STRING", {"multiline": True, "dynamicPrompts": False})}}
```