### PR TITLE
Fix crash on node with VALIDATE_INPUTS and actual inputs

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -21,7 +21,8 @@ def get_input_data(inputs, class_def, unique_id, outputs={}, prompt={}, extra_da
             input_unique_id = input_data[0]
             output_index = input_data[1]
             if input_unique_id not in outputs:
-                return None
+                input_data_all[x] = (None,)
+                continue
             obj = outputs[input_unique_id][output_index]
             input_data_all[x] = obj
         else:


### PR DESCRIPTION
![image](https://github.com/comfyanonymous/ComfyUI/assets/125205205/e4c5e732-a737-4892-8cae-de28535de636)
If a node has inputs from other nodes, you cannot currently implement `VALIDATE_INPUTS` as this causes the execution to crash. Instead of breaking out and returning inputs as `None`, just set that specific input to be `None` so validation can still be done on widget inputs

Test node:
```py
class Example:
    @classmethod
    def INPUT_TYPES(s):
        return {"required": {
            "latent": ("LATENT", {}),
            "text": ("STRING", {"default": "hello"}),
        }}

    @classmethod
    def VALIDATE_INPUTS(s, latent, text):
        print("VALIDATE_INPUTS:" + text + " | " + str(latent is None))
        return True
    
    @classmethod
    def IS_CHANGED(s, latent, text):
        print("IS_CHANGED:" + text + " | " + str(latent is None))
        return text

    RETURN_TYPES = ("STRING",)
    FUNCTION = "test"
    CATEGORY = "utils"
    OUTPUT_NODE = True

    def test(self, latent, text):
        print("EXECUTE:" + text + " | " + str(latent is None))
        return ("hello")


NODE_CLASS_MAPPINGS = {
    "Example": Example
}

```