### PR TITLE
Save the state of PromptQueue and restore it if the application is restarted after a crash

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -683,7 +683,7 @@ def validate_prompt(prompt):
 
 
 class PromptQueue:
-    def __init__(self, server):
+    def __init__(self, server, backup_id):
         self.server = server
         self.mutex = threading.RLock()
         self.not_empty = threading.Condition(self.mutex)
@@ -692,10 +692,31 @@ class PromptQueue:
         self.currently_running = {}
         self.history = {}
         server.prompt_queue = self
+        self.backup_file = backup_id + "_pqbackup.json"
+        if os.path.isfile(self.backup_file):
+            print("Loading backup file")
+            with open(self.backup_file, "r") as f:
+                s = json.loads(f.read())
+                self.queue = s['queue']
+                self.history = s['history']
+                self.task_counter = int(s['task_counter'])
+        
+    def save_backup(self):
+        with open(self.backup_file, "w") as f:
+            if not self.queue:
+                if os.path.isfile(self.backup_file): os.remove(self.backup_file)
+            else:
+                s = {
+                    'queue':self.queue,
+                    'history':self.history,
+                    'task_counter':self.task_counter
+                }
+                json.dump(s,f)
 
     def put(self, item):
         with self.mutex:
             heapq.heappush(self.queue, item)
+            self.save_backup()
             self.server.queue_updated()
             self.not_empty.notify()
 
@@ -716,6 +737,7 @@ class PromptQueue:
             self.history[prompt[1]] = { "prompt": prompt, "outputs": {} }
             for o in outputs:
                 self.history[prompt[1]]["outputs"][o] = outputs[o]
+            self.save_backup()
             self.server.queue_updated()
 
     def get_current_queue(self):
@@ -732,6 +754,7 @@ class PromptQueue:
     def wipe_queue(self):
         with self.mutex:
             self.queue = []
+            self.save_backup()
             self.server.queue_updated()
 
     def delete_queue_item(self, function):
@@ -743,6 +766,7 @@ class PromptQueue:
                     else:
                         self.queue.pop(x)
                         heapq.heapify(self.queue)
+                    self.save_backup()
                     self.server.queue_updated()
                     return True
         return False
@@ -759,7 +783,9 @@ class PromptQueue:
     def wipe_history(self):
         with self.mutex:
             self.history = {}
+            self.save_backup()
 
     def delete_history_item(self, id_to_delete):
         with self.mutex:
             self.history.pop(id_to_delete, None)
+            self.save_backup()

--- a/main.py
+++ b/main.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     server = server.PromptServer(loop)
-    q = execution.PromptQueue(server)
+    q = execution.PromptQueue(server, "main")
 
     extra_model_paths_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extra_model_paths.yaml")
     if os.path.isfile(extra_model_paths_config_path):


### PR DESCRIPTION
I often leave ComfyUI running with a long queue of prompts while I sleep or do other stuff, but sometimes it crashes because it runs out of memory or something and I lose my entire prompt queue and history.

With this simple modification, the state of PromptQueue is saved every time something is added/removed to the queue/history and if the application is restarted after a crash, it automatically reloads the state from this backup and resumes processing it.

It doesn't fully save/restore the state of the application, just the queue and history, but it gets the job done for me.