### PR TITLE
Dockerfile and automatic generation of images via GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.*
+!.git
+__pycache__/
+*.py[cod]
+input
+models
+notebooks
+output

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,101 @@
+name: Build and publish Docker images
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: cu118
+            name: CUDA 11.8
+            pytorch_install_args: "--index-url https://download.pytorch.org/whl/cu118"
+          - id: cu121
+            name: CUDA 12.1
+            pytorch_install_args: "--index-url https://download.pytorch.org/whl/cu121"
+          - id: cu124
+            name: CUDA 12.4
+            pytorch_install_args: "--index-url https://download.pytorch.org/whl/cu124"
+          - id: rocm6.2
+            name: ROCm 6.2
+            pytorch_install_args: "--index-url https://download.pytorch.org/whl/rocm6.2"
+          - id: cpu
+            name: CPU only
+            pytorch_install_args: "--index-url https://download.pytorch.org/whl/cpu"
+            extra_args: --cpu
+
+
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check which repositories to use
+        id: repositories
+        run: |
+          echo "GHCR_IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY_OWNER}/comfyui" >> "$GITHUB_ENV"
+          if [[ -n "${DOCKERHUB_USERNAME}" ]]; then
+            echo "DOCKERHUB_IMAGE_NAME=${DOCKERHUB_USERNAME}/comfyui" >> "$GITHUB_ENV"
+          else
+            echo "DOCKERHUB_IMAGE_NAME=" >> "$GITHUB_ENV"
+            echo "No Docker Hub username set, only deploying to GitHub Container Repository"
+          fi
+        env:
+            DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+            GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ env.DOCKERHUB_IMAGE_NAME }}
+            ${{ env.GHCR_IMAGE_NAME }}
+          flavor: |
+            suffix=-${{ matrix.id }},onlatest=true
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            # set latest tag for default branch
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_IMAGE_NAME != ''
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PYTORCH_INSTALL_ARGS=${{ matrix.pytorch_install_args }}
+            EXTRA_ARGS=${{ matrix.extra_args }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.id }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.id }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1
+
+ARG PYTHON_VERSION=3.12
+
+FROM python:${PYTHON_VERSION}-slim
+
+ARG PYTORCH_INSTALL_ARGS=""
+ARG EXTRA_ARGS=""
+ARG USERNAME=comfyui
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# Fail fast on errors or unset variables
+SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
+
+RUN <<EOF
+	groupadd --gid ${USER_GID} ${USERNAME}
+	useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
+EOF
+
+RUN <<EOF
+	apt-get update
+	apt-get install -y --no-install-recommends \
+		git \
+		git-lfs \
+		rsync \
+		fonts-recommended
+EOF
+
+# run instructions as user
+USER ${USER_UID}:${USER_GID}
+
+WORKDIR /app
+
+ENV XDG_CACHE_HOME=/cache
+ENV PIP_CACHE_DIR=/cache/pip
+ENV VIRTUAL_ENV=/app/venv
+ENV VIRTUAL_ENV_CUSTOM=/app/custom_venv
+
+# create cache directory. During build we will use a cache mount,
+# but later this is useful for custom node installs
+RUN --mount=type=cache,target=/cache/,uid=${USER_UID},gid=${USER_GID} \
+	mkdir -p ${PIP_CACHE_DIR}
+
+# create virtual environment to manage packages
+RUN python -m venv ${VIRTUAL_ENV}
+
+# run python from venv (prefer custom_venv over baked-in one)
+ENV PATH="${VIRTUAL_ENV_CUSTOM}/bin:${VIRTUAL_ENV}/bin:${PATH}"
+
+RUN --mount=type=cache,target=/cache/,uid=${USER_UID},gid=${USER_GID} \
+	pip install torch torchvision torchaudio ${PYTORCH_INSTALL_ARGS}
+
+# copy requirements files first so packages can be cached separately
+COPY --chown=${USER_UID}:${USER_GID} requirements.txt .
+RUN --mount=type=cache,target=/cache/,uid=${USER_UID},gid=${USER_GID} \
+	pip install -r requirements.txt
+
+# Not strictly required for comfyui, but prevents non-working variants of
+# cv2 being pulled in by custom nodes
+RUN --mount=type=cache,target=/cache/,uid=${USER_UID},gid=${USER_GID} \
+	pip install opencv-python-headless
+
+COPY --chown=${USER_UID}:${USER_GID} . .
+
+COPY --chown=nobody:${USER_GID} .git .git
+
+# default environment variables
+ENV COMFYUI_ADDRESS=0.0.0.0
+ENV COMFYUI_PORT=8188
+ENV COMFYUI_EXTRA_ARGS=""
+# default start command
+CMD \
+	if [ -d "${VIRTUAL_ENV_CUSTOM}" ]; then \
+		rsync -aP "${VIRTUAL_ENV}/" "${VIRTUAL_ENV_CUSTOM}/" ;\
+		sed -i "s!${VIRTUAL_ENV}!${VIRTUAL_ENV_CUSTOM}!g" "${VIRTUAL_ENV_CUSTOM}/pyvenv.cfg" ;\
+	fi ;\
+	python -u main.py --listen "${COMFYUI_ADDRESS}" --port "${COMFYUI_PORT}" ${EXTRA_ARGS} ${COMFYUI_EXTRA_ARGS}

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ COPY --chown=nobody:${USER_GID} .git .git
 # default environment variables
 ENV COMFYUI_ADDRESS=0.0.0.0
 ENV COMFYUI_PORT=8188
