### PR TITLE
fix: Ensure proper handling of images with mixed ratios.

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -532,7 +532,17 @@ export class ComfyApp {
 								}
 							}
 							this.imageRects.push([x, y, cellWidth, cellHeight]);
-							ctx.drawImage(img, x, y, cellWidth, cellHeight);
+
+                            let wratio = cellWidth/img.width;
+                            let hratio = cellHeight/img.height;
+                            var ratio = Math.min(wratio, hratio);
+
+                            let imgHeight = ratio * img.height;
+                            let imgY = row * cellHeight + shiftY + (cellHeight - imgHeight)/2;
+                            let imgWidth = ratio * img.width;
+                            let imgX = col * cellWidth + shiftX + (cellWidth - imgWidth)/2;
+
+							ctx.drawImage(img, imgX, imgY, imgWidth, imgHeight);
 							ctx.filter = "none";
 						}
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -533,14 +533,14 @@ export class ComfyApp {
 							}
 							this.imageRects.push([x, y, cellWidth, cellHeight]);
 
-                            let wratio = cellWidth/img.width;
-                            let hratio = cellHeight/img.height;
-                            var ratio = Math.min(wratio, hratio);
+							let wratio = cellWidth/img.width;
+							let hratio = cellHeight/img.height;
+							var ratio = Math.min(wratio, hratio);
 
-                            let imgHeight = ratio * img.height;
-                            let imgY = row * cellHeight + shiftY + (cellHeight - imgHeight)/2;
-                            let imgWidth = ratio * img.width;
-                            let imgX = col * cellWidth + shiftX + (cellWidth - imgWidth)/2;
+							let imgHeight = ratio * img.height;
+							let imgY = row * cellHeight + shiftY + (cellHeight - imgHeight)/2;
+							let imgWidth = ratio * img.width;
+							let imgX = col * cellWidth + shiftX + (cellWidth - imgWidth)/2;
 
 							ctx.drawImage(img, imgX, imgY, imgWidth, imgHeight);
 							ctx.filter = "none";


### PR DESCRIPTION
Problem:
When multiple images with different ratios are passed to the image widget, images with ratios different from the determined cell ratio appear distorted.

![old_ratio](https://github.com/comfyanonymous/ComfyUI/assets/128333288/923d0b07-5436-4c27-a6c9-b94774ac542e)

Fixed:
Maintain the original image's ratio.

![ratio](https://github.com/comfyanonymous/ComfyUI/assets/128333288/1c6c532c-f474-4ddf-bdcf-fd76c91f46c4)
