### PR TITLE
disable follow_symlinks in static serving for security reason

### DIFF
--- a/server.py
+++ b/server.py
@@ -539,11 +539,11 @@ class PromptServer():
 
         for name, dir in nodes.EXTENSION_WEB_DIRS.items():
             self.app.add_routes([
-                web.static('/extensions/' + urllib.parse.quote(name), dir, follow_symlinks=True),
+                web.static('/extensions/' + urllib.parse.quote(name), dir),
             ])
 
         self.app.add_routes([
-            web.static('/', self.web_root, follow_symlinks=True),
+            web.static('/', self.web_root),
         ])
 
     def get_queue_info(self):


### PR DESCRIPTION
We can use this command to access all the files in the hosting server when `--listen` is specified:
```
curl "http://<comfyhost>:8188/../../../../../../../../../../../../../../etc/passwd"
```

It may be an issue of `aiohttp` but I wonder if the `follow_symlinks` option is neccessary for ComfyUI