### PR TITLE
Add alternative sampler for LCM.

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -522,7 +522,8 @@ class UNIPCBH2(Sampler):
 
 KSAMPLER_NAMES = ["euler", "euler_ancestral", "heun", "heunpp2","dpm_2", "dpm_2_ancestral",
                   "lms", "dpm_fast", "dpm_adaptive", "dpmpp_2s_ancestral", "dpmpp_sde", "dpmpp_sde_gpu",
-                  "dpmpp_2m", "dpmpp_2m_sde", "dpmpp_2m_sde_gpu", "dpmpp_3m_sde", "dpmpp_3m_sde_gpu", "ddpm", "lcm"]
+                  "dpmpp_2m", "dpmpp_2m_sde", "dpmpp_2m_sde_gpu", "dpmpp_3m_sde", "dpmpp_3m_sde_gpu", "ddpm", "lcm",
+                  "lcm_alt"]
 
 class KSAMPLER(Sampler):
     def __init__(self, sampler_function, extra_options={}, inpaint_options={}):


### PR DESCRIPTION
I've found using LCM Lora to be hard to prompt in that LCM tends to require very explicit prompts to generate anything worthwhile. However, the speed is very attractive, so I've been testing all kinds of things as of late and ended up writing my own sampler. I think it's a significant improvement in image composition and sometimes also quality when the prompt is somewhat vague and steps are 15+. Whether this is useful probably depends on your prompting style. This also fixes the issue with the original scheduler that the composition tends to gets simpler as the number of steps increases.

The basic idea is to do the beginning of the inference with diffusion and then transition to using entirely new noise, like the old sampler does. So, if that could be made into a variable tunable from the user interface, this sampler could entirely replace the old one. The old one can be looked at as a special case of this one where the limit is >14.6146.

Here's an example to demonstrate the difference when the prompt is vague.
![lcm_alt-workflow](https://github.com/comfyanonymous/ComfyUI/assets/771803/a4cae8fc-e84f-4e7b-a387-6ef02d1f8c20)
