### PR TITLE
Increase the max number of nodes to support larger workflows, especially modular ones

### DIFF
--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -48,7 +48,7 @@
         EVENT_LINK_COLOR: "#A86",
         CONNECTING_LINK_COLOR: "#AFA",
 
-        MAX_NUMBER_OF_NODES: 1000, //avoid infinite loops
+        MAX_NUMBER_OF_NODES: 5000, //avoid infinite loops
         DEFAULT_POSITION: [100, 100], //default node position
         VALID_SHAPES: ["default", "box", "round", "card"], //,"circle"
 


### PR DESCRIPTION
While it is rare, there exist some workflows with large number of nodes. 

ComfyUI can handle these with no issues but is currently limited by the max nodes 1000 setting. Once the 1000 nodes are reached, the user is not able to create or copy any more nodes in the workflow.

As modular workflows that only execute part of the graph are becoming more common, the number of nodes in the workflows increases quickly. The number of nodes is not directly related to performance because in modular workflows large parts of the graph may be bypassed (example: https://github.com/ech3lon42/trulymodularworkflow). 

Therefore I propose to set the default max number of nodes to a larger value, such as 5000. Perhaps it also makes sense to have a configuration setting for this property in the future.