### PR TITLE
Fix an issue with bypassed nodes having multiple inputs and outputs of the same type

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1943,8 +1943,8 @@ export class ComfyApp {
 
 											link = parent.getInputLink(parent_input);
 											if (link) {
-												parent = parent.getInputNode(parent_input);
 												consumedLinks[parent.id].add(parent_input);
+												parent = parent.getInputNode(parent_input);
 											}
 											found = true;
 											break;

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1908,6 +1908,10 @@ export class ComfyApp {
 					}
 				}
 
+				// Track a list of links to use with bypassed nodes to prevent
+				// linking to the same input
+				let consumedLinks = {};
+
 				// Store all node links
 				for (let i in node.inputs) {
 					let parent = node.getInputNode(i);
@@ -1930,9 +1934,17 @@ export class ComfyApp {
 									for (let parent_input in all_inputs) {
 										parent_input = all_inputs[parent_input];
 										if (parent.inputs[parent_input]?.type === node.inputs[i].type) {
+						  					consumedLinks[parent.id] = consumedLinks[parent.id] || new Set();
+	
+											if (consumedLinks[parent.id].has(parent_input)) {
+												// do not link the same node twice
+												continue;
+											}
+
 											link = parent.getInputLink(parent_input);
 											if (link) {
 												parent = parent.getInputNode(parent_input);
+												consumedLinks[parent.id].add(parent_input);
 											}
 											found = true;
 											break;


### PR DESCRIPTION
See https://github.com/cubiq/ComfyUI_InstantID/issues/51

This is not really an ideal solution as it just assumes the order of inputs of the bypassed node correspond to the order of inputs in the current node. This is kind of what's done before this change, except it just takes the first type it finds which wouldn't work with a typical node that takes in positive and negative conditioning.

However this change feels a little more correct and might solve most cases.

Maybe in addition we could also match by link name, but we can't guarantee that link names are identical either. Some nodes don't even have output names.