### PR TITLE
handle execution_interrupted event on client side

### DIFF
--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -142,9 +142,9 @@ class ComfyApi extends EventTarget {
 					    case "execution_cached":
 						    this.dispatchEvent(new CustomEvent("execution_cached", { detail: msg.data }));
 						    break;
-						case "execution_interrupted":
-							this.dispatchEvent(new CustomEvent("execution_interrupted", { detail: msg.data }));
-							break;
+					    case "execution_interrupted":
+						    this.dispatchEvent(new CustomEvent("execution_interrupted", { detail: msg.data }));
+						    break;
 					    default:
 						    if (this.#registered.has(msg.type)) {
 							    this.dispatchEvent(new CustomEvent(msg.type, { detail: msg.data }));

--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -142,6 +142,9 @@ class ComfyApi extends EventTarget {
 					    case "execution_cached":
 						    this.dispatchEvent(new CustomEvent("execution_cached", { detail: msg.data }));
 						    break;
+						case "execution_interrupted":
+							this.dispatchEvent(new CustomEvent("execution_interrupted", { detail: msg.data }));
+							break;
 					    default:
 						    if (this.#registered.has(msg.type)) {
 							    this.dispatchEvent(new CustomEvent(msg.type, { detail: msg.data }));


### PR DESCRIPTION
This change handles the [`execution_interrupted` message](https://github.com/comfyanonymous/ComfyUI/commit/ffec815257ddf2371b880eafd575838210fcea07#diff-b1534f3f58d78f527c22bf15c92758355aa12b1dfb5d799852f36880fa0c6487R271). Without this change, canceling a prompt results in a client console error about unknown message type:

![image](https://github.com/comfyanonymous/ComfyUI/assets/83140/3573a06b-008a-4a4f-a0db-6a681af800d2)
