### PR TITLE
Don't execute node if any input list is empty

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -68,7 +68,7 @@ def map_node_over_list(obj, input_data_all, func, allow_interrupt=False):
         if allow_interrupt:
             nodes.before_node_execution()
         results.append(getattr(obj, func)())
-    else:
+    elif all(len(v) > 0 for v in input_data_all.values()): # Skip if any list is empty
         for i in range(max_len_input):
             if allow_interrupt:
                 nodes.before_node_execution()


### PR DESCRIPTION
Normally when we are passing lists we extend any lists shorter than the longest by repeating the last item. This works especially well when combining lists of arbitrary length with lists that have only one item. But it doesn't work at all if any list has no items in it. Since that case currently doesn't work at all, it seems like the best interpretation of any list having 0 length is that we don't want the successor node to execute at all. That's exactly what this change does.

This change only affects behavior in the case where there is an empty list among a node's inputs, which previously would always throw an exception due to the implementation of slice_dict. I've tested both with empty lists and non-empty.