### PR TITLE
Fix typo in lowvram patcher

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -278,7 +278,7 @@ class ModelPatcher:
                 if weight_key in self.patches:
                     m.weight_function = LowVramPatch(weight_key, self)
                 if bias_key in self.patches:
-                    m.bias_function = LowVramPatch(weight_key, self)
+                    m.bias_function = LowVramPatch(bias_key, self)
 
                 m.prev_comfy_cast_weights = m.comfy_cast_weights
                 m.comfy_cast_weights = True


### PR DESCRIPTION
Fixes WARNING SHAPE MISMATCH warnings I encountered while merging large fp32 models, may resolve complaints in #3125 and #3122 and #3094 