### PR TITLE
Feature: Disable Metadata Toggle

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1419,7 +1419,8 @@ class SaveImage:
     def INPUT_TYPES(s):
         return {"required": 
                     {"images": ("IMAGE", ),
-                     "filename_prefix": ("STRING", {"default": "ComfyUI"})},
+                     "filename_prefix": ("STRING", {"default": "ComfyUI"}),
+                     "disable_metadata": ("BOOLEAN", {"default": False})},
                 "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},
                 }
 
@@ -1430,7 +1431,7 @@ class SaveImage:
 
     CATEGORY = "image"
 
-    def save_images(self, images, filename_prefix="ComfyUI", prompt=None, extra_pnginfo=None):
+    def save_images(self, images, filename_prefix="ComfyUI", disable_metadata=False, prompt=None, extra_pnginfo=None):
         filename_prefix += self.prefix_append
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
         results = list()
@@ -1438,7 +1439,7 @@ class SaveImage:
             i = 255. * image.cpu().numpy()
             img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
             metadata = None
-            if not args.disable_metadata:
+            if not args.disable_metadata and not disable_metadata:
                 metadata = PngInfo()
                 if prompt is not None:
                     metadata.add_text("prompt", json.dumps(prompt))


### PR DESCRIPTION
This pull request introduces a feature that allows for disabling the saving of prompt metadata directly through the `SaveImage` node.

While the command-line argument `--disable-metadata` exists for this purpose, there are scenarios where more granular control is desirable. This is particularly beneficial in API-driven environments where the server may not have been initiated with this flag.