### PR TITLE
Clarify timestep vs. sigma for cfg_function interface

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -251,7 +251,8 @@ def sampling_function(model, x, sigmas, uncond, cond, cond_scale, model_options=
 
         cond, uncond = calc_cond_uncond_batch(model, cond, uncond, x, sigmas, model_options)
         if "sampler_cfg_function" in model_options:
-            args = {"cond": x - cond, "uncond": x - uncond, "cond_scale": cond_scale, "input": x, "sigma": sigmas}
+            timesteps = model.model_sampling.timestep(sigmas)
+            args = {"cond": x - cond, "uncond": x - uncond, "cond_scale": cond_scale, "timestep": timesteps, "input": x, "sigma": sigmas}
             return x - model_options["sampler_cfg_function"](args)
         else:
             return uncond + (cond - uncond) * cond_scale


### PR DESCRIPTION
`sampler_cfg_function`s were getting a `timestep` parameter which is not a timestep but a noise magnitude (sigma).  This causes [some modules to have wrong scheduling or even sign errors](https://github.com/mcmonkeyprojects/sd-dynamic-thresholding/blob/master/dynthres_comfyui.py#L72).

The primary goal of this PR is to clear the confusion in the code, but I also tried to fix `sd-dynamic-thresholding` by satisfying it's need for a true timestep value:

* First commit addresses the naming of variables in `samplers.py: sampling_function()` and `model_base.py: apply_model()`,
* Second commit adds a true `timestep` field to the arguments of `sampler_cfg_function`,

I haven't added back a `timestep` field to the arguments of `model_function_wrapper`, as I'm not sure if it's needed by anyone. If needed, then it's likely cleaner to pull `timestep = self.model_sampling.timestep(sigma)` out of `apply_model` and pass both `sigma` and `time_step` to `apply_model` and hooks.