### PR TITLE
include associated groups when 'Save Selected as Template'

### DIFF
--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -7154,8 +7154,6 @@ LGraphNode.prototype.executeAction = function(action)
             index += 1;
         }
 
-        var _selected_groups = [];
-
         for (var i = 0; i < selected_nodes_array.length; ++i) {
             var node = selected_nodes_array[i];
             var cloned = node.clone();

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -7166,13 +7166,6 @@ LGraphNode.prototype.executeAction = function(action)
             }
             clipboard_info.nodes.push(cloned.serialize());
 
-            for (var group of this.graph._groups) {
-                group.recomputeInsideNodes();
-                if (group._nodes?.includes(node) && (!_selected_groups.includes(group))) {
-                    _selected_groups.push(group);
-                   clipboard_info.groups.push(group.serialize()); 
-                }
-            }
 
             if (node.inputs && node.inputs.length) {
                 for (var j = 0; j < node.inputs.length; ++j) {
@@ -7200,6 +7193,17 @@ LGraphNode.prototype.executeAction = function(action)
                 }
             }
         }
+
+        //if every node in the group are selected, then the group is "selected"
+        for (var group of this.graph._groups) {
+            group.recomputeInsideNodes();
+            if (group._nodes?.every(function(node){
+                return selected_nodes_array.includes(node)
+            })) {
+               clipboard_info.groups.push(group.serialize()); 
+            }
+        }
+
         localStorage.setItem(
             "litegrapheditor_clipboard",
             JSON.stringify(clipboard_info)


### PR DESCRIPTION
as mentioned in https://github.com/comfyanonymous/ComfyUI/issues/1912

The new 'Save Selected as Template' feature is quite useful. However, it would be beneficial to include the associated 'groups' of the selected nodes when saving template. GROUPs aid in organizing the nodes and sometimes affecting graph functionality, for instance, this is particularly relevant when using features like 'rgthree bypass repeater', which bypasses an entire GROUP. so I modify the `litegraph.core.js` to include saving associated groups of the selected nodes.