### PR TITLE
fix enter key not working in search dialogue

### DIFF
--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -11549,7 +11549,10 @@ LGraphNode.prototype.executeAction = function(action)
                     dialog.close();
                 } else if (e.keyCode == 13) {
                     if (selected) {
-                        select(selected.innerHTML);
+                        if (selected.hasAttribute("data-type") && selected.getAttribute("data-type") != '')
+                            select(selected.getAttribute("data-type"))
+                        else
+                            select(selected.innerHTML)
                     } else if (first) {
                         select(first);
                     } else {


### PR DESCRIPTION
fixes https://github.com/comfyanonymous/ComfyUI/issues/2711

https://github.com/comfyanonymous/ComfyUI/commit/6565c9ad4dcd64238a86e16e5605fed446069952 has slightly changed the element which is passed to the select function of litegraph when using enter to choose the node to be added
we can fix this by using the dom element attribute  data-type instead of the whole item