### PR TITLE
Fix queue on change to respect auto queue checkbox

### DIFF
--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -384,7 +384,7 @@ export class ComfyUI {
 		autoQueueModeEl.style.display = "none";
 
 		api.addEventListener("graphChanged", () => {
-			if (this.autoQueueMode === "change") {
+			if (this.autoQueueMode === "change" && this.autoQueueEnabled) {
 				if (this.lastQueueSize === 0) {
 					this.graphHasChanged = false;
 					app.queuePrompt(0, this.batchCount);

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -384,7 +384,7 @@ export class ComfyUI {
 		autoQueueModeEl.style.display = "none";
 
 		api.addEventListener("graphChanged", () => {
-			if (this.autoQueueMode === "change" && this.autoQueueEnabled) {
+			if (this.autoQueueMode === "change" && this.autoQueueEnabled === true) {
 				if (this.lastQueueSize === 0) {
 					this.graphHasChanged = false;
 					app.queuePrompt(0, this.batchCount);


### PR DESCRIPTION
There are two places this logic could live in, either line 387 or 388 and it makes more sense from UX point of view to discard changes while the autoQueueEnabled was turned off.

Keeps the logic the same as it currently is for instant auto queueing so it needs to manually be triggered

(maybe should still update this.graphHasChanged?)