### PR TITLE
Fine-tuning GitHub Actions

### DIFF
--- a/.github/workflows/windows_release_dependencies.yml
+++ b/.github/workflows/windows_release_dependencies.yml
@@ -33,8 +33,8 @@ jobs:
   build_dependencies:
     runs-on: windows-latest
     steps:
-        - uses: actions/checkout@v3
-        - uses: actions/setup-python@v4
+        - uses: actions/checkout@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
 
@@ -58,7 +58,7 @@ jobs:
             mv temp_wheel_dir cu${{ inputs.cu }}_python_deps
             tar cf cu${{ inputs.cu }}_python_deps.tar cu${{ inputs.cu }}_python_deps
 
-        - uses: actions/cache/save@v3
+        - uses: actions/cache/save@v4
           with:
             path: |
               cu${{ inputs.cu }}_python_deps.tar

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -32,11 +32,11 @@ jobs:
         pull-requests: "read"
     runs-on: windows-latest
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             fetch-depth: 0
             persist-credentials: false
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
         - shell: bash

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -82,7 +82,7 @@ jobs:
 
             cd ..
 
-            "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
+            "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
             mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
 
             cd ComfyUI_windows_portable

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -32,7 +32,7 @@ jobs:
         pull-requests: "read"
     runs-on: windows-latest
     steps:
-        - uses: actions/cache/restore@v3
+        - uses: actions/cache/restore@v4
           id: cache
           with:
             path: |
@@ -48,7 +48,7 @@ jobs:
             pwd
             ls
 
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             fetch-depth: 0
             persist-credentials: false


### PR DESCRIPTION
### 1. Use LZMA2 algorithm for 7zip compression:

LZMA2 is a variant of LZMA, it uses significantly more RAM, and ~70% faster (trade space for time).

[My test](https://github.com/YanWenKun/ComfyUI/actions/workflows/windows_release_package.yml) result:


```
 -m0=lzma2 -mx=5 -mfb=32 -md=16m -ms=on -mf=BCJ2
 8m 53s 
 1.39 GB package

 -m0=lzma2 -mx=7 -mfb=64 -md=32m -ms=on -mf=BCJ2
 10m 30s 
 1.36 GB package

 -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2
 10m 48s 
 1.36 GB package
```

I didn't test `-mx=9 -mfb=64 -md=64m`, the gain would be marginal.

RAM usage on GitHub Actions looks totally fine.

I've opted for `-mx=8` in the commit.

### 2. Updating GitHub Actions versions

Underneath is simply a node.js runtime version bump from 16 to 20. Tested and confirmed no issues to be concerned about.