### PR TITLE
In the websockets API, the progress message doesn't say what type of progress it is.

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,7 +152,7 @@ async def run(server, address='', port=8188, verbose=True, call_on_start=None):
 def hijack_progress(server):
     def hook(value, total, preview_image):
         comfy.model_management.throw_exception_if_processing_interrupted()
-        progress = {"value": value, "max": total, "prompt_id": server.last_prompt_id, "node": server.last_node_id}
+        progress = {"value": value, "max": total, "prompt_id": server.last_prompt_id, "node": server.last_node_id, "preview_image": preview_image is not None}
 
         server.send_sync("progress", progress, server.client_id)
         if preview_image is not None:


### PR DESCRIPTION
In the websockets API.  It sends messages with values & totals but doesn't say whether the progress is for rendering or something else.