### PR TITLE
fix: onprompt handler synchronization

### DIFF
--- a/server.py
+++ b/server.py
@@ -447,7 +447,7 @@ class PromptServer():
             resp_code = 200
             out_string = ""
             json_data =  await request.json()
-            json_data = self.trigger_on_prompt(json_data)
+            json_data =  await self.trigger_on_prompt(json_data)
 
             if "number" in json_data:
                 number = float(json_data['number'])


### PR DESCRIPTION
problem:
If `await` is absent, the `coroutine` returns instead of JSON object