### PR TITLE
feat: support node smart offload, reduce peak VRAM/RAM usage

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -122,6 +122,7 @@ parser.add_argument("--multi-user", action="store_true", help="Enables per-user 
 
 parser.add_argument("--verbose", action="store_true", help="Enables more debug prints.")
 
+parser.add_argument("--node-smart-offload-level", type=int, default=0, choices=[0, 1, 2], help="automatically release unreferenced node outputs, helping to reduce peak VRAM/RAM usage during execution and mitigate out-of-memory issues. 0: Means disabling this feature; 1: Only release outputs that were never referenced; 2: Release all currently unreferenced outputs.")
 
 if comfy.options.args_parsing:
     args = parser.parse_args()


### PR DESCRIPTION
For the purpose of decoupling, or to avoid reloading the model every time a node is executed, node developers tend to separate the model loading as an individual node, so that the execution speed can benefit from the node cache. Although ComfyUI implements the internal model management method `model_management.load_models_gpu`, it is unrealistic to expect all custom nodes to adopt this approach given the variety of model architectures and developers.

In the current implementation, the outputs of all nodes are always referenced during the workflow execution. This prevents some larger models or tensors from being effectively garbage-collected, resulting in CUDA memory overflow.

Let's take the following workflow as an example:

![image](https://github.com/comfyanonymous/ComfyUI/assets/29772821/0411a75e-dce9-485f-abec-b04b9d2f4895)

Before the execution of node `24`, the models loaded by `🔎Yoloworld Model Loader` and `🔎ESAM Model Loader` **should** have been released, and this portion of GPU memory could have been returned to the subsequent memory-intensive `KSampler`, instead of causing a CUDA out-of-memory error in later steps.

![20240613191248](https://github.com/comfyanonymous/ComfyUI/assets/29772821/e3ce29b8-2574-43d9-a0c0-9ba354c4f9f9)

In the example above, `AllocateVRAM` is used to simulate the GPU memory allocation scenario, and it is a simple custom node implementation.

```
class AllocateVRAM:
    @classmethod
    def INPUT_TYPES(s):
        return {
            "required": { 
                "anything": (any_type,),
                "size": ("FLOAT", {"min": 0, "max": 1024, "step": 0.01, "default": 1}),
            }
        }
    RETURN_TYPES = (any_type, "TENSOR")
    RETURN_NAMES = ("anything", "tensor")
    FUNCTION = "main"
    CATEGORY = "util"
    def main(self, anything, size):
        num_elements = 1_073_741_824 // 4
        tensor = torch.randn(int(float(num_elements) * size), device='cuda')
        return (anything, tensor)
```

It simulates subsequent, more complex workflows.

This PR aims to automatically release unreferenced node outputs, helping to reduce peak VRAM/RAM usage during execution and mitigate out-of-memory issues. 
The following modes are supported:
* 0: Means disabling this feature; 
* 1: Only release outputs that were never referenced; 
* 2: Release all currently unreferenced outputs.

When setting --node-smart-offload-level to 2 in the launch parameters, the example workflow above runs well on an A10 GPU with 22GB of memory. 

This implementation has good compatibility and I believe many workflows would benefit from this. 