### PR TITLE
include information about prompt ID in print statement

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,7 +97,7 @@ def prompt_worker(q, server):
         if server.client_id is not None:
             server.send_sync("executing", { "node": None, "prompt_id": prompt_id }, server.client_id)
 
-        print("Prompt executed in {:.2f} seconds".format(time.perf_counter() - execution_start_time))
+        print("Prompt executed in {:.2f} seconds. ID: {}".format(time.perf_counter() - execution_start_time, prompt_id))
         gc.collect()
         comfy.model_management.soft_empty_cache()
 


### PR DESCRIPTION
I think including this info is better for two reasons.

1. It makes it easier to distinguish console output from long sessions and how they correspond to individual prompts.
2. It makes it easier for users to implement workarounds when necessary. While they can use the API with no ID to get the entire history and extract it from the json, seeing the prompt ID in the terminal output makes fixes like [these](https://github.com/Fannovel16/comfyui_controlnet_aux#faces-and-poses) more user friendly.