### PR TITLE
Add a configured node output cache metaclass.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv/
 !/web/extensions/core/
 /tests-ui/data/object_info.json
 /user/
+node_cache_config.yaml

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This ui will let you design and execute advanced stable diffusion pipelines usin
 - Starts up very fast.
 - Works fully offline: will never download anything.
 - [Config file](extra_model_paths.yaml.example) to set the search paths for models.
+- Cache loaded models(node output) in memory between different workflows. And the cache size can be configured.
+- [Node cache size config file](node_cache_config.yaml.example) to set the node's lrucache size.
 
 Workflow examples can be found on the [Examples page](https://comfyanonymous.github.io/ComfyUI_examples/)
 

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -116,6 +116,16 @@ parser.add_argument("--multi-user", action="store_true", help="Enables per-user 
 
 parser.add_argument("--verbose", action="store_true", help="Enables more debug prints.")
 
+def load_node_cache_config(p: str):
+    import yaml
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except:  # noqa: E722
+        return {}
+
+parser.add_argument("--node-cache-config", type=load_node_cache_config, default='node_cache_config.yaml',
+                    metavar="PATH", help="Load node_cache_config.yaml files.")
 
 if comfy.options.args_parsing:
     args = parser.parse_args()

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 import torch
 import math
 import struct
@@ -7,7 +8,7 @@ import numpy as np
 from PIL import Image
 import logging
 
-from cachetools import LRUCache, cachedmethod
+from cachetools import LRUCache, cachedmethod, keys
 from threading import Lock
 
 
@@ -523,6 +524,15 @@ class BaseCachedNode(type):
         fn_name = find_attr(ENTRY_POINT_METHOD)
         fn = find_attr(fn_name)
 
+        key_fn = keys.methodkey
+        with suppress(Exception):
+            is_change_fn = find_attr("IS_CHANGED").__func__
+
+            def kf(self, *args, **kwargs):
+                return keys.hashkey(is_change_fn(self, *args, **kwargs))
+
+            key_fn = kf
+
         from comfy.cli_args import args
 
         maxsize = args.node_cache_config.get(name, DEFAULT_CACHE_SIZE)
@@ -532,6 +542,8 @@ class BaseCachedNode(type):
         # Set entry-point method
         dct[ENTRY_POINT_METHOD] = fn_name
         # Add cache decorator to entry-point method
-        dct[fn_name] = cachedmethod(lambda self: self.__node_cache__, lock=lambda self: self.__node_cache_lock__)(fn)
+        dct[fn_name] = cachedmethod(
+            lambda self: self.__node_cache__, key=key_fn, lock=lambda self: self.__node_cache_lock__
+        )(fn)
         logging.debug(f"decorator <class {name}> <FUNCTION {fn_name}> with cache<size: {maxsize}>")
         return super().__new__(cls, name, bases, dct)

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -7,6 +7,10 @@ import numpy as np
 from PIL import Image
 import logging
 
+from cachetools import LRUCache, cachedmethod
+from threading import Lock
+
+
 def load_torch_file(ckpt, safe_load=False, device=None):
     if device is None:
         device = torch.device("cpu")
@@ -481,3 +485,53 @@ class ProgressBar:
 
     def update(self, value):
         self.update_absolute(self.current + value)
+
+
+# Defualt cache size is 1, which is compatible with previous versions.
+DEFAULT_CACHE_SIZE = 1
+ENTRY_POINT_METHOD = "FUNCTION" # node entry point method name
+
+class BaseCachedNode(type):
+    """Metaclass for cached node: Used to add a class-level LRU cache to each class that uses this.
+
+    usage:
+    ```python
+    class NodeExample(metaclass=BaseCachedNode):
+        ...
+    # or
+    class NodeExampleSubclass(SomeBaseClass, metaclass=BaseCachedNode):
+        ...
+    ```
+
+    NOTE: Make sure that every args and kwargs of FUNCTION(entry point method) is hashable
+    """
+
+    def __new__(cls, name: str, bases: tuple, dct: dict):
+        def find_attr(name: str):
+            # find in attribute dict of the class to be created
+            attr = dct.get(name, None)
+            if attr:
+                return attr
+
+            # find in base class
+            for b in bases:
+                attr = getattr(b, name, None)
+                if attr:
+                    return attr
+            raise TypeError(f"No attribute {name} defined in class or it's baseclass")
+
+        fn_name = find_attr(ENTRY_POINT_METHOD)
+        fn = find_attr(fn_name)
+
+        from comfy.cli_args import args
+
+        maxsize = args.node_cache_config.get(name, DEFAULT_CACHE_SIZE)
+        dct["__node_cache__"] = LRUCache(maxsize)
+        dct["__node_cache_lock__"] = Lock()
+
+        # Set entry-point method
+        dct[ENTRY_POINT_METHOD] = fn_name
+        # Add cache decorator to entry-point method
+        dct[fn_name] = cachedmethod(lambda self: self.__node_cache__, lock=lambda self: self.__node_cache_lock__)(fn)
+        logging.debug(f"decorator <class {name}> <FUNCTION {fn_name}> with cache<size: {maxsize}>")
+        return super().__new__(cls, name, bases, dct)

--- a/node_cache_config.yaml.example
+++ b/node_cache_config.yaml.example
@@ -1,0 +1,6 @@
+# Rename this to node_cache_config.yaml and ComfyUI will load it
+# node_class_type: int(cache size)
+VAELoader: 2
+CheckpointLoaderSimple: 2
+UNETLoader: 1   # default is 1
+ControlNetLoader: 2

--- a/nodes.py
+++ b/nodes.py
@@ -511,7 +511,7 @@ class LoadLatent:
         return True
 
 
-class CheckpointLoader:
+class CheckpointLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "config_name": (folder_paths.get_filename_list("configs"), ),
@@ -526,7 +526,7 @@ class CheckpointLoader:
         ckpt_path = folder_paths.get_full_path("checkpoints", ckpt_name)
         return comfy.sd.load_checkpoint(config_path, ckpt_path, output_vae=True, output_clip=True, embedding_directory=folder_paths.get_folder_paths("embeddings"))
 
-class CheckpointLoaderSimple:
+class CheckpointLoaderSimple(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "ckpt_name": (folder_paths.get_filename_list("checkpoints"), ),
@@ -541,7 +541,7 @@ class CheckpointLoaderSimple:
         out = comfy.sd.load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, embedding_directory=folder_paths.get_folder_paths("embeddings"))
         return out[:3]
 
-class DiffusersLoader:
+class DiffusersLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(cls):
         paths = []
@@ -568,7 +568,7 @@ class DiffusersLoader:
         return comfy.diffusers_load.load_diffusers(model_path, output_vae=output_vae, output_clip=output_clip, embedding_directory=folder_paths.get_folder_paths("embeddings"))
 
 
-class unCLIPCheckpointLoader:
+class unCLIPCheckpointLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "ckpt_name": (folder_paths.get_filename_list("checkpoints"), ),
@@ -650,7 +650,7 @@ class LoraLoaderModelOnly(LoraLoader):
     def load_lora_model_only(self, model, lora_name, strength_model):
         return (self.load_lora(model, None, lora_name, strength_model, 0)[0],)
 
-class VAELoader:
+class VAELoader(metaclass=comfy.utils.BaseCachedNode):
     @staticmethod
     def vae_list():
         vaes = folder_paths.get_filename_list("vae")
@@ -715,7 +715,7 @@ class VAELoader:
         vae = comfy.sd.VAE(sd=sd)
         return (vae,)
 
-class ControlNetLoader:
+class ControlNetLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "control_net_name": (folder_paths.get_filename_list("controlnet"), )}}
@@ -824,7 +824,7 @@ class ControlNetApplyAdvanced:
         return (out[0], out[1])
 
 
