### PR TITLE
Add Tcmalloc startup mode to solve memory leakage issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ For 6700, 6600 and maybe other RDNA2 or older: ```HSA_OVERRIDE_GFX_VERSION=10.3.
 
 For AMD 7600 and maybe other RDNA3 cards: ```HSA_OVERRIDE_GFX_VERSION=11.0.0 python main.py```
 
+### Using tcmalloc to solve memory leakage problems
+View the tcmalloc_start.sh logic, execute it, render LD_PRELOAD and load TCMALLOC
+#### For Example
+```shell
+# According to the operating system, install tcmalloc
+# Execute: sh tcmalloc_start.sh  | sh tcmalloc_start.sh --force-fp16 ...
+sh tcmalloc_start.sh
+```
+
 # Notes
 
 Only parts of the graph that have an output with all the correct inputs will be executed.

--- a/tcmalloc_start.sh
+++ b/tcmalloc_start.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# python3 executable
+if [[ -z "${python_cmd}" ]]
+then
+    python_cmd="python3"
+fi
+
+
+if [[ -z "${LAUNCH_SCRIPT}" ]]
+then
+    LAUNCH_SCRIPT="main.py"
+fi
+
+# this script cannot be run as root by default
+can_run_as_root=0
+
+# read any command line flags to the webui.sh script
+while getopts "f" flag > /dev/null 2>&1
+do
+    case ${flag} in
+        f) can_run_as_root=1;;
+        *) break;;
+    esac
+done
+
+# Do not reinstall existing pip packages on Debian/Ubuntu
+export PIP_IGNORE_INSTALLED=0
+
+# Pretty print
+delimiter="################################################################"
+
+printf "\n%s\n" "${delimiter}"
+printf "\e[1m\e[32mExecute ComfyUI through Tcmalloc\n"
+printf "\e[1m\e[32mWorking directory: ${SCRIPT_DIR}\n"
+# Do not run as root
+if [[ $(id -u) -eq 0 && can_run_as_root -eq 0 ]]
+then
+    printf "\n%s\n" "${delimiter}"
+    printf "\e[1m\e[31mERROR: This script must not be launched as root, aborting...\e[0m"
+    printf "\n%s\n" "${delimiter}"
+    exit 1
+else
+    printf "\n%s\n" "${delimiter}"
+    printf "Running on \e[1m\e[32m%s\e[0m user" "$(whoami)"
+    printf "\n%s\n" "${delimiter}"
+fi
+
+# Try using TCMalloc on Linux
+prepare_tcmalloc() {
+    if [[ "${OSTYPE}" == "linux"* ]] && [[ -z "${NO_TCMALLOC}" ]] && [[ -z "${LD_PRELOAD}" ]]; then
+        # check glibc version
+        LIBC_VER=$(echo $(ldd --version | awk 'NR==1 {print $NF}') | grep -oP '\d+\.\d+')
+        echo "glibc version is $LIBC_VER"
+        libc_vernum=$(expr $LIBC_VER)
+        # Since 2.34 libpthread is integrated into libc.so
+        libc_v234=2.34
+        # Define Tcmalloc Libs arrays
+        TCMALLOC_LIBS=("libtcmalloc(_minimal|)\.so\.\d" "libtcmalloc\.so\.\d")
+        # Traversal array
+        for lib in "${TCMALLOC_LIBS[@]}"
+        do
+            # Determine which type of tcmalloc library the library supports
+            TCMALLOC="$(PATH=/usr/sbin:$PATH ldconfig -p | grep -P $lib | head -n 1)"
+            TC_INFO=(${TCMALLOC//=>/})
+            if [[ ! -z "${TC_INFO}" ]]; then
+                echo "Check TCMalloc: ${TC_INFO}"
+                # Determine if the library is linked to libpthread and resolve undefined symbol: pthread_key_create
+                if [ $(echo "$libc_vernum < $libc_v234" | bc) -eq 1 ]; then
+                    # glibc < 2.34 pthread_key_create into libpthread.so. check linking libpthread.so...
+                    if ldd ${TC_INFO[2]} | grep -q 'libpthread'; then
+                        echo "$TC_INFO is linked with libpthread,execute LD_PRELOAD=${TC_INFO[2]}"
+                        # set fullpath LD_PRELOAD (To be on the safe side)
+                        export LD_PRELOAD="${TC_INFO[2]}"
+                        break
+                    else
+                        echo "$TC_INFO is not linked with libpthread will trigger undefined symbol: pthread_Key_create error"
+                    fi
+                else
+                    # Version 2.34 of libc.so (glibc) includes the pthread library IN GLIBC. (USE ubuntu 22.04 and modern linux system and WSL)
+                    # libc.so(glibc) is linked with a library that works in ALMOST ALL Linux userlands. SO NO CHECK!
+                    echo "$TC_INFO is linked with libc.so,execute LD_PRELOAD=${TC_INFO[2]}"
+                    # set fullpath LD_PRELOAD (To be on the safe side)
+                    export LD_PRELOAD="${TC_INFO[2]}"
+                    break
+                fi
+            fi
+        done
+        if [[ -z "${LD_PRELOAD}" ]]; then
+            printf "\e[1m\e[31mCannot locate TCMalloc. Do you have tcmalloc or google-perftool installed on your system? (improves CPU memory usage)\e[0m\n"
+        fi
+    fi
+}
+printf "\n%s\n" "${delimiter}"
+printf "Launching main.py..."
+printf "\n%s\n" "${delimiter}"
+prepare_tcmalloc
+"${python_cmd}" -u "${LAUNCH_SCRIPT}" "$@"
+
+
+


### PR DESCRIPTION
Note: As I have been researching Comfyui recently, I would like to know if you have any plans related to this tcmalloc, so I suggest that if so, I will close this PR.


I have seen that some people have raised issues about memory leaks, while others have answered them, but no one has updated the information to README.md. Before watching Comfyui, I also saw the same issue with Stable Diffusion webui, but they were encapsulated in a script to provide users with choices.

Comfyui does not have a startup script, and there is no relevant introduction to the README.md file. Therefore, I would like to add tcmalloc related information to the README.md file to facilitate quick problem-solving for everyone。
issues：https://github.com/comfyanonymous/ComfyUI/issues/1462

Update content:
## README.md
-----------------content start-----------------
Line: 179
### Using tcmalloc to solve memory leakage problems
Check the tcmalloc_start.sh logic, modify it as needed, and then execute it , render LD_PRELOAD and load TCMALLOC
#### For Example
```shell
# According to the operating system, install tcmalloc
# Execute: sh tcmalloc_start.sh --force-fp16 ...(Other) | HSA_OVERRIDE_GFX_VERSION=10.3.0 ./tcmalloc_start.sh ...
sh tcmalloc_start.sh
```
Execution rendering：
Normal process
![image](https://github.com/comfyanonymous/ComfyUI/assets/5028386/d4c9e1f5-7d1a-48dc-ba71-a1983e305302)
With environment variables: HSA-OverRIDE_GFX_VERSION, py file print (os. environment ["HSA-OverRIDE_GFX_VERSION"])
![image](https://github.com/comfyanonymous/ComfyUI/assets/5028386/48190a1a-4855-4c69-9520-6cc0ca8e56fa)

------------------content end----------------

## tcmalloc_start.sh
-----------------content start-----------------
Obtained through modifying webui scripts
Quoted from: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/dev/webui.sh
Branch: dev
------------------content end----------------
