### PR TITLE
Don't use PEP 604 type hints, to stay compatible with Python<3.10.

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -751,7 +751,7 @@ class PromptQueue:
             if len(self.history) > MAXIMUM_HISTORY_SIZE:
                 self.history.pop(next(iter(self.history)))
 
-            status_dict: dict|None = None
+            status_dict: Optional[dict] = None
             if status is not None:
                 status_dict = copy.deepcopy(status._asdict())
 


### PR DESCRIPTION
`status_dict: dict|None = None` relies on PEP 604 to use the `|` to mean "or". Previously (Python<3.10) one had to use `Union` or `Optional`. The previous change (https://github.com/comfyanonymous/ComfyUI/commit/1b3d65bd84c8026dea234643861491279886218c) is probably breaking ComfyUI for some people who are using older versions of python. This PR fixes the issue.