### PR TITLE
Add 'constant' data value input nodes

### DIFF
--- a/comfy_extras/nodes_constant_values,.py
+++ b/comfy_extras/nodes_constant_values,.py
@@ -1,0 +1,79 @@
+class _CONSTANT_BASE:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(s) -> dict:
+        raise NotImplementedError
+
+    RETURN_TYPES: tuple = ()
+    RETURN_NAMES: tuple = ()
+
+    CATEGORY: str = "constants"
+
+    FUNCTION: str = "process"
+
+    OUTPUT_NODE: bool = False
+
+    def process(self, value) -> tuple:
+        return (value,)
+
+
+class ConstantFloat(_CONSTANT_BASE):
+    @classmethod
+    def INPUT_TYPES(s) -> dict:
+        return {
+            "required": {
+                "value": ("FLOAT", {"default": 0.0})
+            }
+        }
+
+    RETURN_TYPES = ("FLOAT",)
+    RETURN_NAMES = ("float",)
+
+
+class ConstantInteger(_CONSTANT_BASE):
+    @classmethod
+    def INPUT_TYPES(s) -> dict:
+        return {
+            "required": {
+                "value": ("INT", {"default": 0})
+            }
+        }
+
+    RETURN_TYPES = ("INT",)
+    RETURN_NAMES = ("int",)
+
+
+class ConstantString(_CONSTANT_BASE):
+    @classmethod
+    def INPUT_TYPES(s) -> dict:
+        return {
+            "required" : {
+                "value": ("STRING", {"multiline": False})
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("string",)
+
+
+class ConstantStringMultiline(_CONSTANT_BASE):
+    @classmethod
+    def INPUT_TYPES(s) -> dict:
+        return {
+            "required": {
+                "value": ("STRING", {"multiline": True})
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("string",)
+
+
+NODE_CLASS_MAPPINGS = {
+    "ConstantFloat": ConstantFloat,
+    "ConstantInteger": ConstantInteger,
+    "ConstantString": ConstantString,
+    "ConstantStringMultiline": ConstantStringMultiline,
+}

--- a/nodes.py
+++ b/nodes.py
@@ -1992,6 +1992,7 @@ def init_custom_nodes():
         "nodes_audio.py",
         "nodes_sd3.py",
         "nodes_gits.py",
+        "nodes_constant_values.py"
     ]
 
     import_failed = []


### PR DESCRIPTION
There are numerous times in workflows where it is useful or advantageous to have individual data input nodes for primitive datatypes (INT, STRING (both multiline and not), FLOAT).

However, these nodes are NOT provided as part of ComfyUI.  There are numerous external node packs which include primitive datatype nodes.

This pull request is designed to make these part of ComfyUI in its 'extras' group of nodes.

---

Note that my coding style for nodes is to design a "base" node so that the bare minimum of changes are necessary for the actual nodes themselves to function.  In this case, the `_CONSTANT_BASE` node acts as a structure defining the various data types for components of the node that are accepted later.  And make sure that things're implemented before running.  As such, however, because we only have to override a few small bits (`RETURN_TYPES`, `RETURN_NAMES`, and `INPUT_TYPES` definitions), the rest of the node base makes sure everything else "just works" without having to duplicate code.  That's the only reason it was used here, because of how I code nodes.

Revisions / changes are welcome if necessary, but I think adding these primitive "constant" nodes would be a positive improvement and inclusion (it's also not a major set of changes).