### PR TITLE
Provide requirements files for different GPU makes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ Note: pytorch does not support python 3.12 yet so make sure your python version 
 ### AMD GPUs (Linux only)
 AMD users can install rocm and pytorch with pip if you don't have it already installed, this is the command to install the stable version:
 
-```pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.6```
+```pip install -r requirements-rocm5.6.txt```
 
 This is the command to install the nightly with ROCm 5.7 that might have some performance improvements:
-```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm5.7```
+```pip install -r requirements-rocm5.7-nightly.txt```
 
 ### NVIDIA
 
 Nvidia users should install pytorch using this command:
 
-```pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu121```
+```pip install -r requirements-cu121.txt```
 
 #### Troubleshooting
 

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,0 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+torch
+torchvision
+torchaudio

--- a/requirements-cu118.txt
+++ b/requirements-cu118.txt
@@ -1,0 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cu118
+
+torch
+torchvision
+torchaudio

--- a/requirements-cu121.txt
+++ b/requirements-cu121.txt
@@ -1,0 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cu121
+
+torch
+torchvision
+torchaudio

--- a/requirements-rocm5.6.txt
+++ b/requirements-rocm5.6.txt
@@ -1,0 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/rocm5.6
+
+torch
+torchvision
+torchaudio

--- a/requirements-rocm5.7-nightly.txt
+++ b/requirements-rocm5.7-nightly.txt
@@ -1,0 +1,6 @@
+--pre
+--index-url https://download.pytorch.org/whl/nightly/rocm5.7
+
+torch
+torchvision
+torchaudio


### PR DESCRIPTION
Instead of listing the commands required to install the GPU-specific packages in the README, create a separate requirements-*.txt for each variant, which contains both the (extra) index URL and the packages.

This makes it easier to update the GPU-specific requirements without having to check whether the README has changed.

This is especially, but not exclusively, useful for automated builds, like https://github.com/comfyanonymous/ComfyUI/pull/1469, from which this was extracted.