### PR TITLE
Load node title from _meta

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -2149,6 +2149,7 @@ export class ComfyApp {
 			const data = apiData[id];
 			const node = LiteGraph.createNode(data.class_type);
 			node.id = isNaN(+id) ? id : +id;
+			node.title = data._meta.title;
 			graph.add(node);
 		}
 


### PR DESCRIPTION
This PR addresses an issue arising when loading a workflow from json in API format. 

When loading a workflow serialized with the API format (clicking on Save API Format), the title field is ignored even if present in the data. 
In the serialization function, the title is added to the output with the following lines: 
```javascript
if (this.ui.settings.getSettingValue("Comfy.DevMode")) {
		// Ignored by the backend.
		node_data["_meta"] = {
			title: node.title,
		}
	}
```
The proposed code change mirrors this in the loading function. 