### PR TITLE
Ensure samplers seed the global RNG even when add_noise is disabled

### DIFF
--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -255,6 +255,7 @@ class SamplerCustom:
         latent = latent_image
         latent_image = latent["samples"]
         if not add_noise:
+            torch.manual_seed(noise_seed)
             noise = torch.zeros(latent_image.size(), dtype=latent_image.dtype, layout=latent_image.layout, device="cpu")
         else:
             batch_inds = latent["batch_index"] if "batch_index" in latent else None

--- a/nodes.py
+++ b/nodes.py
@@ -1324,6 +1324,7 @@ class SetLatentNoiseMask:
 def common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent, denoise=1.0, disable_noise=False, start_step=None, last_step=None, force_full_denoise=False):
     latent_image = latent["samples"]
     if disable_noise:
+        torch.manual_seed(seed)
         noise = torch.zeros(latent_image.size(), dtype=latent_image.dtype, layout=latent_image.layout, device="cpu")
     else:
         batch_inds = latent["batch_index"] if "batch_index" in latent else None


### PR DESCRIPTION
currently no global RNG seed gets set _at all_ with the built in samplers (advanced KSampler, SamplerCustom) if `add_noise` is not enabled. this means anything using the global RNG (i.e. `euler_a`) will find the RNG in an undefined state. it becomes impossible to reproduce generations.

this simple pull just ensures `torch.manual_seed()` gets called even in the non-`add_noise` code path.

visual demonstration:

## current behavior

![image](https://github.com/comfyanonymous/ComfyUI/assets/157360029/b26e81ac-7507-47b1-a0ea-e29e4b22dca2)

## with this pull

![image](https://github.com/comfyanonymous/ComfyUI/assets/157360029/7e274a99-a00f-485a-bbc6-98187f518371)

***

unfortunately, a lot of other custom nodes copy the current ComfyUI code with this issue and will need to be changed individually.

closes #2833 (i hope)