### PR TITLE
Send node description (if any) to the UI

### DIFF
--- a/server.py
+++ b/server.py
@@ -398,7 +398,7 @@ class PromptServer():
             info['output_name'] = obj_class.RETURN_NAMES if hasattr(obj_class, 'RETURN_NAMES') else info['output']
             info['name'] = node_class
             info['display_name'] = nodes.NODE_DISPLAY_NAME_MAPPINGS[node_class] if node_class in nodes.NODE_DISPLAY_NAME_MAPPINGS.keys() else node_class
-            info['description'] = obj_class.DESCRIPTION if hasattr(node_class,'DESCRIPTION') else ''
+            info['description'] = obj_class.DESCRIPTION if hasattr(obj_class,'DESCRIPTION') else ''
             info['category'] = 'sd'
             if hasattr(obj_class, 'OUTPUT_NODE') and obj_class.OUTPUT_NODE == True:
                 info['output_node'] = True

--- a/server.py
+++ b/server.py
@@ -398,7 +398,7 @@ class PromptServer():
             info['output_name'] = obj_class.RETURN_NAMES if hasattr(obj_class, 'RETURN_NAMES') else info['output']
             info['name'] = node_class
             info['display_name'] = nodes.NODE_DISPLAY_NAME_MAPPINGS[node_class] if node_class in nodes.NODE_DISPLAY_NAME_MAPPINGS.keys() else node_class
-            info['description'] = ''
+            info['description'] = obj_class.DESCRIPTION if hasattr(node_class,'DESCRIPTION') else ''
             info['category'] = 'sd'
             if hasattr(obj_class, 'OUTPUT_NODE') and obj_class.OUTPUT_NODE == True:
                 info['output_node'] = True


### PR DESCRIPTION
The front end has a field 'description' for nodes which is currently always set to ''.

This one line change sets that field to the custom node DESCRIPTION attribute, if it is set, else leaves it as ''.

This can be used to allow more robust selection of special front-end behaviour

For instance, `DESCRIPTION="displays_text"` might indicate that a node should expect to receive some text to display (there's a PR coming with that functionality if this one is merged!)