### PR TITLE
Fix error when more cond masks passed in than batch size

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -34,7 +34,7 @@ def get_area_and_mult(conds, x_in, timestep_in):
         mask = conds['mask']
         assert(mask.shape[1] == x_in.shape[2])
         assert(mask.shape[2] == x_in.shape[3])
-        mask = mask[:,area[2]:area[0] + area[2],area[3]:area[1] + area[3]] * mask_strength
+        mask = mask[:input_x.shape[0],area[2]:area[0] + area[2],area[3]:area[1] + area[3]] * mask_strength
         mask = mask.unsqueeze(1).repeat(input_x.shape[0] // mask.shape[0], input_x.shape[1], 1, 1)
     else:
         mask = torch.ones_like(input_x)


### PR DESCRIPTION
Currently, there is code to handle the case that there are less masks than batch size, but if the masks exceed batch size, the math on line 38 breaks, trying to repeat 0 times (and causing the mask batch size to not match expected length even if the math did work out somehow).

This PR simply caps the mask tensor batch size at the size of input_x, making use of cond masks less frustrating when changing batch size as often happens with video workflows.