### PR TITLE
ValueError: Paths don't have the same drive-- Update server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -270,13 +270,17 @@ class PromptServer():
 
                 if "subfolder" in request.rel_url.query:
                     full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
-                    # Normalize paths to ensure the same drive letter
+                     # Normalize paths to ensure the same drive letter
                     full_output_dir = os.path.normpath(full_output_dir)
-                    output_dir = os.path.normpath(output_dir)
+                    output_dir = os.path.normpath(output_dir)                    
                     
-                    if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
+                    # Extract drive letters from paths
+                    drive_full_output_dir = os.path.splitdrive(os.path.abspath(full_output_dir))[0]
+                    drive_output_dir = os.path.splitdrive(os.path.abspath(output_dir))[0]
+
+                    if drive_full_output_dir != drive_output_dir:
                         return web.Response(status=403)
-                    output_dir = full_output_dir
+                    output_dir = full_output_dir 
 
                 filename = os.path.basename(filename)
                 file = os.path.join(output_dir, filename)


### PR DESCRIPTION
Error handling request
Traceback (most recent call last):
  File "D:\Blender_ComfyUI\python_embeded\lib\site-packages\aiohttp\web_protocol.py", line 433, in _handle_request
    resp = await request_handler(request)
  File "<enhanced_experience vendors.sentry_sdk.integrations.aiohttp>", line 139, in sentry_app_handle
  File "<enhanced_experience vendors.sentry_sdk._compat>", line 115, in reraise
  File "<enhanced_experience vendors.sentry_sdk.integrations.aiohttp>", line 129, in sentry_app_handle
  File "D:\Blender_ComfyUI\python_embeded\lib\site-packages\aiohttp\web_app.py", line 504, in _handle
    resp = await handler(request)
  File "D:\Blender_ComfyUI\python_embeded\lib\site-packages\aiohttp\web_middlewares.py", line 117, in impl
    return await handler(request)
  File "D:\Blender_ComfyUI\ComfyUI\server.py", line 47, in cache_control
    response: web.Response = await handler(request)
  File "<enhanced_experience patches.comfyui.html_resources_patcher>", line 26, in http_resource_injector
  File "D:\Blender_ComfyUI\ComfyUI\server.py", line 273, in view_image
    if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
  File "D:\Blender_ComfyUI\python_embeded\lib\ntpath.py", line 807, in commonpath
    raise ValueError("Paths don't have the same drive")
ValueError: Paths don't have the same drive

    # Normalize paths to ensure the same drive letter
    full_output_dir = os.path.normpath(full_output_dir)
    output_dir = os.path.normpath(output_dir)