### PR TITLE
Fix denoised_output in SamplerCustom+LCM

### DIFF
--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -744,7 +744,7 @@ def sample_lcm(model, x, sigmas, extra_args=None, callback=None, disable=None, n
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)
         if callback is not None:
-            callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised})
+            callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised.clone()})
 
         x = denoised
         if sigmas[i + 1] > 0:


### PR DESCRIPTION
`denoised_output` seem to be overwritten by `output`.

![image](https://github.com/comfyanonymous/ComfyUI/assets/22386664/f28438ca-02bb-4f74-8af7-50ec7d7a94fa)
