### PR TITLE
add execution_time return for api /history and ws message

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -715,12 +715,12 @@ class PromptQueue:
             self.server.queue_updated()
             return (item, i)
 
-    def task_done(self, item_id, outputs):
+    def task_done(self, item_id, outputs, execution_time):
         with self.mutex:
             prompt = self.currently_running.pop(item_id)
             if len(self.history) > MAXIMUM_HISTORY_SIZE:
                 self.history.pop(next(iter(self.history)))
-            self.history[prompt[1]] = { "prompt": prompt, "outputs": {} }
+            self.history[prompt[1]] = { "prompt": prompt, "outputs": {} , "execution_time": execution_time }
             for o in outputs:
                 self.history[prompt[1]]["outputs"][o] = outputs[o]
             self.server.queue_updated()

--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ def prompt_worker(q, server):
             e.execute(item[2], prompt_id, item[3], item[4])
             need_gc = True
             current_time = time.perf_counter()
-            execution_time = "%.2f" % (current_time - execution_start_time)
+            execution_time = round(current_time - execution_start_time, 2)
             q.task_done(item_id, e.outputs_ui, execution_time)
             if server.client_id is not None:
                 server.send_sync("executing", { "node": None, "prompt_id": prompt_id, "execution_time": execution_time }, server.client_id)

--- a/main.py
+++ b/main.py
@@ -108,12 +108,12 @@ def prompt_worker(q, server):
             prompt_id = item[1]
             e.execute(item[2], prompt_id, item[3], item[4])
             need_gc = True
-            q.task_done(item_id, e.outputs_ui)
-            if server.client_id is not None:
-                server.send_sync("executing", { "node": None, "prompt_id": prompt_id }, server.client_id)
-
             current_time = time.perf_counter()
-            execution_time = current_time - execution_start_time
+            execution_time = "%.2f" % (current_time - execution_start_time)
+            q.task_done(item_id, e.outputs_ui, execution_time)
+            if server.client_id is not None:
+                server.send_sync("executing", { "node": None, "prompt_id": prompt_id, "execution_time": execution_time }, server.client_id)
+
             print("Prompt executed in {:.2f} seconds".format(execution_time))
 
         if need_gc:


### PR DESCRIPTION
Conveniently track the execution time of each queue.