### PR TITLE
Fix node getBounding for collapsed nodes

### DIFF
--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -3796,7 +3796,7 @@
         out = out || new Float32Array(4);
         out[0] = this.pos[0] - 4;
         out[1] = this.pos[1] - LiteGraph.NODE_TITLE_HEIGHT;
-        out[2] = this.size[0] + 4;
+        out[2] = this.flags.collapsed ? (this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH) : this.size[0] + 4;
         out[3] = this.flags.collapsed ? LiteGraph.NODE_TITLE_HEIGHT : this.size[1] + LiteGraph.NODE_TITLE_HEIGHT;
 
         if (this.onBounding) {


### PR DESCRIPTION
The getBounding wasn't considering the collapsed flag for the width, so collapsed nodes were being grabbed wrongly by near groups.