### PR TITLE
Memory optimizations to allow bigger images

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -80,6 +80,7 @@ class LatentPreviewMethod(enum.Enum):
     TAESD = "taesd"
 
 parser.add_argument("--preview-method", type=LatentPreviewMethod, default=LatentPreviewMethod.NoPreviews, help="Default preview method for sampler nodes.", action=EnumAction)
+parser.add_argument("--preview-cpu", action="store_true", help="To use the CPU for preview (slow).")
 
 attn_group = parser.add_mutually_exclusive_group()
 attn_group.add_argument("--use-split-cross-attention", action="store_true", help="Use the split cross attention optimization. Ignored when xformers is used.")
@@ -99,6 +100,7 @@ vram_group.add_argument("--cpu", action="store_true", help="To use the CPU for e
 
 parser.add_argument("--disable-smart-memory", action="store_true", help="Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.")
 
+parser.add_argument("--memory-estimation-multiplier", type=float, default=-1, help="Multiplier for the memory estimation.")
 
 parser.add_argument("--dont-print-server", action="store_true", help="Don't print server output.")
 parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test for CI.")

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -224,6 +224,8 @@ class VAE:
                 samples = samples_in[x:x+batch_number].to(self.vae_dtype).to(self.device)
                 pixel_samples[x:x+batch_number] = torch.clamp((self.first_stage_model.decode(samples).cpu().float() + 1.0) / 2.0, min=0.0, max=1.0)
         except model_management.OOM_EXCEPTION as e:
+            pixel_samples = None
+
             tile_size = 64
             while tile_size >= 8:
                 overlap = tile_size // 4
@@ -263,6 +265,8 @@ class VAE:
                 samples[x:x+batch_number] = self.first_stage_model.encode(pixels_in).cpu().float()
 
         except model_management.OOM_EXCEPTION as e:
+            samples = None
+
             tile_size = 512
             while tile_size >= 64:
                 overlap = tile_size // 8

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -155,11 +155,19 @@ class VAE:
         if 'decoder.up_blocks.0.resnets.0.norm1.weight' in sd.keys(): #diffusers format
             sd = diffusers_convert.convert_vae_state_dict(sd)
 
-        self.memory_used_encode = lambda shape: (2078 * shape[2] * shape[3]) * 1.7 #These are for AutoencoderKL and need tweaking
-        self.memory_used_decode = lambda shape: (2562 * shape[2] * shape[3] * 64) * 1.7
+        self.memory_used_encode = lambda shape, dtype: (1767 * shape[2] * shape[3]) * model_management.dtype_size(dtype) #These are for AutoencoderKL and need tweaking (should be lower)
+        self.memory_used_decode = lambda shape, dtype: (2178 * shape[2] * shape[3] * 64) * model_management.dtype_size(dtype)
 
         if config is None:
-            if "taesd_decoder.1.weight" in sd:
+            if "decoder.mid.block_1.mix_factor" in sd:
+                encoder_config = {'double_z': True, 'z_channels': 4, 'resolution': 256, 'in_channels': 3, 'out_ch': 3, 'ch': 128, 'ch_mult': [1, 2, 4, 4], 'num_res_blocks': 2, 'attn_resolutions': [], 'dropout': 0.0}
+                decoder_config = encoder_config.copy()
+                decoder_config["video_kernel_size"] = [3, 1, 1]
+                decoder_config["alpha"] = 0.0
+                self.first_stage_model = AutoencodingEngine(regularizer_config={'target': "comfy.ldm.models.autoencoder.DiagonalGaussianRegularizer"},
+                                                            encoder_config={'target': "comfy.ldm.modules.diffusionmodules.model.Encoder", 'params': encoder_config},
+                                                            decoder_config={'target': "comfy.ldm.modules.temporal_ae.VideoDecoder", 'params': decoder_config})
+            elif "taesd_decoder.1.weight" in sd:
                 self.first_stage_model = comfy.taesd.taesd.TAESD()
             else:
                 #default SD1.x/SD2.x VAE parameters
@@ -179,9 +187,11 @@ class VAE:
         if device is None:
             device = model_management.vae_device()
         self.device = device
-        self.offload_device = model_management.vae_offload_device()
+        offload_device = model_management.vae_offload_device()
         self.vae_dtype = model_management.vae_dtype()
         self.first_stage_model.to(self.vae_dtype)
+
+        self.patcher = comfy.model_patcher.ModelPatcher(self.first_stage_model, load_device=self.device, offload_device=offload_device)
 
     def decode_tiled_(self, samples, tile_x=64, tile_y=64, overlap = 16):
         steps = samples.shape[0] * comfy.utils.get_tiled_scale_steps(samples.shape[3], samples.shape[2], tile_x, tile_y, overlap)
@@ -211,10 +221,11 @@ class VAE:
         return samples
 
     def decode(self, samples_in):
-        self.first_stage_model = self.first_stage_model.to(self.device)
+        pixel_samples = None
+
         try:
-            memory_used = self.memory_used_decode(samples_in.shape)
-            model_management.free_memory(memory_used, self.device)
+            memory_used = self.memory_used_decode(samples_in.shape, self.vae_dtype)
+            model_management.load_models_gpu([self.patcher], memory_required=memory_used)
             free_memory = model_management.get_free_memory(self.device)
             batch_number = int(free_memory / memory_used)
             batch_number = max(1, batch_number)
@@ -223,6 +234,7 @@ class VAE:
             for x in range(0, samples_in.shape[0], batch_number):
                 samples = samples_in[x:x+batch_number].to(self.vae_dtype).to(self.device)
                 pixel_samples[x:x+batch_number] = torch.clamp((self.first_stage_model.decode(samples).cpu().float() + 1.0) / 2.0, min=0.0, max=1.0)
+
         except model_management.OOM_EXCEPTION as e:
             pixel_samples = None
 
@@ -239,23 +251,22 @@ class VAE:
 
             if pixel_samples is None:
                 raise e
-        finally:
-            self.first_stage_model = self.first_stage_model.to(self.offload_device)
+
         pixel_samples = pixel_samples.cpu().movedim(1,-1)
         return pixel_samples
 
     def decode_tiled(self, samples, tile_x=64, tile_y=64, overlap = 16):
-        self.first_stage_model = self.first_stage_model.to(self.device)
+        model_management.load_model_gpu(self.patcher)
         output = self.decode_tiled_(samples, tile_x, tile_y, overlap)
-        self.first_stage_model = self.first_stage_model.to(self.offload_device)
         return output.movedim(1,-1)
 
     def encode(self, pixel_samples):
-        self.first_stage_model = self.first_stage_model.to(self.device)
         pixel_samples = pixel_samples.movedim(-1,1)
+        samples = None
+
         try:
-            memory_used = self.memory_used_encode(pixel_samples.shape) #NOTE: this constant along with the one in the decode above are estimated from the mem usage for the VAE and could change.
-            model_management.free_memory(memory_used, self.device)
+            memory_used = self.memory_used_encode(pixel_samples.shape, self.vae_dtype)
+            model_management.load_models_gpu([self.patcher], memory_required=memory_used)
             free_memory = model_management.get_free_memory(self.device)
             batch_number = int(free_memory / memory_used)
             batch_number = max(1, batch_number)
@@ -280,15 +291,13 @@ class VAE:
 
             if samples is None:
                 raise e
-        finally:
-            self.first_stage_model = self.first_stage_model.to(self.offload_device)
+
         return samples
 
     def encode_tiled(self, pixel_samples, tile_x=512, tile_y=512, overlap = 64):
-        self.first_stage_model = self.first_stage_model.to(self.device)
+        model_management.load_model_gpu(self.patcher)
         pixel_samples = pixel_samples.movedim(-1,1)
         samples = self.encode_tiled_(pixel_samples, tile_x=tile_x, tile_y=tile_y, overlap=overlap)
-        self.first_stage_model = self.first_stage_model.to(self.offload_device)
         return samples
 
     def get_sd(self):
@@ -474,6 +483,7 @@ def load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, o
 
     if output_vae:
         vae_sd = comfy.utils.state_dict_prefix_replace(sd, {"first_stage_model.": ""}, filter_keys=True)
+        vae_sd = model_config.process_vae_state_dict(vae_sd)
         vae = VAE(sd=vae_sd)
 
     if output_clip:
@@ -498,20 +508,18 @@ def load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, o
     return (model_patcher, clip, vae, clipvision)
 
 
-def load_unet(unet_path): #load unet in diffusers format
-    sd = comfy.utils.load_torch_file(unet_path)
+def load_unet_state_dict(sd): #load unet in diffusers format
     parameters = comfy.utils.calculate_parameters(sd)
     unet_dtype = model_management.unet_dtype(model_params=parameters)
     if "input_blocks.0.0.weight" in sd: #ldm
         model_config = model_detection.model_config_from_unet(sd, "", unet_dtype)
         if model_config is None:
-            raise RuntimeError("ERROR: Could not detect model type of: {}".format(unet_path))
+            return None
         new_sd = sd
 
     else: #diffusers
         model_config = model_detection.model_config_from_diffusers_unet(sd, unet_dtype)
         if model_config is None:
-            print("ERROR UNSUPPORTED UNET", unet_path)
             return None
 
         diffusers_keys = comfy.utils.unet_to_diffusers(model_config.unet_config)
@@ -530,6 +538,14 @@ def load_unet(unet_path): #load unet in diffusers format
     if len(left_over) > 0:
         print("left over keys in unet:", left_over)
     return comfy.model_patcher.ModelPatcher(model, load_device=model_management.get_torch_device(), offload_device=offload_device)
+
+def load_unet(unet_path):
+    sd = comfy.utils.load_torch_file(unet_path)
+    model = load_unet_state_dict(sd)
+    if model is None:
+        print("ERROR UNSUPPORTED UNET", unet_path)
+        raise RuntimeError("ERROR: Could not detect model type of: {}".format(unet_path))
+    return model
 
 def save_checkpoint(output_path, model, clip, vae, metadata=None):
     model_management.load_models_gpu([model, clip.load_model()])

--- a/latent_preview.py
+++ b/latent_preview.py
@@ -6,6 +6,7 @@ from comfy.cli_args import args, LatentPreviewMethod
 from comfy.taesd.taesd import TAESD
 import folder_paths
 import comfy.utils
+from comfy import model_management
 
 MAX_PREVIEW_RESOLUTION = 512
 
@@ -18,11 +19,12 @@ class LatentPreviewer:
         return ("JPEG", preview_image, MAX_PREVIEW_RESOLUTION)
 
 class TAESDPreviewerImpl(LatentPreviewer):
-    def __init__(self, taesd):
+    def __init__(self, taesd, device):
         self.taesd = taesd
+        self.device = device
 
     def decode_latent_to_preview(self, x0):
-        x_sample = self.taesd.decoder(x0[:1])[0].detach()
+        x_sample = self.taesd.decoder(x0[:1].to(self.device))[0].detach()
         # x_sample = self.taesd.unscale_latents(x_sample).div(4).add(0.5)  # returns value in [-2, 2]
         x_sample = x_sample.sub(0.5).mul(2)
 
@@ -52,6 +54,8 @@ class Latent2RGBPreviewer(LatentPreviewer):
 def get_previewer(device, latent_format):
     previewer = None
     method = args.preview_method
+    if args.preview_cpu:
+        device = torch.device("cpu")
     if method != LatentPreviewMethod.NoPreviews:
         # TODO previewer methods
         taesd_decoder_path = None
@@ -71,7 +75,7 @@ def get_previewer(device, latent_format):
         if method == LatentPreviewMethod.TAESD:
             if taesd_decoder_path:
                 taesd = TAESD(None, taesd_decoder_path).to(device)
-                previewer = TAESDPreviewerImpl(taesd)
+                previewer = TAESDPreviewerImpl(taesd, device)
             else:
                 print("Warning: TAESD previews enabled, but could not find models/vae_approx/{}".format(latent_format.taesd_decoder_name))
 
@@ -94,7 +98,10 @@ def prepare_callback(model, steps, x0_output_dict=None):
 
         preview_bytes = None
         if previewer:
-            preview_bytes = previewer.decode_latent_to_preview_image(preview_format, x0)
+            try:
+                preview_bytes = previewer.decode_latent_to_preview_image(preview_format, x0)
+            except model_management.OOM_EXCEPTION as e:
+                pass
         pbar.update_absolute(step + 1, total_steps, preview_bytes)
     return callback
 


### PR DESCRIPTION
I realized that my hardware could generate bigger images than I was being able to generate, with those changes I went from the limit of 1024x1024 to 2184x2184 on my 2GB VRAM GPU, that is ~4x bigger.

Now that we have the LCM and we only need 5 steps, it is reasonable to generate bigger images and the limitation was just the OOM errors.

List of changes:

- **TAESD PREVIEW** - The TAESD preview uses the GPU by default and it gets OOM stopping the generation even when there is enough memory for the generation process, the first change was to ignore the OOM of the preview and just don't show the preview if it gets a OOM, the second change was the command line option `--preview-cpu` to use the CPU for the preview, so you can get TAESD previews even with low VRAM and big sizes.

- **SPLIT ATTENTION** - The split attention allows to have bigger images but it was limiting the steps by a fixed amount that was not enough in many cases, another issue is that the steps were powers of 2, but the steps must be a divider of the `q.shape[1]`, when generating images with sizes like 512x512, 1024x1024, 2048x2048 it is ok to have the steps been a power of 2 but for other sizes the dividers of the `q.shape[1]` where not a power of two, making it skip the correct divider and getting the OOM even when it could be using another number of steps, and in other situations the estimated memory requirement is bigger than the correct divider, skipping it. So to solve it I added the command line option `--memory-estimation-multiplier` so we can adjust the value of the `modifier` that already exists to fit our need and even disable the estimation by setting it to zero, the other change was to compute the next step by finding the next divider instead of multiplying by 2. With these changes it is unlikely someone will get a OOM again in this part of the code if they adjust the memory multiplier properly when needed, based on my tests you will get a OOM error in other parts of the code before, in places that cannot be split anyway.

- **VAE ENCODE/DECODE** - The last thing limiting the generation was the VAE encoding/decoding, it already has a tiled option as fallback in case of OOM but it runs with just the default tile size, but it often gets OOM even when a smaller tile size would solve the problem, so now it tries first with the default tile size as before but in case of OOM in the tiled process, it tries a smaller tile size. I set the limit as the smaller value possible, but it is unlikely it will get there unless someone is generating an extreme batch size for their hardware, but if it gets there it will work anyway and even this lowest tile size has a reasonable quality for this extreme tiling, which is better than a OOM that makes you lose all images.

The default values keep the same behavior as before, so for those that don't have issues with OOM it will work in the same way.