### PR TITLE
Fix return type of CheckpointLoaderSimple

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -441,7 +441,7 @@ class CheckpointLoaderSimple:
     def INPUT_TYPES(s):
         return {"required": { "ckpt_name": (folder_paths.get_filename_list("checkpoints"), ),
                              }}
-    RETURN_TYPES = ("MODEL", "CLIP", "VAE")
+    RETURN_TYPES = ("MODEL", "CLIP", "VAE", "CLIP_VISION")
     FUNCTION = "load_checkpoint"
 
     CATEGORY = "loaders"


### PR DESCRIPTION
The `RETURN_TYPES` property of `CheckpointLoaderSample` does not match with the variables returned by the corresponding function.