### PR TITLE
Refactor code to use pathlib for loading custom nodes

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -8,6 +8,7 @@ import traceback
 import math
 import time
 import random
+from pathlib import Path
 
 from PIL import Image, ImageOps
 from PIL.PngImagePlugin import PngInfo
@@ -1772,15 +1773,21 @@ def load_custom_nodes():
         print()
 
 def init_custom_nodes():
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_latent.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_hypernetwork.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_upscale_model.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_post_processing.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_mask.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_rebatch.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_model_merging.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_tomesd.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_clip_sdxl.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_canny.py"))
-    load_custom_node(os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras"), "nodes_freelunch.py"))
+    extras_dir = Path(__file__).resolve().parent / "comfy_extras"
+
+    for node_file in [
+        "nodes_latent.py",
+        "nodes_hypernetwork.py",
+        "nodes_upscale_model.py",
+        "nodes_post_processing.py",
+        "nodes_mask.py",
+        "nodes_rebatch.py",
+        "nodes_model_merging.py",
+        "nodes_tomesd.py",
+        "nodes_clip_sdxl.py",
+        "nodes_canny.py",
+        "nodes_freelunch.py"
+    ]:
+        load_custom_node(extras_dir / node_file)
+    
     load_custom_nodes()


### PR DESCRIPTION
In this commit, I refactored the code responsible for loading custom nodes to use the pathlib module for improved readability and maintainability. Instead of using nested os.path.join calls to construct file paths, I utilized the Path class from pathlib. This change makes the code cleaner and more Pythonic.

I created a Path object for the directory containing the custom nodes, based on the current script's location (Path(__file__).resolve().parent). Then, I iterated through a list of node file names, appending each one to the directory path to obtain the full path to the node file. This approach simplifies the code and makes it easier to add or modify custom node files in the future.

Overall, this refactoring enhances the code's maintainability and readability while preserving its functionality.