### PR TITLE
Fix renaming upload widget

### DIFF
--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -349,7 +349,7 @@ export class GroupNodeConfig {
 		}
 		if (config[0] === "IMAGEUPLOAD") {
 			if (!extra) extra = {};
-			extra.widget = `${prefix}${config[1]?.widget ?? "image"}`;
+			extra.widget = this.oldToNewWidgetMap[node.index]?.["image"] ?? "image";
 		}
 
 		if (extra) {

--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -349,7 +349,7 @@ export class GroupNodeConfig {
 		}
 		if (config[0] === "IMAGEUPLOAD") {
 			if (!extra) extra = {};
-			extra.widget = this.oldToNewWidgetMap[node.index]?.["image"] ?? "image";
+			extra.widget = this.oldToNewWidgetMap[node.index]?.[config[1]?.widget ?? "image"] ?? "image";
 		}
 
 		if (extra) {


### PR DESCRIPTION
Create a group node containing 1 or more LoadImage nodes
Manage group node -> Rename `image` widget
Previously would crash as the button couldnt locate the image widget