### PR TITLE
sort execution order by PRIORITY

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -367,6 +367,11 @@ class PromptExecutor:
             while len(to_execute) > 0:
                 #always execute the output that depends on the least amount of unexecuted nodes first
                 to_execute = sorted(list(map(lambda a: (len(recursive_will_execute(prompt, self.outputs, a[-1])), a[-1]), to_execute)))
+                #except that we execute nodes with higher PRIOIRTY first
+                def priority(prompt, item):
+                    class_ = nodes.NODE_CLASS_MAPPINGS[prompt[item]['class_type']]
+                    return class_.PRIORITY if hasattr(class_, 'PRIORITY') else 0
+                to_execute = sorted( to_execute, key = lambda a : priority(prompt, a[-1]), reverse=True )
                 output_node_id = to_execute.pop(0)[-1]
 
                 # This call shouldn't raise anything if there's an error deep in


### PR DESCRIPTION
Add an optional class attribute `PRIORITY` for custom nodes (meaningful only if `OUTPUT_NODE = True`) to control the order of execution. 

**Motivation**

Developing custom nodes, I would like them to be able to communicate in ways that are complicated, or just messy, to do by connecting them together in the map. For instance, a node might set a parameter that is used by many other nodes without needing to link them all together. But in order to make this work, a developer needs to be able to ensure the 'setting' node executes before the 'getting' nodes. 

Other uses might include fail-fast, quick preview of slow operations, data caching etc..

**How does this solve the problem**

Output nodes to be executed are currently sorted by number of unexecuted nodes upon which they depend (smallest first); this pull request simply adds a subsequent sort by `PRIORITY` (highest first, default of 0).

A node that has to be executed before other nodes (such as a 'setter') is marked as an `OUTPUT_NODE`, and then given the class attribute `PRIORITY = 1` (or higher). 

**Why is this a good solution**

- The code is only changed in a single location
- If `PRIORITY` is not used the execution is unchanged (sort order within the same `PRIORITY` is retained)
