### PR TITLE
Add batch number to filename

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1434,7 +1434,7 @@ class SaveImage:
         filename_prefix += self.prefix_append
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
         results = list()
-        for image in images:
+        for (batch_number, image) in enumerate(images):
             i = 255. * image.cpu().numpy()
             img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
             metadata = None
@@ -1446,7 +1446,8 @@ class SaveImage:
                     for x in extra_pnginfo:
                         metadata.add_text(x, json.dumps(extra_pnginfo[x]))
 
-            file = f"{filename}_{counter:05}_.png"
+            filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
+            file = f"{filename_with_batch_num}_{counter:05}_.png"
             img.save(os.path.join(full_output_folder, file), pnginfo=metadata, compress_level=self.compress_level)
             results.append({
                 "filename": file,


### PR DESCRIPTION
Allow configurable addition of batch number to output file name.

Existing png files with workflow metadata can still be dropped in without any problems; the default is to not append the batch number.

Very useful to people like me who generate a lot of images in batches and find an image to continue working on in a future review  (at this point there is no way to regenerate the image using the `Latent From Batch` node as I've lost the batch number)

![append_batch_num](https://github.com/comfyanonymous/ComfyUI/assets/2114069/1000ef68-1c98-4d4a-945b-dfc7a096ddb4)
