### PR TITLE
Add holding directory for IPAdapters

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -34,6 +34,8 @@ folder_names_and_paths["photomaker"] = ([os.path.join(models_dir, "photomaker")]
 
 folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
 
+folder_names_and_paths["ipadapter"] = ([os.path.join(models_dir, "ipadapter")], supported_pt_extensions)
+
 output_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
 temp_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "temp")
 input_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "input")


### PR DESCRIPTION
The most popular IPAdapter custom node https://github.com/cubiq/ComfyUI_IPAdapter_plus puts these models into the `models/ipadapter` directory.

This PR adds that holding directory as a default.

cc @cubiq 