### PR TITLE
Cleanup if idle (w/ a flag `use_maximum_caching` to tell the server whether it should unload and free memory)

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def execute_prestartup_script():
 
         for possible_module in possible_modules:
             module_path = os.path.join(custom_node_path, possible_module)
-            if os.path.isfile(module_path) or module_path.endswith(".disabled") or module_path == "__pycache__":
+            if os.path.isfile(module_path) or module_path.endswith(".disabled") or possible_module == "__pycache__":
                 continue
 
             script_path = os.path.join(module_path, "prestartup_script.py")

--- a/script_examples/basic_api_example.py
+++ b/script_examples/basic_api_example.py
@@ -106,6 +106,11 @@ def queue_prompt(prompt):
     req =  request.Request("http://127.0.0.1:8188/prompt", data=data)
     request.urlopen(req)
 
+def set_maximum_caching(use_maximum_caching):
+    p = {"use_maximum_caching": use_maximum_caching}
+    data = json.dumps(p).encode('utf-8')
+    req =  request.Request("http://127.0.0.1:8188/set_maximum_caching", data=data)
+    request.urlopen(req)
 
 prompt = json.loads(prompt_text)
 #set the text prompt for our positive CLIPTextEncode
@@ -114,7 +119,7 @@ prompt["6"]["inputs"]["text"] = "masterpiece best quality man"
 #set the seed for our KSampler node
 prompt["3"]["inputs"]["seed"] = 5
 
-
+set_maximum_caching(True)
 queue_prompt(prompt)
 
 

--- a/server.py
+++ b/server.py
@@ -651,4 +651,5 @@ class PromptServer():
         if len(self.sockets) == 0:
             with self.prompt_queue.mutex:
                 if len(self.prompt_queue.currently_running) == 0 and len(self.prompt_queue.queue) == 0:
-                    comfy.model_management.unload_all_models()
+                    self.prompt_queue.set_flag("unload_models", True)
+                    self.prompt_queue.set_flag("free_memory", True)


### PR DESCRIPTION
Hi, it's me again. I previously submitted a PR regarding cleaning up cache (related to #3192) but have since closed it due to overlooking some crucial details.

After further tweaking, I still believe we should minimize memory usage when ComfyUI is used as a B/S (Browser/Server) application. However, based on your feedback about users who operate the server side alone, I have introduced a new variable called `use_maximum_caching` and an endpoint `/set_maximum_caching`. This allows API callers to configure the server to maximize cache preservation.

The main change is in the `server.py`. By default, it assumes a B/S application mode, as this is the most common usage scenario for ComfyUI users, who may not have the capability to optimize the system. In this mode, the server will free up VRAM when there are no websocket connections and the queue is empty.

API users wishing to preserve cache can set `use_maximum_caching` to True. This adjustment, as demonstrated in `script_examples/basic_api_example.py`, prevents the server from clearing cache when idle.

Please consider this change. Thanks.

P.S. There is a typo in `main.py` which is unrelated to this issue; I apologize for the confusion caused by including that commit in this PR. I'm unsure how to remove it.