### PR TITLE
defaultInput

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -142,7 +142,7 @@ app.registerExtension({
 			const r = origOnNodeCreated ? origOnNodeCreated.apply(this) : undefined;
 			if (this.widgets) {
 				for (const w of this.widgets) {
-					if (w?.options?.forceInput) {
+					if (w?.options?.forceInput || w?.options?.defaultInput) {
 						const config = nodeData?.input?.required[w.name] || nodeData?.input?.optional?.[w.name] || [w.type, w.options || {}];
 						convertToInput(this, w, config);
 					}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1248,6 +1248,10 @@ export class ComfyApp {
 							if (!config.widget.options) config.widget.options = {};
 							config.widget.options.forceInput = inputData[1].forceInput;
 						}
+						if(widgetCreated && inputData[1]?.defaultInput && config?.widget) {
+							if (!config.widget.options) config.widget.options = {};
+							config.widget.options.defaultInput = inputData[1].defaultInput;
+						}
 					}
 
 					for (const o in nodeData["output"]) {


### PR DESCRIPTION
Create a `defaultInput` option (like `forceInput`) which does what it sounds like - the widget gets converted to an input by default, but can be changed back to a widget if desired. Usage is simply:

```python
REQUIRED = {"string_normally_input": ("STRING", {"default":"", "defaultInput": True})}
```

No change to behaviour if the option isn't used.