### PR TITLE
Safari: Draws certain elements on CPU. In case of search popup, can cause 10 seconds+ main thread lock due to painting.

### DIFF
--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -117,7 +117,7 @@
         
         search_hide_on_mouse_leave: true, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
         search_filter_enabled: false, // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]
-        search_show_all_on_open: true, // [true!] opens the results list when opening the search widget
+        search_show_all_on_open: false, // [true!] opens the results list when opening the search widget
         
         auto_load_slot_types: false, // [if want false, use true, run, get vars values to be statically set, than disable] nodes types and nodeclass association with node types need to be calculated, if dont want this, calculate once and set registered_slot_[in/out]_types and slot_types_[in/out]
         
@@ -11425,8 +11425,7 @@ LGraphNode.prototype.executeAction = function(action)
                         ,type_filter_out: false
                         ,show_general_if_none_on_typefilter: true
                         ,show_general_after_typefiltered: true
-                        ,hide_on_mouse_leave: (!window.ontouchstart || navigator.maxTouchPoints === 0)
-                        // disable hiding on mouse leave behavior on mobile
+                        ,hide_on_mouse_leave: LiteGraph.search_hide_on_mouse_leave
                         ,show_all_if_empty: true
                         ,show_all_on_open: LiteGraph.search_show_all_on_open
                     };

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -115,7 +115,7 @@
         shift_click_do_break_link_from: false, // [false!] prefer false if results too easy to break links - implement with ALT or TODO custom keys
         click_do_break_link_to: false, // [false!]prefer false, way too easy to break links
         
-        search_hide_on_mouse_leave: true, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
+        search_hide_on_mouse_leave: false, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
         search_filter_enabled: false, // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]
         search_show_all_on_open: false, // [true!] opens the results list when opening the search widget
         

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -117,7 +117,7 @@
         
         search_hide_on_mouse_leave: true, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
         search_filter_enabled: false, // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]
-        search_show_all_on_open: true, // [true!] opens the results list when opening the search widget
+        search_show_all_on_open: false, // [true!] opens the results list when opening the search widget
         
         auto_load_slot_types: false, // [if want false, use true, run, get vars values to be statically set, than disable] nodes types and nodeclass association with node types need to be calculated, if dont want this, calculate once and set registered_slot_[in/out]_types and slot_types_[in/out]
         

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -117,7 +117,7 @@
         
         search_hide_on_mouse_leave: true, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
         search_filter_enabled: false, // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]
-        search_show_all_on_open: false, // [true!] opens the results list when opening the search widget
+        search_show_all_on_open: true, // [true!] opens the results list when opening the search widget
         
         auto_load_slot_types: false, // [if want false, use true, run, get vars values to be statically set, than disable] nodes types and nodeclass association with node types need to be calculated, if dont want this, calculate once and set registered_slot_[in/out]_types and slot_types_[in/out]
         

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -115,9 +115,9 @@
         shift_click_do_break_link_from: false, // [false!] prefer false if results too easy to break links - implement with ALT or TODO custom keys
         click_do_break_link_to: false, // [false!]prefer false, way too easy to break links
         
-        search_hide_on_mouse_leave: false, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
+        search_hide_on_mouse_leave: true, // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
         search_filter_enabled: false, // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]
-        search_show_all_on_open: false, // [true!] opens the results list when opening the search widget
+        search_show_all_on_open: true, // [true!] opens the results list when opening the search widget
         
         auto_load_slot_types: false, // [if want false, use true, run, get vars values to be statically set, than disable] nodes types and nodeclass association with node types need to be calculated, if dont want this, calculate once and set registered_slot_[in/out]_types and slot_types_[in/out]
         
@@ -11425,7 +11425,8 @@ LGraphNode.prototype.executeAction = function(action)
                         ,type_filter_out: false
                         ,show_general_if_none_on_typefilter: true
                         ,show_general_after_typefiltered: true
-                        ,hide_on_mouse_leave: LiteGraph.search_hide_on_mouse_leave
+                        ,hide_on_mouse_leave: (!window.ontouchstart || navigator.maxTouchPoints === 0)
+                        // disable hiding on mouse leave behavior on mobile
                         ,show_all_if_empty: true
                         ,show_all_on_open: LiteGraph.search_show_all_on_open
                     };

--- a/web/style.css
+++ b/web/style.css
@@ -197,6 +197,7 @@ button.comfy-close-menu-btn {
 .comfy-modal button:hover,
 .comfy-menu-actions button:hover {
 	filter: brightness(1.2);
+	will-change: transform;
 	cursor: pointer;
 }
 
@@ -462,11 +463,13 @@ dialog::backdrop {
 	z-index: 9999 !important;
 	background-color: var(--comfy-menu-bg) !important;
 	filter: brightness(95%);
+	will-change: transform;
 }
 
 .litegraph.litecontextmenu .litemenu-entry:hover:not(.disabled):not(.separator) {
 	background-color: var(--comfy-menu-bg) !important;
 	filter: brightness(155%);
+	will-change: transform;
 	color: var(--input-text);
 }
 
@@ -527,12 +530,14 @@ dialog::backdrop {
 	color: var(--input-text);
 	background-color: var(--comfy-input-bg);
 	filter: brightness(80%);
+	will-change: transform;
 	padding-left: 0.2em;
 }
 
 .litegraph.lite-search-item.generic_type {
 	color: var(--input-text);
 	filter: brightness(50%);
+	will-change: transform;
 }
 
 @media only screen and (max-width: 450px) {


### PR DESCRIPTION
The solution I took is to use a CSS rule to force `filter: brightness()` to execute on GPU instead of CPU. This is apparently a hint that is needed for Safari. Chrome et al appear to do it for us automatically. 

My test case was simply having 536 nodes in the search results box. I reach this number after installing about 15 comfyui plugins using the plugin manager. I noticed that the larger the results list was, the longer the denial of interaction was under Safari. 

I have tested to confirm that adding `will-change: transform` is enough to eliminate the performance problem, and out of all the strategies I came up with, this is the one that best guarantees no other change is made to visuals or behavior of the program. I was initially going to replace filter:brightness with a bgcolor change.

~~I also rolled in a small change to improve behavior of the same node search box for mobile. I think it's a clear improvement, but it's not perfect yet since I still see some interactions like tapping in certain areas in the dialog will still quit the dialog. Since this change makes it disable the default "close search on mouseout" behavior it should strictly be an improvement in this area.~~ There are going to be more mobile improvements coming, i just wanted to unbreak the search box first.