### PR TITLE
Allow GrowMask node to work with batches (for AnimateDiff)

### DIFF
--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -17,9 +17,15 @@ def composite(destination, source, x, y, mask = None, multiplier = 8, resize_sou
     if mask is None:
         mask = torch.ones_like(source)
     else:
+        if len(mask.shape) != 3:  # Check if mask has a batch dimension
+            print("is batch")
+            mask = mask.unsqueeze(0)  # Add a batch dimension to the mask tensor
         mask = mask.clone()
-        mask = torch.nn.functional.interpolate(mask[None, None], size=(source.shape[2], source.shape[3]), mode="bilinear")
-        mask = mask.repeat((source.shape[0], source.shape[1], 1, 1))
+        resized_masks = []
+        for i in range(mask.shape[0]):
+            resized_mask = torch.nn.functional.interpolate(mask[i][None, None], size=(source.shape[2], source.shape[3]), mode="bilinear")
+            resized_masks.append(resized_mask)
+        mask = torch.cat(resized_masks, dim=0)
 
     # calculate the bounds of the source that will be overlapping the destination
     # this prevents the source trying to overwrite latent pixels that are out of bounds

--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -325,8 +325,8 @@ class GrowMask:
     def expand_mask(self, mask, expand, tapered_corners):
         c = 0 if tapered_corners else 1
         kernel = np.array([[c, 1, c],
-                        [1, 1, 1],
-                        [c, 1, c]])
+                           [1, 1, 1],
+                           [c, 1, c]])
         mask = mask.reshape((-1, mask.shape[-2], mask.shape[-1]))
         out = []
         for m in mask:


### PR DESCRIPTION
Currently the GrowMask node doesn't work properly with batches, only grows the first mask and then returns everything as single image like this:
![image](https://github.com/comfyanonymous/ComfyUI/assets/40791699/76d59641-26d3-4a78-a8b1-db527ac7c275)
After this change it works and is compatible with AnimateDiff:
![image](https://github.com/comfyanonymous/ComfyUI/assets/40791699/2aaba28b-1e00-49c5-8170-7d3fe2551c1f)
