### PR TITLE
Add zoom controls to the web UI

### DIFF
--- a/web/extensions/core/simpleTouchSupport.js
+++ b/web/extensions/core/simpleTouchSupport.js
@@ -52,6 +52,7 @@ app.registerExtension({
 				}
 				touchTime = null;
 			}
+			app.updateScaleValue()
 		});
 
 		app.canvasEl.addEventListener(

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -614,6 +614,39 @@ export class ComfyUI {
 					app.resetView();
 				}
 			}),
+			$el("div", { style: { marginTop: "1em" } }, [
+				$el("label", { innerHTML: "Zoom" }),
+				$el("button", {
+					innerHTML: "-",
+					onclick: () => {
+						this.app.incrementScale(-0.1);
+					},
+					style: { marginLeft: "0.5em", padding: "2px 5px", fontSize: "12px" },
+				}),
+				$el("input", {
+					id: "scaleValue",
+					type: "text",
+					value: this.app.getZoomLevel(),
+					style: { marginLeft: "0.5em", paddingLeft: "0px", width: "50px", textAlign: "center" },
+					onchange: (e) => {
+						console.log(e.target.value)
+						const value = parseFloat(e.target.value.replace('%', ''));
+						if (!isNaN(value)) {
+							this.app.setScale(value / 100);
+						} else {
+							console.log('target')
+							e.target.value = this.app.getZoomLevel(); // Reset to the current zoom level if input is invalid
+						}
+					},
+				}),
+				$el("button", {
+					innerHTML: "+",
+					onclick: () => {
+						this.app.incrementScale(0.1);
+					},
+					style: { marginLeft: "0.5em", padding: "2px 5px", fontSize: "12px" },
+				}),
+			]),
 		]);
 
 		const devMode = this.settings.addSetting({


### PR DESCRIPTION
I've found zooming on my trackpad to be really finicky so I built controls to tell you the zoom level and provide more control over zoom. 

This PR adds zoom controls to the webs UI. The default workflow/view will initialize at 100% and update from the input, +/- buttons and via scroll wheel or touch zoom.

Screenshot, note the new controls below "Reset View"
<img width="1920" alt="Screenshot 2024-06-05 at 12 50 06 AM" src="https://github.com/comfyanonymous/ComfyUI/assets/23443968/4b3e8510-1930-4e88-b608-a045abca014e">
