### PR TITLE
Add support for url_prefix

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -39,6 +39,7 @@ parser.add_argument("--tls-keyfile", type=str, help="Path to TLS (SSL) key file.
 parser.add_argument("--tls-certfile", type=str, help="Path to TLS (SSL) certificate file. Enables TLS, makes app accessible at https://... requires --tls-keyfile to function")
 parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
 parser.add_argument("--max-upload-size", type=float, default=100, help="Set the maximum upload size in MB.")
+parser.add_argument("--url-prefix", type=str, default="", help="Specify a URL prefix for the server.")
 
 parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
 parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory.")

--- a/main.py
+++ b/main.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    server = server.PromptServer(loop)
+    server = server.PromptServer(loop, url_prefix=args.url_prefix)
     q = execution.PromptQueue(server)
 
     extra_model_paths_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extra_model_paths.yaml")
@@ -247,7 +247,7 @@ if __name__ == "__main__":
             import webbrowser
             if os.name == 'nt' and address == '0.0.0.0':
                 address = '127.0.0.1'
-            webbrowser.open(f"{scheme}://{address}:{port}")
+            webbrowser.open(f"{scheme}://{address}:{port}/{args.url_prefix}/")
         call_on_start = startup_server
 
     try:


### PR DESCRIPTION
Added support for url prefix in server address.
E.g. if you want to open your ComfyUI server at `<address>:8188/comfy_server/`
You can run with `python3 main.py --url-prefix comfy_server`