### PR TITLE
Fix logging not handling onChange

### DIFF
--- a/web/scripts/logging.js
+++ b/web/scripts/logging.js
@@ -269,6 +269,9 @@ export class ComfyLogging {
 			id: settingId,
 			name: settingId,
 			defaultValue: true,
+			onChange: (value) => {
+				this.enabled = value;
+			},
 			type: (name, setter, value) => {
 				return $el("tr", [
 					$el("td", [
@@ -283,7 +286,7 @@ export class ComfyLogging {
 							type: "checkbox",
 							checked: value,
 							onchange: (event) => {
-								setter((this.enabled = event.target.checked));
+								setter(event.target.checked);
 							},
 						}),
 						$el("button", {


### PR DESCRIPTION
This meant when the setting value was changed from its default by the settings loading, it was not reacting to the change.

I've also had a quick check of all other settings and they all appear correct.