-class UNETLoader:
+class UNETLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "unet_name": (folder_paths.get_filename_list("unet"), ),
@@ -839,7 +839,7 @@ class UNETLoader:
         model = comfy.sd.load_unet(unet_path)
         return (model,)
 
-class CLIPLoader:
+class CLIPLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "clip_name": (folder_paths.get_filename_list("clip"), ),
@@ -859,7 +859,7 @@ class CLIPLoader:
         clip = comfy.sd.load_clip(ckpt_paths=[clip_path], embedding_directory=folder_paths.get_folder_paths("embeddings"), clip_type=clip_type)
         return (clip,)
 
-class DualCLIPLoader:
+class DualCLIPLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "clip_name1": (folder_paths.get_filename_list("clip"), ), "clip_name2": (folder_paths.get_filename_list("clip"), ),
@@ -875,7 +875,7 @@ class DualCLIPLoader:
         clip = comfy.sd.load_clip(ckpt_paths=[clip_path1, clip_path2], embedding_directory=folder_paths.get_folder_paths("embeddings"))
         return (clip,)
 
-class CLIPVisionLoader:
+class CLIPVisionLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "clip_name": (folder_paths.get_filename_list("clip_vision"), ),
@@ -905,7 +905,7 @@ class CLIPVisionEncode:
         output = clip_vision.encode_image(image)
         return (output,)
 
-class StyleModelLoader:
+class StyleModelLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "style_model_name": (folder_paths.get_filename_list("style_models"), )}}
@@ -970,7 +970,7 @@ class unCLIPConditioning:
             c.append(n)
         return (c, )
 
-class GLIGENLoader:
+class GLIGENLoader(metaclass=comfy.utils.BaseCachedNode):
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "gligen_name": (folder_paths.get_filename_list("gligen"), )}}


### PR DESCRIPTION
Implement a configurable node output cache metaclass to reduce unnecessary node executions.

The same model currently leads to reloading due to different node IDs between workflows. Loading the model from disk takes a long time.