### PR TITLE
onExecutionStart

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -994,6 +994,10 @@ export class ComfyApp {
 		api.addEventListener("execution_start", ({ detail }) => {
 			this.runningNodeId = null;
 			this.lastExecutionError = null
+			this.graph._nodes.forEach((node) => {
+				if (node.onExecutionStart)
+					node.onExecutionStart()
+			})
 		});
 
 		api.addEventListener("execution_error", ({ detail }) => {


### PR DESCRIPTION
On execution start, call onExecutionStart on all nodes which have it.

Allows a custom node to initialize itself - for instance, to clear any UI output from the previous run.