### PR TITLE
Allow pasting nodes with connections in firefox

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -671,6 +671,10 @@ export class ComfyApp {
 	 */
 	#addPasteHandler() {
 		document.addEventListener("paste", (e) => {
+			// ctrl+shift+v is used to paste nodes with connections
+			// this is handled by litegraph
+			if(this.shiftDown) return;
+
 			let data = (e.clipboardData || window.clipboardData);
 			const items = data.items;
 
@@ -853,7 +857,7 @@ export class ComfyApp {
 				}
 
 				// Ctrl+V Paste
-				if ((e.key === 'v' || e.key == 'V') && (e.metaKey || e.ctrlKey)) {
+				if ((e.key === 'v' || e.key == 'V') && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
 					// Trigger onPaste
 					return true;
 				}


### PR DESCRIPTION
Firefox doesnt fire a paste event on ctrl+shift+v (Chrome does) so we dont want to block the default litegraph key handler 

This update means you cant use ctrl+shift+v to paste images/json and will always use the litegraph clipboard with that shortcut, but I don't think that's a problem (maybe even a feature 😅)