### PR TITLE
Allow no preview model for latent_preview

### DIFF
--- a/latent_preview.py
+++ b/latent_preview.py
@@ -82,7 +82,9 @@ def prepare_callback(model, steps, x0_output_dict=None):
     if preview_format not in ["JPEG", "PNG"]:
         preview_format = "JPEG"
 
-    previewer = get_previewer(model.load_device, model.model.latent_format)
+    previewer = None
+    if model:
+        previewer = get_previewer(model.load_device, model.model.latent_format)
 
     pbar = comfy.utils.ProgressBar(steps)
     def callback(step, x0, x, total_steps):


### PR DESCRIPTION
This makes it easy for modules to show progress bar without preview
Example usage:
```python
callback = latent_preview.prepare_callback(None, len(image))
```
to initialize and then to use
```python
callback(i, None, None, len(p.init_images))
```
to update the bar.