### PR TITLE
webp loader fix

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -2099,16 +2099,16 @@ export class ComfyApp {
 				}
 			}
 		} else if (file.type === "image/webp") {
-			const pngInfo = await getWebpMetadata(file);
+			const pngInfo = await getWebpMetadata(file);	// getWebpMetadata returns parsed JSON, so much simpler
 			if (pngInfo) {
 				if (pngInfo.workflow) {
-					this.loadGraphData(JSON.parse(pngInfo.workflow));
+					this.loadGraphData(pngInfo.workflow);
 				} else if (pngInfo.Workflow) {
-					this.loadGraphData(JSON.parse(pngInfo.Workflow)); // Support loading workflows from that webp custom node.
+					this.loadGraphData(pngInfo.Workflow); // Support loading workflows from that webp custom node.
 				} else if (pngInfo.prompt) {
-					this.loadApiJson(JSON.parse(pngInfo.prompt));
+					this.loadApiJson(pngInfo.prompt);
 				} else if (pngInfo.Prompt) {
-					this.loadApiJson(JSON.parse(pngInfo.Prompt)); // Support loading prompts from that webp custom node.
+					this.loadApiJson(pngInfo.Prompt); // Support loading prompts from that webp custom node.
 				}
 			}
 		} else if (file.type === "application/json" || file.name?.endsWith(".json")) {

--- a/web/scripts/pnginfo.js
+++ b/web/scripts/pnginfo.js
@@ -128,12 +128,7 @@ export function getWebpMetadata(file) {
 					if (String.fromCharCode(...webp.slice(offset + 8, offset + 8 + 6)) == "Exif\0\0") {
 						offset += 6;
 					}
-					let data = parseExifData(webp.slice(offset + 8, offset + 8 + chunk_length));
-					for (var key in data) {
-						var value = data[key];
-						let index = value.indexOf(':');
-						txt_chunks[value.slice(0, index)] = value.slice(index + 1);
-					}
+					txt_chunks = parseExifData(webp.slice(offset + 8, offset + 8 + chunk_length));  // we get only 1 tag with the whole prompt already parsed
 				}
 
 				offset += 8 + chunk_length;

--- a/web/scripts/pnginfo.js
+++ b/web/scripts/pnginfo.js
@@ -79,10 +79,11 @@ function parseExifData(exifData) {
 			let value;
 			if (type === 2) {
 				// ASCII string
-				value = String.fromCharCode(...exifData.slice(valueOffset, valueOffset + numValues - 1));
+				value = String.fromCharCode(...exifData.slice(valueOffset, valueOffset + numValues - 1)).replace("[NaN]", "[0]");
 			}
 
-			result[tag] = value;
+			// result[tag] = value; // with type 2, tag is a an integer = 37510
+      			Object.assign(result, JSON.parse(value));	// return parsed json immediately, it's already clean: "{prompt:{},workflow:{}}"
 		}
 
 		return result;


### PR DESCRIPTION
This is the way to generate the type 2 exif tag 37510, that is seeked for in pnginfo.js
```
    exif = img.getexif()
    dump = json.dumps(metadata)
    exif[ExifTags.Base.UserComment] = json.dumps(metadata)
    exif_dat = exif.tobytes()
    img.save(image_path, exif=exif_dat)
```
In doing so, you cannot import this escaped json string, the way pnginfo reads it. pnginfo now parses it and send it ready to consume to app.js. also there is no txt_chunks, there will always, only will be 1 single exif tag with the whole prompt.
app.js is also modified to reflect this fix.
Tested and working.
Once you accept this patch, I will also PR you the jpeg import addon.
thank you!