### PR TITLE
add query to fix 1723

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1592,7 +1592,7 @@ export class ComfyApp {
 								all_inputs = all_inputs.concat(Object.keys(parent.inputs))
 								for (let parent_input in all_inputs) {
 									parent_input = all_inputs[parent_input];
-									if (parent.inputs[parent_input].type === node.inputs[i].type) {
+									if (parent.inputs[parent_input]?.type === node.inputs[i].type) {
 										link = parent.getInputLink(parent_input);
 										if (link) {
 											parent = parent.getInputNode(parent_input);


### PR DESCRIPTION
Fixes #1723 

Trivial, safe change - change `.type ===` to `?.type ===`, which will fail if the input is undefined instead of raising an error