### PR TITLE
Exempt IPEX from non_blocking previews fixing segmentation faults.

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -659,6 +659,8 @@ def supports_cast(device, dtype): #TODO
 def device_supports_non_blocking(device):
     if is_device_mps(device):
         return False #pytorch bug? mps doesn't support non blocking
+    if is_intel_xpu():
+        return False
     if args.deterministic: #TODO: figure out why deterministic breaks non blocking from gpu to cpu (previews)
         return False
     if directml_enabled:


### PR DESCRIPTION
Sorry, forgot to send this patch earlier. See https://github.com/intel/intel-extension-for-pytorch/issues/636#issuecomment-2144804349 and the thread in general for the discussion on this but it seems like the argument is that the runtime is fine and that the XPU-CPU transfer is not ready yet in IPEX before returning the image data so it needs to be set to non-blocking.