### PR TITLE
Fix TAESD preview to only decode first latent, instead of all

### DIFF
--- a/latent_preview.py
+++ b/latent_preview.py
@@ -22,7 +22,7 @@ class TAESDPreviewerImpl(LatentPreviewer):
         self.taesd = taesd
 
     def decode_latent_to_preview(self, x0):
-        x_sample = self.taesd.decoder(x0)[0].detach()
+        x_sample = self.taesd.decoder(x0[:1])[0].detach()
         # x_sample = self.taesd.unscale_latents(x_sample).div(4).add(0.5)  # returns value in [-2, 2]
         x_sample = x_sample.sub(0.5).mul(2)
 


### PR DESCRIPTION
The TAESD preview returns the first latent anyway to be displayed, but the code before performed decoding on all latents and returned the first index. For single images that is fine, but 1) causes slowdowns when using batches greater than one, and 2) causes VRAM OOM when batch size is a fairly large number.

Changed code now passes only the first latent into the decoder, in the form [1, :, :, :] via slicing, and then stores result into x_sample as [channels, h, w] same as before. No more VRAM isssues with large batch sizes, and preview is faster for any batch size > 1.