### PR TITLE
Fix to LoadImage Node for #3416 HDR images loading additional smaller…

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1461,12 +1461,22 @@ class LoadImage:
         
         output_images = []
         output_masks = []
+        w, h = None, None
+        
         for i in ImageSequence.Iterator(img):
             i = node_helpers.pillow(ImageOps.exif_transpose, i)
 
             if i.mode == 'I':
                 i = i.point(lambda i: i * (1 / 255))
             image = i.convert("RGB")
+
+            if len(output_images) == 0:
+                w = image.size[0]
+                h = image.size[1]
+            
+            if image.size[0] != w or image.size[1] != h:
+                continue
+            
             image = np.array(image).astype(np.float32) / 255.0
             image = torch.from_numpy(image)[None,]
             if 'A' in i.getbands():

--- a/nodes.py
+++ b/nodes.py
@@ -1462,6 +1462,8 @@ class LoadImage:
         output_images = []
         output_masks = []
         w, h = None, None
+
+        excluded_formats = ['MPO']
         
         for i in ImageSequence.Iterator(img):
             i = node_helpers.pillow(ImageOps.exif_transpose, i)
@@ -1487,7 +1489,7 @@ class LoadImage:
             output_images.append(image)
             output_masks.append(mask.unsqueeze(0))
 
-        if len(output_images) > 1:
+        if len(output_images) > 1 and img.format not in excluded_formats:
             output_image = torch.cat(output_images, dim=0)
             output_mask = torch.cat(output_masks, dim=0)
         else:


### PR DESCRIPTION
… images.

Added a blocking if statement  in the ImageSequence.Iterator that checks if subsequent images after the first match dimensionally, and prevent them from being appended to output_images if they do not match. 

This effectively filters out gain maps from HDR images types.

This addresses #3416