### PR TITLE
Add browser test action synced with TS repo

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -43,6 +43,10 @@ jobs:
         python main.py --cpu &
         wait-for-it --service 127.0.0.1:8188 -t 600
       working-directory: ComfyUI
+    - name: Install ComfyUI_frontend dependencies
+      run: |
+        npm ci
+      working-directory: ComfyUI_frontend
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
       working-directory: ComfyUI_frontend

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -1,0 +1,57 @@
+# This is a temporary action during frontend TS migration.
+# This file should be removed after TS migration is completed.
+# The browser test is here to ensure TS repo is working the same way as the
+# current JS code.
+# If you are adding UI feature, please sync your changes to the TS repo:
+# huchenlei/ComfyUI_frontend and update test expectation files accordingly.
+name: Playwright Browser Tests CI
+
+on:
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout ComfyUI
+      uses: actions/checkout@v4
+      with:
+        repository: "comfyanonymous/ComfyUI"
+        path: "ComfyUI"
+    - name: Checkout ComfyUI_frontend
+      uses: actions/checkout@v4
+      with:
+        repository: "huchenlei/ComfyUI_frontend"
+        path: "ComfyUI_frontend"
+        ref: "23a4ee83144d9bf22e7218b9c78c71f8544c8b27"
+    - uses: actions/setup-node@v3
+      with:
+        node-version: lts/*
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install requirements
+      run: |
+        python -m pip install --upgrade pip
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+        pip install -r requirements.txt
+        pip install wait-for-it
+      working-directory: ComfyUI
+    - name: Start ComfyUI server
+      run: |
+        python main.py --cpu &
+        wait-for-it --service 127.0.0.1:8188 -t 600
+      working-directory: ComfyUI
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+      working-directory: ComfyUI_frontend
+    - name: Run Playwright tests
+      run: npx playwright test
+      working-directory: ComfyUI_frontend
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: ComfyUI_frontend/playwright-report/
+        retention-days: 30


### PR DESCRIPTION
This PR adds an github action for browser tests with [PlayWright](https://github.com/microsoft/playwright).

The browser tests should prevent accidental front end UI regression, and keep the front-end features synced in the current repo & in TS repo ([huchenlei/ComfyUI_frontend](https://github.com/huchenlei/ComfyUI_frontend)) during the TS migration period.

