### PR TITLE
feat: ✨ add a method to extend convertable widget types

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -12,6 +12,12 @@ export function getWidgetConfig(slot) {
 	return slot.widget[CONFIG] ?? slot.widget[GET_CONFIG]();
 }
 
+export function addValidType(type) {
+    if (!VALID_TYPES.includes(type)) {
+        VALID_TYPES.push(type);
+    }
+}
+
 function getConfig(widgetName) {
 	const { nodeData } = this.constructor;
 	return nodeData?.input?.required[widgetName] ?? nodeData?.input?.optional?.[widgetName];


### PR DESCRIPTION
Simple "hook" to allow extending `VALID_TYPES` (used for widget conversion).

This is how I'm using it in mtb:

```js
import { app } from '../../scripts/app.js'
import * as COMFY_WIDGET_INPUTS from '../../extensions/core/widgetInputs.js'

app.registerExtension({
  name: 'mtb.widgets',
  setup: () => {
      COMFY_WIDGET_INPUTS.addValidType?.('COLOR')
  }
});
```