### PR TITLE
Add type annotation UnetWrapperFunction

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -3,7 +3,7 @@ import copy
 import inspect
 import logging
 import uuid
-from typing import Callable, Protocol, TypedDict, Optional
+from typing import Callable, Protocol, TypedDict, Optional, List
 
 import comfy.utils
 import comfy.model_management
@@ -24,10 +24,14 @@ class UnetApplyConds(TypedDict):
 
 
 class UnetParams(TypedDict):
+    # Tensor of shape [B, C, H, W]
     input: torch.Tensor
+    # Tensor of shape [B]
     timestep: torch.Tensor
     c: UnetApplyConds
-    cond_or_uncond: torch.Tensor
+    # List of [0, 1], [0], [1], ...
+    # 0 means unconditional, 1 means conditional
+    cond_or_uncond: List[int]
 
 
 UnetWrapperFunction = Callable[[UnetApplyFunction, UnetParams], torch.Tensor]

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -3,38 +3,10 @@ import copy
 import inspect
 import logging
 import uuid
-from typing import Callable, Protocol, TypedDict, Optional, List
 
 import comfy.utils
 import comfy.model_management
-
-
-class UnetApplyFunction(Protocol):
-    """Function signature protocol on comfy.model_base.BaseModel.apply_model"""
-    def __call__(self, x: torch.Tensor, t: torch.Tensor, **kwargs) -> torch.Tensor:
-        pass
-
-
-class UnetApplyConds(TypedDict):
-    """Optional conditions for unet apply function."""
-    c_concat: Optional[torch.Tensor]
-    c_crossattn: Optional[torch.Tensor]
-    control: Optional[torch.Tensor]
-    transformer_options: Optional[dict]
-
-
-class UnetParams(TypedDict):
-    # Tensor of shape [B, C, H, W]
-    input: torch.Tensor
-    # Tensor of shape [B]
-    timestep: torch.Tensor
-    c: UnetApplyConds
-    # List of [0, 1], [0], [1], ...
-    # 0 means unconditional, 1 means conditional
-    cond_or_uncond: List[int]
-
-
-UnetWrapperFunction = Callable[[UnetApplyFunction, UnetParams], torch.Tensor]
+from comfy.types import UnetWrapperFunction
 
 
 def apply_weight_decompose(dora_scale, weight):

--- a/comfy/types.py
+++ b/comfy/types.py
@@ -1,0 +1,32 @@
+import torch
+from typing import Callable, Protocol, TypedDict, Optional, List
+
+
+class UnetApplyFunction(Protocol):
+    """Function signature protocol on comfy.model_base.BaseModel.apply_model"""
+
+    def __call__(self, x: torch.Tensor, t: torch.Tensor, **kwargs) -> torch.Tensor:
+        pass
+
+
+class UnetApplyConds(TypedDict):
+    """Optional conditions for unet apply function."""
+
+    c_concat: Optional[torch.Tensor]
+    c_crossattn: Optional[torch.Tensor]
+    control: Optional[torch.Tensor]
+    transformer_options: Optional[dict]
+
+
+class UnetParams(TypedDict):
+    # Tensor of shape [B, C, H, W]
+    input: torch.Tensor
+    # Tensor of shape [B]
+    timestep: torch.Tensor
+    c: UnetApplyConds
+    # List of [0, 1], [0], [1], ...
+    # 0 means unconditional, 1 means conditional
+    cond_or_uncond: List[int]
+
+
+UnetWrapperFunction = Callable[[UnetApplyFunction, UnetParams], torch.Tensor]


### PR DESCRIPTION
When I was implementing IC-Light, I found that it is hard to reason what are available to the callback. https://github.com/huchenlei/ComfyUI-IC-Light-Native/blob/893f5238d87e7ca4ffd4a810a124972289778857/ic_light_nodes.py#L118

This PR adds type annotation for `unet_wrapper_function`, so developer can figure out how the function should behave without running the debugger.