### PR TITLE
Use Replicatable order (alphabetical) for custom node loading

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1838,7 +1838,7 @@ def load_custom_nodes():
     node_paths = folder_paths.get_folder_paths("custom_nodes")
     node_import_times = []
     for custom_node_path in node_paths:
-        possible_modules = os.listdir(os.path.realpath(custom_node_path))
+        possible_modules = sorted(os.listdir(os.path.realpath(custom_node_path)))
         if "__pycache__" in possible_modules:
             possible_modules.remove("__pycache__")
 


### PR DESCRIPTION
Currently the order will change depending on environment, this should probably be common everywhere.

This also helps fix some of the other issues other custom nodes have (unrelated issues with dependencies) by freezing the order of loading modules:

https://github.com/cubiq/ComfyUI_IPAdapter_plus/issues/162#issuecomment-1883210197