### PR TITLE
Node UI enhancements

### DIFF
--- a/comfy_extras/ui_decorator.py
+++ b/comfy_extras/ui_decorator.py
@@ -27,7 +27,7 @@ def ui_signal(signals:str|list[str]):
             returns_tuple  = returns_tuple[:-len(signals)]
 
             for i,key in enumerate(signals):
-                returns_ui['key'] = popped_returns[i]
+                returns_ui[key] = popped_returns[i]
 
             return { "ui":returns_ui, "result": returns_tuple }
         clazz._ui_signal_decorated_function = _ui_signal_decorated_function

--- a/comfy_extras/ui_decorator.py
+++ b/comfy_extras/ui_decorator.py
@@ -27,7 +27,7 @@ def ui_signal(signals:str|list[str]):
             returns_tuple  = returns_tuple[:-len(signals)]
 
             for i,key in enumerate(signals):
-                returns_ui[key] = popped_returns[i]
+                returns['ui']['key'] = popped_returns[i]
 
             return { "ui":returns_ui, "result": returns_tuple }
         clazz._ui_signal_decorated_function = _ui_signal_decorated_function
@@ -35,7 +35,6 @@ def ui_signal(signals:str|list[str]):
         clazz.OUTPUT_NODE = True
         clazz.UI_OUTPUT = clazz.UI_OUTPUT+"," if hasattr(clazz, 'UI_OUTPUT') else ""
         clazz.UI_OUTPUT += ",".join(signals)
-        return clazz
 
     return decorator
         

--- a/comfy_extras/ui_decorator.py
+++ b/comfy_extras/ui_decorator.py
@@ -35,6 +35,7 @@ def ui_signal(signals:str|list[str]):
         clazz.OUTPUT_NODE = True
         clazz.UI_OUTPUT = clazz.UI_OUTPUT+"," if hasattr(clazz, 'UI_OUTPUT') else ""
         clazz.UI_OUTPUT += ",".join(signals)
+        return clazz
 
     return decorator
         

--- a/comfy_extras/ui_decorator.py
+++ b/comfy_extras/ui_decorator.py
@@ -27,7 +27,7 @@ def ui_signal(signals:str|list[str]):
             returns_tuple  = returns_tuple[:-len(signals)]
 
             for i,key in enumerate(signals):
-                returns['ui']['key'] = popped_returns[i]
+                returns_ui[key] = popped_returns[i]
 
             return { "ui":returns_ui, "result": returns_tuple }
         clazz._ui_signal_decorated_function = _ui_signal_decorated_function
@@ -35,6 +35,7 @@ def ui_signal(signals:str|list[str]):
         clazz.OUTPUT_NODE = True
         clazz.UI_OUTPUT = clazz.UI_OUTPUT+"," if hasattr(clazz, 'UI_OUTPUT') else ""
         clazz.UI_OUTPUT += ",".join(signals)
+        return clazz
 
     return decorator
         

--- a/comfy_extras/ui_decorator.py
+++ b/comfy_extras/ui_decorator.py
@@ -1,0 +1,41 @@
+def ui_signal(signals:str|list[str]):
+    """
+    Return a decorator for Node classes.
+    @param signals - a list of strings that name the signals to be sent to the UI. 
+    (For convenience, a string gets converted to a list of length 1)
+
+    The decorator performs the following:
+    The class has OUTPUT_NODE set to True.
+    The class UI_OUTPUT is appended (or created) with a comma separated list of these signals
+    The class FUNCTION is wrapped such that the last len(signals) are removed, and added to the
+    ui dictionary using signals as keys.
+
+    So ui_signals(["first","second"]) will wrap a function returning (something, somethingelse, first_signal, second_signal)
+    and will return { "ui": {"first":first_signal, "second":second_signal}, "result":(something, somethingelse) }
+    """
+    signals:iter = [signals,] if isinstance(signals,str) else signals
+    def decorator(clazz):
+        internal_function_name = getattr(clazz,'FUNCTION')
+        if internal_function_name=='_ui_signal_decorated_function':
+            raise Exception("Can't nest ui_signal decorators")
+        def _ui_signal_decorated_function(self, **kwargs):
+            returns = getattr(self,internal_function_name)(**kwargs)
+            returns_tuple = returns['result']    if isinstance(returns,dict) else returns
+            returns_ui    = returns.get('ui',{}) if isinstance(returns,dict) else {}
+
+            popped_returns = returns_tuple[-len(signals):]
+            returns_tuple  = returns_tuple[:-len(signals)]
+
+            for i,key in enumerate(signals):
+                returns['ui']['key'] = popped_returns[i]
+
+            return { "ui":returns_ui, "result": returns_tuple }
+        clazz._ui_signal_decorated_function = _ui_signal_decorated_function
+        clazz.FUNCTION = '_ui_signal_decorated_function'
+        clazz.OUTPUT_NODE = True
+        clazz.UI_OUTPUT = clazz.UI_OUTPUT+"," if hasattr(clazz, 'UI_OUTPUT') else ""
+        clazz.UI_OUTPUT += ",".join(signals)
+
+    return decorator
+        
+            

