### PR TITLE
If the output type is an array, use combo

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1306,7 +1306,8 @@ export class ComfyApp {
 					}
 
 					for (const o in nodeData["output"]) {
-						const output = nodeData["output"][o];
+						let output = nodeData["output"][o];
+						if(output instanceof Array) output = "COMBO";
 						const outputName = nodeData["output_name"][o] || output;
 						const outputShape = nodeData["output_is_list"][o] ? LiteGraph.GRID_SHAPE : LiteGraph.CIRCLE_SHAPE ;
 						this.addOutput(outputName, output, { shape: outputShape });


### PR DESCRIPTION
Should fix custom nodes that are returning arrays as an output type 