### PR TITLE
Group node fixes

### DIFF
--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -331,16 +331,17 @@ export class GroupNodeConfig {
 
 	getInputConfig(node, inputName, seenInputs, config, extra) {
 		let name = node.inputs?.find((inp) => inp.name === inputName)?.label ?? inputName;
+		let key = name;
 		let prefix = "";
 		// Special handling for primitive to include the title if it is set rather than just "value"
 		if ((node.type === "PrimitiveNode" && node.title) || name in seenInputs) {
 			prefix = `${node.title ?? node.type} `;
-			name = `${prefix}${inputName}`;
+			key = name = `${prefix}${inputName}`;
 			if (name in seenInputs) {
 				name = `${prefix}${seenInputs[name]} ${inputName}`;
 			}
 		}
-		seenInputs[name] = (seenInputs[name] ?? 1) + 1;
+		seenInputs[key] = (seenInputs[key] ?? 1) + 1;
 
 		if (inputName === "seed" || inputName === "noise_seed") {
 			if (!extra) extra = {};
@@ -1010,10 +1011,10 @@ export class GroupNodeHandler {
 				const newName = map[oldName];
 				const widgetIndex = this.node.widgets.findIndex((w) => w.name === newName);
 				const mainWidget = this.node.widgets[widgetIndex];
-				if (this.populatePrimitive(node, nodeId, oldName, i, linkedShift)) {
+				if (this.populatePrimitive(node, nodeId, oldName, i, linkedShift) || widgetIndex === -1) {
 					// Find the inner widget and shift by the number of linked widgets as they will have been removed too
 					const innerWidget = this.innerNodes[nodeId].widgets?.find((w) => w.name === oldName);
-					linkedShift += innerWidget.linkedWidgets?.length ?? 0;
+					linkedShift += innerWidget?.linkedWidgets?.length ?? 0;
 				}
 				if (widgetIndex === -1) {
 					continue;


### PR DESCRIPTION
- Fix name counter preventing more than 3 of the same node (make 5 of any type of node, before it would only show widgets from the first 3, now shows from them all)
![image](https://github.com/comfyanonymous/ComfyUI/assets/125205205/b0879318-65d8-497c-9a1a-f28b36408431)

- Fix linked widget value offset when populating values
![image](https://github.com/comfyanonymous/ComfyUI/assets/125205205/9f453940-1cd2-41d5-8657-5fa50618bc0c)
making this into a group would have had all values off by 1, this is fixed
![image](https://github.com/comfyanonymous/ComfyUI/assets/125205205/f9de0d10-6cf8-4f01-9eca-7f4a3eab3789)
