### PR TITLE
improve: better error message for execution of missing node

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -622,8 +622,17 @@ def full_type_name(klass):
 def validate_prompt(prompt):
     outputs = set()
     for x in prompt:
+        if 'class_type' not in prompt[x]:
+            error = {
+                "type": "invalid_prompt",
+                "message": f"Cannot execute due to a missing node",
+                "details": f"Node ID '#{x}'",
+                "extra_info": {}
+            }
+            return (False, error, [], [])
+
         class_ = nodes.NODE_CLASS_MAPPINGS[prompt[x]['class_type']]
-        if hasattr(class_, 'OUTPUT_NODE') and class_.OUTPUT_NODE == True:
+        if hasattr(class_, 'OUTPUT_NODE') and class_.OUTPUT_NODE is True:
             outputs.add(x)
 
     if len(outputs) == 0:


### PR DESCRIPTION
Provide a better error message when attempting to execute the workflow with a missing node.

![image](https://github.com/comfyanonymous/ComfyUI/assets/128333288/6058587e-ec5a-4c2d-9ff1-0068c92185f9)
