### PR TITLE
Fix dom widgets not being hidden when node is not visible

### DIFF
--- a/web/scripts/domWidget.js
+++ b/web/scripts/domWidget.js
@@ -177,6 +177,7 @@ LGraphCanvas.prototype.computeVisibleNodes = function () {
 			for (const w of node.widgets) {
 				if (w.element) {
 					w.element.hidden = hidden;
+					w.element.style.display = hidden ? "none" : null;
 					if (hidden) {
 						w.options.onHide?.(w);
 					}


### PR DESCRIPTION
If you quickly drag a SaveAnimatedWEBP node, with an animated image on it, off the edge of the window so it isnt visible, the image will get "stuck" at the edge