### PR TITLE
Fix infinite while loop being possible in ddim_scheduler

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -295,7 +295,7 @@ def simple_scheduler(model, steps):
 def ddim_scheduler(model, steps):
     s = model.model_sampling
     sigs = []
-    ss = len(s.sigmas) // steps
+    ss = max(len(s.sigmas) // steps, 1)
     x = 1
     while x < len(s.sigmas):
         sigs += [float(s.sigmas[x])]


### PR DESCRIPTION
If ```ddim_scheduler``` is ever called on a model whose model_sampling sigmas contain less sigmas than the requested steps, the current code will result in an infinite while loop due to ```ss``` being set to 0.

This PR makes sure ```ss``` will be at least 1 to prevent ComfyUI from hanging forever.