### PR TITLE
Reduce prompt spam

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,7 +121,8 @@ def prompt_worker(q, server):
 
             current_time = time.perf_counter()
             execution_time = current_time - execution_start_time
-            print("Prompt executed in {:.2f} seconds".format(execution_time))
+            if execution_time >= 0.01:
+                print(f"Prompt executed in {execution_time:.2f} seconds")
 
         flags = q.get_flags()
         free_memory = flags.get("free_memory", False)

--- a/server.py
+++ b/server.py
@@ -453,7 +453,6 @@ class PromptServer():
 
         @routes.post("/prompt")
         async def post_prompt(request):
-            print("got prompt")
             resp_code = 200
             out_string = ""
             json_data =  await request.json()


### PR DESCRIPTION
When using Comfy for SDXL Turbo real-time prompting, my console is filled with "got prompt" and "Prompt executed in 0.000 seconds".

This removes the "got prompt" debug log, and changes the execution time to only show when it makes sense.