### PR TITLE
Group manage fixes

### DIFF
--- a/web/extensions/core/groupNode.js
+++ b/web/extensions/core/groupNode.js
@@ -910,6 +910,9 @@ export class GroupNodeHandler {
 		const self = this;
 		const onNodeCreated = this.node.onNodeCreated;
 		this.node.onNodeCreated = function () {
+			if (!this.widgets) {
+				return;
+			}
 			const config = self.groupData.nodeData.config;
 			if (config) {
 				for (const n in config) {

--- a/web/extensions/core/groupNodeManage.css
+++ b/web/extensions/core/groupNodeManage.css
@@ -48,7 +48,7 @@
 	list-style: none;
 }
 .comfy-group-manage-list-items {
-	max-height: 70vh;
+	max-height: calc(100% - 40px);
 	overflow-y: scroll;
 	overflow-x: hidden;
 }


### PR DESCRIPTION
1. Fixes scroll in manage window with many nodes (duplicate the default workflow a few times, convert to group, manage)  #2655
2. Fixes crash on modified input where group has no widgets (add 2x ImageInvert, hide the first ones input, save) #2665