### PR TITLE
add issue templates for ComfyUI Issues Page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: "Something is broken inside of ComfyUI. (Do not use this if you're just having issues and need help, or if the issue relates to a custom node)"
+labels: [ "Potential Bug" ]
+body:
+    - type: markdown
+      attributes:
+        value: |
+                Before submitting a **Bug Report**, please ensure the following:
+
+                **1:** You are running the latest version of ComfyUI.
+                **2:** You have looked at the existing bug reports and made sure this isn't already reported.
+                **3:** This is an actual bug in ComfyUI, not just a support question and not caused by an custom node. A bug is when you can specify exact steps to replicate what went wrong and others will be able to repeat your steps and see the same issue happen.
+
+                If unsure, ask on the [ComfyUI Matrix Space](https://app.element.io/#/room/%23comfyui_space%3Amatrix.org) or the [Comfy Org Discord](https://discord.gg/comfyorg) first.
+    - type: textarea
+      attributes:
+            label: Expected Behavior
+            description: "What you expected to happen."
+      validations:
+            required: true
+    - type: textarea
+      attributes:
+                label: Actual Behavior
+                description: "What actually happened. Please include a screenshot of the issue if possible."
+      validations:
+                required: true
+    - type: textarea
+      attributes:
+                label: Steps to Reproduce
+                description: "Describe how to reproduce the issue. Please be sure to attach a workflow JSON or PNG, ideally one that doesn't require custom nodes to test. If the bug open happens when certain custom nodes are used, most likely that custom node is what has the bug rather than ComfyUI, in which case it should be reported to the node's author."
+      validations:
+                required: true
+    - type: textarea
+      attributes:
+                label: Debug Logs
+                description: "Please copy the output from your terminal logs here."
+                render: powershell
+      validations:
+                required: true
+    - type: textarea
+      attributes:
+                label: Other
+                description: "Any other additional information you think might be helpful."
+      validations:
+                required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ComfyUI Matrix Space
+    url: https://app.element.io/#/room/%23comfyui_space%3Amatrix.org
+    about: The ComfyUI Matrix Space is available for support and general discussion related to ComfyUI (Matrix is like Discord but open source).
+  - name: Comfy Org Discord
+    url: https://discord.gg/comfyorg
+    about: The Comfy Org Discord is available for support and general discussion related to ComfyUI.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: "You have an idea for something new you would like to see added to ComfyUI's core."
+labels: [ "Feature" ]
+body:
+    - type: markdown
+      attributes:
+        value: |
+                Before submitting a **Feature Request**, please ensure the following:
+
+                **1:** You are running the latest version of ComfyUI.
+                **2:** You have looked to make sure there is not already a feature that does what you need, and there is not already a Feature Request listed for the same idea.
+                **3:** This is something that makes sense to add to ComfyUI Core, and wouldn't make more sense as a custom node.
+
+                If unsure, ask on the [ComfyUI Matrix Space](https://app.element.io/#/room/%23comfyui_space%3Amatrix.org) or the [Comfy Org Discord](https://discord.gg/comfyorg) first.
+    - type: textarea
+      attributes:
+            label: Feature Idea
+            description: "Describe the feature you want to see."
+      validations:
+            required: true
+    - type: textarea
+      attributes:
+                label: Existing Solutions
+                description: "Please search through available custom nodes / extensions to see if there are existing custom solutions for this. If so, please link the options you found here as a reference."
+      validations:
+                required: false
+    - type: textarea
+      attributes:
+                label: Other
+                description: "Any other additional information you think might be helpful."
+      validations:
+                required: false

--- a/.github/ISSUE_TEMPLATE/user-support.yml
+++ b/.github/ISSUE_TEMPLATE/user-support.yml
@@ -1,0 +1,32 @@
+name: User Support
+description: "Use this if you need help with something, or you're experiencing an issue."
+labels: [ "User Support" ]
+body:
+    - type: markdown
+      attributes:
+        value: |
+            Before submitting a **User Report** issue, please ensure the following:
+
+            **1:** You are running the latest version of ComfyUI.
+            **2:** You have made an effort to find public answers to your question before asking here. In other words, you googled it first, and scrolled through recent help topics.
+
+                If unsure, ask on the [ComfyUI Matrix Space](https://app.element.io/#/room/%23comfyui_space%3Amatrix.org) or the [Comfy Org Discord](https://discord.gg/comfyorg) first.
+    - type: textarea
+      attributes:
+            label: Your question
+            description: "Post your question here. Please be as detailed as possible."
+      validations:
+            required: true
+    - type: textarea
+      attributes:
+                label: Logs
+                description: "If your question relates to an issue you're experiencing, please go to `Server` -> `Logs` -> potentially set `View Type` to `Debug` as well, then copypaste all the text into here."
+                render: powershell
+      validations:
+                required: false
+    - type: textarea
+      attributes:
+                label: Other
+                description: "Any other additional information you think might be helpful."
+      validations:
+                required: false


### PR DESCRIPTION
This adds issue templates so that newly submitted GitHub Issues will have an option to select a template, and will be asked to fill out relevant information.

You can see an example of this in action on the Swarm issues page: https://github.com/mcmonkeyprojects/SwarmUI/issues/new/choose

The selection looks like:
![image](https://github.com/comfyanonymous/ComfyUI/assets/4000772/7c12aafc-8b81-48bb-9d74-0418cbb7400d)

And each option gives a form like so:
![image](https://github.com/comfyanonymous/ComfyUI/assets/4000772/b62707d7-0f0b-43da-a2d4-0dd3dd30202e)

When submitted it looks like so: <https://github.com/mcmonkeyprojects/SwarmUI/issues/29>
![image](https://github.com/comfyanonymous/ComfyUI/assets/4000772/902b475b-0bdb-4736-93ed-013b3cda555f)

Note how it automatically adds the appropriate issue label, and formats the logs cleanly, and etc.

Obviously for the ComfyUI version I'm PRing here, it has Comfy-specific info rather than Swarm info. This includes a link to the Comfy Org Discord and to the ComfyUI Matrix Space.

Users will still have the option to "open a blank issue" if their needs are outside of what the templates cover, and works exactly like normal.

Consider this a "v1" of issue templates that gets the issues in a much more organized place than they are now. Potentially in the future we can split this up further with eg Litegraph frontend issues that have separate requirements and autoassign the frontend contributors rather than comfyanon, or things like that.
We'll also want eg a GitHub Action that automatically closes "User Support" threads after <x> days of inactivity, which I'll look into setting up in a followup soon.