### PR TITLE
Widget input/primitive updates

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -533,7 +533,7 @@ app.registerExtension({
 							if (k === "min") {
 								const theirMax = config2[1]["max"];
 								if (theirMax != null && v1 > theirMax) {
-									console.log("Invalid connection, min > max");
+									console.log("connection rejected: min > max", v1, theirMax);
 									return false;
 								}
 								getCustomConfig()[k] = v1 == null ? v2 : v2 == null ? v1 : Math.max(v1, v2);
@@ -541,7 +541,7 @@ app.registerExtension({
 							} else if (k === "max") {
 								const theirMin = config2[1]["min"];
 								if (theirMin != null && v1 < theirMin) {
-									console.log("Invalid connection, max < min");
+									console.log("connection rejected: max < min", v1, theirMin);
 									return false;
 								}
 								getCustomConfig()[k] = v1 == null ? v2 : v2 == null ? v1 : Math.min(v1, v2);
@@ -549,17 +549,20 @@ app.registerExtension({
 							} else if (k === "step") {
 								let step;
 								if (v1 == null) {
+									// No current step
 									step = v2;
 								} else if (v2 == null) {
+									// No new step
 									step = v1;
 								} else {
 									if (v1 < v2) {
+										// Ensure v1 is larger for the mod
 										const a = v2;
 										v2 = v1;
 										v1 = a;
 									}
 									if (v1 % v2) {
-										console.log("Steps not divisible", "current:", v1, "new:", v2);
+										console.log("connection rejected: steps not divisible", "current:", v1, "new:", v2);
 										return false;
 									}
 


### PR DESCRIPTION
A few updates to improve primitives:

1. Allow connecting primitives to other numbers that have configs that are different but have some overlap, and merge the constraints, e.g.

   Input 1: [step = 10, min = 20, max = 50]
   Input 2: [step = 5, min = 5, max = 30]

   Connecting a primitive to the two of these will be restricted to [step = 10, min = 20, max = 30]

   If the steps are not simply divisible (e.g. you tried to connect step = 8 to the above example) it'll be rejected.

2. Removes the "config" object that was previously stored in the graph and if a COMBO widget was converted would contain the full list, and not refresh if new items were added between sessions.
It now loads gets the config dynamically from the node definition instead of storing it.

3. "Refresh" button now reloads combo values in primitives (e.g. you add a new model, it'll now appear in the dropdown)

4. Removes the comma separated list of models as the input type and removes the full list of values from saved graph json

Existing workflows with converted widgets should continue to work without changes.
There are a lot of edge cases to handle with this so any additional testing would be appreciated!