### PR TITLE
Allow negative values on X and Y from ImageCompositeMasked

### DIFF
--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -46,8 +46,8 @@ class LatentCompositeMasked:
             "required": {
                 "destination": ("LATENT",),
                 "source": ("LATENT",),
-                "x": ("INT", {"default": 0, "min": 0, "max": MAX_RESOLUTION, "step": 8}),
-                "y": ("INT", {"default": 0, "min": 0, "max": MAX_RESOLUTION, "step": 8}),
+                "x": ("INT", {"default": 0, "min": -MAX_RESOLUTION, "max": MAX_RESOLUTION, "step": 8}),
+                "y": ("INT", {"default": 0, "min": -MAX_RESOLUTION, "max": MAX_RESOLUTION, "step": 8}),
                 "resize_source": ("BOOLEAN", {"default": False}),
             },
             "optional": {


### PR DESCRIPTION
Update ImageCompositeMasked on nodes_mask.py to allow negative values on X and Y