### PR TITLE
Fix SD2.x CLIP Config

### DIFF
--- a/comfy/sd2_clip_config.json
+++ b/comfy/sd2_clip_config.json
@@ -15,7 +15,7 @@
   "max_position_embeddings": 77,
   "model_type": "clip_text_model",
   "num_attention_heads": 16,
-  "num_hidden_layers": 24,
+  "num_hidden_layers": 23,
   "pad_token_id": 1,
   "projection_dim": 1024,
   "torch_dtype": "float32",


### PR DESCRIPTION
In SD2.x, there is no 24th layer in the model because CLIP Skip is enabled by default.
ref: https://huggingface.co/stabilityai/stable-diffusion-2-1/blob/dfa8b92116db63212e987c64a1b74db00e098e73/text_encoder/config.json#L19

After applying this fix, errors when loading the model and unnecessary processing will be eliminated.
This change does not affect the inference result because inference refers to layer_idx.