### PR TITLE
Show message on error when loading wf from file (works on drag and drop)

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -2157,6 +2157,14 @@ export class ComfyApp {
 		api.dispatchEvent(new CustomEvent("promptQueued", { detail: { number, batchCount } }));
 	}
 
+	showErrorOnFileLoad(file) {
+		this.ui.dialog.show(
+			$el("div", [
+				$el("p", {textContent: `Unable to find workflow in ${file.name}`})
+			]).outerHTML
+		);
+	}
+
 	/**
 	 * Loads workflow data from the specified file
 	 * @param {File} file
@@ -2164,27 +2172,27 @@ export class ComfyApp {
 	async handleFile(file) {
 		if (file.type === "image/png") {
 			const pngInfo = await getPngMetadata(file);
-			if (pngInfo) {
-				if (pngInfo.workflow) {
-					await this.loadGraphData(JSON.parse(pngInfo.workflow));
-				} else if (pngInfo.prompt) {
-					this.loadApiJson(JSON.parse(pngInfo.prompt));
-				} else if (pngInfo.parameters) {
-					importA1111(this.graph, pngInfo.parameters);
-				}
+			if (pngInfo?.workflow) {
+				await this.loadGraphData(JSON.parse(pngInfo.workflow));
+			} else if (pngInfo?.prompt) {
+				this.loadApiJson(JSON.parse(pngInfo.prompt));
+			} else if (pngInfo?.parameters) {
+				importA1111(this.graph, pngInfo.parameters);
+			} else {
+				this.showErrorOnFileLoad(file);
 			}
 		} else if (file.type === "image/webp") {
 			const pngInfo = await getWebpMetadata(file);
-			if (pngInfo) {
-				if (pngInfo.workflow) {
-					this.loadGraphData(JSON.parse(pngInfo.workflow));
-				} else if (pngInfo.Workflow) {
-					this.loadGraphData(JSON.parse(pngInfo.Workflow)); // Support loading workflows from that webp custom node.
-				} else if (pngInfo.prompt) {
-					this.loadApiJson(JSON.parse(pngInfo.prompt));
-				} else if (pngInfo.Prompt) {
-					this.loadApiJson(JSON.parse(pngInfo.Prompt)); // Support loading prompts from that webp custom node.
-				}
+			// Support loading workflows from that webp custom node.
+			const workflow = pngInfo?.workflow || pngInfo?.Workflow;
+			const prompt = pngInfo?.prompt || pngInfo?.Prompt;
+
+			if (workflow) {
+				this.loadGraphData(JSON.parse(workflow));
+			} else if (prompt) {
+				this.loadApiJson(JSON.parse(prompt));
+			} else {
+				this.showErrorOnFileLoad(file);
 			}
 		} else if (file.type === "application/json" || file.name?.endsWith(".json")) {
 			const reader = new FileReader();
@@ -2205,7 +2213,11 @@ export class ComfyApp {
 				await this.loadGraphData(JSON.parse(info.workflow));
 			} else if (info.prompt) {
 				this.loadApiJson(JSON.parse(info.prompt));
+			} else {
+				this.showErrorOnFileLoad(file);
 			}
+		} else {
+			this.showErrorOnFileLoad(file);
 		}
 	}
 


### PR DESCRIPTION
Had a few files that were named `Comfy_nnnnn_.jpg` and didn't notice the jpg format at first. Small PR to show a message about not finding a workflow when one is not present.

Additional small code change to remove unnecessary indentation level.
![loader-message-3](https://github.com/comfyanonymous/ComfyUI/assets/2114069/0abd8374-be85-482a-835b-702daeb92304)
![loader-message-2](https://github.com/comfyanonymous/ComfyUI/assets/2114069/e40e9167-898a-40e4-acc1-c1c44411d041)
![loader-message-1](https://github.com/comfyanonymous/ComfyUI/assets/2114069/3d36ef65-14dc-4045-b8e9-83f864819c64)
