### PR TITLE
Update node_helpers.py

### DIFF
--- a/node_helpers.py
+++ b/node_helpers.py
@@ -7,18 +7,18 @@ def conditioning_set_values(conditioning, values={}):
         for k in values:
             n[1][k] = values[k]
         c.append(n)
-
     return c
 
 def pillow(fn, arg):
+    x = None  # Ensure x is initialized
     prev_value = None
     try:
         x = fn(arg)
-    except (OSError, UnidentifiedImageError, ValueError): #PIL issues #4472 and #2445, also fixes ComfyUI issue #3416
+    except (OSError, UnidentifiedImageError, ValueError): # PIL issues #4472 and #2445, also fixes ComfyUI issue #3416
         prev_value = ImageFile.LOAD_TRUNCATED_IMAGES
         ImageFile.LOAD_TRUNCATED_IMAGES = True
         x = fn(arg)
     finally:
         if prev_value is not None:
             ImageFile.LOAD_TRUNCATED_IMAGES = prev_value
-        return x
+    return x  # Move return statement outside the finally block


### PR DESCRIPTION
Fix: Initialize variable x in pillow function to prevent UnboundLocalError

- Initialized variable `x` to None at the beginning of the `pillow` function.
- Ensured `x` is always assigned a value, preventing UnboundLocalError when exceptions occur.
- Moved the `return x` statement outside the `finally` block to maintain consistent execution flow.

This fixes the issue where the variable `x` was being accessed before being assigned, causing errors during image loading.
