### PR TITLE
Fixed scroll issue with Mange Group Node

### DIFF
--- a/web/extensions/core/groupNodeManage.css
+++ b/web/extensions/core/groupNodeManage.css
@@ -41,6 +41,8 @@
 }
 .comfy-group-manage-list {
 	border-right: 1px solid var(--comfy-menu-bg);
+	overflow-y: scroll;
+	overflow-x: hidden;
 }
 .comfy-group-manage-list ul {
 	margin: 40px 0 0;
@@ -49,8 +51,6 @@
 }
 .comfy-group-manage-list-items {
 	max-height: 70vh;
-	overflow-y: scroll;
-	overflow-x: hidden;
 }
 .comfy-group-manage-list li {
 	display: flex;


### PR DESCRIPTION
In some cases, when there are a lot of nodes to manage, you cannot see some nodes in the end. I transferred the overflow css from ul to the parent div containing it. This solves the issue, but I haven't tested it for other side effects. 