### PR TITLE
Work around Safari rendering issue that causes UI hang

### DIFF
--- a/web/lib/litegraph.css
+++ b/web/lib/litegraph.css
@@ -234,9 +234,13 @@
     margin-left: 5px;
     font-size: 14px;
     padding: 2px 5px;
+/*
+    These three properties being here triggers some rendering bug in Safari that freezes the ComfyUI for many seconds
+
     position: relative;
     top: -2px;
     opacity: 0.8;
+*/
     border-radius: 4px;
  }
 


### PR DESCRIPTION
A rendering issue in Safari 17.2.1 (19617.1.17.11.12) on my M1 MBP was causing ~12s UI hangs while drawing the popup menu from 6565c9a

This patch clears 3 CSS properties from that patch, each of which separately, or any combo together triggers the UI hang.  Without all 3, the menu still renders, looks OK, and doesn't hang my Safari.