### PR TITLE
Fix preview latent on AMD Devices for Windows.

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -630,6 +630,8 @@ def supports_dtype(device, dtype): #TODO
 def device_supports_non_blocking(device):
     if is_device_mps(device):
         return False #pytorch bug? mps doesn't support non blocking
+    if directml_enabled:
+        return False #fix for AMD devices on Windows.
     return True
 
 def device_should_use_non_blocking(device):

--- a/latent_preview.py
+++ b/latent_preview.py
@@ -24,12 +24,17 @@ class TAESDPreviewerImpl(LatentPreviewer):
         self.taesd = taesd
 
     def decode_latent_to_preview(self, x0):
-        x_sample = self.taesd.decode(x0[:1])[0].detach()
-        x_sample = 255. * torch.clamp((x_sample + 1.0) / 2.0, min=0.0, max=1.0)
-        x_sample = np.moveaxis(x_sample.to(device="cpu", dtype=torch.uint8, non_blocking=comfy.model_management.device_supports_non_blocking(x_sample.device)).numpy(), 0, 2)
+        self.latent_rgb_factors = self.latent_rgb_factors.to(dtype=x0.dtype, device=x0.device)
+        latent_image = x0[0].permute(1, 2, 0) @ self.latent_rgb_factors
 
-        preview_image = Image.fromarray(x_sample)
-        return preview_image
+        latents_ubyte = (((latent_image + 1) / 2)
+                            .clamp(0, 1)  # change scale from -1..1 to 0..1
+                            .mul(0xFF)  # to 0..255
+                            )
+        latents_ubyte = latents_ubyte.to(dtype=torch.uint8)
+        latents_ubyte = latents_ubyte.to(device="cpu", dtype=torch.uint8, non_blocking=comfy.model_management.device_supports_non_blocking(latent_image.device))
+
+        return Image.fromarray(latents_ubyte.numpy())
 
 
 class Latent2RGBPreviewer(LatentPreviewer):


### PR DESCRIPTION
Improve Latent Preview by forcing `dtype=uint8`
Check if device supports non-blocking