### PR TITLE
Fix unintended exponential algorithm in recursive_will_execute

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -194,27 +194,26 @@ def recursive_execute(server, prompt, outputs, current_item, extra_data, execute
 
     return (True, None, None)
 
-def recursive_will_execute(prompt, outputs, current_item, memo={}):
+def recursive_will_execute(prompt, outputs, current_item, memo):
     unique_id = current_item
 
     if unique_id in memo:
         return memo[unique_id]
 
     inputs = prompt[unique_id]['inputs']
-    will_execute = []
     if unique_id in outputs:
-        return []
+        return {}
 
+    will_execute = {unique_id}
     for x in inputs:
         input_data = inputs[x]
         if isinstance(input_data, list):
             input_unique_id = input_data[0]
-            output_index = input_data[1]
             if input_unique_id not in outputs:
-                will_execute += recursive_will_execute(prompt, outputs, input_unique_id, memo)
+                will_execute.update(recursive_will_execute(prompt, outputs, input_unique_id, memo))
 
-    memo[unique_id] = will_execute + [unique_id]
-    return memo[unique_id]
+    memo[unique_id] = will_execute
+    return will_execute
 
 def recursive_output_delete_if_changed(prompt, old_prompt, outputs, current_item):
     unique_id = current_item
@@ -375,16 +374,13 @@ class PromptExecutor:
                           broadcast=False)
             executed = set()
             output_node_id = None
-            to_execute = []
 
-            for node_id in list(execute_outputs):
-                to_execute += [(0, node_id)]
+            to_execute = set(execute_outputs)
 
             while len(to_execute) > 0:
                 #always execute the output that depends on the least amount of unexecuted nodes first
-                memo = {}
-                to_execute = sorted(list(map(lambda a: (len(recursive_will_execute(prompt, self.outputs, a[-1], memo)), a[-1]), to_execute)))
-                output_node_id = to_execute.pop(0)[-1]
+                output_node_id = min(to_execute, key=lambda a: len(recursive_will_execute(prompt, self.outputs, a, {})))
+                to_execute.remove(output_node_id)
 
                 # This call shouldn't raise anything if there's an error deep in
                 # the actual SD code, instead it will report the node where the

--- a/execution.py
+++ b/execution.py
@@ -379,7 +379,8 @@ class PromptExecutor:
 
             while len(to_execute) > 0:
                 #always execute the output that depends on the least amount of unexecuted nodes first
-                output_node_id = min(to_execute, key=lambda a: len(recursive_will_execute(prompt, self.outputs, a, {})))
+                memo = {}
+                output_node_id = min(to_execute, key=lambda a: len(recursive_will_execute(prompt, self.outputs, a, memo)))
                 to_execute.remove(output_node_id)
 
                 # This call shouldn't raise anything if there's an error deep in


### PR DESCRIPTION
The intention of `recursive_will_execute` is to count the number of nodes that will be executed given some target nodes.  However, the implementation used a list instead of a set for the count, so nodes were unintentionally getting duplicated.  The count of each node ended up being the number of paths that reach that node instead of just 1.  In general, there may be exponentially many paths which led to OOM errors with deeper graphs.