### PR TITLE
Improve http api for large cluster deployment environments to make it more friendly

### DIFF
--- a/server.py
+++ b/server.py
@@ -373,6 +373,7 @@ class PromptServer():
             device_name = comfy.model_management.get_torch_device_name(device)
             vram_total, torch_vram_total = comfy.model_management.get_total_memory(device, torch_total_too=True)
             vram_free, torch_vram_free = comfy.model_management.get_free_memory(device, torch_free_too=True)
+            prompt_queue_tasks_remaining = self.prompt_queue.get_tasks_remaining()
             system_stats = {
                 "system": {
                     "os": os.name,
@@ -391,7 +392,10 @@ class PromptServer():
                     }
                 ],
                 "instance": {
-                    "instance_id": self.instance_id
+                    "instance_id": self.instance_id,
+                    "prompt_queue": {
+                        "tasks_remaining": prompt_queue_tasks_remaining
+                    },
                 },
             }
             return web.json_response(system_stats)

--- a/server.py
+++ b/server.py
@@ -48,6 +48,12 @@ async def cache_control(request: web.Request, handler):
         response.headers.setdefault('Cache-Control', 'no-cache')
     return response
 
+@web.middleware
+async def instance_global_header(request: web.Request, handler):
+    response: web.Response = await handler(request)
+    response.headers.setdefault('ComfyUI-instance-id', PromptServer.instance.instance_id)
+    return response
+
 def create_cors_middleware(allowed_origin: str):
     @web.middleware
     async def cors_middleware(request: web.Request, handler):
@@ -78,7 +84,7 @@ class PromptServer():
         self.messages = asyncio.Queue()
         self.number = 0
 
-        middlewares = [cache_control]
+        middlewares = [cache_control, instance_global_header]
         if args.enable_cors_header:
             middlewares.append(create_cors_middleware(args.enable_cors_header))
 
@@ -91,6 +97,7 @@ class PromptServer():
         self.routes = routes
         self.last_node_id = None
         self.client_id = None
+        self.instance_id = uuid.uuid4().hex;
 
         self.on_prompt_handlers = []
 
@@ -382,7 +389,10 @@ class PromptServer():
                         "torch_vram_total": torch_vram_total,
                         "torch_vram_free": torch_vram_free,
                     }
-                ]
+                ],
+                "instance": {
+                    "instance_id": self.instance_id
+                },
             }
             return web.json_response(system_stats)
 


### PR DESCRIPTION
see: https://github.com/comfyanonymous/ComfyUI/issues/2401

Add a new instance id generated while server bootstrapping to help identify instances in a cluster environment.

Add the `ComfyUI-instance-id` http header to make http api identifiable in a cluster environment.

Add server instance id and prompt queue remaining task count field to make it show more runtime informations