### PR TITLE
fix: main menu vanishing

### DIFF
--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -90,11 +90,14 @@ function dragElement(dragEl, settings) {
 	}).observe(dragEl);
 
 	function ensureInBounds() {
-		if (dragEl.classList.contains("comfy-menu-manual-pos")) {
+		try {
 			newPosX = Math.min(document.body.clientWidth - dragEl.clientWidth, Math.max(0, dragEl.offsetLeft));
 			newPosY = Math.min(document.body.clientHeight - dragEl.clientHeight, Math.max(0, dragEl.offsetTop));
 
 			positionElement();
+		}
+		catch(exception){
+			// robust
 		}
 	}
 


### PR DESCRIPTION
Always ensure In bounds.

Fixed an issue where the main menu disappears intermittently as the coordinates become negative.