### PR TITLE
Load titles from API format JSON

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -2238,6 +2238,7 @@ export class ComfyApp {
 			const data = apiData[id];
 			const node = LiteGraph.createNode(data.class_type);
 			node.id = isNaN(+id) ? id : +id;
+			node.title = data._meta?.title ?? node.title
 			graph.add(node);
 		}
 


### PR DESCRIPTION
Currently, after the user sets custom titles for nodes, saving workflow to API format stores the titles like so:
```
  "0": {
    "inputs": {
      ...
    },
    "class_type": ...,
    "_meta": {
      "title": "My Title"
    }
  }
```
However, when loading the API workflow from a JSON, the user-set titles are ignored and reset back to the default titles. This is a simple fix that sets the titles correctly from `_meta` when loading from API format workflow JSON.