### PR TITLE
Bypass browser cache for SaveImage node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1311,7 +1311,8 @@ class SaveImage:
             results.append({
                 "filename": file,
                 "subfolder": subfolder,
-                "type": self.type
+                "type": self.type,
+                "time": int(time.time())
             })
             counter += 1
 


### PR DESCRIPTION
The preview for the `SaveImage` node doesn't get updated when the user deletes images from the output folder. This is due to the browser caching the image. Since the URL doesn't change, the user is presented with the cached image instead.

![Untitled](https://github.com/comfyanonymous/ComfyUI/assets/125218114/a5496c46-3b0c-4b40-88c7-fb66090026c5)

This PR bypasses the cache by adding the current timestamp as an argument to the URL, forcing a reload.