### PR TITLE
add delayed activation to SAG node

### DIFF
--- a/comfy_extras/nodes_sag.py
+++ b/comfy_extras/nodes_sag.py
@@ -108,9 +108,7 @@ class SelfAttentionGuidance:
 
     def patch(self, model, scale, blur_sigma, activation_proportion):
         m = model.clone()
-        model_sampling = m.model.model_sampling
-        sigmin = model_sampling.sigma(model_sampling.timestep(model_sampling.sigma_min))
-        sigmax = model_sampling.sigma(model_sampling.timestep(model_sampling.sigma_max))
+        sigma_start = m.model.model_sampling.percent_to_sigma(activation_proportion)
         
         attn_scores = None
 
@@ -149,7 +147,7 @@ class SelfAttentionGuidance:
             x = args["input"]
             if min(cfg_result.shape[2:]) <= 4: #skip when too small to add padding
                 return cfg_result
-            if 1-activation_proportion < (sigma - sigmin) / (sigmax - sigmin):
+            if sigma > sigma_start:
                 return cfg_result
             # create the adversarially blurred image
             degraded = create_blur_map(uncond_pred, uncond_attn, sag_sigma, sag_threshold)

--- a/comfy_extras/nodes_sag.py
+++ b/comfy_extras/nodes_sag.py
@@ -99,15 +99,19 @@ class SelfAttentionGuidance:
         return {"required": { "model": ("MODEL",),
                              "scale": ("FLOAT", {"default": 0.5, "min": -2.0, "max": 5.0, "step": 0.1}),
                              "blur_sigma": ("FLOAT", {"default": 2.0, "min": 0.0, "max": 10.0, "step": 0.1}),
+                             "activation_proportion": ("FLOAT", {"default": 0.75, "min": 0.0, "max": 1.0, "step": 0.05, "round": 0.01}),
                               }}
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch"
 
     CATEGORY = "_for_testing"
 
-    def patch(self, model, scale, blur_sigma):
+    def patch(self, model, scale, blur_sigma, activation_proportion):
         m = model.clone()
-
+        model_sampling = m.model.model_sampling
+        sigmin = model_sampling.sigma(model_sampling.timestep(model_sampling.sigma_min))
+        sigmax = model_sampling.sigma(model_sampling.timestep(model_sampling.sigma_max))
+        
         attn_scores = None
 
         # TODO: make this work properly with chunked batches
@@ -145,7 +149,8 @@ class SelfAttentionGuidance:
             x = args["input"]
             if min(cfg_result.shape[2:]) <= 4: #skip when too small to add padding
                 return cfg_result
-
+            if 1-activation_proportion < (sigma - sigmin) / (sigmax - sigmin):
+                return cfg_result
             # create the adversarially blurred image
             degraded = create_blur_map(uncond_pred, uncond_attn, sag_sigma, sag_threshold)
             degraded_noised = degraded + x - uncond_pred


### PR DESCRIPTION
This allows to only use the self-attention guidance after some percentage of the sigma have been done. So to take advantage without the slow-down. Activation at 75% works wonder and barely slows down the generation time! :)

I just tried starting at 90% and it's very nice too!