### PR TITLE
JavaScript extension versions

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -142,7 +142,7 @@ app.registerExtension({
 			const r = origOnNodeCreated ? origOnNodeCreated.apply(this) : undefined;
 			if (this.widgets) {
 				for (const w of this.widgets) {
-					if (w?.options?.forceInput) {
+					if (w?.options?.forceInput || w?.options?.defaultInput) {
 						const config = nodeData?.input?.required[w.name] || nodeData?.input?.optional?.[w.name] || [w.type, w.options || {}];
 						convertToInput(this, w, config);
 					}

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -142,7 +142,7 @@ app.registerExtension({
 			const r = origOnNodeCreated ? origOnNodeCreated.apply(this) : undefined;
 			if (this.widgets) {
 				for (const w of this.widgets) {
-					if (w?.options?.forceInput || w?.options?.defaultInput) {
+					if (w?.options?.forceInput) {
 						const config = nodeData?.input?.required[w.name] || nodeData?.input?.optional?.[w.name] || [w.type, w.options || {}];
 						convertToInput(this, w, config);
 					}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1248,6 +1248,10 @@ export class ComfyApp {
 							if (!config.widget.options) config.widget.options = {};
 							config.widget.options.forceInput = inputData[1].forceInput;
 						}
+						if(widgetCreated && inputData[1]?.defaultInput && config?.widget) {
+							if (!config.widget.options) config.widget.options = {};
+							config.widget.options.defaultInput = inputData[1].defaultInput;
+						}
 					}
 
 					for (const o in nodeData["output"]) {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1634,8 +1634,20 @@ export class ComfyApp {
 		if (!extension.name) {
 			throw new Error("Extensions must have a 'name' property.");
 		}
-		if (this.extensions.find((ext) => ext.name === extension.name)) {
-			throw new Error(`Extension named '${extension.name}' already registered.`);
+		const index = app.extensions.findIndex((ext) => extension.name === ext.name);
+		if (index >= 0) {
+			if (extension.version) {
+				const installed_version = app.extensions[index].version;
+				if (installed_version && (installed_version >= extension.version)) {
+					console.log(`${extension.name} version ${installed_version} already installed`)
+					return;
+				} else {
+					console.log(`${extension.name} being replaced with version ${extension.version}`)
+					app.extensions.splice(index,1); 
+				}	
+			} else {
+				throw new Error(`Extension named '${extension.name}' already registered.`);
+			}
 		}
 		this.extensions.push(extension);
 	}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1637,12 +1637,13 @@ export class ComfyApp {
 		const index = app.extensions.findIndex((ext) => extension.name === ext.name);
 		if (index >= 0) {
 			if (extension.version) {
-				const installed_version = app.extensions[index].version;
-				if (installed_version && (installed_version >= extension.version)) {
-					console.log(`${extension.name} version ${installed_version} already installed`)
+				var installed_version = 0;
+				if (app.extensions[index].version) { installed_version = app.extensions[index].version; }
+				if (installed_version >= extension.version) {
+					console.log(`${extension.name} version ${installed_version} already installed, won't replace with version ${extension.version}`)
 					return;
 				} else {
-					console.log(`${extension.name} being replaced with version ${extension.version}`)
+					console.log(`${extension.name} version ${installed_version} being replaced with version ${extension.version}`)
 					app.extensions.splice(index,1); 
 				}	
 			} else {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1248,10 +1248,6 @@ export class ComfyApp {
 							if (!config.widget.options) config.widget.options = {};
 							config.widget.options.forceInput = inputData[1].forceInput;
 						}
-						if(widgetCreated && inputData[1]?.defaultInput && config?.widget) {
-							if (!config.widget.options) config.widget.options = {};
-							config.widget.options.defaultInput = inputData[1].defaultInput;
-						}
 					}
 
 					for (const o in nodeData["output"]) {


### PR DESCRIPTION
Use a version attribute to deal with JavaScript extensions with the same name.

Custom node developers may have utility scripts they use across multiple custom nodes which can be independently deployed. When two custom nodes use the same script, the current result is ```throw new Error(`Extension named '${extension.name}' already registered.`);```. This is (sort of) ok until the developer updates the script: then a user might have an old version with one custom node and a new version with another, and the new one may be rejected.

The PR allows a version to be added to an extension; if a clash of extension names is detected, the higher version is kept and the lower version rejected (or removed). If there is no version number, the current behaviour is unchanged.

Version (a float) is declared in the call to `app.registerExtension`:
```javascript
app.registerExtension({
	name: "my.node.extension",
	version: 2,
```

Obviously the developer has the responsibility to ensure higher versions are backward compatible!