### PR TITLE
arbitrary file read vulnerability fix

### DIFF
--- a/server.py
+++ b/server.py
@@ -44,6 +44,10 @@ async def send_socket_catch_exception(function, message):
 
 @web.middleware
 async def cache_control(request: web.Request, handler):
+    # 
+    if ".." in str(request.raw_path):
+        raise Exception("request path is invliad")
+    
     response: web.Response = await handler(request)
     if request.path.endswith('.js') or request.path.endswith('.css'):
         response.headers.setdefault('Cache-Control', 'no-cache')

--- a/server.py
+++ b/server.py
@@ -44,7 +44,7 @@ async def send_socket_catch_exception(function, message):
 
 @web.middleware
 async def cache_control(request: web.Request, handler):
-    # 
+    # arbitrary file read vulnerability
     if ".." in str(request.raw_path):
         raise Exception("request path is invliad")
     


### PR DESCRIPTION
When starting comfyui using the root account, there is a security vulnerability. Users can pass " curl --path-as-is http://ip:port/../../../../.. /etc/passwd " accessing files that should not be accessed