### PR TITLE
improve dom widget performance

### DIFF
--- a/web/scripts/domWidget.js
+++ b/web/scripts/domWidget.js
@@ -11,9 +11,10 @@ function intersect(a, b) {
 	else return null;
 }
 
-function getClipPath(node, element, elRect) {
+function getClipPath(node, element) {
 	const selectedNode = Object.values(app.canvas.selected_nodes)[0];
 	if (selectedNode && selectedNode !== node) {
+		const elRect = element.getBoundingClientRect();
 		const MARGIN = 7;
 		const scale = app.canvas.ds.scale;
 
@@ -269,7 +270,7 @@ LGraphNode.prototype.addDOMWidget = function (name, type, element, options) {
 			});
 
 			if (enableDomClipping) {
-				element.style.clipPath = getClipPath(node, element, elRect);
+				element.style.clipPath = getClipPath(node, element);
 				element.style.willChange = "clip-path";
 			}
 


### PR DESCRIPTION
This PR improve dom widget performance with a simple 3-line change.

I've discovered a performance issue with the rendering of DOM widgets:
In simple terms, the calculation for the ClipPath is only necessary when collisions with the selected node occur. However, due to incorrect parameters passed in the previous code, all DOM widgets were constantly calculating their own ClipPaths, even when it served no purpose. This could potentially cause performance issues when there are many DOM widgets.

Additionally, I have already verified that there are no issues with the fix in my own maintained litegraph.ts library.