### PR TITLE
Add example for how to add custom API routes

### DIFF
--- a/custom_nodes/example_node.py.example
+++ b/custom_nodes/example_node.py.example
@@ -106,6 +106,16 @@ class Example:
 # Set the web directory, any .js file in that directory will be loaded by the frontend as a frontend extension
 # WEB_DIRECTORY = "./somejs"
 
+
+# Add custom API routes, using router
+from aiohttp import web
+from server import PromptServer
+
+@PromptServer.instance.routes.get("/hello")
+async def get_hello(request):
+    return web.json_response("hello")
+
+
 # A dictionary that contains all nodes you want to export with their names
 # NOTE: names should be globally unique
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
It looks like support for this feature was added in #354 
Supplement example files to improve discoverability of this feature