### PR TITLE
generate predictable noise in batches

### DIFF
--- a/comfy/sample.py
+++ b/comfy/sample.py
@@ -10,12 +10,15 @@ def prepare_noise(latent_image, seed, noise_inds=None):
     creates random noise given a latent image and a seed.
     optional arg skip can be used to skip and discard x number of noise generations for a given seed
     """
-    generator = torch.manual_seed(seed)
-    if noise_inds is None:
-        return torch.randn(latent_image.size(), dtype=latent_image.dtype, layout=latent_image.layout, generator=generator, device="cpu")
-    
-    unique_inds, inverse = np.unique(noise_inds, return_inverse=True)
     noises = []
+    if noise_inds is None:
+        for i in range(latent_image.size()[0]):
+            generator = torch.manual_seed(seed + i)
+            noises.append(torch.randn(latent_image[i].size(), dtype=latent_image.dtype, layout=latent_image.layout, generator=generator, device="cpu"))
+        return torch.stack(noises, axis=0)
+    
+    generator = torch.manual_seed(seed)
+    unique_inds, inverse = np.unique(noise_inds, return_inverse=True)
     for i in range(unique_inds[-1]+1):
         noise = torch.randn([1] + list(latent_image.size())[1:], dtype=latent_image.dtype, layout=latent_image.layout, generator=generator, device="cpu")
         if i in unique_inds:


### PR DESCRIPTION
In other UIs, such as Auto WebUI, when you generate with `seed=1` and `batch size=2`, it will generate as a batch 2 images, wherein the first image is equal to `seed=1`, and the second image is `seed=2`.

In ComfyUI if you generate with `seed=1`, and `batch_size=2`, it will generate a batch of 2 images, wherein the first image is equal to `seed=1`, and the second image is unique, and has no single seed that can recreate it - the only way to get it again is to generate `seed=1,batch_size=2` again.

---

Why does this matter? Consider a real world usage pattern:
- Start with a good enough prompt/settings, then generate many images with random seeds.
- Look through the results to find the seed you like best.
- Select that seed, copy it, and tweak settings to refine the image to perfect it.

To perform this pattern in ComfyUI, you are currently obligated to (A) keep `batch_size` as `1` to ensure you always have a replicable seed, and (B) never use the seed randomize option, as it generates *then* changes the seed, such that you lose track of the seed you just used unless you go find the output image and drag it back into the UI to get the seed back, which is annoying.
(B) is something that should absolutely be changed, but that's external to the current PR. This PR solves (A).

----

I'm a little worried about this PR as frankly there's a lot of code here doing... odd things (it looks like the `unique_inds` thing might be intended as an awkward hack to de-unobtanium the extra seeds? That's an awful way if so. Significant manual labor rewiring nodes to try to get it back vs. just increment the seed number and call it done).

Arguably there might be reason to have a setting to reinstate the old behavior for those who prefer? Idk why you would though. Or to replicate old batch results exactly I guess?

----

The actual origin case for this PR is in StableSwarmUI (ref https://github.com/Stability-AI/StableSwarmUI/issues/84 ) I added controls over batch size, and want image metadata to show an accurate seed such that it can be replicated and reused even with batching turned off.

Other options available to me would be
(A) offer a 'batch index' in metadata and add an option to match batch index using what I assume the unique_inds thing does. Not sure if that's even correct.
(B) somehow specify multiple seeds manually from swarm? I don't think there's a way to do that. (It would be very useful to have a way to supply noise from a separate node btw - consider eg implementing something like var seed, or custom noise suppliers of other forms).
Neither of these seem great. Not sure if either is even possible. Both would be very specialized solutions very unique to StableSwarmUI and its workflow generator, leaving any other users out-of-luck.
So I think having implicitly incremental seeds is the best solution.