### PR TITLE
feat: Add transformer_function and sampler_cfg_rescaler hook

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -460,6 +460,8 @@ class BasicTransformerBlock(nn.Module):
         return checkpoint(self._forward, (x, context, transformer_options), self.parameters(), self.checkpoint)
 
     def _forward(self, x, context=None, transformer_options={}):
+        if "transformer_function" in transformer_options:
+            return transformer_options["transformer_function"](self, x, context, transformer_options)
         extra_options = {}
         block = transformer_options.get("block", None)
         block_index = transformer_options.get("block_index", 0)

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -19,23 +19,26 @@ def apply_weight_decompose(dora_scale, weight):
     return weight * (dora_scale / weight_norm)
 
 def set_model_options_patch_replace(model_options, patch, name, block_name, number, transformer_index=None):
+    return set_model_transformer_options(model_options, patch, name, block_name, number, transformer_index, "patches_replace")
+
+def set_model_transformer_options(model_options, patch, name, block_name, number, transformer_index=None, opt_key="patches_replace"):
     to = model_options["transformer_options"].copy()
 
-    if "patches_replace" not in to:
-        to["patches_replace"] = {}
+    if opt_key not in to:
+        to[opt_key] = {}
     else:
-        to["patches_replace"] = to["patches_replace"].copy()
+        to[opt_key] = to[opt_key].copy()
 
-    if name not in to["patches_replace"]:
-        to["patches_replace"][name] = {}
+    if name not in to[opt_key]:
+        to[opt_key][name] = {}
     else:
-        to["patches_replace"][name] = to["patches_replace"][name].copy()
+        to[opt_key][name] = to[opt_key][name].copy()
 
     if transformer_index is not None:
         block = (block_name, number, transformer_index)
     else:
         block = (block_name, number)
-    to["patches_replace"][name][block] = patch
+    to[opt_key][name][block] = patch
     model_options["transformer_options"] = to
     return model_options
 
@@ -158,8 +161,11 @@ class ModelPatcher:
     def set_model_output_block_patch(self, patch):
         self.set_model_patch(patch, "output_block_patch")
 
-    def set_model_transformer_function(self, transformer_function):
-        self.model_options["transformer_options"]["transformer_function"] = transformer_function
+    def set_model_attn1_function_wrapper(self, patch, block_name, number, transformer_index=None):
+        set_model_transformer_options(self.model_options, patch, "attn1", block_name, number, transformer_index, "attn_function_wrapper")
+
+    def set_model_attn2_function_wrapper(self, patch, block_name, number, transformer_index=None):
+        set_model_transformer_options(self.model_options, patch, "attn2", block_name, number, transformer_index, "attn_function_wrapper")
 
     def set_model_sampler_cfg_rescaler(self, cfg_rescaler_fn, disable_cfg1_optimization=False):
         self.model_options["sampler_cfg_rescaler"] = cfg_rescaler_fn

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -158,6 +158,14 @@ class ModelPatcher:
     def set_model_output_block_patch(self, patch):
         self.set_model_patch(patch, "output_block_patch")
 
+    def set_model_transformer_function(self, transformer_function):
+        self.model_options["transformer_options"]["transformer_function"] = transformer_function
+
+    def set_model_sampler_cfg_rescaler(self, cfg_rescaler_fn, disable_cfg1_optimization=False):
+        self.model_options["sampler_cfg_rescaler"] = cfg_rescaler_fn
+        if disable_cfg1_optimization:
+            self.model_options["disable_cfg1_optimization"] = True
+
     def add_object_patch(self, name, obj):
         self.object_patches[name] = obj
 

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -249,6 +249,8 @@ def cfg_function(model, cond_pred, uncond_pred, cond_scale, x, timestep, model_o
 #The main sampling function shared by all the samplers
 #Returns denoised
 def sampling_function(model, x, timestep, uncond, cond, cond_scale, model_options={}, seed=None):
+    if "sampler_cfg_rescaler" in model_options:
+        cond_scale = model_options["sampler_cfg_rescaler"]({"cond_scale": cond_scale, "timestep": timestep})
     if math.isclose(cond_scale, 1.0) and model_options.get("disable_cfg1_optimization", False) == False:
         uncond_ = None
     else:

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -250,7 +250,7 @@ def cfg_function(model, cond_pred, uncond_pred, cond_scale, x, timestep, model_o
 #Returns denoised
 def sampling_function(model, x, timestep, uncond, cond, cond_scale, model_options={}, seed=None):
     if "sampler_cfg_rescaler" in model_options:
-        cond_scale = model_options["sampler_cfg_rescaler"]({"cond_scale": cond_scale, "timestep": timestep})
+        cond_scale = model_options["sampler_cfg_rescaler"]({"cond_scale": cond_scale, "sigma": timestep})
     if math.isclose(cond_scale, 1.0) and model_options.get("disable_cfg1_optimization", False) == False:
         uncond_ = None
     else:


### PR DESCRIPTION
The authors of the [T-GATE](https://github.com/HaozheLiu-ST/T-GATE) introduced a speed up tech, like DeepCache

> We find that cross-attention outputs converge to a fixed point during the initial denoising steps.
> 
> Ignoring text conditions in the fidelity-improving stage not only reduces computation complexity, but also slightly decreases FID score. This yields a simple and training-free method called TGATE for efficient generation, which caches the cross-attention output once it converges and keeps it fixed during the remaining inference steps.

####  Major Features
- Training-Free.
- Easily Integrate into Existing Frameworks.
- Only a few lines of code are required.
- Friendly support CNN-based U-Net, Transformer, and Consistency Model
- 10%-50% speed up for different diffusion models.

#### Implementation details

I have implement a [T-GATE comfyui node](https://github.com/JettHu/ComfyUI_TGate), but introduced some hooks. More detail of T-GATE nodes see [T-GATE comfyui node](https://github.com/JettHu/ComfyUI_TGate).

Resolves https://github.com/comfyanonymous/ComfyUI/issues/3285
