### PR TITLE
allow slot name in loadApiJson

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1873,9 +1873,13 @@ export class ComfyApp {
 			for (const input in data.inputs ?? {}) {
 				const value = data.inputs[input];
 				if (value instanceof Array) {
-					const [fromId, fromSlot] = value;
+					let [fromId, fromSlot] = value;
 					const fromNode = app.graph.getNodeById(fromId);
 					const toSlot = node.inputs?.findIndex((inp) => inp.name === input);
+
+					if(typeof fromSlot === "string")
+					    fromSlot = fromNode.outputs?.findIndex((outpt) => outpt.name === fromSlot);
+
 					if (toSlot !== -1) {
 						fromNode.connect(fromSlot, node, toSlot);
 					}


### PR DESCRIPTION
I thought this could add some flexiblity and security. 
Basically json api workflow exports outputs by their slot index (`[id, slot number]`), to match litegraph's link convention. But with this change, the api workflow can export outputs as `[id, slot name]` and as result even if a node changes its output order in the future, the api workflow should remain valid. 
We can also change the export code to export slot name by default, but for now I think this change would do.