### PR TITLE
add cache of load checkpoints

### DIFF
--- a/comfy/node_cache.py
+++ b/comfy/node_cache.py
@@ -57,13 +57,13 @@ def checkpoint_cache_decorator(func):
         # get matched ckpt, vae, controlnet queue
         cache_mapper = caches_mapping.get(dir_name, None)
 
-        if cache_mapper is not None and device in (None, torch.device("cpu"), {}):
+        if cache_mapper is not None:
             if cache_mapper.get_cache(ckpt) is not None:
                 return cache_mapper.get_cache(ckpt)
 
         sd = func(ckpt, *args, device=device, **kwargs)
 
-        if cache_mapper is not None and device in (None, torch.device("cpu"), {}):
+        if cache_mapper is not None:
             cache_mapper.add_cache(ckpt, sd)
             print(f"[==Cache==] Add {dir_name}  {model_name} to cache")
             cache_mapper.clear_cache()

--- a/comfy/node_cache.py
+++ b/comfy/node_cache.py
@@ -28,7 +28,7 @@ class Cache:
             print(f"[==Cache==]  Removed {k} from cache.")
 
     def add_cache(self, k, item):
-        """模型patch会修改key的名字，缓存之前保留一份key的数据和值的引用"""
+        """model patch change the key name of tensor, cache the names here"""
         keys = list(item.keys())
         values = list(item.values())
         self._cache[k] = (keys, values)

--- a/comfy/node_cache.py
+++ b/comfy/node_cache.py
@@ -1,0 +1,72 @@
+from collections import OrderedDict, namedtuple
+from functools import wraps
+import os
+
+import torch
+
+MAX_CHECKPOINT_CACHE = int(os.environ.get("MAX_CHECKPOINT_CACHE", 1))
+MAX_CONTROLNET_CACHE = int(os.environ.get("MAX_CONTROLNET_CACHE", 1))
+MAX_VAE_CACHE = int(os.environ.get("MAX_VAE_CACHE", 1))
+
+
+class Cache:
+    def __init__(self, max_cache_size=0):
+        self._max_size = max_cache_size
+        self._cache = OrderedDict()
+
+    @property
+    def cache(self):
+        return self._cache
+
+    @property
+    def size(self):
+        return self._max_size
+
+    def clear_cache(self):
+        while len(self._cache) > self.size:
+            k, _ = self._cache.popitem(last=False)
+            print(f"[==Cache==]  Removed {k} from cache.")
+
+    def add_cache(self, k, item):
+        """模型patch会修改key的名字，缓存之前保留一份key的数据和值的引用"""
+        keys = list(item.keys())
+        values = list(item.values())
+        self._cache[k] = (keys, values)
+        self._cache.move_to_end(k)
+
+    def get_cache(self, k):
+        data = self._cache.get(k)
+        if data:
+            keys, values = data
+            return dict(zip(keys, values))
+        return None
+
+
+caches_mapping = {
+    "checkpoints": Cache(max_cache_size=MAX_CHECKPOINT_CACHE),
+    "controlnet": Cache(max_cache_size=MAX_CONTROLNET_CACHE),
+    "vae": Cache(max_cache_size=MAX_VAE_CACHE),
+}
+
+
+def checkpoint_cache_decorator(func):
+    @wraps(func)
+    def wrapper(ckpt, *args, device=None, **kwargs):
+        model_dir, model_name = os.path.split(ckpt)
+        dir_name = os.path.basename(model_dir)
+        # get matched ckpt, vae, controlnet queue
+        cache_mapper = caches_mapping.get(dir_name, None)
+
+        if cache_mapper is not None and device in (None, torch.device("cpu"), {}):
+            if cache_mapper.get_cache(ckpt) is not None:
+                return cache_mapper.get_cache(ckpt)
+
+        sd = func(ckpt, *args, device=device, **kwargs)
+
+        if cache_mapper is not None and device in (None, torch.device("cpu"), {}):
+            cache_mapper.add_cache(ckpt, sd)
+            print(f"[==Cache==] Add {dir_name}  {model_name} to cache")
+            cache_mapper.clear_cache()
+        return sd
+
+    return wrapper

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -2,11 +2,13 @@ import torch
 import math
 import struct
 import comfy.checkpoint_pickle
+from comfy.node_cache import checkpoint_cache_decorator
 import safetensors.torch
 import numpy as np
 from PIL import Image
 import logging
 
+@checkpoint_cache_decorator
 def load_torch_file(ckpt, safe_load=False, device=None):
     if device is None:
         device = torch.device("cpu")


### PR DESCRIPTION
> Hello
>
> I used my method to reduce the loss of multiple switching and loading of the model. Although comfyui's current use of memory is efficient enough, I still dare to try it. I found that the effect is quite obvious. I hope it can be used by the author. See if this can usually be applied to the trunk branch.

Here is an example.
![aa](https://github.com/comfyanonymous/ComfyUI/assets/31640191/6e7e7c5f-e914-4bd9-a98a-0ceb2bebff27)



