### PR TITLE
Make conditioning broadcasting more robust

### DIFF
--- a/comfy/sample.py
+++ b/comfy/sample.py
@@ -38,8 +38,10 @@ def broadcast_cond(cond, batch, device):
     copy = []
     for p in cond:
         t = p[0]
-        if t.shape[0] < batch:
-            t = torch.cat([t] * batch)
+        if t.shape[0] != batch:
+            t_list = [t for _ in range(batch // t.shape[0])]
+            t_list.append(t[:batch % t.shape[0]])
+            t = torch.cat(t_list)
         t = t.to(device)
         copy += [[t] + p[1:]]
     return copy


### PR DESCRIPTION
Currently, this function assumes that the conditioning `t` must have a shape of `torch.Size([1, ..., ...])` and doesn't work correctly if the first dimension is anything but 1. This commit makes it more robust, and allows the first dimension to be any non-zero value. E.g. This allows a `t` with shape `torch.Size([5, ..., ...])` for batch inputs.