### PR TITLE
feat: ✨ add support for "*" output types

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -454,7 +454,7 @@ def validate_inputs(prompt, item, validated):
             o_id = val[0]
             o_class_type = prompt[o_id]['class_type']
             r = nodes.NODE_CLASS_MAPPINGS[o_class_type].RETURN_TYPES
-            if r[val[1]] != type_input:
+            if r[val[1]] != "*" and r[val[1]] != type_input:
                 received_type = r[val[1]]
                 details = f"{x}, {received_type} != {type_input}"
                 error = {


### PR DESCRIPTION
effectively skipping type checking.
There are already trick to do the same for inputs using `kwargs`.

There are probably implications I haven't fully thought about and I didn't test it extensively myself