### PR TITLE
Fix Perp-Neg math

### DIFF
--- a/comfy_extras/nodes_perpneg.py
+++ b/comfy_extras/nodes_perpneg.py
@@ -35,7 +35,7 @@ class PerpNeg:
 
             pos = noise_pred_pos - noise_pred_nocond
             neg = noise_pred_neg - noise_pred_nocond
-            perp = ((torch.mul(pos, neg).sum())/(torch.norm(neg)**2)) * neg
+            perp = neg - ((torch.mul(neg, pos).sum())/(torch.norm(pos)**2)) * pos
             perp_neg = perp * neg_scale
             cfg_result = noise_pred_nocond + cond_scale*(pos - perp_neg)
             cfg_result = x - cfg_result


### PR DESCRIPTION
Adjusts the Perp-Neg implementation to match the [paper](https://arxiv.org/abs/2304.04968) (see Algorithm 1 in Appendix A.1). Fixes #2858
With this fix, Perp-Neg correctly ignores any components of the negative prompt that are parallel to the positive prompt. In other words, common parts are ignored as intended.

Positive: "forest"
Negative: "forest"

Before:
![ComfyUI_00195_](https://github.com/comfyanonymous/ComfyUI/assets/114889020/baa165a3-813c-417b-b46e-615b0c7d0bfb)

After:
![ComfyUI_00197_](https://github.com/comfyanonymous/ComfyUI/assets/114889020/00167d0c-3966-46ec-b7b1-b37124728a2c)

edit: oops, didn't realize renaming the branch would close the PR. sorry for the noise