### PR TITLE
Fix model and cond transformer options patches merge

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -208,6 +208,7 @@ def calc_cond_uncond_batch(model, cond, uncond, x_in, timestep, model_options):
                         cur_patches[p] = cur_patches[p] + patches[p]
                     else:
                         cur_patches[p] = patches[p]
+                transformer_options["patches"] = cur_patches
             else:
                 transformer_options["patches"] = patches
 


### PR DESCRIPTION
Fixes an issue where if `model_options` has `transformer_options` with `patches` and conditionings have `patches` the `patches` on conditionings are lost.

In the original code
```
transformer_options = {}
if 'transformer_options' in model_options:
    transformer_options = model_options['transformer_options'].copy()  


if patches is not None:
    if "patches" in transformer_options:
        cur_patches = transformer_options["patches"].copy() # --> Here the dict is copied
        for p in patches:
            if p in cur_patches:
                cur_patches[p] = cur_patches[p] + patches[p] # --> this change doesn't go back into transformer_options
            else:
                cur_patches[p] = patches[p]  # --> this change doesn't go back into transformer_options
        # --> need to rewrite cur_patches into transformer_options here
    else:
        transformer_options["patches"] = patches
```