### PR TITLE
Allow custom samplers to request discard penultimate sigma

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -652,6 +652,7 @@ def sampler_object(name):
 class KSampler:
     SCHEDULERS = SCHEDULER_NAMES
     SAMPLERS = SAMPLER_NAMES
+    DISCARD_PENULTIMATE_SIGMA_SAMPLERS = set(('dpm_2', 'dpm_2_ancestral', 'uni_pc', 'uni_pc_bh2'))
 
     def __init__(self, model, steps, device, sampler=None, scheduler=None, denoise=None, model_options={}):
         self.model = model
@@ -670,7 +671,7 @@ class KSampler:
         sigmas = None
 
         discard_penultimate_sigma = False
-        if self.sampler in ['dpm_2', 'dpm_2_ancestral', 'uni_pc', 'uni_pc_bh2']:
+        if self.sampler in self.DISCARD_PENULTIMATE_SIGMA_SAMPLERS:
             steps += 1
             discard_penultimate_sigma = True
 


### PR DESCRIPTION
currently custom samplers can add themselves to the list of built-in samplers but there's no facility to request discarding the penultimate sigma. this minor change moves the list of samplers subject to discard penultimate sigma into a `set` that exists as a class property.

this allows a custom sampler that wants to skip the penultimate sigma to do something like:

```python
from comfy.samplers import KSampler
KSampler.DISCARD_PENULTIMATE_SIGMA_SAMPLERS.add('sonar_dpmpp_sde')
```