### PR TITLE
don't try to rehide defaultInput widget

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -9,6 +9,7 @@ function isConvertableWidget(widget, config) {
 }
 
 function hideWidget(node, widget, suffix = "") {
+	if (widget.type.includes(CONVERTED_TYPE)) { return; } // already hidden, don't do it again
 	widget.origType = widget.type;
 	widget.origComputeSize = widget.computeSize;
 	widget.origSerializeValue = widget.serializeValue;

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -161,7 +161,7 @@ app.registerExtension({
 					if (input.widget && !input.widget.config[1]?.forceInput) {
 						const w = this.widgets.find((w) => w.name === input.widget.name);
 						if (w) {
-							hideWidget(this, w);
+							if (!input.widget.config[1]?.defaultInput) hideWidget(this, w);
 						} else {
 							convertToWidget(this, input)
 						}


### PR DESCRIPTION
defaultInput widgets are converted to an input, which includes hiding the widget; hiding them again creates an infinite loop in serializeValue. So don't rehide them.

Also make hideWidget safer by checking if `widget.type.includes(CONVERTED_TYPE)` already.

