### PR TITLE
Fix template sorting

### DIFF
--- a/web/extensions/core/nodeTemplates.js
+++ b/web/extensions/core/nodeTemplates.js
@@ -164,7 +164,7 @@ class ManageTemplates extends ComfyDialog {
 										var prev_i = el.dataset.id;
 
 										if ( el == this.draggedEl && prev_i != i ) {
-											[this.templates[i], this.templates[prev_i]] = [this.templates[prev_i], this.templates[i]];
+											this.templates.splice(i, 0, this.templates.splice(prev_i, 1)[0]);
 										}
 										el.dataset.id = i;
 									});


### PR DESCRIPTION
It is currently swapping entries rather than moving when you drag to re-order the templates

e.g. if you have [a,b,c,d] and you drag d to the top to get [d,a,b,c]
if you then close and reopen, you get [d,b,c,a]