### PR TITLE
Update extra_model_paths.yaml.example with comfy specific example

### DIFF
--- a/extra_model_paths.yaml.example
+++ b/extra_model_paths.yaml.example
@@ -1,5 +1,20 @@
 #Rename this to extra_model_paths.yaml and ComfyUI will load it
 
+#config for comfyui
+#your base path should be either an existing comfy install or a central folder where you store all of your models, loras, etc.
+#in this example, we make a central folder called c:/machine-learning/ and replicate the ComfyUI models folder structure inside
+comfyui:
+    base_path: c:/machine-learning/
+    checkpoints: models/checkpoints/
+    clip: models/clip/
+    clip_vision: models/clip_vision/
+    configs: models/configs/
+    controlnet: models/controlnet/
+    embeddings: models/embeddings/
+    loras: models/loras/
+    upscale_models: models/upscale_models/
+    vae: models/vae/
+
 #config for a1111 ui
 #all you have to do is change the base_path to where yours is installed
 a111:


### PR DESCRIPTION
This file only references A111, which isn't helpful to making it work for ComfyUI. These changes make it clear how to format it for ComfyUI.