### PR TITLE
API: Add support for URL's in images & masks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Pillow
 scipy
 tqdm
 psutil
+requests


### PR DESCRIPTION
Right now, the only way to use an input image via the API is to first upload it to the same server as Comfy.

This is inconvenient if you are running a cluster of Comfy nodes as you need to make sure that all the `input` subfolders stay in sync.

This change allows for URL's to be passed for images & masks so the server can download them on its own.

The requests to retrieve the images are being done synchronously via the `requests` library.