### PR TITLE
feat: support graph control

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -9,6 +9,7 @@ import math
 import time
 import random
 import logging
+import enum
 
 from PIL import Image, ImageOps, ImageSequence, ImageFile
 from PIL.PngImagePlugin import PngInfo
@@ -43,6 +44,12 @@ def interrupt_processing(value=True):
     comfy.model_management.interrupt_current_processing(value)
 
 MAX_RESOLUTION=16384
+
+class AnyType(str):
+  def __ne__(self, __value: object) -> bool:
+    return False
+
+any_type = AnyType("*")
 
 class CLIPTextEncode:
     @classmethod
@@ -1730,6 +1737,30 @@ class ImagePadForOutpaint:
         return (new_image, mask)
 
 
+class GraphControlSignal(enum.Enum):
+    SKIP = 0
+    CONTINUE = 1
+
+class GraphControl:
+    ALL_VALUES = [signal.name for signal in GraphControlSignal]
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {
+            "anything": (any_type, ),
+            "boolean": ("BOOLEAN", {"default": True}),
+            "true_signal": (s.ALL_VALUES, {"default": GraphControlSignal.CONTINUE.name}),
+            "false_signal": (s.ALL_VALUES, {"default": GraphControlSignal.SKIP.name}),
+        }}
+    RETURN_TYPES = (any_type, "GraphControlSignal", "BOOLEAN")
+    RETURN_NAMES = ("anything", "signal", "boolean")
+    FUNCTION = "main"
+
+    CATEGORY = "graph"
+
+    def main(self, anything, boolean, true_signal, false_signal):
+        signal = GraphControlSignal[true_signal if boolean else false_signal]
+        return (anything, signal, boolean)
+
 NODE_CLASS_MAPPINGS = {
     "KSampler": KSampler,
     "CheckpointLoaderSimple": CheckpointLoaderSimple,
@@ -1797,6 +1828,7 @@ NODE_CLASS_MAPPINGS = {
     "ConditioningZeroOut": ConditioningZeroOut,
     "ConditioningSetTimestepRange": ConditioningSetTimestepRange,
     "LoraLoaderModelOnly": LoraLoaderModelOnly,
+    "GraphControl": GraphControl,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {


### PR DESCRIPTION
This commit aims to support graph control, allowing for the execution or skipping of certain branches of the graph based on conditions. I believe that as ComfyUI gains popularity, the demand for graph control will increase, especially in the field of portraiture, where it may be necessary to execute different subsequent processes depending on whether the input image contains multiple people, a single person, or no one. Alternatively, when the user does not provide a mask, a simpler process may be executed. This commit, by modifying recursive_execute and introducing the GraphControl node, supports this branching logic.

![image](https://github.com/comfyanonymous/ComfyUI/assets/29772821/d0114fae-8602-492b-ba96-812ca44da9d2)

Since the input boolean value is true, the Preview Image node above is executed, while the Preview Image node below is skipped. This is a simple use case, but in actual work, it may be connected to a much more complex workflow.
I believe that the implementation of this feature in this PR is already sufficiently simple, and the logic evaluation nodes can be entirely left to the community to create. Some possible use cases include:
* IsMaskEmpty
* IsIntGreaterThan
* IsContainsHuman

I believe that the existence of this capability is necessary, as it will greatly enrich the possibilities of ComfyUI. If you have any other ideas, feel free to discuss them at any time.