### PR TITLE
Fix: mask editor inpaint area

### DIFF
--- a/web/extensions/core/maskeditor.js
+++ b/web/extensions/core/maskeditor.js
@@ -110,6 +110,7 @@ class MaskEditorDialog extends ComfyDialog {
 
 	createButton(name, callback) {
 		var button = document.createElement("button");
+		button.style.pointerEvents = "auto";
 		button.innerText = name;
 		button.addEventListener("click", callback);
 		return button;
@@ -146,6 +147,7 @@ class MaskEditorDialog extends ComfyDialog {
 		divElement.style.display = "flex";
 		divElement.style.position = "relative";
 		divElement.style.top = "2px";
+		divElement.style.pointerEvents = "auto";
 		self.brush_slider_input = document.createElement('input');
 		self.brush_slider_input.setAttribute('type', 'range');
 		self.brush_slider_input.setAttribute('min', '1');
@@ -173,6 +175,7 @@ class MaskEditorDialog extends ComfyDialog {
 		bottom_panel.style.left = "20px";
 		bottom_panel.style.right = "20px";
 		bottom_panel.style.height = "50px";
+		bottom_panel.style.pointerEvents = "none";
 
 		var brush = document.createElement("div");
 		brush.id = "brush";


### PR DESCRIPTION

I tried to do an inpaint on my image, and found that I was unable to brush the bottom area, as shown below:

<img width="1278" alt="image" src="https://github.com/comfyanonymous/ComfyUI/assets/16166258/8e8aa049-bc90-40a2-8e4d-26ab22ade157">

After investigation, it was caused by an invisible div element that wrapped the buttons and slider.

There was an issue https://github.com/comfyanonymous/ComfyUI/issues/2246 and an PR https://github.com/comfyanonymous/ComfyUI/pull/2249  about this problem, but the PR didn't fix that all, so I create this PR.

