### PR TITLE
Cleanup (for VRAM) if idle

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def execute_prestartup_script():
 
         for possible_module in possible_modules:
             module_path = os.path.join(custom_node_path, possible_module)
-            if os.path.isfile(module_path) or module_path.endswith(".disabled") or module_path == "__pycache__":
+            if os.path.isfile(module_path) or module_path.endswith(".disabled") or possible_module == "__pycache__":
                 continue
 
             script_path = os.path.join(module_path, "prestartup_script.py")


### PR DESCRIPTION
This PR introduces a new function, `cleanup_if_idle`, which is triggered in two scenarios: when a user leaves and when the queue is updated. Its primary purpose is to efficiently release unused resources, ensuring better availability for other applications running on the same machine.

Related Issue: Fixes #3192