### PR TITLE
fix(websockets_api_example.py): prevent errors if 'images' is not in node_output

### DIFF
--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -41,15 +41,14 @@ def get_images(ws, prompt):
             continue #previews are binary data
 
     history = get_history(prompt_id)[prompt_id]
-    for o in history['outputs']:
-        for node_id in history['outputs']:
-            node_output = history['outputs'][node_id]
-            images_output = []
-            if 'images' in node_output:
-                for image in node_output['images']:
-                    image_data = get_image(image['filename'], image['subfolder'], image['type'])
-                    images_output.append(image_data)
-            output_images[node_id] = images_output
+    for node_id in history['outputs']:
+        node_output = history['outputs'][node_id]
+        images_output = []
+        if 'images' in node_output:
+            for image in node_output['images']:
+                image_data = get_image(image['filename'], image['subfolder'], image['type'])
+                images_output.append(image_data)
+        output_images[node_id] = images_output
 
     return output_images
 

--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -44,8 +44,8 @@ def get_images(ws, prompt):
     for o in history['outputs']:
         for node_id in history['outputs']:
             node_output = history['outputs'][node_id]
+            images_output = []
             if 'images' in node_output:
-                images_output = []
                 for image in node_output['images']:
                     image_data = get_image(image['filename'], image['subfolder'], image['type'])
                     images_output.append(image_data)


### PR DESCRIPTION
There are some node_outputs that do not have an `images` field, which causes the following problems:

```
Traceback (most recent call last):
  File "comfy_websocket.py", line 73, in <module>
    images = get_images(ws, prompt)
  File "comfy_websocket.py", line 63, in get_images
    output_images[node_id] = images_output
UnboundLocalError: local variable 'images_output' referenced before assignment
```

This PR fixes that.