### PR TITLE
Add api/ prefix to api endpoints

### DIFF
--- a/server.py
+++ b/server.py
@@ -527,9 +527,20 @@ class PromptServer():
                     self.prompt_queue.delete_history_item(id_to_delete)
 
             return web.Response(status=200)
-        
+
     def add_routes(self):
         self.user_manager.add_routes(self.routes)
+
+        # Prefix every route with /api for easier matching for delegation.
+        # This is very useful for frontend dev server, which need to forward
+        # everything except serving of static files.
+        # Currently both the old endpoints without prefix and new endpoints with
+        # prefix are supported.
+        api_routes = web.RouteTableDef()
+        for route in self.routes:
+            assert isinstance(route, web.RouteDef)
+            api_routes.route(route.method, "/api" + route.path)(route.handler, **route.kwargs)
+        self.app.add_routes(api_routes)
         self.app.add_routes(self.routes)
 
         for name, dir in nodes.EXTENSION_WEB_DIRS.items():


### PR DESCRIPTION
Related to https://github.com/huchenlei/ComfyUI_frontend/pull/43

This PR prefixes every api endpoint with `api/` prefix, so that they can be easily identified and proxyed in the frontend dev server. Old endpoints are kept functioning the same way as before.