### PR TITLE
Add group templating

### DIFF
--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -7154,8 +7154,6 @@ LGraphNode.prototype.executeAction = function(action)
             index += 1;
         }
 
-        var _selected_groups = [];
-
         for (var i = 0; i < selected_nodes_array.length; ++i) {
             var node = selected_nodes_array[i];
             var cloned = node.clone();

--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -7166,13 +7166,6 @@ LGraphNode.prototype.executeAction = function(action)
             }
             clipboard_info.nodes.push(cloned.serialize());
 
-            for (var group of this.graph._groups) {
-                group.recomputeInsideNodes();
-                if (group._nodes?.includes(node) && (!_selected_groups.includes(group))) {
-                    _selected_groups.push(group);
-                   clipboard_info.groups.push(group.serialize()); 
-                }
-            }
 
             if (node.inputs && node.inputs.length) {
                 for (var j = 0; j < node.inputs.length; ++j) {
@@ -7200,6 +7193,17 @@ LGraphNode.prototype.executeAction = function(action)
                 }
             }
         }
+
+        //if every node in the group are selected, then the group is "selected"
+        for (var group of this.graph._groups) {
+            group.recomputeInsideNodes();
+            if (group._nodes?.every(function(node){
+                return selected_nodes_array.includes(node)
+            })) {
+               clipboard_info.groups.push(group.serialize()); 
+            }
+        }
+
         localStorage.setItem(
             "litegrapheditor_clipboard",
             JSON.stringify(clipboard_info)


### PR DESCRIPTION
The new 'Save Selected as Template' feature is quite useful. 

I slightly added a bit more functionality: when ALL the nodes in a GROUP are selected, then that GROUP will also be "selected" (copyToClipboard).

I think this is quite useful  for advanced users, because GROUP helps organizing the nodes and sometimes affecting graph functionality, for instance, some nodes like 'rgthree bypass repeater' works on an entire GROUP. 

Perhaps you might consider integrating it into the main codebase : )
