### PR TITLE
Fix frontend webp prompt handling

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -2107,6 +2107,8 @@ export class ComfyApp {
 					this.loadGraphData(JSON.parse(pngInfo.Workflow)); // Support loading workflows from that webp custom node.
 				} else if (pngInfo.prompt) {
 					this.loadApiJson(JSON.parse(pngInfo.prompt));
+				} else if (pngInfo.Prompt) {
+					this.loadApiJson(JSON.parse(pngInfo.Prompt)); // Support loading prompts from that webp custom node.
 				}
 			}
 		} else if (file.type === "application/json" || file.name?.endsWith(".json")) {


### PR DESCRIPTION
The Image Save node in WAS Node Suite will save prompts in `Prompt` instead of `prompt`: https://github.com/WASasquatch/was-node-suite-comfyui/blob/33534f2e48682ddcf580436ea39cffc7027cbb89/WAS_Node_Suite.py#L7227-L7238. But the frontend doens't support `Prompt`. This PR fixed this problem.