### PR TITLE
fix unet_wrapper_function name in ModelPatcher

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -107,10 +107,10 @@ class ModelPatcher:
                 for k in patch_list:
                     if hasattr(patch_list[k], "to"):
                         patch_list[k] = patch_list[k].to(device)
-        if "unet_wrapper_function" in self.model_options:
-            wrap_func = self.model_options["unet_wrapper_function"]
+        if "model_function_wrapper" in self.model_options:
+            wrap_func = self.model_options["model_function_wrapper"]
             if hasattr(wrap_func, "to"):
-                self.model_options["unet_wrapper_function"] = wrap_func.to(device)
+                self.model_options["model_function_wrapper"] = wrap_func.to(device)
 
     def model_dtype(self):
         if hasattr(self.model, "get_dtype"):


### PR DESCRIPTION
fix unet_wrapper_function name in ModelPatcher.  
It should be the same as in method set_model_unet_function_wrapper.
Make the .to attribute of wrap_func work.