### PR TITLE
Fix internal reroutes connected to other groups

### DIFF
--- a/tests-ui/tests/groupNode.test.js
+++ b/tests-ui/tests/groupNode.test.js
@@ -405,9 +405,14 @@ describe("group node", () => {
 		group1.outputs.LATENT.connectTo(group2.inputs.LATENT);
 
 		const decode = ez.VAEDecode(group2.outputs.LATENT, group2.outputs.VAE);
-		ez.PreviewImage(decode.outputs[0]);
+		const preview = ez.PreviewImage(decode.outputs[0]);
 
-		expect((await graph.toPrompt()).output).toEqual({});
+		expect((await graph.toPrompt()).output).toEqual({
+			[latent.id]: { inputs: { width: 512, height: 512, batch_size: 1 }, class_type: "EmptyLatentImage" },
+			[vae.id]: { inputs: { vae_name: "vae1.safetensors" }, class_type: "VAELoader" },
+			[decode.id]: { inputs: { samples: [latent.id + "", 0], vae: [vae.id + "", 0] }, class_type: "VAEDecode" },
+			[preview.id]: { inputs: { images: [decode.id + "", 0] }, class_type: "PreviewImage" },
+		});
 	});
 	test("displays generated image on group node", async () => {
 		const { ez, graph, app } = await start();

--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -602,6 +602,10 @@ export class GroupNodeHandler {
 				innerNode = innerNode.getInputNode(0);
 			}
 
+			if (l && GroupNodeHandler.isGroupNode(innerNode)) {
+				return innerNode.updateLink(l);
+			}
+
 			link.origin_id = innerNode.id;
 			link.origin_slot = l?.origin_slot ?? output.slot;
 			return link;


### PR DESCRIPTION
Fixes internal reroutes connected to other group nodes
The example in the issue #2231 can be used for checking

