### PR TITLE
Prevent cleaning graph state on undo/redo

### DIFF
--- a/web/extensions/core/undoRedo.js
+++ b/web/extensions/core/undoRedo.js
@@ -71,24 +71,27 @@ function graphEqual(a, b, root = true) {
 }
 
 const undoRedo = async (e) => {
+	const updateState = async (source, target) => {
+		const prevState = source.pop();
+		if (prevState) {
+			target.push(activeState);
+			isOurLoad = true;
+			// Pause rendering to decrease graph flicker
+			app.canvas.stopRendering();
+			try {
+				await app.loadGraphData(prevState, false);
+				activeState = prevState;
+			} finally {
+				app.canvas.startRendering();
+			}
+		}
+	}
 	if (e.ctrlKey || e.metaKey) {
 		if (e.key === "y") {
-			const prevState = redo.pop();
-			if (prevState) {
-				undo.push(activeState);
-				isOurLoad = true;
-				await app.loadGraphData(prevState);
-				activeState = prevState;
-			}
+			updateState(redo, undo);
 			return true;
 		} else if (e.key === "z") {
-			const prevState = undo.pop();
-			if (prevState) {
-				redo.push(activeState);
-				isOurLoad = true;
-				await app.loadGraphData(prevState);
-				activeState = prevState;
-			}
+			updateState(undo, redo);
 			return true;
 		}
 	}

--- a/web/extensions/core/undoRedo.js
+++ b/web/extensions/core/undoRedo.js
@@ -76,14 +76,8 @@ const undoRedo = async (e) => {
 		if (prevState) {
 			target.push(activeState);
 			isOurLoad = true;
-			// Pause rendering to decrease graph flicker
-			app.canvas.stopRendering();
-			try {
-				await app.loadGraphData(prevState, false);
-				activeState = prevState;
-			} finally {
-				app.canvas.startRendering();
-			}
+			await app.loadGraphData(prevState, false);
+			activeState = prevState;
 		}
 	}
 	if (e.ctrlKey || e.metaKey) {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1559,9 +1559,12 @@ export class ComfyApp {
 	/**
 	 * Populates the graph with the specified workflow data
 	 * @param {*} graphData A serialized graph object
+	 * @param { boolean } clean If the graph state, e.g. images, should be cleared
 	 */
-	async loadGraphData(graphData) {
-		this.clean();
+	async loadGraphData(graphData, clean = true) {
+		if (clean !== false) {
+			this.clean();
+		}
 
 		let reset_invalid_values = false;
 		if (!graphData) {


### PR DESCRIPTION
Fixes #2242

Edit: removed flicker reduction as stop/start rendering seems to trigger some bug in LiteGraph
~~Also attempts to reduce some flicker on undo/redo - most noticably moving CLIPTextEncode nodes, the textareas will flicker. Images will still flicker due to being reloaded (looks likely due to the rand parameter forcing a reload, haven't looked into this)~~