### PR TITLE
Fix models getting patched twice after editing workflow

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -407,6 +407,9 @@ def load_models_gpu(models, memory_required=0):
         unload_model_clones(loaded_model.model)
         total_memory_required[loaded_model.device] = total_memory_required.get(loaded_model.device, 0) + loaded_model.model_memory_required(loaded_model.device)
 
+    if loaded_model.model.load_device == loaded_model.model.current_device:
+        loaded_model.model_unload()
+
     for device in total_memory_required:
         if device != torch.device("cpu"):
             free_memory(total_memory_required[device] * 1.3 + extra_mem, device, models_already_loaded)


### PR DESCRIPTION
This fixes models getting patched twice when running a workflow with cloned model that already resides on GPU.

Steps reproduce the problem:
1. Run default workflow.
2. Add a node that does model.clone() (RescaleCFG i.e.) before the sampler

