### PR TITLE
fix: folder handling issues

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -38,7 +38,10 @@ input_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "inp
 filename_list_cache = {}
 
 if not os.path.exists(input_directory):
-    os.makedirs(input_directory)
+    try:
+        os.makedirs(input_directory)
+    except:
+        print("Failed to create input directory")
 
 def set_output_directory(output_dir):
     global output_directory

--- a/nodes.py
+++ b/nodes.py
@@ -1808,7 +1808,7 @@ def load_custom_nodes():
     node_paths = folder_paths.get_folder_paths("custom_nodes")
     node_import_times = []
     for custom_node_path in node_paths:
-        possible_modules = os.listdir(custom_node_path)
+        possible_modules = os.listdir(os.path.realpath(custom_node_path))
         if "__pycache__" in possible_modules:
             possible_modules.remove("__pycache__")
 


### PR DESCRIPTION
This fixes two problems:

1. program crash if it can't create the input folder. Now it only prints an error message
2. program crash if the custom_nodes folder is a symlink. Now it will follow the symlink.

These are issues found while [packaging comfyui for NixOS](https://github.com/NixOS/nixpkgs/pull/268378)