### PR TITLE
Force input and output images to be always reloaded in the UI

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -411,7 +411,7 @@ export class ComfyApp {
 						this.images = output.images;
 						imagesChanged = true;
 						imgURLs = imgURLs.concat(output.images.map(params => {
-							return api.apiURL("/view?" + new URLSearchParams(params).toString() + app.getPreviewFormatParam());
+							return api.apiURL("/view?" + new URLSearchParams(params).toString() + app.getPreviewFormatParam() + "&rand=" + Math.random());
 						}))
 					}
 				}
@@ -1213,9 +1213,9 @@ export class ComfyApp {
 			for (const node of app.graph._nodes) {
 				node.onGraphConfigured?.();
 			}
-			
+
 			const r = onConfigure?.apply(this, arguments);
-			
+
 			// Fire after onConfigure, used by primitves to generate widget using input nodes config
 			for (const node of app.graph._nodes) {
 				node.onAfterGraphConfigured?.();
@@ -1231,7 +1231,7 @@ export class ComfyApp {
 	async #loadExtensions() {
 	    const extensions = await api.getExtensions();
 	    this.logging.addEntry("Comfy.App", "debug", { Extensions: extensions });
-	
+
 	    const extensionPromises = extensions.map(async ext => {
 	        try {
 	            await import(api.apiURL(ext));
@@ -1239,7 +1239,7 @@ export class ComfyApp {
 	            console.error("Error loading extension", ext, error);
 	        }
 	    });
-	
+
 	    await Promise.all(extensionPromises);
 	}
 

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -278,7 +278,7 @@ export const ComfyWidgets = {
 		let disable_rounding = app.ui.settings.getSettingValue("Comfy.DisableFloatRounding")
 		if (precision == 0) precision = undefined;
 		const { val, config } = getNumberDefaults(inputData, 0.5, precision, !disable_rounding);
-		return { widget: node.addWidget(widgetType, inputName, val, 
+		return { widget: node.addWidget(widgetType, inputName, val,
 			function (v) {
 				if (config.round) {
 					this.value = Math.round(v/config.round)*config.round;
@@ -356,7 +356,7 @@ export const ComfyWidgets = {
 				subfolder = name.substring(0, folder_separator);
 				name = name.substring(folder_separator + 1);
 			}
-			img.src = api.apiURL(`/view?filename=${encodeURIComponent(name)}&type=input&subfolder=${subfolder}${app.getPreviewFormatParam()}`);
+			img.src = api.apiURL(`/view?filename=${encodeURIComponent(name)}&type=input&subfolder=${subfolder}${app.getPreviewFormatParam()}&rand=${Math.random()}`);
 			node.setSizeForImage?.();
 		}
 


### PR DESCRIPTION
This fixes an annoyance of the UI: you generate an image, let’s say `ComfyUI_00001_.png`. Then you remove that image from the `output` directory and generate another image. The new image will also be named `ComfyUI_00001_.png`, and the “Save Image” widget will show you the old image which you deleted rather than the newly generated one (tested in Firefox 119 on Linux).

This fixes the issue by appending a random parameter to the image request. I would have preferred to solve this via caching headers on the server side. However, at least Firefox ignores caching headers for requests triggered via `img.src` – as long as the URL is identical, the second image never triggers a new request.