--- a/comfy_extras/ui_decorator.py
+++ b/comfy_extras/ui_decorator.py
@@ -27,7 +27,8 @@ def ui_signal(signals:str|list[str]):
             returns_tuple  = returns_tuple[:-len(signals)]
 
             for i,key in enumerate(signals):
-                returns_ui[key] = popped_returns[i]
+                if popped_returns[i] is not None:
+                    returns_ui[key] = popped_returns[i]
 
             return { "ui":returns_ui, "result": returns_tuple }
         clazz._ui_signal_decorated_function = _ui_signal_decorated_function

--- a/comfy_extras/ui_decorator.py
+++ b/comfy_extras/ui_decorator.py
@@ -27,7 +27,7 @@ def ui_signal(signals:str|list[str]):
             returns_tuple  = returns_tuple[:-len(signals)]
 
             for i,key in enumerate(signals):
-                returns['ui']['key'] = popped_returns[i]
+                returns_ui['key'] = popped_returns[i]
 
             return { "ui":returns_ui, "result": returns_tuple }
         clazz._ui_signal_decorated_function = _ui_signal_decorated_function

--- a/server.py
+++ b/server.py
@@ -399,6 +399,7 @@ class PromptServer():
             info['name'] = node_class
             info['display_name'] = nodes.NODE_DISPLAY_NAME_MAPPINGS[node_class] if node_class in nodes.NODE_DISPLAY_NAME_MAPPINGS.keys() else node_class
             info['description'] = obj_class.DESCRIPTION if hasattr(obj_class,'DESCRIPTION') else ''
+            info['ui_output'] = obj_class.UI_OUTPUT if hasattr(obj_class, 'UI_OUTPUT') else ''
             info['category'] = 'sd'
             if hasattr(obj_class, 'OUTPUT_NODE') and obj_class.OUTPUT_NODE == True:
                 info['output_node'] = True

