### PR TITLE
DOC: Add custom_nodes to the example extra_model_paths.

### DIFF
--- a/extra_model_paths.yaml.example
+++ b/extra_model_paths.yaml.example
@@ -22,6 +22,7 @@ a111:
 
 #config for comfyui
 #your base path should be either an existing comfy install or a central folder where you store all of your models, loras, etc.
+#absolute paths can be used to specify directories outside of the base_path.
 
 #comfyui:
 #     base_path: path/to/comfyui/
@@ -34,6 +35,7 @@ a111:
 #     loras: models/loras/
 #     upscale_models: models/upscale_models/
 #     vae: models/vae/
+#     custom_nodes: custom_nodes/
 
 #other_ui:
 #    base_path: path/to/ui


### PR DESCRIPTION
Trivial improvement to the `extra_model_paths.yaml.example` file, I read the source code to figure out how to change the custom_nodes directory. This simple addition makes it clear additional the custom_node path can be specified in the yaml, and that absolute paths also work.