### PR TITLE
Allow saving images in WEBP and JPEG formats

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1320,10 +1320,9 @@ class SaveImage:
                 if not args.disable_metadata:
                     metadata = {}
                     if prompt is not None:
-                        metadata["prompt"] = json.dumps(prompt)
+                        metadata["prompt"] = prompt
                     if extra_pnginfo is not None:
-                        for x in extra_pnginfo:
-                            metadata[x] = json.dumps(extra_pnginfo[x])
+                        metadata.update(extra_pnginfo)
                     exif = img.getexif()
                     exif[ExifTags.Base.UserComment] = json.dumps(metadata)
                     kwargs["exif"] = exif.tobytes()

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -3,7 +3,7 @@ import { ComfyWidgets } from "./widgets.js";
 import { ComfyUI, $el } from "./ui.js";
 import { api } from "./api.js";
 import { defaultGraph } from "./defaultGraph.js";
-import { getPngMetadata, getWebpMetadata, importA1111, getLatentMetadata } from "./pnginfo.js";
+import { getPngMetadata, getWebpMetadata, getJpegMetadata, importA1111, getLatentMetadata } from "./pnginfo.js";
 
 /**
  * @typedef {import("types/comfy").ComfyExtension} ComfyExtension
@@ -1213,9 +1213,9 @@ export class ComfyApp {
 			for (const node of app.graph._nodes) {
 				node.onGraphConfigured?.();
 			}
-			
+
 			const r = onConfigure?.apply(this, arguments);
-			
+
 			// Fire after onConfigure, used by primitves to generate widget using input nodes config
 			for (const node of app.graph._nodes) {
 				node.onAfterGraphConfigured?.();
@@ -1231,7 +1231,7 @@ export class ComfyApp {
 	async #loadExtensions() {
 	    const extensions = await api.getExtensions();
 	    this.logging.addEntry("Comfy.App", "debug", { Extensions: extensions });
-	
+
 	    const extensionPromises = extensions.map(async ext => {
 	        try {
 	            await import(api.apiURL(ext));
@@ -1239,7 +1239,7 @@ export class ComfyApp {
 	            console.error("Error loading extension", ext, error);
 	        }
 	    });
-	
+
 	    await Promise.all(extensionPromises);
 	}
 
@@ -1803,6 +1803,15 @@ export class ComfyApp {
 					this.loadGraphData(JSON.parse(pngInfo.workflow));
 				} else if (pngInfo.Workflow) {
 					this.loadGraphData(JSON.parse(pngInfo.Workflow)); // Support loading workflows from that webp custom node.
+				}
+			}
+		} else if (file.type === "image/jpeg") {
+			const pngInfo = await getJpegMetadata(file);
+			if (pngInfo) {
+				if (pngInfo.workflow) {
+					this.loadGraphData(JSON.parse(pngInfo.workflow));
+				} else if (pngInfo.Workflow) {
+					this.loadGraphData(JSON.parse(pngInfo.Workflow));
 				}
 			}
 		} else if (file.type === "application/json" || file.name?.endsWith(".json")) {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1800,18 +1800,18 @@ export class ComfyApp {
 			const pngInfo = await getWebpMetadata(file);
 			if (pngInfo) {
 				if (pngInfo.workflow) {
-					this.loadGraphData(JSON.parse(pngInfo.workflow));
+					this.loadGraphData(pngInfo.workflow);
 				} else if (pngInfo.Workflow) {
-					this.loadGraphData(JSON.parse(pngInfo.Workflow)); // Support loading workflows from that webp custom node.
+					this.loadGraphData(pngInfo.Workflow); // Support loading workflows from that webp custom node.
 				}
 			}
 		} else if (file.type === "image/jpeg") {
 			const pngInfo = await getJpegMetadata(file);
 			if (pngInfo) {
 				if (pngInfo.workflow) {
-					this.loadGraphData(JSON.parse(pngInfo.workflow));
+					this.loadGraphData(pngInfo.workflow);
 				} else if (pngInfo.Workflow) {
-					this.loadGraphData(JSON.parse(pngInfo.Workflow));
+					this.loadGraphData(pngInfo.Workflow);
 				}
 			}
 		} else if (file.type === "application/json" || file.name?.endsWith(".json")) {

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -599,7 +599,7 @@ export class ComfyUI {
 		const fileInput = $el("input", {
 			id: "comfy-file-input",
 			type: "file",
-			accept: ".json,image/png,.latent,.safetensors",
+			accept: ".json,image/png,image/webp,image/jpeg,.latent,.safetensors",
 			style: {display: "none"},
 			parent: document.body,
 			onchange: () => {
@@ -662,7 +662,7 @@ export class ComfyUI {
 							this.batchCount = i.srcElement.value;
 							document.getElementById("batchCountInputNumber").value = i.srcElement.value;
 						},
-					}),		
+					}),
 				]),
 
 				$el("div",[
@@ -676,7 +676,7 @@ export class ComfyUI {
 						type: "checkbox",
 						checked: false,
 						title: "Automatically queue prompt when the queue size hits 0",
-						
+
 					}),
 				])
 			]),


### PR DESCRIPTION
Saving large images as PNG isn’t great, these tend to gets quite large. Lossy file formats allow to save on the bandwidth quite considerably.

This adds a file type selection to the “Save Image” node. PNG is still the default but selecting WEBP and JPEG is possible as well.

The non-trivial part here is saving the metadata. It needs to go into EXIF, but EXIF doesn’t allow either duplicate or custom tags. So while there was existing code to decode EXIF metadata in WEBP images, I’m not sure how exactly data was saved without violating the EXIF standard. I’ve left this decoding logic as a fallback just in case. The decoding logic for JPEG files doesn’t have this fallback, so it is simpler.

Instead of storing each metadata field individually, I’ve created a single JSON object with all metadata fields and put it into the UserComment EXIF tag. The double JSON encoding isn’t nice, but it has to be there for compatibility with the old WEBP logic.

I’ve made sure that both WEBP and JPEG images can be loaded and workflow will be decoded correctly from the saved metadata.