### PR TITLE
change repeat to batch size to use a view

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -253,7 +253,9 @@ def repeat_to_batch_size(tensor, batch_size, dim=0):
     if tensor.shape[dim] > batch_size:
         return tensor.narrow(dim, 0, batch_size)
     elif tensor.shape[dim] < batch_size:
-        return tensor.repeat(dim * [1] + [math.ceil(batch_size / tensor.shape[dim])] + [1] * (len(tensor.shape) - 1 - dim)).narrow(dim, 0, batch_size)
+        expand_shape = list(tensor.shape)
+        expand_shape[dim] = batch_size
+        return tensor.expand(expand_shape)
     return tensor
 
 def resize_to_batch_size(tensor, batch_size):


### PR DESCRIPTION
This changes the `repeat_to_batch_size` function to use a view.  This is a very minor performance fix that avoids unnecessarily copying that data.  It seems to work from my limited testing, if there's anything that modifies tensors that have gone through this on a per batch item basis it will NOT work properly and that'd need to be gone over.