### PR TITLE
Fix node growing with DOM widgets when adding image even if enough space

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -411,7 +411,7 @@ export class ComfyApp {
 		node.prototype.setSizeForImage = function (force) {
 			if(!force && this.animatedImages) return;
 
-			if (this.inputHeight) {
+			if (this.inputHeight || this.freeWidgetSpace > 210) {
 				this.setSize(this.size);
 				return;
 			}

--- a/web/scripts/domWidget.js
+++ b/web/scripts/domWidget.js
@@ -120,6 +120,8 @@ function computeSize(size) {
 		freeSpace -= 220;
 	}
 
+	this.freeWidgetSpace = freeSpace;
+
 	if (freeSpace < 0) {
 		// Not enough space for all widgets so we need to grow
 		size[1] -= freeSpace;


### PR DESCRIPTION
To recreate issue:
1. Load default workflow
2. Select KSampler (with previews enabled) and/or Save Image node + CLIPTextEncode
3. Convert to group
4. Generate (Node will grow to show image)
5. F5
6. Generate again
7. Node shouldnt grow again