### PR TITLE
Serve Prometheus metrics for queue size at `/metrics`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Pillow
 scipy
 tqdm
 psutil
+prometheus-client


### PR DESCRIPTION
Implements a simple Prometheus metric `queue_size` to emit the current queue size. We already have the `/queue` route, but this  PR adds a `/metrics` route so we can hook ComfyUI up to central Prometheus servers.

These are the metrics we get going to `http://127.0.0.1:8188/metrics`:
```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 13543.0
python_gc_objects_collected_total{generation="1"} 1405.0
python_gc_objects_collected_total{generation="2"} 213.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 685.0
python_gc_collections_total{generation="1"} 61.0
python_gc_collections_total{generation="2"} 6.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="10",patchlevel="12",version="3.10.12"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 3.0731644928e+010
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 2.560425984e+09
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.704306482e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 22.29
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 40.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP queue_size Current queue size
# TYPE queue_size gauge
queue_size 2.0
```