### PR TITLE
Remove forced lowercase on embeddings endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -127,7 +127,7 @@ class PromptServer():
         @routes.get("/embeddings")
         def get_embeddings(self):
             embeddings = folder_paths.get_filename_list("embeddings")
-            return web.json_response(list(map(lambda a: os.path.splitext(a)[0].lower(), embeddings)))
+            return web.json_response(list(map(lambda a: os.path.splitext(a)[0], embeddings)))
 
         @routes.get("/extensions")
         async def get_extensions(request):


### PR DESCRIPTION
Most linux file systems use case-sensitive file names by default. MacOS also has them optionally, meaning that this endpoint was basically reporting the wrong names for embeddings that have at least one capital letter. Windows preserves case, but is case-insensitive.

This leads to the completions provided by [ComfyUI-Custom-Scripts](https://github.com/pythongosssss/ComfyUI-Custom-Scripts) to cause an ignored embedding warning upon image generation.

Another option is to load embeddings case-insensitive, but in the case that a user (for some godforsaken reason) has multiple distinct embeddings with the same name but different capitalisation, the choice would be ambiguous.