### PR TITLE
Fix `/view` returning images with wrong orientation

### DIFF
--- a/server.py
+++ b/server.py
@@ -302,6 +302,7 @@ class PromptServer():
 
                     if channel == 'rgb':
                         with Image.open(file) as img:
+                            img = ImageOps.exif_transpose(img)
                             if img.mode == "RGBA":
                                 r, g, b, a = img.split()
                                 new_img = Image.merge('RGB', (r, g, b))

--- a/server.py
+++ b/server.py
@@ -277,6 +277,7 @@ class PromptServer():
                 if os.path.isfile(file):
                     if 'preview' in request.rel_url.query:
                         with Image.open(file) as img:
+                            img = ImageOps.exif_transpose(img)
                             preview_info = request.rel_url.query['preview'].split(';')
                             image_format = preview_info[0]
                             if image_format not in ['webp', 'jpeg'] or 'a' in request.rel_url.query.get('channel', ''):
@@ -318,6 +319,7 @@ class PromptServer():
 
                     elif channel == 'a':
                         with Image.open(file) as img:
+                            img = ImageOps.exif_transpose(img)
                             if img.mode == "RGBA":
                                 _, _, _, a = img.split()
                             else:


### PR DESCRIPTION
This fixes the issue where `/view` endpoint returns images with wrong orientation when the image has EXIF orientation.
See https://github.com/comfyanonymous/ComfyUI/issues/1621 for details.