### PR TITLE
Changed default of LatentBatchSeedBehavior to fixed

### DIFF
--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -126,7 +126,7 @@ class LatentBatchSeedBehavior:
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "samples": ("LATENT",),
-                              "seed_behavior": (["random", "fixed"],),}}
+                              "seed_behavior": (["random", "fixed"],{"default": "fixed"}),}}
 
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "op"


### PR DESCRIPTION
as title says, the default value was changed to fixed as random is already default behavior for batch latent seeds. This is mainly for QoL as you can just get onto noodling it in right away. 