### PR TITLE
Add title to the API workflow json.

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1784,7 +1784,10 @@ export class ComfyApp {
 				output[String(node.id)] = {
 					inputs,
 					class_type: node.comfyClass,
-					title: node.title,
+					// Ignored by the backend.
+					"_meta": {
+						title: node.title,
+					},
 				};
 			}
 		}

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1784,6 +1784,7 @@ export class ComfyApp {
 				output[String(node.id)] = {
 					inputs,
 					class_type: node.comfyClass,
+					title: node.title,
 				};
 			}
 		}


### PR DESCRIPTION

Add title to the API workflow json.

Motivation: API client users can find nodes by title, instead of just by class_type.

Related 
* [[Feature Request] Custom API node IDs #1326](https://github.com/comfyanonymous/ComfyUI/issues/1326)
* [[Feature Request] Save json with title label value in API mode. #1433](https://github.com/comfyanonymous/ComfyUI/issues/1433)
* [custom names for nodes in API export #2031](https://github.com/comfyanonymous/ComfyUI/issues/2031)

