### PR TITLE
fix: handle null case for currentNode widgets to prevent scroll error

### DIFF
--- a/web/extensions/core/contextMenuFilter.js
+++ b/web/extensions/core/contextMenuFilter.js
@@ -25,7 +25,7 @@ const ext = {
 				requestAnimationFrame(() => {
 					const currentNode = LGraphCanvas.active_canvas.current_node;
 					const clickedComboValue = currentNode.widgets
-						.filter(w => w.type === "combo" && w.options.values.length === values.length)
+						?.filter(w => w.type === "combo" && w.options.values.length === values.length)
 						.find(w => w.options.values.every((v, i) => v === values[i]))
 						?.value;
 


### PR DESCRIPTION
I noticed that when a scrollable list is long (say, you have many checkpoints) it's possible for the list filter at the top of the div to be scrolled offscreen. It turns out currentNode.widgets can be null, and in that case the script errors out and scrolling to the top of the list on display is never called. This guards against that so the script should always continue on as normal, and the filter is reached.