### PR TITLE
add get model list to api

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -29,6 +29,7 @@ folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_m
 folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], [])
 
 folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
+folder_names_and_paths["facerestore_models"] = ([os.path.join(models_dir, "facerestore_models")], supported_pt_extensions)
 
 output_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
 temp_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "temp")

--- a/server.py
+++ b/server.py
@@ -124,6 +124,15 @@ class PromptServer():
         async def get_root(request):
             return web.FileResponse(os.path.join(self.web_root, "index.html"))
 
+        @routes.get("/models")
+        def get_models_lists(request):
+            which_models = request.rel_url.query.get("model", "")
+            try:
+                models_dir = folder_paths.get_filename_list(which_models.lower())
+                return web.json_response(list(models_dir))
+            except:
+                return web.json_response(list([""]))
+
         @routes.get("/embeddings")
         def get_embeddings(self):
             embeddings = folder_paths.get_filename_list("embeddings")


### PR DESCRIPTION
i would like to get list of models for further use on client. in my case i would like to modify workflow_api.json
```  useEffect(() => {
    fetch('http://127.0.0.1:8188/models?model=' + props.modelName)
      .then((res) => {
        if (res.status == 200) return res.json();
      })
      .then((resJson) => {
        setModels(resJson);
      });
  }, []);
```