### PR TITLE
Improvements to the webUI History and Queue lists

### DIFF
--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -265,7 +265,7 @@ class ComfyList {
 	}
 
 	async show() {
-		this.element.style.display = "block";
+		this.element.style.display = "flex";
 		this.button.textContent = "Close";
 
 		await this.load();
@@ -412,7 +412,6 @@ export class ComfyUI {
 		this.menuContainer = $el("div.comfy-menu", { parent: document.body }, [
 			$el("div.drag-handle.comfy-menu-header", {
 				style: {
-					overflow: "hidden",
 					position: "relative",
 					width: "100%",
 					cursor: "default"

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -420,7 +420,7 @@ export class ComfyUI {
 			{
 				parent: document.body,
 				onclick: () => {
-					this.menuContainer.style.display = "block";
+					this.menuContainer.style.display = "flex";
 					this.menuHamburger.style.display = "none";
 				},
 			},

--- a/web/scripts/ui.js
+++ b/web/scripts/ui.js
@@ -204,6 +204,7 @@ class ComfyList {
 		this.#reverse = reverse || false;
 		this.element = $el("div.comfy-list");
 		this.element.style.display = "none";
+        this.last_keys = null;
 	}
 
 	get visible() {
@@ -212,50 +213,67 @@ class ComfyList {
 
 	async load() {
 		const items = await api.getItems(this.#type);
-		this.element.replaceChildren(
-			...Object.keys(items).flatMap((section) => [
-				$el("h4", {
-					textContent: section,
-				}),
-				$el("div.comfy-list-items", [
-					...(this.#reverse ? items[section].reverse() : items[section]).map((item) => {
-						// Allow items to specify a custom remove action (e.g. for interrupt current prompt)
-						const removeAction = item.remove || {
-							name: "Delete",
-							cb: () => api.deleteItem(this.#type, item.prompt[1]),
-						};
-						return $el("div", {textContent: item.prompt[0] + ": "}, [
-							$el("button", {
-								textContent: "Load",
-								onclick: async () => {
-									await app.loadGraphData(item.prompt[3].extra_pnginfo.workflow, true, false);
-									if (item.outputs) {
-										app.nodeOutputs = item.outputs;
-									}
-								},
-							}),
-							$el("button", {
-								textContent: removeAction.name,
-								onclick: async () => {
-									await removeAction.cb();
-									await this.update();
-								},
-							}),
-						]);
-					}),
-				]),
-			]),
-			$el("div.comfy-list-actions", [
-				$el("button", {
-					textContent: "Clear " + this.#text,
-					onclick: async () => {
-						await api.clearItems(this.#type);
-						await this.load();
-					},
-				}),
-				$el("button", {textContent: "Refresh", onclick: () => this.load()}),
-			])
-		);
+        const keys = Object.keys(items);
+        var entry = (item) => {
+            // Allow items to specify a custom remove action (e.g. for interrupt current prompt)
+            const removeAction = item.remove || {
+                name: "Delete",
+                cb: () => api.deleteItem(this.#type, item.prompt[1]),
+            };
+            return $el("div", {textContent: item.prompt[0] + ": "}, [
+                $el("button", {
+                    textContent: "Load",
+                    onclick: async () => {
+                        await app.loadGraphData(item.prompt[3].extra_pnginfo.workflow, true, false);
+                        if (item.outputs) {
+                            app.nodeOutputs = item.outputs;
+                        }
+                    },
+                }),
+                $el("button", {
+                    textContent: removeAction.name,
+                    onclick: async () => {
+                        await removeAction.cb();
+                        await this.update();
+                    },
+                }),
+            ]);
+					
+        };
+
+        if (JSON.stringify(keys) === JSON.stringify(this.last_keys)) {
+            // we can replace inside the container elements instead of recreating them
+            // this will preserve the scroll position approximately
+            // to truely preserve the scroll position, we would need to do something react-like
+            // in the sense of preserving the DOM nodes and reusing them
+            Array.from(this.element.getElementsByClassName("comfy-list-items")).forEach((section, i) => 
+                section.replaceChildren(...(this.#reverse ? items[keys[i]].reverse() : items[keys[i]]).map(entry))
+            );
+            
+        } else {
+            this.last_keys = keys;
+            // rebuild the list of lists
+            this.element.replaceChildren(
+                ...keys.flatMap((section) => [
+                    $el("h4", {
+                        textContent: section,
+                    }),
+                    $el("div.comfy-list-items", [
+                        ...(this.#reverse ? items[section].reverse() : items[section]).map(entry),
+                    ]),
+                ]),
+                $el("div.comfy-list-actions", [
+                    $el("button", {
+                        textContent: "Clear " + this.#text,
+                        onclick: async () => {
+                            await api.clearItems(this.#type);
+                            await this.load();
+                        },
+                    }),
+                    $el("button", {textContent: "Refresh", onclick: () => this.load()}),
+                ])
+            );
+        }
 	}
 
 	async update() {

--- a/web/style.css
+++ b/web/style.css
@@ -117,6 +117,7 @@ body {
 	padding: 10px;
 	border-radius: 0 8px 8px 8px;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.4);
+    max-height: 95vh;
 }
 
 .comfy-menu-header {
@@ -233,11 +234,14 @@ span.drag-handle::after {
 	margin-bottom: 10px;
 	border-color: var(--border-color);
 	border-style: solid;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    overflow-y: hidden;
 }
 
 .comfy-list-items {
-	overflow-y: scroll;
-	max-height: 100px;
+    overflow-y: auto;
 	min-height: 25px;
 	background-color: var(--comfy-input-bg);
 	padding: 5px;

--- a/web/style.css
+++ b/web/style.css
@@ -311,6 +311,7 @@ button.comfy-queue-btn {
 		left: auto !important;
 		right: 0 !important;
 		border-radius: 0;
+        max-height: 100vh !important;
 	}
 
 	.comfy-menu span.drag-handle {

--- a/web/style.css
+++ b/web/style.css
@@ -117,7 +117,7 @@ body {
 	padding: 10px;
 	border-radius: 0 8px 8px 8px;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.4);
-    max-height: 95vh;
+	max-height: 95vh;
 }
 
 .comfy-menu-header {
@@ -234,14 +234,14 @@ span.drag-handle::after {
 	margin-bottom: 10px;
 	border-color: var(--border-color);
 	border-style: solid;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-    overflow-y: hidden;
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	overflow-y: hidden;
 }
 
 .comfy-list-items {
-    overflow-y: auto;
+	overflow-y: auto;
 	min-height: 25px;
 	background-color: var(--comfy-input-bg);
 	padding: 5px;


### PR DESCRIPTION
This PR updates UI code and CSS to achieve the following features for the prompt history and prompt queue lists.
   - Automatic scaling of the size of the list
   - Approximate preservation of the scroll position when the list is updated.
   
This second part fixes a longstanding annoying that myself and other users have noted where the scroll position is lost even when no new elements are added, as a result of the websocket refreshing the list in the background.

The preservation of scroll position is "approximate" because it does not properly add the offset from new or deleted entries after update. To really solve this problem, we'd have to reimplement a minimal version of the react dom-diffing algorithm, in order to preserve the individual dom elements themselves, and therefore the scroll anchors that the browser uses. I didn't do that, because it felt like a lot of added complexity for very little gain.