### PR TITLE
   Enhanced /history, with status about errors, completion.

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,7 +110,12 @@ def prompt_worker(q, server):
 
             e.execute(item[2], prompt_id, item[3], item[4])
             need_gc = True
-            q.task_done(item_id, e.outputs_ui)
+            q.task_done(item_id,
+                        e.outputs_ui,
+                        status=execution.PromptQueue.ExecutionStatus(
+                            status_str='success' if e.success else 'error',
+                            completed=e.success,
+                            notes=e.status_notes))
             if server.client_id is not None:
                 server.send_sync("executing", { "node": None, "prompt_id": prompt_id }, server.client_id)
 


### PR DESCRIPTION
**Motivation:** API clients sometime miss websockets messages, its nice to be able to see how the job via the `/history` endpoint. I am writing a 3rd party API client that can schedule workflows from python, and it is a bit fragile depending on the websockets API for errors. The `/history` endpoint is reliable, but the error is opaque. This change gives an API a clear indicator and reason why the job failed.

Example output of `/history`:

```json
{
  "b1b64df6-9b2c-4a09-bd0e-b6c294702085": {
    // ... old prompt and output dictionaries here.
    "status": {
      "status_str": "success",
      "completed": true,
      "notes": [
        [
          "execution_start",
          { "prompt_id": "b1b64df6-9b2c-4a09-bd0e-b6c294702085" }
        ],
        [
          "execution_cached",
          { "nodes": [], "prompt_id": "b1b64df6-9b2c-4a09-bd0e-b6c294702085" }
        ]
      ]
    }
  }
}
```

Methodology:  I hide `executor.server.send_sync()` behind a new `add_note()` function, and store `(event,message)` tuples into a list (`executor.status_notes`), which is then stored in the `history` dictionary when `task_done()` is called, just like the other `task_done()` arguments.

* Optional: I used Python's type hints and NamedTuple, let me know if you want me to get rid of that.
* Optional: I can put this behind a history[prompt_id]['_meta'] key if you want it to be clear that it isn't used, like I did previously with the PR [Add title to the API workflow json. #2380](https://github.com/comfyanonymous/ComfyUI/pull/2380).
