### PR TITLE
Make seed randomize widget run before queued

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1581,6 +1581,21 @@ export class ComfyApp {
 				({ number, batchCount } = this.#queueItems.pop());
 
 				for (let i = 0; i < batchCount; i++) {
+					const pBefore = await this.graphToPrompt();
+							
+					for (const n of pBefore.workflow.nodes) {
+						const node = graph.getNodeById(n.id);
+						if (node.widgets) {
+							for (const widget of node.widgets) {
+								// Allow widgets to run callbacks after a prompt has been queued
+								// e.g. random seed after every gen
+								if (widget.beforeQueued) {
+									widget.beforeQueued();
+								}
+							}
+						}
+					}
+
 					const p = await this.graphToPrompt();
 
 					try {

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -27,7 +27,7 @@ export function addValueControlWidget(node, targetWidget, defaultValue = "random
         values: ["fixed", "increment", "decrement", "randomize"],
         serialize: false, // Don't include this in prompt.
     });
-    valueControl.afterQueued = () => {
+    valueControl.beforeQueued = () => {
 
 		var v = valueControl.value;
 


### PR DESCRIPTION
Implements #1084 , helpful to keep the seed the samein the generated image