### PR TITLE
Use localhost by default

### DIFF
--- a/server.py
+++ b/server.py
@@ -633,7 +633,7 @@ class PromptServer():
         await site.start()
 
         if address == '':
-            address = '0.0.0.0'
+            address = '127.0.0.1'
         if verbose:
             print("Starting server\n")
             print("To see the GUI go to: http://{}:{}".format(address, port))


### PR DESCRIPTION
Using 0.0.0.0 potentially allows other people on a network to access the application. This may be a security issue on public networks and is probably not what the user is expecting for a local running application. I'd suggest that people who do need this explicitly specify the address so they are aware this is happening.