### PR TITLE
Enable browser tests on push

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -7,6 +7,8 @@
 name: Playwright Browser Tests CI
 
 on:
+  push:
+    branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
 


### PR DESCRIPTION
As Github Action is free for public repo, enable CI test on push as well.