### PR TITLE
Added two HTTP endpoints to retrieve streamlined task information and code opt, etc.,

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -140,9 +140,9 @@ def recursive_execute(server, prompt, outputs, current_item, extra_data, execute
     input_data_all = None
     try:
         input_data_all = get_input_data(inputs, class_def, unique_id, outputs, prompt, extra_data)
+        server.last_node_id = unique_id
         if server.client_id is not None:
-            server.last_node_id = unique_id
-            server.send_sync("executing", { "node": unique_id, "prompt_id": prompt_id }, server.client_id)
+            server.send_sync("executing", {"node": unique_id, "prompt_id": prompt_id}, server.client_id)
 
         obj = object_storage.get((unique_id, class_type), None)
         if obj is None:

--- a/nodes.py
+++ b/nodes.py
@@ -1911,6 +1911,8 @@ def load_custom_nodes():
     node_paths = folder_paths.get_folder_paths("custom_nodes")
     node_import_times = []
     for custom_node_path in node_paths:
+        if not os.path.exists(custom_node_path):
+            continue
         possible_modules = os.listdir(os.path.realpath(custom_node_path))
         if "__pycache__" in possible_modules:
             possible_modules.remove("__pycache__")

--- a/server.py
+++ b/server.py
@@ -443,6 +443,23 @@ class PromptServer():
             prompt_id = request.match_info.get("prompt_id", None)
             return web.json_response(self.prompt_queue.get_history(prompt_id=prompt_id))
 
+        @routes.get("/output/{prompt_id}")
+        async def get_output_id(request):
+            str = request.match_info.get("prompt_id", None)
+            output = {}
+            if str is None:
+                return web.json_response(output)
+            prompt_ids = str.split(",")
+            for prompt_id in prompt_ids:
+                the_result = self.prompt_queue.get_history(prompt_id=prompt_id)
+                if len(the_result) == 0:
+                    return web.json_response(output)
+
+                result_info = {'outputs': the_result[prompt_id]['outputs']}
+                output[prompt_id] = result_info
+
+            return web.json_response(output)
+
         @routes.get("/queue")
         async def get_queue(request):
             queue_info = {}
@@ -450,6 +467,29 @@ class PromptServer():
             queue_info['queue_running'] = current_queue[0]
             queue_info['queue_pending'] = current_queue[1]
             return web.json_response(queue_info)
+
+        @routes.get("/queue_summary")
+        async def get_queue_summary(request):
+            queue_info = {}
+            current_queue = self.prompt_queue.get_current_queue()
+
+            running_queue = current_queue[0]
+            running_ids = list()
+            for queue in running_queue:
+                prompt_id = queue[1]
+                running_ids.append(prompt_id)
+                running_info = {'prompt_id': prompt_id, 'current_node_id': self.last_node_id}
+                queue_info['running_status'] = running_info
+
+            pending_queue = current_queue[1]
+            pending_ids = list()
+            for queue in pending_queue:
+                pending_ids.append(queue[1])
+
+            queue_info['queue_running'] = running_ids
+            queue_info['queue_pending'] = pending_ids
+            return web.json_response(queue_info)
+
 
         @routes.post("/prompt")
         async def post_prompt(request):


### PR DESCRIPTION
Hi, 
    I'm the ComfyUI java invoke client developer: [https://github.com/hiforce/pixel-force-open-client](https://github.com/hiforce/pixel-force-open-client).  We have been developing and delivering enterprise solutions based on ComfyUI for some time now. From an application integration perspective, we've identified that the data transmitted each time through the /queue and /history/${promptId} endpoints is too large, often leading to connection interruptions and excessive transfer of unnecessary information. Therefore, we have patched the system by introducing two new endpoints with more concise data: /queue_summary and /output/${promptId}.

Furthermore, in this commit, we have added protection checks for cases where the custom plugin path does not exist during plugin loading.

  BR