### PR TITLE
Draft PR for SSD loading

### DIFF
--- a/comfy/ldm/modules/diffusionmodules/openaimodel.py
+++ b/comfy/ldm/modules/diffusionmodules/openaimodel.py
@@ -492,36 +492,51 @@ class UNetModel(nn.Module):
         if legacy:
             #num_heads = 1
             dim_head = ch // num_heads if use_spatial_transformer else num_head_channels
-        self.middle_block = TimestepEmbedSequential(
-            ResBlock(
-                ch,
-                time_embed_dim,
-                dropout,
-                dims=dims,
-                use_checkpoint=use_checkpoint,
-                use_scale_shift_norm=use_scale_shift_norm,
-                dtype=self.dtype,
-                device=device,
-                operations=operations
-            ),
-            if (resnet_only_mid_block is False):
-                SpatialTransformer(  # always uses a self-attn
-                                ch, num_heads, dim_head, depth=transformer_depth_middle, context_dim=context_dim,
-                                disable_self_attn=disable_middle_self_attn, use_linear=use_linear_in_transformer,
-                                use_checkpoint=use_checkpoint, dtype=self.dtype, device=device, operations=operations
-                            ),
-                ResBlock(
-                    ch,
-                    time_embed_dim,
-                    dropout,
-                    dims=dims,
-                    use_checkpoint=use_checkpoint,
-                    use_scale_shift_norm=use_scale_shift_norm,
-                    dtype=self.dtype,
-                    device=device,
-                    operations=operations
-                ),
-        )
+        if resnet_only_mid_block is False:
+            self.middle_block = TimestepEmbedSequential(
+                    ResBlock(
+                        ch,
+                        time_embed_dim,
+                        dropout,
+                        dims=dims,
+                        use_checkpoint=use_checkpoint,
+                        use_scale_shift_norm=use_scale_shift_norm,
+                        dtype=self.dtype,
+                        device=device,
+                        operations=operations
+                    ),
+                    SpatialTransformer(  # always uses a self-attn
+                                    ch, num_heads, dim_head, depth=transformer_depth_middle, context_dim=context_dim,
+                                    disable_self_attn=disable_middle_self_attn, use_linear=use_linear_in_transformer,
+                                    use_checkpoint=use_checkpoint, dtype=self.dtype, device=device, operations=operations
+                                ),
+                    ResBlock(
+                        ch,
+                        time_embed_dim,
+                        dropout,
+                        dims=dims,
+                        use_checkpoint=use_checkpoint,
+                        use_scale_shift_norm=use_scale_shift_norm,
+                        dtype=self.dtype,
+                        device=device,
+                        operations=operations
+                    ),
+                )
+        else:
+            self.middle_block = TimestepEmbedSequential(
+                    ResBlock(
+                        ch,
+                        time_embed_dim,
+                        dropout,
+                        dims=dims,
+                        use_checkpoint=use_checkpoint,
+                        use_scale_shift_norm=use_scale_shift_norm,
+                        dtype=self.dtype,
+                        device=device,
+                        operations=operations
+                    ),
+            )
+
         self._feature_size += ch
         transformer_depth = upsampling_depth if upsampling_depth is not None else transformer_depth
         self.output_blocks = nn.ModuleList([])

--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -189,5 +189,16 @@ class SDXL(supported_models_base.BASE):
     def clip_target(self):
         return supported_models_base.ClipTarget(sdxl_clip.SDXLTokenizer, sdxl_clip.SDXLClipModel)
 
+class SSD1B(SDXL):
+        unet_config = {
+                "model_channels": 320,
+                "use_linear_in_transformer": True,
+                "transformer_depth": [0, 2, 4],  # SDXL is [0, 2, 10] here
+                "upsampling_depth": [0,[2,1,1],[4,4,10]],
+                "resnet_only_mid_block": True,
+                "context_dim": 2048,
+                "adm_in_channels": 2816
+                    }
 
-models = [SD15, SD20, SD21UnclipL, SD21UnclipH, SDXLRefiner, SDXL]
+
+models = [SD15, SD20, SD21UnclipL, SD21UnclipH, SDXLRefiner, SDXL,SSD1B]

--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -193,7 +193,7 @@ class SSD1B(SDXL):
         unet_config = {
                 "model_channels": 320,
                 "use_linear_in_transformer": True,
-                "transformer_depth": [0, 2, 4],  # SDXL is [0, 2, 10] here
+                "transformer_depth": [0, 2, 4],  
                 "upsampling_depth": [0,[2,1,1],[4,4,10]],
                 "resnet_only_mid_block": True,
                 "context_dim": 2048,


### PR DESCRIPTION
This PR is meant to enable SSD 1B loading in ComfyUI. This currently requires the ability to pass list-of-lists ```transformer depth```, ability to specify separate list-of-lists optionally to load in upsampling blocks, and the ability to instantiate a middle block with only a single Resnet instead of the Resnet-Attention-Resnet style middle block.


This is a currently a work in progress. Feel free to contribute to this PR!