### PR TITLE
Fix Hypertile Issue with extreme case

### DIFF
--- a/comfy_extras/nodes_hypertile.py
+++ b/comfy_extras/nodes_hypertile.py
@@ -3,6 +3,7 @@
 import math
 from einops import rearrange
 import random
+from functools import cache
 
 def random_divisor(value: int, min_value: int, /, max_options: int = 1, counter = 0) -> int:
     min_value = min(min_value, value)
@@ -16,6 +17,39 @@ def random_divisor(value: int, min_value: int, /, max_options: int = 1, counter 
     idx = random.randint(0, len(ns) - 1)
 
     return ns[idx]
+
+def iterative_closest_divisors(hw:int, aspect_ratio:float) -> tuple[int, int]:
+    """
+    Finds h and w such that h*w = hw and h/w = aspect_ratio
+    We check all possible divisors of hw and return the closest to the aspect ratio
+    """
+    divisors = [i for i in range(2, hw + 1) if hw % i == 0] # all divisors of hw
+    pairs = [(i, hw // i) for i in divisors] # all pairs of divisors of hw
+    ratios = [w/h for h, w in pairs] # all ratios of pairs of divisors of hw
+    closest_ratio = min(ratios, key=lambda x: abs(x - aspect_ratio)) # closest ratio to aspect_ratio
+    closest_pair = pairs[ratios.index(closest_ratio)] # closest pair of divisors to aspect_ratio
+    return closest_pair
+
+@cache
+def find_hw_candidates(hw:int, aspect_ratio:float) -> tuple[int, int]:
+    """
+    Finds h and w such that h*w = hw and h/w = aspect_ratio
+    """
+    h, w = round(math.sqrt(hw * aspect_ratio)), round(math.sqrt(hw / aspect_ratio))
+    # find h and w such that h*w = hw and h/w = aspect_ratio
+    if h * w != hw:
+        w_candidate = hw / h
+        # check if w is an integer
+        if not w_candidate.is_integer():
+            h_candidate = hw / w
+            # check if h is an integer
+            if not h_candidate.is_integer():
+                return iterative_closest_divisors(hw, aspect_ratio)
+            else:
+                h = int(h_candidate)
+        else:
+            w = int(w_candidate)
+    return h, w
 
 class HyperTile:
     @classmethod
@@ -50,7 +84,7 @@ class HyperTile:
                 aspect_ratio = shape[-1] / shape[-2]
 
                 hw = q.size(1)
-                h, w = round(math.sqrt(hw * aspect_ratio)), round(math.sqrt(hw / aspect_ratio))
+                h, w = find_hw_candidates(hw, aspect_ratio)
 
                 factor = 2**((q.shape[-1] // model_channels) - 1) if scale_depth else 1
                 nh = random_divisor(h, latent_tile_size * factor, swap_size, self.counter)


### PR DESCRIPTION
Assume the following case

512x768 -> 1.2x upscale

Temporarily, it will lead to make 8740 = 76 * 115 -shape tensor.

This is from
round (512  * 1.2) = 614
614 // 8 = **76**

round (768 * 1.2) = 922
922 // 8 = **115**

Whileas the aspect ratio is 1.5, the values are:

(8740*1.5)**0.5 =114.49890829173874 
Thus the rounded value is **114.**

This will fail the h*w = hw assertion, leading to shape mismatch.

Note that ComfyUI should be almost safe from this issue since comfyUI [auto-detects aspect ratio](https://github.com/comfyanonymous/ComfyUI/blob/4781819a85847a8cf180a41d0ee4cdf99979e5be/comfy/ldm/modules/diffusionmodules/openaimodel.py#L607) unlike the original code. 

I'm not sure why they has changed the reference code from [this](https://github.com/tfernd/HyperTile/blob/main/playground.ipynb).