### PR TITLE
Command option to set different devices for extensions

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -43,6 +43,7 @@ parser.add_argument("--input-directory", type=str, default=None, help="Set the C
 parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")
 parser.add_argument("--disable-auto-launch", action="store_true", help="Disable auto launching the browser.")
 parser.add_argument("--cuda-device", type=int, default=None, metavar="DEVICE_ID", help="Set the id of the cuda device this instance will use.")
+parser.add_argument("--extension-device", type=str, default=None, help="Set the device for extensions in the format 'extension:device;extension:device;...'.")
 cm_group = parser.add_mutually_exclusive_group()
 cm_group.add_argument("--cuda-malloc", action="store_true", help="Enable cudaMallocAsync (enabled by default for torch 2.0 and up).")
 cm_group.add_argument("--disable-cuda-malloc", action="store_true", help="Disable cudaMallocAsync.")

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -41,6 +41,12 @@ if args.directml is not None:
     # torch_directml.disable_tiled_resources(True)
     lowvram_available = False #TODO: need to find a way to get free memory in directml before this can be enabled by default.
 
+extensions_devices = {}
+if args.extension_device is not None:
+    for ext_dev in args.extension_device.split(";"):
+        ext, dev = ext_dev.split(":")
+        extensions_devices[ext] = dev
+
 try:
     import intel_extension_for_pytorch as ipex
     if torch.xpu.is_available():
@@ -69,6 +75,12 @@ def is_intel_xpu():
 def get_torch_device():
     global directml_enabled
     global cpu_state
+    global extensions_devices
+
+    extension = comfy.utils.get_extension_calling()
+    if extension is not None and extension in extensions_devices:
+        return torch.device(extensions_devices[extension])
+
     if directml_enabled:
         global directml_device
         return directml_device

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -77,9 +77,11 @@ def get_torch_device():
     global cpu_state
     global extensions_devices
 
-    extension = comfy.utils.get_extension_calling()
-    if extension is not None and extension in extensions_devices:
-        return torch.device(extensions_devices[extension])
+    extension_stack = comfy.utils.get_extension_calling()
+    if extension_stack is not None:
+        for extension in extension_stack:
+            if extension in extensions_devices:
+                return torch.device(extensions_devices[extension])
 
     if directml_enabled:
         global directml_device

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -4,7 +4,18 @@ import struct
 import comfy.checkpoint_pickle
 import safetensors.torch
 import numpy as np
+import inspect
+import re
 from PIL import Image
+
+def get_extension_calling():
+    for frame in inspect.stack():
+        if "/custom_nodes/" in frame.filename:
+            stack_module = inspect.getmodule(frame[0]) 
+            if stack_module:
+                return re.sub(r".*\.?custom_nodes\.([^\.]+).*", r"\1", stack_module.__name__).split(".")[0]
+
+    return None
 
 def load_torch_file(ckpt, safe_load=False, device=None):
     if device is None:

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -5,12 +5,13 @@ import comfy.checkpoint_pickle
 import safetensors.torch
 import numpy as np
 import inspect
+import os
 import re
 from PIL import Image
 
 def get_extension_calling():
     for frame in inspect.stack():
-        if "/custom_nodes/" in frame.filename or "\\custom_nodes\\" in frame.filename:
+        if os.sep + "custom_nodes" + os.sep in frame.filename:
             stack_module = inspect.getmodule(frame[0])
             if stack_module:
                 return re.sub(r".*\.?custom_nodes\.([^\.]+).*", r"\1", stack_module.__name__.replace("\\", ".").replace("/", ".")).split(".")[0]

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -14,7 +14,15 @@ def get_extension_calling():
         if os.sep + "custom_nodes" + os.sep in frame.filename:
             stack_module = inspect.getmodule(frame[0])
             if stack_module:
-                return re.sub(r".*\.?custom_nodes\.([^\.]+).*", r"\1", stack_module.__name__.replace("\\", ".").replace("/", ".")).split(".")[0]
+                stack = []
+
+                parts = re.sub(r".*\.?custom_nodes\.([^\.]+).*", r"\1", stack_module.__name__.replace(os.sep, ".")).split(".")
+
+                while len(parts) > 0:
+                    stack.append(".".join(parts))
+                    parts.pop()
+
+                return stack
 
     return None
 

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -10,8 +10,8 @@ from PIL import Image
 
 def get_extension_calling():
     for frame in inspect.stack():
-        if "/custom_nodes/" in frame.filename:
-            stack_module = inspect.getmodule(frame[0]) 
+        if "/custom_nodes/" in frame.filename or "\\custom_nodes\\" in frame.filename:
+            stack_module = inspect.getmodule(frame[0])
             if stack_module:
                 return re.sub(r".*\.?custom_nodes\.([^\.]+).*", r"\1", stack_module.__name__.replace("\\", ".").replace("/", ".")).split(".")[0]
 

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -13,7 +13,7 @@ def get_extension_calling():
         if "/custom_nodes/" in frame.filename:
             stack_module = inspect.getmodule(frame[0]) 
             if stack_module:
-                return re.sub(r".*\.?custom_nodes\.([^\.]+).*", r"\1", stack_module.__name__).split(".")[0]
+                return re.sub(r".*\.?custom_nodes\.([^\.]+).*", r"\1", stack_module.__name__.replace("\\", ".").replace("/", ".")).split(".")[0]
 
     return None
 


### PR DESCRIPTION
This PR adds the feature to set different devices for extensions.

Sometimes we need to run the nodes from an extension on a different device, instead of the default torch device.

In my case I use it to make some extensions run on CPU because I have low vram and those extension can run on different devices without problem.

With this PR you can use the command line option `--extension-device 'extension:device;extension:device;...'` to set the device you want for your extensions.

The extension name used in the command is the extension base module, in other words, it is the folder name of the extension inside the custom_nodes folder or the name of the file in case of a single file extension.