### PR TITLE
exclude directory no_auto_execute from automaticaly execute javascript

### DIFF
--- a/server.py
+++ b/server.py
@@ -135,6 +135,7 @@ class PromptServer():
             
             for name, dir in nodes.EXTENSION_WEB_DIRS.items():
                 files = glob.glob(os.path.join(glob.escape(dir), '**/*.js'), recursive=True)
+                files = [file for file in files if 'no_auto_execute' not in file]
                 extensions.extend(list(map(lambda f: "/extensions/" + urllib.parse.quote(
                     name) + "/" + os.path.relpath(f, dir).replace("\\", "/"), files)))
 


### PR DESCRIPTION
js files in directory  no_auto_execute will not be automaticaly executed like all other js files inside extension inside WEB_DIRECTORY
this is solution to bug report : 
https://github.com/comfyanonymous/ComfyUI/issues/3332