### PR TITLE
Controls for menu sorting behavior

### DIFF
--- a/web/extensions/core/sortMenuMode.js
+++ b/web/extensions/core/sortMenuMode.js
@@ -1,0 +1,37 @@
+import { app } from "../../scripts/app.js";
+
+const id = "Comfy.SortMenuMode";
+const ext = {
+	name: id,
+	async setup(app) {
+		app.ui.settings.addSetting({
+			id,
+			name: "Sort Menu",
+			type: "combo",
+			defaultValue: 0,
+			options: [
+				{ text: "LiteGraph Default", value: "litegraph" },
+				{ text: "True", value: "true" },
+				{ text: "False", value: "false" },
+			],
+			onChange(value) {
+				switch (value) {
+					case "litegraph": // Default
+						if (localStorage.getItem("Comfy.Settings.Comfy.SortMenuMode.defAutoSort") != null) {
+							LiteGraph.auto_sort_node_types = JSON.parse(localStorage.getItem("Comfy.Settings.Comfy.SortMenuMode.defAutoSort")); // reset to original;
+							localStorage.removeItem("Comfy.Settings.Comfy.SortMenuMode.defAutoSort");
+						}
+						break;
+					
+					default:
+						if (localStorage.getItem("Comfy.Settings.Comfy.SortMenuMode.defAutoSort") == null) {
+							localStorage.setItem(["Comfy.Settings.Comfy.SortMenuMode.defAutoSort"], LiteGraph.auto_sort_node_types);
+						}
+						LiteGraph.auto_sort_node_types = JSON.parse(value);
+				}
+			},
+		});
+	},
+};
+
+app.registerExtension(ext);


### PR DESCRIPTION
Adds menu option to override litegraph default menu sorting behavior by altering LiteGraph.auto_sort_node_types boolean.

<img width="363" alt="image" src="https://github.com/comfyanonymous/ComfyUI/assets/1894851/5c6c8484-6538-418d-ae25-17684810dc07">

Default = The "auto_sort_node_types" as defined in litegraph.core.js
True = Sorted (case sensitive)
False = Unsorted (currently the default in litegraph.core.js)

**Sort Menu = Default || False**
<img width="360" alt="image" src="https://github.com/comfyanonymous/ComfyUI/assets/1894851/49d91a5d-ea49-41c6-b59b-26ef2313cf9b">

**Sort Menu = True**
<img width="363" alt="image" src="https://github.com/comfyanonymous/ComfyUI/assets/1894851/1f75f185-3eac-4430-9267-4fc5968e63f3">
