### PR TITLE
Fix similar 'save image' filename overwriting existing file instead of incrementing

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -258,7 +258,7 @@ def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height
         raise Exception(err)
 
     try:
-        counter = max(filter(lambda a: a[1][:-1] == filename and a[1][-1] == "_", map(map_filename, os.listdir(full_output_folder))))[0] + 1
+        counter = max(filter(lambda a: a[1][:-1].casefold() == filename.casefold() and a[1][-1] == "_", map(map_filename, os.listdir(full_output_folder))))[0] + 1
     except ValueError:
         counter = 1
     except FileNotFoundError:


### PR DESCRIPTION
Problem
---
On Windows, saving an image with a filename that already exists with a different case causes it to overwrite the existing image file instead of incrementing the name.

For example, if I first save with a filename_prefix of "abc", and then save again with "Abc", the second image will overwrite the first without warning.

Expected Behavior
---
The filename should increment despite the difference in case, resulting in "abc_00001_.png" and "Abc_00002_.png", because Windows's file system is case insensitive.

Solution
---
Add `.casefold()` to the code that counts the number of files with the same name, making it case insensitive.