### PR TITLE
Make extension loading order deterministic (CORE-188)

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,8 +19,10 @@ def execute_prestartup_script():
         return False
 
     node_paths = folder_paths.get_folder_paths("custom_nodes")
+    node_paths = sorted(node_paths)
     for custom_node_path in node_paths:
         possible_modules = os.listdir(custom_node_path)
+        possible_modules = sorted(possible_modules)
         node_prestartup_times = []
 
         for possible_module in possible_modules:

--- a/nodes.py
+++ b/nodes.py
@@ -1910,9 +1910,11 @@ def load_custom_node(module_path, ignore=set()):
 def load_custom_nodes():
     base_node_names = set(NODE_CLASS_MAPPINGS.keys())
     node_paths = folder_paths.get_folder_paths("custom_nodes")
+    node_paths = sorted(node_paths)
     node_import_times = []
     for custom_node_path in node_paths:
         possible_modules = os.listdir(os.path.realpath(custom_node_path))
+        possible_modules = sorted(possible_modules)
         if "__pycache__" in possible_modules:
             possible_modules.remove("__pycache__")
 


### PR DESCRIPTION
Currently, the order that extensions are loaded in is not deterministic. `os.listdir` [returns in whatever order the filesystem returns the files in](https://stackoverflow.com/a/4813116), so you can even have it not be deterministic on the same machine depending where the files are located. I noticed this when trying to use comfyUI on my SSD vs off a ramdisk, the ramdisk returned the extensions in a different order causing conflicting extensions to be resolved differently, breaking the workflow.

This PR just sorts the extensions before loading, so across different systems and filesystems, extensions will always be loaded in the same order, so conflicts will always be resolved the same.