### PR TITLE
Fixed Issue with LoadImage node when loading PNG files with embedded ICC profiles.

### DIFF
--- a/node_helpers.py
+++ b/node_helpers.py
@@ -1,3 +1,4 @@
+from PIL import Image, ImageFile
 
 def conditioning_set_values(conditioning, values={}):
     c = []
@@ -8,3 +9,16 @@ def conditioning_set_values(conditioning, values={}):
         c.append(n)
 
     return c
+
+def open_image(path):
+    try :
+        ImageFile.LOAD_TRUNCATED_IMAGES = False
+        img = Image.open(path)
+    
+    except:
+        ImageFile.LOAD_TRUNCATED_IMAGES = True
+        img = Image.open(path)
+        
+    finally:
+        ImageFile.LOAD_TRUNCATED_IMAGES = False
+        return img

--- a/nodes.py
+++ b/nodes.py
@@ -13,8 +13,6 @@ import logging
 from PIL import Image, ImageOps, ImageSequence, ImageFile
 from PIL.PngImagePlugin import PngInfo
 
-ImageFile.LOAD_TRUNCATED_IMAGES = True
-
 import numpy as np
 import safetensors.torch
 
@@ -1459,6 +1457,10 @@ class LoadImage:
     FUNCTION = "load_image"
     def load_image(self, image):
         image_path = folder_paths.get_annotated_filepath(image)
+        
+        if image_path.endswith(".png"):
+            ImageFile.LOAD_TRUNCATED_IMAGES = True
+        
         img = Image.open(image_path)
         output_images = []
         output_masks = []

--- a/nodes.py
+++ b/nodes.py
@@ -10,14 +10,13 @@ import time
 import random
 import logging
 
-from PIL import Image, ImageOps, ImageSequence, ImageFile
+from PIL import Image, ImageOps, ImageSequence
 from PIL.PngImagePlugin import PngInfo
 
 import numpy as np
 import safetensors.torch
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy"))
-
 
 import comfy.diffusers_load
 import comfy.samplers
@@ -1458,10 +1457,8 @@ class LoadImage:
     def load_image(self, image):
         image_path = folder_paths.get_annotated_filepath(image)
         
-        if image_path.endswith(".png"):
-            ImageFile.LOAD_TRUNCATED_IMAGES = True
+        img = node_helpers.open_image(image_path)
         
-        img = Image.open(image_path)
         output_images = []
         output_masks = []
         for i in ImageSequence.Iterator(img):

--- a/nodes.py
+++ b/nodes.py
@@ -10,8 +10,11 @@ import time
 import random
 import logging
 
-from PIL import Image, ImageOps, ImageSequence
+from PIL import Image, ImageOps, ImageSequence, ImageFile
 from PIL.PngImagePlugin import PngInfo
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True
+
 import numpy as np
 import safetensors.torch
 


### PR DESCRIPTION
Fixed Value Error: Decompressed Data Too Large thrown by PIL when attempting to opening PNG files with large embedded ICC colorspaces.

Error occurs because PIL misinterprets large embedded ICC profiles in PNG images as malicious decompression bombs, and throws 

By setting the follow flag to true when loading PNG images PIL discards meta data, preventing the error:  

ImageFile.LOAD_TRUNCATED_IMAGES = True