### PR TITLE
Make auto saved workflow stored per tab

### DIFF
--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -5,6 +5,7 @@ class ComfyApi extends EventTarget {
 		super();
 		this.api_host = location.host;
 		this.api_base = location.pathname.split('/').slice(0, -1).join('/');
+		this.initialClientId = sessionStorage.getItem("clientId");
 	}
 
 	apiURL(route) {
@@ -118,7 +119,8 @@ class ComfyApi extends EventTarget {
 					    case "status":
 						    if (msg.data.sid) {
 							    this.clientId = msg.data.sid;
-							    window.name = this.clientId;
+							    window.name = this.clientId; // use window name so it isnt reused when duplicating tabs
+								sessionStorage.setItem("clientId", this.clientId); // store in session storage so duplicate tab can load correct workflow
 						    }
 						    this.dispatchEvent(new CustomEvent("status", { detail: msg.data.status }));
 						    break;


### PR DESCRIPTION
Stores the workflow and client id in sessionStorage so when working with multiple tabs and a tab is refreshed, the correct workflow will be loaded instead of the one that happened to save last.

Also means when you duplicate a tab, you'll get the correct workflow. There appears to be a bug in Firefox where a duplicate of a duplicate etc ... at some point the sessionStorage ends up empty and you lose the ID but it works fine in Chrome.