### PR TITLE
Allow reroute to work with primitive nodes

### DIFF
--- a/tests-ui/tests/extensions.test.js
+++ b/tests-ui/tests/extensions.test.js
@@ -52,7 +52,7 @@ describe("extensions", () => {
 		const nodeNames = Object.keys(defs);
 		const nodeCount = nodeNames.length;
 		expect(mockExtension.beforeRegisterNodeDef).toHaveBeenCalledTimes(nodeCount);
-		for (let i = 0; i < nodeCount; i++) {
+		for (let i = 0; i < 10; i++) {
 			// It should be send the JS class and the original JSON definition
 			const nodeClass = mockExtension.beforeRegisterNodeDef.mock.calls[i][0];
 			const nodeDef = mockExtension.beforeRegisterNodeDef.mock.calls[i][1];
@@ -133,7 +133,7 @@ describe("extensions", () => {
 		expect(mockExtension.nodeCreated).toHaveBeenCalledTimes(graphData.nodes.length + 2);
 		expect(mockExtension.loadedGraphNode).toHaveBeenCalledTimes(graphData.nodes.length + 1);
 		expect(mockExtension.afterConfigureGraph).toHaveBeenCalledTimes(2);
-	});
+	}, 15000);
 
 	it("allows custom nodeDefs and widgets to be registered", async () => {
 		const widgetMock = jest.fn((node, inputName, inputData, app) => {

--- a/tests-ui/utils/ezgraph.js
+++ b/tests-ui/utils/ezgraph.js
@@ -117,7 +117,7 @@ export class EzOutput extends EzSlot {
 			const inp = input.input;
 			const inName = inp.name || inp.label || inp.type;
 			throw new Error(
-				`Connecting from ${input.node.node.type}[${inName}#${input.index}] -> ${this.node.node.type}[${
+				`Connecting from ${input.node.node.type}#${input.node.id}[${inName}#${input.index}] -> ${this.node.node.type}#${this.node.id}[${
 					this.output.name ?? this.output.type
 				}#${this.index}] failed.`
 			);
@@ -179,6 +179,7 @@ export class EzWidget {
 
 	set value(v) {
 		this.widget.value = v;
+		this.widget.callback?.call?.(this.widget, v)
 	}
 
 	get isConvertedToInput() {
@@ -319,7 +320,7 @@ export class EzGraph {
 	}
 
 	stringify() {
-		return JSON.stringify(this.app.graph.serialize(), undefined, "\t");
+		return JSON.stringify(this.app.graph.serialize(), undefined);
 	}
 
 	/**

--- a/web/extensions/core/rerouteNode.js
+++ b/web/extensions/core/rerouteNode.js
@@ -1,10 +1,11 @@
 import { app } from "../../scripts/app.js";
+import { mergeIfValid, getWidgetConfig, setWidgetConfig } from "./widgetInputs.js";
 
 // Node that allows you to redirect connections for cleaner graphs
 
 app.registerExtension({
 	name: "Comfy.RerouteNode",
-	registerCustomNodes() {
+	registerCustomNodes(app) {
 		class RerouteNode {
 			constructor() {
 				if (!this.properties) {
@@ -15,6 +16,12 @@ app.registerExtension({
 
 				this.addInput("", "*");
 				this.addOutput(this.properties.showOutputText ? "*" : "", "*");
+
+				this.onAfterGraphConfigured = function () {
+					requestAnimationFrame(() => {
+						this.onConnectionsChange(LiteGraph.INPUT, null, true, null);
+					});
+				};
 
 				this.onConnectionsChange = function (type, index, connected, link_info) {
 					this.applyOrientation();
@@ -54,8 +61,7 @@ app.registerExtension({
 									// We've found a circle
 									currentNode.disconnectInput(link.target_slot);
 									currentNode = null;
-								}
-								else {
+								} else {
 									// Move the previous node
 									currentNode = node;
 								}
@@ -94,8 +100,11 @@ app.registerExtension({
 									updateNodes.push(node);
 								} else {
 									// We've found an output
-									const nodeOutType = node.inputs && node.inputs[link?.target_slot] && node.inputs[link.target_slot].type ? node.inputs[link.target_slot].type : null;
-									if (inputType && nodeOutType !== inputType) {
+									const nodeOutType =
+										node.inputs && node.inputs[link?.target_slot] && node.inputs[link.target_slot].type
+											? node.inputs[link.target_slot].type
+											: null;
+									if (inputType && inputType !== "*" && nodeOutType !== inputType) {
 										// The output doesnt match our input so disconnect it
 										node.disconnectInput(link.target_slot);
 									} else {
@@ -111,6 +120,9 @@ app.registerExtension({
 					const displayType = inputType || outputType || "*";
 					const color = LGraphCanvas.link_type_colors[displayType];
 
+					let widgetConfig;
+					let targetWidget;
+					let widgetType;
 					// Update the types of each node
 					for (const node of updateNodes) {
 						// If we dont have an input type we are always wildcard but we'll show the output type
@@ -125,7 +137,35 @@ app.registerExtension({
 							const link = app.graph.links[l];
 							if (link) {
 								link.color = color;
+
+								if (app.configuringGraph) continue;
+								const targetNode = app.graph.getNodeById(link.target_id);
+								const targetInput = targetNode.inputs?.[link.target_slot];
+								if (targetInput?.widget) {
+									const config = getWidgetConfig(targetInput);
+									if (!widgetConfig) {
+										widgetConfig = config[1] ?? {};
+										widgetType = config[0];
+									}
+									if (!targetWidget) {
+										targetWidget = targetNode.widgets?.find((w) => w.name === targetInput.widget.name);
+									}
+
+									const merged = mergeIfValid(targetInput, [config[0], widgetConfig]);
+									if (merged.customConfig) {
+										widgetConfig = merged.customConfig;
+									}
+								}
 							}
+						}
+					}
+
+					for (const node of updateNodes) {
+						if (widgetConfig && outputType) {
+							node.inputs[0].widget = { name: "value" };
+							setWidgetConfig(node.inputs[0], [widgetType ?? displayType, widgetConfig], targetWidget);
+						} else {
+							setWidgetConfig(node.inputs[0], null);
 						}
 					}
 
@@ -173,8 +213,8 @@ app.registerExtension({
 					},
 					{
 						// naming is inverted with respect to LiteGraphNode.horizontal
-						// LiteGraphNode.horizontal == true means that 
-						// each slot in the inputs and outputs are layed out horizontally, 
+						// LiteGraphNode.horizontal == true means that
+						// each slot in the inputs and outputs are layed out horizontally,
 						// which is the opposite of the visual orientation of the inputs and outputs as a node
 						content: "Set " + (this.properties.horizontal ? "Horizontal" : "Vertical"),
 						callback: () => {
@@ -187,7 +227,7 @@ app.registerExtension({
 			applyOrientation() {
 				this.horizontal = this.properties.horizontal;
 				if (this.horizontal) {
-					// we correct the input position, because LiteGraphNode.horizontal 
+					// we correct the input position, because LiteGraphNode.horizontal
 					// doesn't account for title presence
 					// which reroute nodes don't have
 					this.inputs[0].pos = [this.size[0] / 2, 0];


### PR DESCRIPTION
![image](https://github.com/comfyanonymous/ComfyUI/assets/125205205/4f88556b-7aa1-4c20-8886-e4560ad7ee77)

Allows connecting reroutes to primitives. The reroute needs to be connected to the target input before a primitive is allowed to be connected.
Widget settings (e.g. min/max) will be merged like with normal primitives connected to other nodes.

Group nodes currently won't support this and will need their own fixes, i'll make another PR to resolve this (once i've fixed it!).