+ENV COMFYUI_EXTRA_BUILD_ARGS="${EXTRA_ARGS}"
 ENV COMFYUI_EXTRA_ARGS=""
 # default start command
 CMD \
@@ -75,4 +76,4 @@ CMD \
 		rsync -aP "${VIRTUAL_ENV}/" "${VIRTUAL_ENV_CUSTOM}/" ;\
 		sed -i "s!${VIRTUAL_ENV}!${VIRTUAL_ENV_CUSTOM}!g" "${VIRTUAL_ENV_CUSTOM}/pyvenv.cfg" ;\
 	fi ;\
-	python -u main.py --listen "${COMFYUI_ADDRESS}" --port "${COMFYUI_PORT}" ${EXTRA_ARGS} ${COMFYUI_EXTRA_ARGS}
+	python -u main.py --listen "${COMFYUI_ADDRESS}" --port "${COMFYUI_PORT}" ${COMFYUI_EXTRA_BUILD_ARGS} ${COMFYUI_EXTRA_ARGS}

--- a/README.md
+++ b/README.md
@@ -235,6 +235,29 @@ Install the dependencies by opening your terminal inside the ComfyUI folder and:
 
 After this you should have everything installed and can proceed to running ComfyUI.
 
+
+## Docker
+
+You can build a docker image with the `Dockerfile` in this repo.
+Specify, `PYTORCH_INSTALL_ARGS` build arg with one of the PyTorch commands above to build for AMD or NVIDIA GPUs.
+```shell
+docker build --build-arg PYTORCH_INSTALL_ARGS="--index-url https://download.pytorch.org/whl/cu122" .
+```
+```shell
+docker build --build-arg PYTORCH_INSTALL_ARGS="--index-url https://download.pytorch.org/whl/rocm6.2" .
+```
+The `Dockerfile` requires BuildKit to be enabled. If your Docker does not support the buildx command, you can
+enable BuildKit by setting the `DOCKER_BUILDKIT` environment variable.
+```shell
+DOCKER_BUILDKIT=1 docker build --build-arg PYTORCH_INSTALL_ARGS="--index-url https://download.pytorch.org/whl/cu124" .
+```
+> [!NOTE]
+> For building the CPU-only image, it is recommended that you add the --cpu flag to the EXTRA_ARGS build arg:
+>
+> ```shell
+> docker build --build-arg PYTORCH_INSTALL_ARGS="--index-url https://download.pytorch.org/whl/cpu" --build-arg EXTRA_ARGS=--cpu .
+> ```
+
 ### Others:
 
 #### Apple Mac silicon

--- a/README.md
+++ b/README.md
@@ -238,6 +238,22 @@ After this you should have everything installed and can proceed to running Comfy
 
 ## Docker
 
