### PR TITLE
Fix modifiers triggering key down checks for undo history

### DIFF
--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -843,6 +843,7 @@ export class GroupNodeHandler {
 			const r = onDrawForeground?.apply?.(this, arguments);
 			if (+app.runningNodeId === this.id && this.runningInternalNodeId !== null) {
 				const n = groupData.nodes[this.runningInternalNodeId];
+				if(!n) return;
 				const message = `Running ${n.title || n.type} (${this.runningInternalNodeId}/${groupData.nodes.length})`;
 				ctx.save();
 				ctx.font = "12px sans-serif";

--- a/web/extensions/core/undoRedo.js
+++ b/web/extensions/core/undoRedo.js
@@ -106,6 +106,7 @@ const bindInput = (activeEl) => {
 	}
 };
 
+let keyIgnored = false;
 window.addEventListener(
 	"keydown",
 	(e) => {
@@ -115,6 +116,9 @@ window.addEventListener(
 				// Ignore events on inputs, they have their native history
 				return;
 			}
+
+			keyIgnored = e.key === "Control" || e.key === "Shift" || e.key === "Alt" || e.key === "Meta";
+			if (keyIgnored) return;
 
 			// Check if this is a ctrl+z ctrl+y
 			if (await undoRedo(e)) return;
@@ -126,6 +130,13 @@ window.addEventListener(
 	},
 	true
 );
+
+window.addEventListener("keyup", (e) => {
+	if (keyIgnored) {
+		keyIgnored = false;
+		checkState();
+	}
+});
 
 // Handle clicking DOM elements (e.g. widgets)
 window.addEventListener("mouseup", () => {


### PR DESCRIPTION
Fixes modifier keys triggering multiple history entries, e.g. previously shift+drag/alt+drag and move node would store each position while it was being dragged rather than just the start/end of the drag events