### PR TITLE
Ability for extensions to provide custom extra_data to prompt

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -34,10 +34,12 @@ def get_input_data(inputs, class_def, unique_id, outputs={}, prompt={}, extra_da
         for x in h:
             if h[x] == "PROMPT":
                 input_data_all[x] = [prompt]
-            if h[x] == "EXTRA_PNGINFO":
+            elif h[x] == "EXTRA_PNGINFO":
                 input_data_all[x] = [extra_data.get('extra_pnginfo', None)]
-            if h[x] == "UNIQUE_ID":
+            elif h[x] == "UNIQUE_ID":
                 input_data_all[x] = [unique_id]
+            elif h[x] == "EXTRA_DATA":
+                input_data_all[x] = [extra_data.get(x, None)]
     return input_data_all
 
 def map_node_over_list(obj, input_data_all, func, allow_interrupt=False):

--- a/tests-ui/tests/extensions.test.js
+++ b/tests-ui/tests/extensions.test.js
@@ -25,6 +25,7 @@ describe("extensions", () => {
 			nodeCreated: jest.fn(),
 			beforeConfigureGraph: jest.fn(),
 			afterConfigureGraph: jest.fn(),
+			// provideExtraData not testable without prompt.
 		};
 
 		const { app, ez, graph } = await start({

--- a/web/scripts/api.js
+++ b/web/scripts/api.js
@@ -194,12 +194,14 @@ class ComfyApi extends EventTarget {
 	 *
 	 * @param {number} number The index at which to queue the prompt, passing -1 will insert the prompt at the front of the queue
 	 * @param {object} prompt The prompt data to queue
+	 * @param {object} extra_data extra data added to the prompt request
 	 */
-	async queuePrompt(number, { output, workflow }) {
+	async queuePrompt(number, { output, workflow }, extra_data) {
+		extra_data = { extra_pnginfo: { workflow }, ...extra_data }
 		const body = {
 			client_id: this.clientId,
 			prompt: output,
-			extra_data: { extra_pnginfo: { workflow } },
+			extra_data,
 		};
 
 		if (number === -1) {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -2119,7 +2119,9 @@ export class ComfyApp {
 					const p = await this.graphToPrompt();
 
 					try {
-						const res = await api.queuePrompt(number, p);
+						const extra_datas = await this.#invokeExtensionsAsync("provideExtraData");
+						const extra_data = Object.assign({}, ...extra_datas)
+						const res = await api.queuePrompt(number, p, extra_data);
 						this.lastNodeErrors = res.node_errors;
 						if (this.lastNodeErrors.length > 0) {
 							this.canvas.draw(true, true);

--- a/web/types/comfy.d.ts
+++ b/web/types/comfy.d.ts
@@ -58,6 +58,11 @@ export interface ComfyExtension {
 	 * @param app The ComfyUI app instance
 	 */
 	nodeCreated(node: LGraphNode, app: ComfyApp);
+	/**
+	 * Allows the extension to add custom extra_data to the prompt queue
+	 * @param app The ComfyUI app instance
+	 */
+	provideExtraData(app: ComfyApp): Promise<unknown>;
 }
 
 export type ComfyObjectInfo = {


### PR DESCRIPTION
# Use case:
An extension allows the user to store some session-specific settings in the web-ui.
A custom node needs access to that data.

See the following discussion https://github.com/comfyanonymous/ComfyUI/discussions/3476

# Description of the changes
This PR adds
- js extension method provideExtraData which allows an extension developer to provide additional data which is sent with ui-requests to the `/prompt` endpoint.
- custom nodes may specify hidden inputs with type "EXTRA_DATA". the parameter name is looked up in the extra_data object from the prompt, and if there is any, that data is passed to the execution function of the custom node.

# Example Code

## js
```js
app.registerExtension({
    name: "my-example-extension",
    async provideExtraData() {
        return {my_custom_data: { hello: "world"}}
    }
})
```

## python
```js
class MyExampleNode:
    @classmethod
    def INPUT_TYPES(s):
        return {
            "hidden": {
                "my_custom_data": "EXTRA_DATA"
            }
        }

    RETURN_TYPES = ("FLOAT",)
    CATEGORY = "example"
    FUNCTION = "extra_data_example"
    OUTPUT_NODE = False

    def extra_data_example(self, my_custom_data=None):
        if my_custom_data is None:
            print("extra_data my_custom_data is None")
        else:
            print("my_custom_data " + json.dumps(my_custom_data, indent=4)")

        return 1.0 # some fake output, just so the node can be executed
```