### PR TITLE
Add keybind to cancel current generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Workflow examples can be found on the [Examples page](https://comfyanonymous.git
 |---------------------------|--------------------------------------------------------------------------------------------------------------------|
 | Ctrl + Enter              | Queue up current graph for generation                                                                              |
 | Ctrl + Shift + Enter      | Queue up current graph as first for generation                                                                     |
-| Ctrl + K                  | Cancel currently running generation                                                                                |
+| Ctrl + Alt + Enter        | Cancel currently running generation                                                                                |
+| Ctrl + Alt + Del/Bksp     | Cancel all queued prompts                                                                                          |
 | Ctrl + Z/Ctrl + Y         | Undo/Redo                                                                                                          |
 | Ctrl + S                  | Save workflow                                                                                                      |
 | Ctrl + O                  | Load workflow                                                                                                      |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Workflow examples can be found on the [Examples page](https://comfyanonymous.git
 |---------------------------|--------------------------------------------------------------------------------------------------------------------|
 | Ctrl + Enter              | Queue up current graph for generation                                                                              |
 | Ctrl + Shift + Enter      | Queue up current graph as first for generation                                                                     |
+| Ctrl + K                  | Cancel currently running generation                                                                                |
 | Ctrl + Z/Ctrl + Y         | Undo/Redo                                                                                                          |
 | Ctrl + S                  | Save workflow                                                                                                      |
 | Ctrl + O                  | Load workflow                                                                                                      |

--- a/web/extensions/core/keybinds.js
+++ b/web/extensions/core/keybinds.js
@@ -23,6 +23,7 @@ app.registerExtension({
 				Backspace: "#comfy-clear-button",
 				Delete: "#comfy-clear-button",
 				d: "#comfy-load-default-button",
+				k: "#comfy-cancel-generate-button",
 			};
 
 			const modifierKeybindId = modifierKeyIdMap[event.key];

--- a/web/extensions/core/keybinds.js
+++ b/web/extensions/core/keybinds.js
@@ -8,7 +8,21 @@ app.registerExtension({
 
 			// Queue prompt using ctrl or command + enter
 			if (modifierPressed && event.key === "Enter") {
-				app.queuePrompt(event.shiftKey ? -1 : 0).then();
+				event.preventDefault();
+
+				if (!event.altKey) {
+					app.queuePrompt(event.shiftKey ? -1 : 0).then();
+				} else {
+					// Cancel currently running prompt with alt
+					app.stopPromptGeneration(0);
+				}
+
+				return;
+			}
+
+			// Clear pending prompts using ctrl + alt + backspace
+			if (modifierPressed && event.altKey && event.key === "Backspace") {
+				app.clearPromptQueue();
 				return;
 			}
 
@@ -23,7 +37,6 @@ app.registerExtension({
 				Backspace: "#comfy-clear-button",
 				Delete: "#comfy-clear-button",
 				d: "#comfy-load-default-button",
-				k: "#comfy-cancel-generate-button",
 			};
 
 			const modifierKeybindId = modifierKeyIdMap[event.key];

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1905,6 +1905,34 @@ export class ComfyApp {
 		}
 	}
 
+	async stopPromptGeneration() {
+		const runningKey = "Running";
+		const type = "queue";
+		const items = await api.getItems(type);
+
+		if (!items || !(runningKey in items) || items[runningKey].length === 0) {
+			return;
+		}
+
+		const item = items[runningKey][0];
+		const removeAction = item.remove || {
+			name: "Delete",
+			cb: () => api.deleteItem(type, item.prompt[1]),
+		};
+		await removeAction.cb();
+	}
+
+	async clearPromptQueue() {
+		if (this.#processingQueue) {
+			return;
+		}
+
+		this.#processingQueue = true;
+		await api.clearItems("queue");
+		await this.stopPromptGeneration(); // Clear remaining running prompt
+		this.#processingQueue = false;
+	}
+
 	/**
 	 * Loads workflow data from the specified file
 	 * @param {File} file

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1906,20 +1906,7 @@ export class ComfyApp {
 	}
 
 	async stopPromptGeneration() {
-		const runningKey = "Running";
-		const type = "queue";
-		const items = await api.getItems(type);
-
-		if (!items || !(runningKey in items) || items[runningKey].length === 0) {
-			return;
-		}
-
-		const item = items[runningKey][0];
-		const removeAction = item.remove || {
-			name: "Delete",
-			cb: () => api.deleteItem(type, item.prompt[1]),
-		};
-		await removeAction.cb();
+		await api.interrupt();
 	}
 
 	async clearPromptQueue() {
@@ -1928,8 +1915,7 @@ export class ComfyApp {
 		}
 
 		this.#processingQueue = true;
-		await api.clearItems("queue");
-		await this.stopPromptGeneration(); // Clear remaining running prompt
+		await api.clearItems("queue").then(() => api.interrupt());
 		this.#processingQueue = false;
 	}
 

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -471,6 +471,7 @@ class ComfyList {
 							}),
 							$el("button", {
 								textContent: removeAction.name,
+								id: "comfy-cancel-generate-button",
 								onclick: async () => {
 									await removeAction.cb();
 									await this.update();

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -471,7 +471,6 @@ class ComfyList {
 							}),
 							$el("button", {
 								textContent: removeAction.name,
-								id: "comfy-cancel-generate-button",
 								onclick: async () => {
 									await removeAction.cb();
 									await this.update();


### PR DESCRIPTION
Added a way to cancel the current run without touching the mouse while the queue is open in the UI, so a generation can be started then canceled using the keyboard only.

~I am not preferential to the key used -- I chose K because it's like C and didn't want to use Ctrl+C. Perhaps a different key would be less invasive depending on the browser.~

Editing original comment with updated keybinds used in this PR:

**Ctrl + Alt + Enter** --- Cancel currently running generation
**Ctrl + Alt + Backspace** --- Cancel all queued prompts