### PR TITLE
feat: optimizing the time for model weights to be copied between devices

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -304,8 +304,8 @@ class LoadedModel:
 
         return self.real_model
 
-    def model_unload(self):
-        self.model.unpatch_model(self.model.offload_device)
+    def model_unload(self, skip_underlying_model=False):
+        self.model.unpatch_model(self.model.offload_device, skip_underlying_model)
         self.model.model_patches_to(self.model.offload_device)
 
     def __eq__(self, other):
@@ -322,7 +322,7 @@ def unload_model_clones(model):
 
     for i in to_unload:
         logging.debug("unload clone {}".format(i))
-        current_loaded_models.pop(i).model_unload()
+        current_loaded_models.pop(i).model_unload(skip_underlying_model=True)
 
 def free_memory(memory_required, device, keep_loaded=[]):
     unloaded_model = False

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -387,7 +387,7 @@ class ModelPatcher:
 
         return weight
 
-    def unpatch_model(self, device_to=None):
+    def unpatch_model(self, device_to=None, skip_underlying_model=False):
         if self.model_lowvram:
             for m in self.model.modules():
                 if hasattr(m, "prev_comfy_cast_weights"):
@@ -409,7 +409,7 @@ class ModelPatcher:
 
         self.backup = {}
 
-        if device_to is not None:
+        if device_to is not None and not skip_underlying_model:
             self.model.to(device_to)
             self.current_device = device_to
 


### PR DESCRIPTION
Issue Link: [https://github.com/comfyanonymous/ComfyUI/issues/3047](https://github.com/comfyanonymous/ComfyUI/issues/3047)

During my usage, I noticed frequent copying of model weights between devices (GPU and CPU). This situation occurs repeatedly, especially when a base model is repeatedly packed by `ModelPatcher`.

Take the following workflow as an example:

![image](https://github.com/comfyanonymous/ComfyUI/assets/29772821/0dddbe01-bb96-43d3-9752-8803b2797af4)

When loading the checkpoint, the base weights are packed by ModelPatcher and placed into the global cache `comfy.model_management.current_loaded_models` (referred to as `ModelPatcher 0`). At this point, the base model weights reside on the CPU. When reaching the `KSampler 0`, `comfy.sample.prepare_sampling` moves the base model weights contained in `ModelPatcher 0` to the GPU via `comfy.model_management.load_models_gpu`.

After the model passes through the `FreeU_V2` node, a new `ModelPatcher` (referred to as ModelPatcher 1) is generated via `comfy.model_patcher.ModelPatcher.clone`. When it reaches `KSampler 1`, it again goes through `comfy.model_management.load_models_gpu`. However, unlike before, `comfy.model_management.unload_model_clones` is invoked, moving the base model weights of ModelPatcher 1 to the CPU through [current_loaded_models.pop(i).model_unload](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/model_management.py#L325) (Note that ModelPatcher 1 and ModelPatcher 0 point to the same base weights). Subsequently, ModelPatcher 1 moves the weights back to the GPU via [model_load](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/model_management.py#L407).

In other words, during the second `comfy.model_management.load_models_gpu` call, the model weights are needlessly moved from GPU to CPU and back to GPU within a short period. This movement between devices is unnecessary and becomes notably time-consuming, especially when the CPU load is high.

This PR aims to eliminate this unnecessary overhead. I have printed the timing in the `unpatch_model` and `patch_model` functions. Before optimization:
```
[unpatch_model] send model to device, id:139683753852592, current device: cuda:0,  target device: cpu, elapsed: 0.3737630844116211
[patch_model] send model to device, id:139683753852592, current device: cpu, target device: cuda:0, elapsed: 0.3245677947998047
```
After optimization:
```
[unpatch_model] skip send model to device, id:139931462273680, current device: cuda:0, target device: cpu
[patch_model] send model to device, id:139931462273680, current device: cuda:0, target device: cuda:0, elapsed: 0.017429828643798828
```
As seen in this simple example, nearly 0.7s of overhead has been eliminated.

I have conducted multiple tests on this PR based on the above workflow. Below are the average results:

| Metric | vRAM avg | vRAM peak | First Inference | Subsequent Inference |
| - | - | - | - | - |
| Before Optimization | 16.33% | 19.29% | 7.95s | 3.79s |
| After Optimization | 16.33% | 19.29% | 6.76s | 2.92s |

It can be observed that there is no significant change in peak VRAM and average VRAM, but there has been a reduction in the execution time of the workflow.

Any node that calls the `model.clone()` method may benefit from this PR, such as the `Apply IPAdapter`, and so on.

These tests were conducted on the latest version of ComfyUI, on a machine configured with `252G, 96C, A10`.

If there are any misunderstandings or unclear expressions, please let me know. Thank you.
