### PR TITLE
Preserve pnginfo

### DIFF
--- a/server.py
+++ b/server.py
@@ -235,8 +235,9 @@ class PromptServer():
                 if os.path.isfile(file):
                     with Image.open(file) as original_pil:
                         metadata = PngInfo()
-                        for key in original_pil.text:
-                            metadata.add_text(key, original_pil.text[key])
+                        if hasattr(original_pil,'text'):
+                            for key in original_pil.text:
+                                metadata.add_text(key, original_pil.text[key])
                         original_pil = original_pil.convert('RGBA')
                         mask_pil = Image.open(image.file).convert('RGBA')
 

--- a/server.py
+++ b/server.py
@@ -12,6 +12,7 @@ import json
 import glob
 import struct
 from PIL import Image, ImageOps
+from PIL.PngImagePlugin import PngInfo
 from io import BytesIO
 
 try:
@@ -233,13 +234,16 @@ class PromptServer():
 
                 if os.path.isfile(file):
                     with Image.open(file) as original_pil:
+                        metadata = PngInfo()
+                        for key in original_pil.text:
+                            metadata.add_text(key, original_pil.text[key])
                         original_pil = original_pil.convert('RGBA')
                         mask_pil = Image.open(image.file).convert('RGBA')
 
                         # alpha copy
                         new_alpha = mask_pil.getchannel('A')
                         original_pil.putalpha(new_alpha)
-                        original_pil.save(filepath, compress_level=4)
+                        original_pil.save(filepath, compress_level=4, pnginfo=metadata)
 
             return image_upload(post, image_save_function)
 


### PR DESCRIPTION
**Motivation**

When the mask editor saves a modified image, the pngInfo metadata is currently lost. This means that nodes which use the additional pnginfo can't access it when the image being loaded has been mask edited. (I'm writing a suite of such custom nodes...)

**Solution**

When saving, create a PngInfo(), copy the contents of the `.text` attribute (if it exists) into it, and then include it in the save.
