### PR TITLE
Group node fixes

### DIFF
--- a/tests-ui/tests/groupNode.test.js
+++ b/tests-ui/tests/groupNode.test.js
@@ -407,12 +407,18 @@ describe("group node", () => {
 		const decode = ez.VAEDecode(group2.outputs.LATENT, group2.outputs.VAE);
 		const preview = ez.PreviewImage(decode.outputs[0]);
 
-		expect((await graph.toPrompt()).output).toEqual({
+		const output = {
 			[latent.id]: { inputs: { width: 512, height: 512, batch_size: 1 }, class_type: "EmptyLatentImage" },
 			[vae.id]: { inputs: { vae_name: "vae1.safetensors" }, class_type: "VAELoader" },
 			[decode.id]: { inputs: { samples: [latent.id + "", 0], vae: [vae.id + "", 0] }, class_type: "VAEDecode" },
 			[preview.id]: { inputs: { images: [decode.id + "", 0] }, class_type: "PreviewImage" },
-		});
+		};
+		expect((await graph.toPrompt()).output).toEqual(output);
+
+		// Ensure missing connections dont cause errors
+		group2.inputs.VAE.disconnect();
+		delete output[decode.id].inputs.vae;
+		expect((await graph.toPrompt()).output).toEqual(output);
 	});
 	test("displays generated image on group node", async () => {
 		const { ez, graph, app } = await start();

--- a/tests-ui/tests/groupNode.test.js
+++ b/tests-ui/tests/groupNode.test.js
@@ -912,6 +912,9 @@ describe("group node", () => {
 		const r1 = ez.Reroute();
 		const r2 = ez.Reroute();
 
+		latent.widgets.width.value = 64;
+		latent.widgets.height.value = 128;
+
 		latent.widgets.width.convertToInput();
 		latent.widgets.height.convertToInput();
 		latent.widgets.batch_size.convertToInput();
@@ -946,6 +949,9 @@ describe("group node", () => {
 		expect(p2.widgets.value.widget.options?.min).toBe(16); // width/height min
 		expect(p2.widgets.value.widget.options?.max).toBe(8192); // width/height max
 		expect(p2.widgets.value.widget.options?.step).toBe(80); // width/height step * 10
+
+		expect(p1.widgets.value.value).toBe(128);
+		expect(p2.widgets.value.value).toBe(64);
 
 		p1.widgets.value.value = 16;
 		p2.widgets.value.value = 32;

--- a/tests-ui/utils/ezgraph.js
+++ b/tests-ui/utils/ezgraph.js
@@ -78,6 +78,14 @@ export class EzInput extends EzSlot {
 		this.input = input;
 	}
 
+	get connection() {
+		const link = this.node.node.inputs?.[this.index]?.link;
+		if (link == null) {
+			return null;
+		}
+		return new EzConnection(this.node.app, this.node.app.graph.links[link]);
+	}
+
 	disconnect() {
 		this.node.node.disconnectInput(this.index);
 	}

--- a/tests-ui/utils/index.js
+++ b/tests-ui/utils/index.js
@@ -104,3 +104,12 @@ export function createDefaultWorkflow(ez, graph) {
 
 	return { ckpt, pos, neg, empty, sampler, decode, save };
 }
+
+export async function getNodeDefs() {
+	const { api } = require("../../web/scripts/api");
+	return api.getNodeDefs();
+}
+
+export async function getNodeDef(nodeId) {
+	return (await getNodeDefs())[nodeId];
+}

--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -426,6 +426,12 @@ export class GroupNodeConfig {
 			});
 			this.nodeDef.input.required[name] = config;
 			this.newToOldWidgetMap[name] = { node, inputName };
+
+			if (!this.oldToNewWidgetMap[node.index]) {
+				this.oldToNewWidgetMap[node.index] = {};
+			}
+			this.oldToNewWidgetMap[node.index][inputName] = name;
+
 			inputMap[slots.length + i] = this.inputCount++;
 		}
 	}
@@ -916,6 +922,7 @@ export class GroupNodeHandler {
 				this.node.widgets[targetWidgetIndex + i].value = primitiveNode.widgets[i].value;
 			}
 		}
+		return true;
 	}
 
 	populateWidgets() {
@@ -933,16 +940,11 @@ export class GroupNodeHandler {
 				const newName = map[oldName];
 				const widgetIndex = this.node.widgets.findIndex((w) => w.name === newName);
 				const mainWidget = this.node.widgets[widgetIndex];
-				if (!newName) {
-					// New name will be null if its a converted widget
-					this.populatePrimitive(node, nodeId, oldName, i, linkedShift);
-
+				if (this.populatePrimitive(node, nodeId, oldName, i, linkedShift)) {
 					// Find the inner widget and shift by the number of linked widgets as they will have been removed too
 					const innerWidget = this.innerNodes[nodeId].widgets?.find((w) => w.name === oldName);
 					linkedShift += innerWidget.linkedWidgets?.length ?? 0;
-					continue;
 				}
-
 				if (widgetIndex === -1) {
 					continue;
 				}

--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -597,9 +597,13 @@ export class GroupNodeHandler {
 			const output = this.groupData.newToOldOutputMap[link.origin_slot];
 			let innerNode = this.innerNodes[output.node.index];
 			let l;
-			while (innerNode.type === "Reroute") {
+			while (innerNode?.type === "Reroute") {
 				l = innerNode.getInputLink(0);
 				innerNode = innerNode.getInputNode(0);
+			}
+
+			if (!innerNode) {
+				return null;
 			}
 
 			if (l && GroupNodeHandler.isGroupNode(innerNode)) {

--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -915,7 +915,7 @@ export class GroupNodeHandler {
 			if (innerNode.type === "PrimitiveNode") {
 				innerNode.primitiveValue = newValue;
 				const primitiveLinked = this.groupData.primitiveToWidget[old.node.index];
-				for (const linked of primitiveLinked) {
+				for (const linked of primitiveLinked ?? []) {
 					const node = this.innerNodes[linked.nodeId];
 					const widget = node.widgets.find((w) => w.name === linked.inputName);
 

--- a/web/extensions/core/rerouteNode.js
+++ b/web/extensions/core/rerouteNode.js
@@ -54,6 +54,7 @@ app.registerExtension({
 						const linkId = currentNode.inputs[0].link;
 						if (linkId !== null) {
 							const link = app.graph.links[linkId];
+							if (!link) return;
 							const node = app.graph.getNodeById(link.origin_id);
 							const type = node.constructor.type;
 							if (type === "Reroute") {

--- a/web/extensions/core/undoRedo.js
+++ b/web/extensions/core/undoRedo.js
@@ -71,24 +71,27 @@ function graphEqual(a, b, root = true) {
 }
 
 const undoRedo = async (e) => {
+	const updateState = async (source, target) => {
+		const prevState = source.pop();
+		if (prevState) {
+			target.push(activeState);
+			isOurLoad = true;
+			// Pause rendering to decrease graph flicker
+			app.canvas.stopRendering();
+			try {
+				await app.loadGraphData(prevState, false);
+				activeState = prevState;
+			} finally {
+				app.canvas.startRendering();
+			}
+		}
+	}
 	if (e.ctrlKey || e.metaKey) {
 		if (e.key === "y") {
-			const prevState = redo.pop();
-			if (prevState) {
-				undo.push(activeState);
-				isOurLoad = true;
-				await app.loadGraphData(prevState);
-				activeState = prevState;
-			}
+			updateState(redo, undo);
 			return true;
 		} else if (e.key === "z") {
-			const prevState = undo.pop();
-			if (prevState) {
-				redo.push(activeState);
-				isOurLoad = true;
-				await app.loadGraphData(prevState);
-				activeState = prevState;
-			}
+			updateState(undo, redo);
 			return true;
 		}
 	}

--- a/web/extensions/core/undoRedo.js
+++ b/web/extensions/core/undoRedo.js
@@ -76,14 +76,8 @@ const undoRedo = async (e) => {
 		if (prevState) {
 			target.push(activeState);
 			isOurLoad = true;
-			// Pause rendering to decrease graph flicker
-			app.canvas.stopRendering();
-			try {
-				await app.loadGraphData(prevState, false);
-				activeState = prevState;
-			} finally {
-				app.canvas.startRendering();
-			}
+			await app.loadGraphData(prevState, false);
+			activeState = prevState;
 		}
 	}
 	if (e.ctrlKey || e.metaKey) {

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -180,7 +180,7 @@ export function mergeIfValid(output, config2, forceUpdate, recreateWidget, confi
 
 	const isNumber = config1[0] === "INT" || config1[0] === "FLOAT";
 	for (const k of keys.values()) {
-		if (k !== "default" && k !== "forceInput" && k !== "defaultInput") {
+		if (k !== "default" && k !== "forceInput" && k !== "defaultInput" && k !== "control_after_generate" && k !== "multiline") {
 			let v1 = config1[1][k];
 			let v2 = config2[1]?.[k];
 

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -633,6 +633,14 @@ app.registerExtension({
 					}
 				}
 
+				// Restore any saved control values
+				const controlValues = this.controlValues;
+				if(this.lastType === this.widgets[0].type && controlValues?.length === this.widgets.length - 1) {
+					for(let i = 0; i < controlValues.length; i++) {
+						this.widgets[i + 1].value = controlValues[i];
+					}
+				}
+
 				// When our value changes, update other widgets to reflect our changes
 				// e.g. so LoadImage shows correct image
 				const callback = widget.callback;
@@ -721,6 +729,15 @@ app.registerExtension({
 							w.onRemove();
 						}
 					}
+
+					// Temporarily store the current values in case the node is being recreated
+					// e.g. by group node conversion
+					this.controlValues = [];
+					this.lastType = this.widgets[0]?.type;
+					for(let i = 1; i < this.widgets.length; i++) {
+						this.controlValues.push(this.widgets[i].value);
+					}
+					setTimeout(() => { delete this.lastType; delete this.controlValues }, 15);
 					this.widgets.length = 0;
 				}
 			}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1559,9 +1559,12 @@ export class ComfyApp {
 	/**
 	 * Populates the graph with the specified workflow data
 	 * @param {*} graphData A serialized graph object
+	 * @param { boolean } clean If the graph state, e.g. images, should be cleared
 	 */
-	async loadGraphData(graphData) {
-		this.clean();
+	async loadGraphData(graphData, clean = true) {
+		if (clean !== false) {
+			this.clean();
+		}
 
 		let reset_invalid_values = false;
 		if (!graphData) {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1774,7 +1774,9 @@ export class ComfyApp {
 							if (parent?.updateLink) {
 								link = parent.updateLink(link);
 							}
-							inputs[node.inputs[i].name] = [String(link.origin_id), parseInt(link.origin_slot)];
+							if (link) {
+								inputs[node.inputs[i].name] = [String(link.origin_id), parseInt(link.origin_slot)];
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Fixes 3 issues:

1. Fix crash on unlinked grouped reroute
[group_unlinked_reroute.json](https://github.com/comfyanonymous/ComfyUI/files/13640111/group_unlinked_reroute.json) - Disconnect image link between the two group nodes, click queue
   - Before: Crashes on queue
   - After: Shows missing input error

2. Fix converted widget inputs
[group_widget_inputs.json](https://github.com/comfyanonymous/ComfyUI/files/13640163/group_widget_inputs.json) - Convert two KSamplers to a group node
   - Before: Various issues - links disconnected, value lost, fixing the links and queuing gets links incorrect (Return type mismatch between linked nodes)
   - After: Works

3. Add basic support for reroute inputs connected to converted widget inputs 
[reroute_converted_input.json](https://github.com/comfyanonymous/ComfyUI/files/13640717/reroute_converted_input.json) - Convert reroute + latent node to group
   - Before: Unsupported, would add a INT widget to the group that does nothing
   - After: Works for reroutes connected directly to inputs, not via chains. I didn't want to have to basically duplicate the walking reroute path and want to refactor that out in future.


