### PR TITLE
Escape paths when passing them to glob

### DIFF
--- a/server.py
+++ b/server.py
@@ -132,12 +132,12 @@ class PromptServer():
         @routes.get("/extensions")
         async def get_extensions(request):
             files = glob.glob(os.path.join(
-                self.web_root, 'extensions/**/*.js'), recursive=True)
+                glob.escape(self.web_root), 'extensions/**/*.js'), recursive=True)
             
             extensions = list(map(lambda f: "/" + os.path.relpath(f, self.web_root).replace("\\", "/"), files))
             
             for name, dir in nodes.EXTENSION_WEB_DIRS.items():
-                files = glob.glob(os.path.join(dir, '**/*.js'), recursive=True)
+                files = glob.glob(os.path.join(glob.escape(dir), '**/*.js'), recursive=True)
                 extensions.extend(list(map(lambda f: "/extensions/" + urllib.parse.quote(
                     name) + "/" + os.path.relpath(f, dir).replace("\\", "/"), files)))
 


### PR DESCRIPTION
Try to prevent JS search from breaking on pathnames with square brackets.

Tested by renaming my ComfyUI path to `ComfyUI[test]`, then starting without the patch -> no custom nodes show up, nor the "Manager" button.  Checkout branch with my change and start again, Manager button shows up, custom nodes seem to work.

Note that while this is the only use of glob I could find in the ComfyUI code, there are probably custom nodes with the same issue, so I don't know if this will actually make for a reasonable UX if there are square brackets in any pathname.