### PR TITLE
Fix to #3593  - updated attention_pytorch and attention_xformers to properly handle the --dont-upcast-attention flag

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -105,8 +105,8 @@ def attention_basic(q, k, v, heads, mask=None, attn_precision=None):
     )
 
     # force cast to fp32 to avoid overflowing if args.dont_upcast_attention is not set
-    sim = einsum('b i d, b j d -> b i j', q.to(dtype=cast_to_type), k.to(dtype=cast_to_type) * scale
-
+    sim = einsum('b i d, b j d -> b i j', q.to(dtype=cast_to_type), k.to(dtype=cast_to_type)) * scale
+    
     del q, k
 
     if exists(mask):


### PR DESCRIPTION
Fix to #3593 caused by unused `attn_precision` variable not being used to cast `q, k, v` to the proper type in `attention_pytorch` and `attention_xformers`. This leads to the functions not being able to respect the `--dont-upcast-attention` flag and failing to cast `q, k, v` to the same type when calling torch function:
```python
torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False)
```  
which expects `q, k, v` to be of the same dtype.

Also fixed improper casting behavior in `attention_basic`
```python
if attn_precision == torch.float32:
    sim = einsum('b i d, b j d -> b i j', q.float(), k.float()) * scale
else: 
    sim = einsum('b i d, b j d -> b i j', q, k) * scale
```

`sim = einsum('b i d, b j d -> b i j', q, k) * scale` casts to `torch.float32` if `q` or `k` are `torch.float32`. As this is the conditional branch for when the `--dont-upcast-attention` flag is set, proper behavior is to ensure it is not possible to cast to `torch.float32` in cases where `q` is `torch.float16` or `q, k` are passed to the function as different dtypes, and `--dont-upcast-attention` is set.

it is now:
```python
cast_to_type = attn_precision if attn_precision is not None else q.dtype

sim = einsum('b i d, b j d -> b i j', q.to(dtype=cast_to_type), k.to(dtype=cast_to_type)) * scale
```
This ensures that `q, k` are both cast to the expected dtype and `einsum` does not cause an unintended upcast.

Also as `tensor.to(dtype=cast_to_type)` does not copy or re-cast if `tensor.dtype == cast_to_type`, always performing `.to(dtype=cast_to_type)` profiles the same speed as not calling `.to(dtype)` at all in cases where the tensors are already the proper dtype. 

changed calls from `.float()` to `.to(dtype=torch.float32)` in `attention_split` and to `.to(dtype=cast_to_type)` in `attention_basic` as it profiles between 2 and 10 times faster depending on the device the tensor is on.

Profile using .float()
```
 -----------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg       CPU Mem  Self CPU Mem    # of Calls  
-----------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
        aten::transpose         1.62%      17.000us         3.06%      32.000us      10.667us           0 b           0 b             3  
       aten::as_strided         1.43%      15.000us         1.43%      15.000us       5.000us           0 b           0 b             3  
               aten::to         0.29%       3.000us        96.94%       1.015ms     338.333us           0 b           0 b             3  
         aten::_to_copy         1.34%      14.000us        96.66%       1.012ms     337.333us           0 b           0 b             3  
    aten::empty_strided         2.96%      31.000us         2.96%      31.000us      10.333us           0 b           0 b             3  
            aten::copy_        91.79%     961.000us        92.36%     967.000us     322.333us           0 b           0 b             3  
            aten::empty         0.57%       6.000us         0.57%       6.000us       2.000us           0 b           0 b             3  
-----------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 1.047ms
```

Profile using  .to(dtype)

```
-----------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg       CPU Mem  Self CPU Mem    # of Calls  
-----------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
        aten::transpose         9.18%       9.000us        12.24%      12.000us       4.000us           0 b           0 b             3  
       aten::as_strided         6.12%       6.000us         6.12%       6.000us       2.000us           0 b           0 b             3  
             aten::view        19.39%      19.000us        19.39%      19.000us       6.333us           0 b           0 b             3  
               aten::to         2.04%       2.000us        61.22%      60.000us      20.000us           0 b           0 b             3  
         aten::_to_copy         9.18%       9.000us        59.18%      58.000us      19.333us           0 b           0 b             3  
    aten::empty_strided         1.02%       1.000us         1.02%       1.000us       0.333us           0 b           0 b             3  
            aten::copy_        52.04%      51.000us        53.06%      52.000us      17.333us           0 b           0 b             3  
            aten::empty         1.02%       1.000us         1.02%       1.000us       0.333us           0 b           0 b             3  
-----------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 98.000us
```
