### PR TITLE
Align type of SaveAnimatedWEBP/PNG fps value with that of svd_img2vid_conditioning

### DIFF
--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -60,7 +60,7 @@ class SaveAnimatedWEBP:
         return {"required":
                     {"images": ("IMAGE", ),
                      "filename_prefix": ("STRING", {"default": "ComfyUI"}),
-                     "fps": ("FLOAT", {"default": 6.0, "min": 0.01, "max": 1000.0, "step": 0.01}),
+                     "fps": ("INT", {"default": 6, "min": 1, "max": 1024}),
                      "lossless": ("BOOLEAN", {"default": True}),
                      "quality": ("INT", {"default": 80, "min": 0, "max": 100}),
                      "method": (list(s.methods.keys()),),
@@ -103,7 +103,7 @@ class SaveAnimatedWEBP:
         c = len(pil_images)
         for i in range(0, c, num_frames):
             file = f"{filename}_{counter:05}_.webp"
-            pil_images[i].save(os.path.join(full_output_folder, file), save_all=True, duration=int(1000.0/fps), append_images=pil_images[i + 1:i + num_frames], exif=metadata, lossless=lossless, quality=quality, method=method)
+            pil_images[i].save(os.path.join(full_output_folder, file), save_all=True, duration=int(1000/fps), append_images=pil_images[i + 1:i + num_frames], exif=metadata, lossless=lossless, quality=quality, method=method)
             results.append({
                 "filename": file,
                 "subfolder": subfolder,
@@ -125,7 +125,7 @@ class SaveAnimatedPNG:
         return {"required":
                     {"images": ("IMAGE", ),
                      "filename_prefix": ("STRING", {"default": "ComfyUI"}),
-                     "fps": ("FLOAT", {"default": 6.0, "min": 0.01, "max": 1000.0, "step": 0.01}),
+                     "fps": ("INT", {"default": 6, "min": 1, "max": 1024}),
                      "compress_level": ("INT", {"default": 4, "min": 0, "max": 9})
                      },
                 "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},
@@ -158,7 +158,7 @@ class SaveAnimatedPNG:
                     metadata.add(b"comf", x.encode("latin-1", "strict") + b"\0" + json.dumps(extra_pnginfo[x]).encode("latin-1", "strict"), after_idat=True)
 
         file = f"{filename}_{counter:05}_.png"
-        pil_images[0].save(os.path.join(full_output_folder, file), pnginfo=metadata, compress_level=compress_level, save_all=True, duration=int(1000.0/fps), append_images=pil_images[1:])
+        pil_images[0].save(os.path.join(full_output_folder, file), pnginfo=metadata, compress_level=compress_level, save_all=True, duration=int(1000/fps), append_images=pil_images[1:])
         results.append({
             "filename": file,
             "subfolder": subfolder,


### PR DESCRIPTION
By setting the `fps` parameter on the `SaveAnimatedWEBP` and `SaveAnimatedPNG` nodes to the `int` type, it is now consistent with the fps parameter of the `SVD_img2vid_Conditioning` and they can now share a single primitive controlling the value for both nodes.

| Before: ![image](https://github.com/comfyanonymous/ComfyUI/assets/23213464/3cc3bc23-ee5c-409f-8acb-a9dba3ea430c)|After: ![image](https://github.com/comfyanonymous/ComfyUI/assets/23213464/020b9de2-58b1-4563-bfc9-648d378800bb) |
|---|---|