--- a/web/extensions/core/uiOutput.js
+++ b/web/extensions/core/uiOutput.js
@@ -1,0 +1,9 @@
+export function registerUiOutputListener(nodeType, nodeData, message_type, func) {
+    if (nodeData?.ui_output?.includes(message_type)) {
+        const onExecuted = nodeType.prototype.onExecuted;
+        nodeType.prototype.onExecuted = function (message) {
+            onExecuted?.apply(this, arguments);
+            if (message[message_type]) func.apply(this, [message[message_type]]);
+        }
+    }
+};

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -158,7 +158,7 @@ app.registerExtension({
 
 			if (this.inputs) {
 				for (const input of this.inputs) {
-					if (input.widget && !input.widget.config[1]?.forceInput && !input.widget.config[1]?.defaultInput) {
+					if (input.widget && !input.widget.config[1]?.forceInput) {
 						const w = this.widgets.find((w) => w.name === input.widget.name);
 						if (w) {
 							hideWidget(this, w);

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -158,10 +158,10 @@ app.registerExtension({
 
 			if (this.inputs) {
 				for (const input of this.inputs) {
-					if (input.widget && !input.widget.config[1]?.forceInput) {
+					if (input.widget && !input.widget.config[1]?.forceInput && !input.widget.config[1]?.defaultInput) {
 						const w = this.widgets.find((w) => w.name === input.widget.name);
 						if (w) {
-							if (!input.widget.config[1]?.defaultInput) hideWidget(this, w);
+							hideWidget(this, w);
 						} else {
 							convertToWidget(this, input)
 						}

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -158,10 +158,10 @@ app.registerExtension({
 
 			if (this.inputs) {
 				for (const input of this.inputs) {
-					if (input.widget && !input.widget.config[1]?.forceInput && !input.widget.config[1]?.defaultInput) {
+					if (input.widget && !input.widget.config[1]?.forceInput) {
 						const w = this.widgets.find((w) => w.name === input.widget.name);
 						if (w) {
-							hideWidget(this, w);
+							if (!input.widget.config[1]?.defaultInput) hideWidget(this, w);
 						} else {
 							convertToWidget(this, input)
 						}

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -158,7 +158,7 @@ app.registerExtension({
 
 			if (this.inputs) {
 				for (const input of this.inputs) {
-					if (input.widget && !input.widget.config[1]?.forceInput) {
+					if (input.widget && !input.widget.config[1]?.forceInput && !input.widget.config[1]?.defaultInput) {
 						const w = this.widgets.find((w) => w.name === input.widget.name);
 						if (w) {
 							hideWidget(this, w);

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1273,6 +1273,7 @@ export class ComfyApp {
 				}
 			);
 			node.prototype.comfyClass = nodeData.name;
+			node.prototype.ui_output = nodeData.ui_output;
 
 			this.#addNodeContextMenuHandler(node);
 			this.#addDrawBackgroundHandler(node, app);


### PR DESCRIPTION
Longish description below - TL;DR this is creating a mechanism to make it easy for custom nodes to send signals to the front end, and for custom front end functionality to be reused etc.. It has no impact on anyone who doesn't use it!

---

This is in two parts. The first is trivial - add a custom node parameter UI_OUTPUT which is intended to be a comma separated list of keys that the node might send to the front end

Three examples I'm already using:

- `UI_OUTPUT = 'terminate'` to indicate that the node can return a request that the front end terminate execution and turn Auto Queue off (useful if you have a node that iterates through something - put Auto Queue on, submit the task, then when it's finished it can turn Auto Queue off again).
- `UI_OUTPUT = 'modify_self'` to indicate that the node can return a request that the front end node modify the value of a widget
- `UI_OUTPUT = 'display_text'` to indicate that the node can return a text string to be displayed by the front end node

(If desired, the front end code for these three features could be included in the PR).

The point is to make it easy to reuse front end functionality - once `display_text` is written, any node can use it.

Custom front end code like this can attach an `onExecuted` which deals with the message to nodes which might send it:

```JavaScript
app.registerExtension({
	name: "my.node.textdisplayer",
	async beforeRegisterNodeDef(nodeType, nodeData, app) {
		if (nodeData.ui_output.includes('display_text')) {
			const onExecuted = nodeType.prototype.onExecuted;
			nodeType.prototype.onExecuted = function (message) {
				onExecuted?.apply(this, arguments);
				const display_text = message.display_text.join('');
// do something with it
			}
		}
	},
});


```

That change is one line in `server.py` and one line in `app.js`. I considered (and a future PR might offer) that the front end could provide something like `app.registerListener(nodeType,'display_text')`, but that would be considerably more intrusive into the app.js code.

---

The other part is a class decorator that makes it really easy for a custom node to use this feature. Usage is:

```python
@ui_signal(['message_type_one','message_type_two'])
class MyCustomNode():
```

which  
- inserts these two values into `UI_OUTPUT`, 
- sets `OUTPUT_NODE = True`
- wraps the custom node `FUNCTION` class to extract the last n values from the return and put them into the ui dictionary.

So, for instance:
```python
@ui_signal('display_text')
class ShowText():
// (some standard stuff omitted)
    @classmethod    
    def INPUT_TYPES(s):
        return  {"required" : {  } }
    RETURN_TYPES = ("STRING",)
    def func(self):
        return ("text for output node", "text inserted into ui dictionary under key display_text",)
```
`func` returns one more item than indicated in RETURN_TYPES; the decoration removes it from the tuple and puts it into the ui dictionary.
