### PR TITLE
Fix fp16 autocast RuntimeError on Macs.

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -466,7 +466,8 @@ def vae_dtype():
 
 def get_autocast_device(dev):
     if hasattr(dev, 'type'):
-        return dev.type
+        return dev.type if not (dev.type == "mps" and should_use_fp16(
+            dev, prioritize_performance=False)) else "cpu"
     return "cuda"
 
 


### PR DESCRIPTION
Fixes an error that occurs on a Mac M1 when launched with `--force-fp16` and `--gpu-only`.  
`mps` is an unsupported autocast device type for float16.

\
Relevant issue: `https://github.com/pytorch/pytorch/issues/88415`

This change works on the latest pytorch version since the following issues were resolved:
- MPS: torch.manual_seed not working on metal (mps) for torch.randn `https://github.com/pytorch/pytorch/issues/84288`
- RuntimeError when using autocast with CPU device and float32 dtype, works correctly on CUDA device `https://github.com/pytorch/pytorch/issues/100565`