### PR TITLE
Use get_model_object instead of model.model_sampling in Deep Shrink node

### DIFF
--- a/comfy_extras/nodes_model_downscale.py
+++ b/comfy_extras/nodes_model_downscale.py
@@ -20,8 +20,9 @@ class PatchModelAddDownscale:
     CATEGORY = "_for_testing"
 
     def patch(self, model, block_number, downscale_factor, start_percent, end_percent, downscale_after_skip, downscale_method, upscale_method):
-        sigma_start = model.model.model_sampling.percent_to_sigma(start_percent)
-        sigma_end = model.model.model_sampling.percent_to_sigma(end_percent)
+        model_sampling = model.get_model_object("model_sampling")
+        sigma_start = model_sampling.percent_to_sigma(start_percent)
+        sigma_end = model_sampling.percent_to_sigma(end_percent)
 
         def input_block_patch(h, transformer_options):
             if transformer_options["block"][1] == block_number:


### PR DESCRIPTION
PatchModelAddDownscale is accessing `model.model_sampling` directly instead of using `get_model_object` function, causing wrong behavior when using nodes like ModelSamplingDiscrete.

This PR contains fix only for PatchModelAddDownscale node. There might also be another places in code where `model.model_sampling` is being accessed directly, but I'm not sure whether it causes any issues or not.