### PR TITLE
Use CPU for VAE when --novram is selected

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -555,7 +555,10 @@ def intermediate_device():
         return torch.device("cpu")
 
 def vae_device():
-    return get_torch_device()
+    if vram_state == VRAMState.NO_VRAM:
+        return torch.device("cpu")
+    else:
+        return get_torch_device()
 
 def vae_offload_device():
     if args.gpu_only:


### PR DESCRIPTION
This PR forces the VAE to load/run on CPU when the `--novram` command-line option is selected.

I was encountering OOM with 4GB VRAM even with `--novram`, but only at the VAE stage. The fallback to tiled VAE did not work, perhaps because the OS also uses some VRAM and the margin is just so small. However, the VAE doesn't take long compared to the model so I don't mind running it on CPU, and overall this GPU+CPU combination is far faster than CPU-only. I thought about adding another command-line option for this, but it feels like a last-ditch effort to save VRAM so I think it falls under the existing `--novram` option appropriately.

I believe this more or less solves #182.