### PR TITLE
Save widget names in the workflow JSON

### DIFF
--- a/web/lib/litegraph.core.js
+++ b/web/lib/litegraph.core.js
@@ -2593,8 +2593,10 @@
         }
 
         if (this.widgets && this.serialize_widgets) {
+            o.widgets_names = [];
             o.widgets_values = [];
             for (var i = 0; i < this.widgets.length; ++i) {
+                o.widgets_names[i] = this.widgets[i].name;
 				if(this.widgets[i])
 	                o.widgets_values[i] = this.widgets[i].value;
 				else

--- a/web/scripts/defaultGraph.js
+++ b/web/scripts/defaultGraph.js
@@ -13,6 +13,7 @@ export const defaultGraph = {
 			inputs: [{ name: "clip", type: "CLIP", link: 5 }],
 			outputs: [{ name: "CONDITIONING", type: "CONDITIONING", links: [6], slot_index: 0 }],
 			properties: {},
+			widget_names: ["text"],
 			widgets_values: ["text, watermark"],
 		},
 		{
@@ -26,6 +27,7 @@ export const defaultGraph = {
 			inputs: [{ name: "clip", type: "CLIP", link: 3 }],
 			outputs: [{ name: "CONDITIONING", type: "CONDITIONING", links: [4], slot_index: 0 }],
 			properties: {},
+			widget_names: ["text"],
 			widgets_values: ["beautiful scenery nature glass bottle landscape, , purple galaxy bottle,"],
 		},
 		{
@@ -38,6 +40,7 @@ export const defaultGraph = {
 			mode: 0,
 			outputs: [{ name: "LATENT", type: "LATENT", links: [2], slot_index: 0 }],
 			properties: {},
+			widget_names: ["width","height","batch_size"],
 			widgets_values: [512, 512, 1],
 		},
 		{
@@ -56,6 +59,7 @@ export const defaultGraph = {
 			],
 			outputs: [{ name: "LATENT", type: "LATENT", links: [7], slot_index: 0 }],
 			properties: {},
+			widget_names: ["seed","","steps","cfg","sampler_name","scheduler","denoise"],
 			widgets_values: [156680208700286, true, 20, 8, "euler", "normal", 1],
 		},
 		{
@@ -98,6 +102,7 @@ export const defaultGraph = {
 				{ name: "VAE", type: "VAE", links: [8], slot_index: 2 },
 			],
 			properties: {},
+			widget_names: ["ckpt_name"],
 			widgets_values: ["v1-5-pruned-emaonly.ckpt"],
 		},
 	],

--- a/web/types/litegraph.d.ts
+++ b/web/types/litegraph.d.ts
@@ -588,6 +588,7 @@ export type SerializedLGraphNode<T extends LGraphNode = LGraphNode> = {
     outputs: T["outputs"];
     title: T["title"];
     properties: T["properties"];
+    widgets_names?: IWidget["name"][];
     widgets_values?: IWidget["value"][];
 };
 


### PR DESCRIPTION
Currently, any external tooling will have a hard time converting workflow JSON files to the API format.

The main reason is that `widgets_values` is an array and mapping values from that array to widget names requires loading node types from the `/object_info` endpoint as well. However, `/object_info` depends on the plugins installed and thus may miss some of the nodes in the workflow.

This change adds `widget_names` to the JSON, allowing direct conversion of workflow files to API format without prior knowledge of all node types. This could also help with compatibility in the future.

Requires https://github.com/comfyanonymous/litegraph.js/pull/10

Resolves #2275