### PR TITLE
feat: add LoadImages and ImageRebatch nodes

### DIFF
--- a/comfy_extras/nodes_rebatch.py
+++ b/comfy_extras/nodes_rebatch.py
@@ -99,10 +99,29 @@ class LatentRebatch:
 
         return (output_list,)
 
+class ImageRebatch:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": { "images": ("IMAGE",),
+                              "batch_size": ("INT", {"default": 1, "min": 1}),
+                              }}
+    RETURN_TYPES = ("IMAGE",)
+
+    OUTPUT_IS_LIST = (True, )
+    FUNCTION = "rebatch_images"
+    CATEGORY = "image/batch"
+
+    def rebatch_images(self, images, batch_size):
+        batched_images = [images[i:i + batch_size] for i in range(0, len(images), batch_size)]
+
+        return (batched_images,)
+    
 NODE_CLASS_MAPPINGS = {
     "RebatchLatents": LatentRebatch,
+    "RebatchImages": ImageRebatch,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "RebatchLatents": "Rebatch Latents",
+    "RebatchImages": "Rebatch Images",
 }


### PR DESCRIPTION
This pull request adds the following nodes:

- LoadImages: This node allows you to load multiple images at once from a single directory.
- ImageRebatch: This node allows you to rebatch images. This can be useful when dealing with a lot of images at once, for example, upscaling images. Let's say you are using a 4x upscaler but only want it to be upscaled 2x. You would need to upscale all of your images at once with 4x and then downscale them to 2x, which would require you to have enough RAM for the 4x images in the first place. However, with the `ImageRebatch` node, you can avoid this by doing it in batches, thus reducing RAM usage significantly. This also fixes #1611.

edit: It's important to mention that the `ImageRebatch` node only takes effect on the first nodes to which it's connected. This means you'd need one node that performs the upscaling with the model and the downscaling of the result. In my case, I'm using the [ComfyUI-Workflow-Component](https://github.com/ltdrdata/ComfyUI-Workflow-Component) and have created my own upscale workflow.