### PR TITLE
Disable converted widgets & dont run control action if widget disabled

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -22,10 +22,12 @@ function isConvertableWidget(widget, config) {
 }
 
 function hideWidget(node, widget, suffix = "") {
+	widget.origDisabled = widget.disabled;
 	widget.origType = widget.type;
 	widget.origComputeSize = widget.computeSize;
 	widget.origSerializeValue = widget.serializeValue;
 	widget.computeSize = () => [0, -4]; // -4 is due to the gap litegraph adds between widgets automatically
+	widget.disabled = true;
 	widget.type = CONVERTED_TYPE + suffix;
 	widget.serializeValue = () => {
 		// Prevent serializing the widget if we have no input linked
@@ -52,10 +54,12 @@ function showWidget(widget) {
 	widget.type = widget.origType;
 	widget.computeSize = widget.origComputeSize;
 	widget.serializeValue = widget.origSerializeValue;
+	widget.disabled = widget.origDisabled;
 
 	delete widget.origType;
 	delete widget.origComputeSize;
 	delete widget.origSerializeValue;
+	delete widget.origDisabled;
 
 	// Hide any linked widgets, e.g. seed+seedControl
 	if (widget.linkedWidgets) {

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -100,6 +100,7 @@ export function addValueControlWidgets(node, targetWidget, defaultValue = "rando
 	}
 
 	const applyWidgetControl = () => {
+		if (valueControl.disabled) return;
 		var v = valueControl.value;
 
 		if (isCombo && v !== "fixed") {


### PR DESCRIPTION
Fixes issue with control values running on converted widgets
1. Set `Widget Value Control Mode` setting to `before`
2. Load Default
3. Convert KSampler Seed to input
4. Connect primitive, fixed
6. Generate (runs)
7. Generate (runs, should not)