### PR TITLE
Disable follow_symlinks

### DIFF
--- a/server.py
+++ b/server.py
@@ -539,7 +539,7 @@ class PromptServer():
 
         for name, dir in nodes.EXTENSION_WEB_DIRS.items():
             self.app.add_routes([
-                web.static('/extensions/' + urllib.parse.quote(name), dir, follow_symlinks=True),
+                web.static('/extensions/' + urllib.parse.quote(name), dir),
             ])
 
         self.app.add_routes([


### PR DESCRIPTION
I'm checking that this parameter wasn't set by mistake.
The parameter allows a symlink to point to somewhere _outside_ of the static directory. Symlinks that point within the directory will work without enabling this parameter (it's badly named). Therefore enabling this option could make it easy to misconfigure an environment and introduce security issues.