### PR TITLE
Tip PIL image file is truncated error

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1485,19 +1485,23 @@ class LoadImage:
         output_images = []
         output_masks = []
         for i in ImageSequence.Iterator(img):
-            i = ImageOps.exif_transpose(i)
-            if i.mode == 'I':
-                i = i.point(lambda i: i * (1 / 255))
-            image = i.convert("RGB")
-            image = np.array(image).astype(np.float32) / 255.0
-            image = torch.from_numpy(image)[None,]
-            if 'A' in i.getbands():
-                mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
-                mask = 1. - torch.from_numpy(mask)
-            else:
-                mask = torch.zeros((64,64), dtype=torch.float32, device="cpu")
-            output_images.append(image)
-            output_masks.append(mask.unsqueeze(0))
+            try:
+                i = ImageOps.exif_transpose(i)
+                if i.mode == 'I':
+                    i = i.point(lambda i: i * (1 / 255))
+                image = i.convert("RGB")
+                image = np.array(image).astype(np.float32) / 255.0
+                image = torch.from_numpy(image)[None,]
+                if 'A' in i.getbands():
+                    mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
+                    mask = 1. - torch.from_numpy(mask)
+                else:
+                    mask = torch.zeros((64,64), dtype=torch.float32, device="cpu")
+                output_images.append(image)
+                output_masks.append(mask.unsqueeze(0))
+            except OSError as e:
+                logging.warning("!!! Maybe the picture is too big, try using smaller one")
+                return e
 
         if len(output_images) > 1:
             output_image = torch.cat(output_images, dim=0)


### PR DESCRIPTION
Issue:
when the image is too big, comfy will report error:
```
[2024-03-19 22:20] !!! Exception during processing !!!
[2024-03-19 22:20] Traceback (most recent call last):
File "D:\\sd-webui-aki\\comfyui\\execution.py", line 151, in recursive_execute
output_data, output_ui = get_output_data(obj, input_data_all)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "D:\\sd-webui-aki\\comfyui\\execution.py", line 81, in get_output_data
return_values = map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "D:\\sd-webui-aki\\comfyui\\execution.py", line 74, in map_node_over_list
results.append(getattr(obj, func)(\*\*slice_dict(input_data_all, i)))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "D:\\sd-webui-aki\\comfyui\\nodes.py", line 1488, in load_image
i = ImageOps.exif_transpose(i)
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "D:\\sd-webui-aki\\comfyui.ext\\Lib\\site-packages\\PIL\\ImageOps.py", line 617, in exif_transpose
image.load()
File "D:\\sd-webui-aki\\comfyui.ext\\Lib\\site-packages\\PIL\\ImageFile.py", line 288, in load
raise OSError(msg)
OSError: image file is truncated (0 bytes not processed)
```

the details is in: 
<https://github.com/comfyanonymous/ComfyUI/issues/2692>
<https://github.com/fofr/cog-face-to-many/issues/1>

Here give a tip instead of fixing to make user know what happened