### PR TITLE
round float widgets (by default to 0.001)

### DIFF
--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -2,15 +2,19 @@ import { api } from "./api.js"
 
 function getNumberDefaults(inputData, defaultStep) {
 	let defaultVal = inputData[1]["default"];
-	let { min, max, step, round } = inputData[1];
+	let { min, max, step, round, precision } = inputData[1];
 
 	if (defaultVal == undefined) defaultVal = 0;
 	if (min == undefined) min = 0;
 	if (max == undefined) max = 2048;
 	if (step == undefined) step = defaultStep;
-	if (round == undefined) round = 0.001;
+// precision is the number of decimal places to show. 
+// by default, display the the smallest number of decimal places such that changes of size step are visible.
+	if (precision == undefined) precision = Math.max(-Math.floor(Math.log10(step)),0)
+// by default, round the value to those decimal places shown.
+	if (round == undefined) round = Math.round(1000000*Math.pow(0.1,precision))/1000000;
 
-	return { val: defaultVal, config: { min, max, step: 10.0 * step, round } };
+	return { val: defaultVal, config: { min, max, step: 10.0 * step, round, precision } };
 }
 
 export function addValueControlWidget(node, targetWidget, defaultValue = "randomize", values) {

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -2,14 +2,15 @@ import { api } from "./api.js"
 
 function getNumberDefaults(inputData, defaultStep) {
 	let defaultVal = inputData[1]["default"];
-	let { min, max, step } = inputData[1];
+	let { min, max, step, round } = inputData[1];
 
 	if (defaultVal == undefined) defaultVal = 0;
 	if (min == undefined) min = 0;
 	if (max == undefined) max = 2048;
 	if (step == undefined) step = defaultStep;
+	if (round == undefined) round = 0.001;
 
-	return { val: defaultVal, config: { min, max, step: 10.0 * step } };
+	return { val: defaultVal, config: { min, max, step: 10.0 * step, round } };
 }
 
 export function addValueControlWidget(node, targetWidget, defaultValue = "randomize", values) {
@@ -264,7 +265,10 @@ export const ComfyWidgets = {
 	FLOAT(node, inputName, inputData, app) {
 		let widgetType = isSlider(inputData[1]["display"], app);
 		const { val, config } = getNumberDefaults(inputData, 0.5);
-		return { widget: node.addWidget(widgetType, inputName, val, () => {}, config) };
+		return { widget: node.addWidget(widgetType, inputName, val, 
+			function (v) {
+				this.value = Math.round(v/config.round)*config.round;
+			}, config) };
 	},
 	INT(node, inputName, inputData, app) {
 		let widgetType = isSlider(inputData[1]["display"], app);


### PR DESCRIPTION
Float widgets have rounding errors (see https://github.com/comfyanonymous/ComfyUI/issues/889). This PR rounds the widgets to a configurable precision which defaults to 0.001 (the precision displayed - so that the value is identical to what it appears to be).