### PR TITLE
feat: shortcuts for zoom in/out

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,32 +41,32 @@ Workflow examples can be found on the [Examples page](https://comfyanonymous.git
 
 ## Shortcuts
 
-| Keybind                    | Explanation                                                                                                        |
-|----------------------------|--------------------------------------------------------------------------------------------------------------------|
-| Ctrl + Enter               | Queue up current graph for generation                                                                              |
-| Ctrl + Shift + Enter       | Queue up current graph as first for generation                                                                     |
-| Ctrl + Z/Ctrl + Y          | Undo/Redo                                                                                                          |
-| Ctrl + S                   | Save workflow                                                                                                      |
-| Ctrl + O                   | Load workflow                                                                                                      |
-| Ctrl + A                   | Select all nodes                                                                                                   |
-| Alt + C                    | Collapse/uncollapse selected nodes                                                                                 |
-| Ctrl + M                   | Mute/unmute selected nodes                                                                                         |
-| Ctrl + B                   | Bypass selected nodes (acts like the node was removed from the graph and the wires reconnected through)            |
-| Delete/Backspace           | Delete selected nodes                                                                                              |
-| Ctrl + Delete/Backspace    | Delete the current graph                                                                                           |
-| Space                      | Move the canvas around when held and moving the cursor                                                             |
-| Ctrl/Shift + Click         | Add clicked node to selection                                                                                      |
-| Ctrl + C/Ctrl + V          | Copy and paste selected nodes (without maintaining connections to outputs of unselected nodes)                     |
-| Ctrl + C/Ctrl + Shift + V  | Copy and paste selected nodes (maintaining connections from outputs of unselected nodes to inputs of pasted nodes) |
-| Shift + Drag               | Move multiple selected nodes at the same time                                                                      |
-| Ctrl + D                   | Load default graph                                                                                                 |
-| Alt + `+`                  | Canvas Zoom in                                                                                                     |
-| Alt + `-`                  | Canvas Zoom out                                                                                                    |
-| Ctrl + LMB + Vertical drag | Canvas Zoom in/out                                                                                                 |
-| Q                          | Toggle visibility of the queue                                                                                     |
-| H                          | Toggle visibility of history                                                                                       |
-| R                          | Refresh graph                                                                                                      |
-| Double-Click LMB           | Open node quick search palette                                                                                     |
+| Keybind                            | Explanation                                                                                                        |
+|------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| Ctrl + Enter                       | Queue up current graph for generation                                                                              |
+| Ctrl + Shift + Enter               | Queue up current graph as first for generation                                                                     |
+| Ctrl + Z/Ctrl + Y                  | Undo/Redo                                                                                                          |
+| Ctrl + S                           | Save workflow                                                                                                      |
+| Ctrl + O                           | Load workflow                                                                                                      |
+| Ctrl + A                           | Select all nodes                                                                                                   |
+| Alt + C                            | Collapse/uncollapse selected nodes                                                                                 |
+| Ctrl + M                           | Mute/unmute selected nodes                                                                                         |
+| Ctrl + B                           | Bypass selected nodes (acts like the node was removed from the graph and the wires reconnected through)            |
+| Delete/Backspace                   | Delete selected nodes                                                                                              |
+| Ctrl + Delete/Backspace            | Delete the current graph                                                                                           |
+| Space                              | Move the canvas around when held and moving the cursor                                                             |
+| Ctrl/Shift + Click                 | Add clicked node to selection                                                                                      |
+| Ctrl + C/Ctrl + V                  | Copy and paste selected nodes (without maintaining connections to outputs of unselected nodes)                     |
+| Ctrl + C/Ctrl + Shift + V          | Copy and paste selected nodes (maintaining connections from outputs of unselected nodes to inputs of pasted nodes) |
+| Shift + Drag                       | Move multiple selected nodes at the same time                                                                      |
+| Ctrl + D                           | Load default graph                                                                                                 |
+| Alt + `+`                          | Canvas Zoom in                                                                                                     |
+| Alt + `-`                          | Canvas Zoom out                                                                                                    |
+| Ctrl + Shift + LMB + Vertical drag | Canvas Zoom in/out                                                                                                 |
+| Q                                  | Toggle visibility of the queue                                                                                     |
+| H                                  | Toggle visibility of history                                                                                       |
+| R                                  | Refresh graph                                                                                                      |
+| Double-Click LMB                   | Open node quick search palette                                                                                     |
 
 Ctrl can also be replaced with Cmd instead for macOS users
 

--- a/README.md
+++ b/README.md
@@ -41,31 +41,32 @@ Workflow examples can be found on the [Examples page](https://comfyanonymous.git
 
 ## Shortcuts
 
-| Keybind                   | Explanation                                                                                                       |
-|---------------------------|-------------------------------------------------------------------------------------------------------------------|
-| Ctrl + Enter              | Queue up current graph for generation                                                                             |
-| Ctrl + Shift + Enter      | Queue up current graph as first for generation                                                                    |
-| Ctrl + Z/Ctrl + Y         | Undo/Redo                                                                                                         |
-| Ctrl + S                  | Save workflow                                                                                                     |
-| Ctrl + O                  | Load workflow                                                                                                     |
-| Ctrl + A                  | Select all nodes                                                                                                  |
-| Alt + C                   | Collapse/uncollapse selected nodes                                                                                |
-| Ctrl + M                  | Mute/unmute selected nodes                                                                                        |
-| Ctrl + B                  | Bypass selected nodes (acts like the node was removed from the graph and the wires reconnected through)           |
-| Delete/Backspace          | Delete selected nodes                                                                                             |
-| Ctrl + Delete/Backspace   | Delete the current graph                                                                                          |
-| Space                     | Move the canvas around when held and moving the cursor                                                            |
-| Ctrl/Shift + Click        | Add clicked node to selection                                                                                     |
-| Ctrl + C/Ctrl + V         | Copy and paste selected nodes (without maintaining connections to outputs of unselected nodes)                    |
-| Ctrl + C/Ctrl + Shift + V | Copy and paste selected nodes (maintaining connections from outputs of unselected nodes to inputs of pasted nodes)|
-| Shift + Drag              | Move multiple selected nodes at the same time                                                                     |
-| Ctrl + D                  | Load default graph                                                                                                |
-| Alt + `+`                 | Canvas zoom in                                                                                                    |
-| Alt + `-`                 | Canvas zoom out                                                                                                   |
-| Q                         | Toggle visibility of the queue                                                                                    |
-| H                         | Toggle visibility of history                                                                                      |
-| R                         | Refresh graph                                                                                                     |
-| Double-Click LMB          | Open node quick search palette                                                                                    |
+| Keybind                    | Explanation                                                                                                        |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------|
+| Ctrl + Enter               | Queue up current graph for generation                                                                              |
+| Ctrl + Shift + Enter       | Queue up current graph as first for generation                                                                     |
+| Ctrl + Z/Ctrl + Y          | Undo/Redo                                                                                                          |
+| Ctrl + S                   | Save workflow                                                                                                      |
+| Ctrl + O                   | Load workflow                                                                                                      |
+| Ctrl + A                   | Select all nodes                                                                                                   |
+| Alt + C                    | Collapse/uncollapse selected nodes                                                                                 |
+| Ctrl + M                   | Mute/unmute selected nodes                                                                                         |
+| Ctrl + B                   | Bypass selected nodes (acts like the node was removed from the graph and the wires reconnected through)            |
+| Delete/Backspace           | Delete selected nodes                                                                                              |
+| Ctrl + Delete/Backspace    | Delete the current graph                                                                                           |
+| Space                      | Move the canvas around when held and moving the cursor                                                             |
+| Ctrl/Shift + Click         | Add clicked node to selection                                                                                      |
+| Ctrl + C/Ctrl + V          | Copy and paste selected nodes (without maintaining connections to outputs of unselected nodes)                     |
+| Ctrl + C/Ctrl + Shift + V  | Copy and paste selected nodes (maintaining connections from outputs of unselected nodes to inputs of pasted nodes) |
+| Shift + Drag               | Move multiple selected nodes at the same time                                                                      |
+| Ctrl + D                   | Load default graph                                                                                                 |
+| Alt + `+`                  | Canvas Zoom in                                                                                                     |
+| Alt + `-`                  | Canvas Zoom out                                                                                                    |
+| Ctrl + LMB + Vertical drag | Canvas Zoom in/out                                                                                                 |
+| Q                          | Toggle visibility of the queue                                                                                     |
+| H                          | Toggle visibility of history                                                                                       |
+| R                          | Refresh graph                                                                                                      |
+| Double-Click LMB           | Open node quick search palette                                                                                     |
 
 Ctrl can also be replaced with Cmd instead for macOS users
 

--- a/README.md
+++ b/README.md
@@ -41,29 +41,31 @@ Workflow examples can be found on the [Examples page](https://comfyanonymous.git
 
 ## Shortcuts
 
-| Keybind                   | Explanation                                                                                                        |
-|---------------------------|--------------------------------------------------------------------------------------------------------------------|
-| Ctrl + Enter              | Queue up current graph for generation                                                                              |
-| Ctrl + Shift + Enter      | Queue up current graph as first for generation                                                                     |
-| Ctrl + Z/Ctrl + Y         | Undo/Redo                                                                                                          |
-| Ctrl + S                  | Save workflow                                                                                                      |
-| Ctrl + O                  | Load workflow                                                                                                      |
-| Ctrl + A                  | Select all nodes                                                                                                   |
-| Alt + C                   | Collapse/uncollapse selected nodes                                                                                 |
-| Ctrl + M                  | Mute/unmute selected nodes                                                                                         |
-| Ctrl + B                  | Bypass selected nodes (acts like the node was removed from the graph and the wires reconnected through)            |
-| Delete/Backspace          | Delete selected nodes                                                                                              |
-| Ctrl + Delete/Backspace   | Delete the current graph                                                                                           |
-| Space                     | Move the canvas around when held and moving the cursor                                                             |
-| Ctrl/Shift + Click        | Add clicked node to selection                                                                                      |
-| Ctrl + C/Ctrl + V         | Copy and paste selected nodes (without maintaining connections to outputs of unselected nodes)                     |
-| Ctrl + C/Ctrl + Shift + V | Copy and paste selected nodes (maintaining connections from outputs of unselected nodes to inputs of pasted nodes) |
-| Shift + Drag              | Move multiple selected nodes at the same time                                                                      |
-| Ctrl + D                  | Load default graph                                                                                                 |
-| Q                         | Toggle visibility of the queue                                                                                     |
-| H                         | Toggle visibility of history                                                                                       |
-| R                         | Refresh graph                                                                                                      |
-| Double-Click LMB          | Open node quick search palette                                                                                     |
+| Keybind                   | Explanation                                                                                                       |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------|
+| Ctrl + Enter              | Queue up current graph for generation                                                                             |
+| Ctrl + Shift + Enter      | Queue up current graph as first for generation                                                                    |
+| Ctrl + Z/Ctrl + Y         | Undo/Redo                                                                                                         |
+| Ctrl + S                  | Save workflow                                                                                                     |
+| Ctrl + O                  | Load workflow                                                                                                     |
+| Ctrl + A                  | Select all nodes                                                                                                  |
+| Alt + C                   | Collapse/uncollapse selected nodes                                                                                |
+| Ctrl + M                  | Mute/unmute selected nodes                                                                                        |
+| Ctrl + B                  | Bypass selected nodes (acts like the node was removed from the graph and the wires reconnected through)           |
+| Delete/Backspace          | Delete selected nodes                                                                                             |
+| Ctrl + Delete/Backspace   | Delete the current graph                                                                                          |
+| Space                     | Move the canvas around when held and moving the cursor                                                            |
+| Ctrl/Shift + Click        | Add clicked node to selection                                                                                     |
+| Ctrl + C/Ctrl + V         | Copy and paste selected nodes (without maintaining connections to outputs of unselected nodes)                    |
+| Ctrl + C/Ctrl + Shift + V | Copy and paste selected nodes (maintaining connections from outputs of unselected nodes to inputs of pasted nodes)|
+| Shift + Drag              | Move multiple selected nodes at the same time                                                                     |
+| Ctrl + D                  | Load default graph                                                                                                |
+| Alt + `+`                 | Canvas zoom in                                                                                                    |
+| Alt + `-`                 | Canvas zoom out                                                                                                   |
+| Q                         | Toggle visibility of the queue                                                                                    |
+| H                         | Toggle visibility of history                                                                                      |
+| R                         | Refresh graph                                                                                                     |
+| Double-Click LMB          | Open node quick search palette                                                                                    |
 
 Ctrl can also be replaced with Cmd instead for macOS users
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1059,6 +1059,20 @@ export class ComfyApp {
 					// Trigger onPaste
 					return true;
 				}
+
+				if((e.key === '+') && e.altKey) {
+					block_default = true;
+					let scale = this.ds.scale * 1.1;
+					this.ds.changeScale(scale, [this.ds.element.width/2, this.ds.element.height/2]);
+					this.graph.change();
+				}
+
+				if((e.key === '-') && e.altKey) {
+					block_default = true;
+					let scale = this.ds.scale * 1 / 1.1;
+					this.ds.changeScale(scale, [this.ds.element.width/2, this.ds.element.height/2]);
+					this.graph.change();
+				}
 			}
 
 			this.graph.change();

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -953,9 +953,9 @@ export class ComfyApp {
 
 		const origProcessMouseDown = LGraphCanvas.prototype.processMouseDown;
 		LGraphCanvas.prototype.processMouseDown = function(e) {
-			// prepare for ctrl drag: zoom start
-			if(e.ctrlKey && e.buttons) {
-				self.ctrl_mouse_start = [e.x, e.y, this.ds.scale];
+			// prepare for ctrl+shift drag: zoom start
+			if(e.ctrlKey && e.shiftKey && e.buttons) {
+				self.zoom_drag_start = [e.x, e.y, this.ds.scale];
 				return;
 			}
 
@@ -979,17 +979,17 @@ export class ComfyApp {
 
 		const origProcessMouseMove = LGraphCanvas.prototype.processMouseMove;
 		LGraphCanvas.prototype.processMouseMove = function(e) {
-			// handle ctrl drag
-			if(e.ctrlKey && self.ctrl_mouse_start) {
+			// handle ctrl+shift drag
+			if(e.ctrlKey && e.shiftKey && self.zoom_drag_start) {
 				// stop canvas zoom action
 				if(!e.buttons) {
-					self.ctrl_mouse_start = null;
+					self.zoom_drag_start = null;
 					return;
 				}
 
 				// calculate delta
-				let deltaY = e.y - self.ctrl_mouse_start[1];
-				let startScale = self.ctrl_mouse_start[2];
+				let deltaY = e.y - self.zoom_drag_start[1];
+				let startScale = self.zoom_drag_start[2];
 
 				let scale = startScale - deltaY/100;
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -953,6 +953,12 @@ export class ComfyApp {
 
 		const origProcessMouseDown = LGraphCanvas.prototype.processMouseDown;
 		LGraphCanvas.prototype.processMouseDown = function(e) {
+			// prepare for ctrl drag: zoom start
+			if(e.ctrlKey && e.buttons) {
+				self.ctrl_mouse_start = [e.x, e.y, this.ds.scale];
+				return;
+			}
+
 			const res = origProcessMouseDown.apply(this, arguments);
 
 			this.selected_group_moving = false;
@@ -973,6 +979,26 @@ export class ComfyApp {
 
 		const origProcessMouseMove = LGraphCanvas.prototype.processMouseMove;
 		LGraphCanvas.prototype.processMouseMove = function(e) {
+			// handle ctrl drag
+			if(e.ctrlKey && self.ctrl_mouse_start) {
+				// stop canvas zoom action
+				if(!e.buttons) {
+					self.ctrl_mouse_start = null;
+					return;
+				}
+
+				// calculate delta
+				let deltaY = e.y - self.ctrl_mouse_start[1];
+				let startScale = self.ctrl_mouse_start[2];
+
+				let scale = startScale - deltaY/100;
+
+				this.ds.changeScale(scale, [this.ds.element.width/2, this.ds.element.height/2]);
+				this.graph.change();
+
+				return;
+			}
+
 			const orig_selected_group = this.selected_group;
 
 			if (this.selected_group && !this.selected_group_resizing && !this.selected_group_moving) {


### PR DESCRIPTION
New shortcuts for canvas zoom in/out.

alt + `+` : zoom in
alt + `-`  : zoom out
ctrl + shift + LMB + vertical drag: zoom in(up) + out(down)

Several system doesn't have mouse.

https://github.com/comfyanonymous/ComfyUI/issues/3406#issuecomment-2095286274