### PR TITLE
fix(server): Disable access logs

### DIFF
--- a/server.py
+++ b/server.py
@@ -603,7 +603,7 @@ class PromptServer():
             await self.send(*msg)
 
     async def start(self, address, port, verbose=True, call_on_start=None):
-        runner = web.AppRunner(self.app)
+        runner = web.AppRunner(self.app, access_log=None)
         await runner.setup()
         site = web.TCPSite(runner, address, port)
         await site.start()


### PR DESCRIPTION
Disables aiohttp access logs.

At least until there's a proper log level system, these seem quite verbose to be enabled with the logging level comfy ships with(Verbose)

Fixes #1346