### PR TITLE
Add a LoRA example to the script_examples

### DIFF
--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -139,11 +139,14 @@ prompt_text = """
             ]
         }
     },
-    "10" => { "class_type" => "LoraLoaderModelOnly", "inputs" => {
-      "lora_name" => "lora.safetensors",
-      "model" => ["4", 0],
-      "strength_clip" => 1,
-      "strength_model" => 0.5
+    "10" => {
+        "class_type" => "LoraLoaderModelOnly",
+        "inputs" => {
+            "lora_name" => "lora.safetensors",
+            "model" => ["4", 0],
+            "strength_clip" => 1,
+            "strength_model" => 0.5
+        }
     }
 }
 """

--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -145,7 +145,6 @@ prompt_text = """
       "strength_clip" => 1,
       "strength_model" => 0.5
     }
-  }
 }
 """
 

--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -65,7 +65,7 @@ prompt_text = """
                 0
             ],
             "model": [
-                "4",
+                "10",
                 0
             ],
             "negative": [
@@ -138,7 +138,14 @@ prompt_text = """
                 0
             ]
         }
+    },
+    "10" => { "class_type" => "LoraLoaderModelOnly", "inputs" => {
+      "lora_name" => "lora.safetensors",
+      "model" => ["4", 0],
+      "strength_clip" => 1,
+      "strength_model" => 0.5
     }
+  }
 }
 """
 


### PR DESCRIPTION
The websockets_api_example.py was lacking a Lora example using LoraLoaderModelOnly. Therefore I added one after some try and error.
I'm not sure which example lora I am suppose to reference.

I'm an amateur in all of this, feel free to reject, cancel, change as you wish :-)