+There are prebuilt docker images for AMD and NVIDIA GPUs on [GitHub Packages](https://ghcr.io/comfyanonymous/comfyui).
+
+You can pull them to your local docker registry with:
+
+```shell
+# For NVIDIA GPUs
+docker pull ghcr.io/comfyanonymous/comfyui:latest-cu124
+# For AMD GPUs
+docker pull ghcr.io/comfyanonymous/comfyui:latest-rocm6.2
+
+# For CPU only
+docker pull ghcr.io/comfyanonymous/comfyui:latest-cpu
+```
+
+### Building images manually
+
 You can build a docker image with the `Dockerfile` in this repo.
 Specify, `PYTORCH_INSTALL_ARGS` build arg with one of the PyTorch commands above to build for AMD or NVIDIA GPUs.
 ```shell

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,21 @@
+services:
+  comfyui:
+    user: "1000:1000"
+    build: .
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    ports:
+      - "8188:8188"
+    volumes:
+      - "./models:/app/models"
+      - "./input:/app/input"
+      - "./temp:/app/output/temp"
+      - "./output:/app/output"
+      - "./user:/app/user"
+      - "./custom_venv:/app/custom_venv"
+      - "./custom_nodes:/app/custom_nodes"


### PR DESCRIPTION
TL;DR

Building on the [great work of ZacharyACoon](https://github.com/comfyanonymous/ComfyUI/pull/530), I'm providing a Dockerfile that is a bit less complex and more aligned with common best practices, and makes builds more cachable.
Additionally, this PR contains a GitHub Actions workflow that builds the image in five different PyTorch flavours (cu118, cu121, rocm5.6, rocm5.7-nightly, cpu), and pushes them to GitHub Container Repository (works out of the box) and optionally to Docker Hub (requires a username + token configured in action secrets).

You can see the action in action (no pun intended) in my fork: https://github.com/oxc/ComfyUI/actions/workflows/docker.yml

---

### Dockerfile
The first commit adds the Dockerfile. Since you mentioned that you are not too familiar with those, and are unsure about maintaining it, I will go through the commands in the file and give some additional explanations. Hopefully that makes the decision easier.

The Dockerfile is used by docker to _build_ the docker image. It basically is the recipe used to cook a final image. The image itself can then be uploaded to a remote registry, and from there everybody can pull it to their local registry to simply run it in a container.

The docker-compose.yml file can make it easier to _run_ the docker image using docker compose, but is not strictly a requirement.


<details>
<summary>Expand here to see the commented Dockerfile</summary>

```Dockerfile
# syntax=docker/dockerfile:1.4
```
Specifying this [syntax directive](https://docs.docker.com/engine/reference/builder/#syntax) allows us to use certain features like RUN --mount=type=cache.

```Dockerfile
ARG BASE_IMAGE="python:3.11-slim-bookworm"
```
[ARG](https://docs.docker.com/engine/reference/builder/#arg) at the top of the file defines build-args that can be set when building the docker image and used in FROM statements.

```Dockerfile
FROM ${BASE_IMAGE}
```
[FROM](https://docs.docker.com/engine/reference/builder/#from) specifies the base image that we are building our image on. This Dockerfile uses a [python image](https://hub.docker.com/_/python) based on Debian by default, selecting a python version that is supported by PyTorch. 
I personally have not seen making the base image configurable as a build-arg, but it does not really hurt, so I decided to keep it. It might be useful for people who are building their own images, and just want to use a different base image that provides a few more installed tools, for example.

```Dockerfile
ARG PYTORCH_INSTALL_ARGS=""
ARG EXTRA_ARGS=""
ARG USERNAME="comfyui"
ARG USER_UID=1000
ARG USER_GID=${USER_UID}
```
[ARG](https://docs.docker.com/engine/reference/builder/#using-arg-variables) after a FROM define that this build stage uses the mentioned args. These args also include default values, which can be overridden on the command line.

```Dockerfile
RUN \
	--mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
	--mount=target=/var/cache/apt,type=cache,sharing=locked \
	set -eux; \
		apt-get update; \
		apt-get install -y --no-install-recommends \
			git \
			git-lfs

RUN set -eux; \
	groupadd --gid ${USER_GID} ${USERNAME}; \
	useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
```
[RUN](https://docs.docker.com/engine/reference/builder/#run) executes the given shell command. These commands install git in the container, and create the user/group which will be running comfyui.

```Dockerfile
# run instructions as user
USER ${USER_UID}:${USER_GID}
```
[USER](https://docs.docker.com/engine/reference/builder/#user) defines the user/group as which to run the given commands.

```Dockerfile
WORKDIR /app
```
[WORKDIR](https://docs.docker.com/engine/reference/builder/#workdir) defines that all following commands will run in the context of the given directory in the container. You can think of it a bit like `cd`.

```Dockerfile
ENV PIP_CACHE_DIR="/cache/pip"
ENV VIRTUAL_ENV=/app/venv
ENV TRANSFORMERS_CACHE="/app/.cache/transformers"
```
[ENV](https://docs.docker.com/engine/reference/builder/#env) defines environment variables that we will be using later in the file.

```Dockerfile
# create cache directory
RUN mkdir -p ${TRANSFORMERS_CACHE}

# create virtual environment to manage packages
RUN python -m venv ${VIRTUAL_ENV}
```
Create the transformers cache directory that we will be setting later as env.
Run python to create a virtual environment with the venv module.

```Dockerfile
# run python from venv
ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
```
Set the PATH so that pip and python will be run in the context of our venv.

```Dockerfile
COPY --chown=${USER_UID}:${USER_GID} requirements-${GPU_MAKE}.txt .
RUN --mount=type=cache,target=/cache/,uid=${USER_UID},gid=${USER_GID} \
	pip install torch torchvision torchaudio ${PYTORCH_INSTALL_ARGS}
```
Now install the PyTorch dependencies, passing the PYTORCH_INSTALL_ARGS so that users can select which PyTorch index/platform they want to use. This will be passed by the GitHub Action.

```Dockerfile
# copy requirements files first so packages can be cached separately
COPY --chown=${USER_UID}:${USER_GID} requirements.txt .
RUN --mount=type=cache,target=/cache/,uid=${USER_UID},gid=${USER_GID} \
	pip install -r requirements.txt
```
Now we [COPY](https://docs.docker.com/engine/reference/builder/#copy) the requirements.txt to the container, and run pip install on it.
We are using [RUN --mount=type=cache](https://docs.docker.com/engine/reference/builder/#run---mounttypecache) to mount a cache directory for our pip cache that is managed by the docker runtime and shared between builds.

Why are we only copying the requirements file? Here you need to know that docker tries to cache all commands when building an image, but as soon as one command fails to use the cached version, all further commands have to be re-run also. For this reason, it helps to do the more stable stuff earlier in the image, and the more frequently changing things later.
Since copying the program code of ComfyUI will change with every commit, copying it here would invalidate all caches for requirements etc. We need the requirements file however, so we copy only that. As long as it does not change, the result pip install can be cached. One can always run the build command with --no-cache to force a re-run.

You can read more about the cache here: https://docs.docker.com/build/cache/

```Dockerfile
COPY --chown=${USER_UID}:${USER_GID} . .
```
Now, as a last step, we copy the whole program code into the container image.

```Dockerfile
# default environment variables
ENV COMFYUI_ADDRESS=0.0.0.0
ENV COMFYUI_PORT=8188
ENV COMFYUI_EXTRA_BUILD_ARGS="${EXTRA_ARGS}"
ENV COMFYUI_EXTRA_ARGS=""
# default start command
CMD python -u main.py --listen ${COMFYUI_ADDRESS} --port ${COMFYUI_PORT} ${COMFYUI_EXTRA_BUILD_ARGS} ${COMFYUI_EXTRA_ARGS}
```
Finally, we define some more environment variables that can be overridden, and define the [CMD](https://docs.docker.com/engine/reference/builder/#cmd) that will be run when the container is launched.
</details>

### GitHub Action
The GitHub action spawns several jobs in a matrix, one for each supported PyTorch flavor (cu118, cu121, rocm5.6, rocm5.7-nightly, cpu).

For each flavor, it builds the container image, and pushes it to the GitHub Container Registry. This works out of the box with the information provided by GitHub Actions.
If a `DOCKERHUB_USERNAME` and a `DOCKERHUB_TOKEN` secret are configured on the GitHub repository, the action will also login and push to the [Docker Hub](https://hub.docker.com/). Here is the image the action on my fork created: https://hub.docker.com/r/obeliks/comfyui

The workflow uses several actions provided by Docker, one for generating image metadata from the gIthub context, one for logging in, and one for building and pushing. Ultimately, the workflow has been pieced together from the following examples (and adjusted accordingly):
* https://docs.docker.com/build/ci/github-actions/manage-tags-labels/
* https://docs.docker.com/build/ci/github-actions/push-multi-registries/
* https://docs.docker.com/build/ci/github-actions/cache/ 
* https://github.com/docker/metadata-action#latest-tag

I have opted _not_ to add extra complexity to [persist the pip cache in GitHub Actions cache](https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts). In most cases, the persisted layer cache will suffice. Take a look at [this run](https://github.com/oxc/ComfyUI/actions/runs/6133143797) that uses cached layers, compared to [this one](https://github.com/oxc/ComfyUI/actions/runs/6133095021) that creates most of them from scratch. The downloading of those large layers that contain pytorch wheels still takes some time, but is much faster then doing the full build.

Note that it still makes sense to have those pip caches in a cache mount, because it is useful for local building, and should prevent the cache from ending up in the image without having to erase it explicitly.
