### PR TITLE
Add `--no-custom-node` cmd flag

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -118,6 +118,7 @@ parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test
 parser.add_argument("--windows-standalone-build", action="store_true", help="Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup).")
 
 parser.add_argument("--disable-metadata", action="store_true", help="Disable saving prompt metadata in files.")
+parser.add_argument("--no-custom-node", action="store_true", help="Disable loading custom nodes.")
 
 parser.add_argument("--multi-user", action="store_true", help="Enables per-user storage.")
 

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -118,7 +118,7 @@ parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test
 parser.add_argument("--windows-standalone-build", action="store_true", help="Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup).")
 
 parser.add_argument("--disable-metadata", action="store_true", help="Disable saving prompt metadata in files.")
-parser.add_argument("--no-custom-node", action="store_true", help="Disable loading custom nodes.")
+parser.add_argument("--disable-all-custom-nodes", action="store_true", help="Disable loading all custom nodes.")
 
 parser.add_argument("--multi-user", action="store_true", help="Enables per-user storage.")
 

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -2,9 +2,11 @@ import os
 import time
 import logging
 
-supported_pt_extensions = set(['.ckpt', '.pt', '.bin', '.pth', '.safetensors', '.pkl'])
+supported_pt_extensions: set[str] = set(['.ckpt', '.pt', '.bin', '.pth', '.safetensors', '.pkl'])
 
-folder_names_and_paths = {}
+SupportedFileExtensionsType = set[str]
+ScanPathType = list[str]
+folder_names_and_paths: dict[str, tuple[ScanPathType, SupportedFileExtensionsType]] = {}
 
 base_path = os.path.dirname(os.path.realpath(__file__))
 models_dir = os.path.join(base_path, "models")
@@ -26,7 +28,7 @@ folder_names_and_paths["gligen"] = ([os.path.join(models_dir, "gligen")], suppor
 
 folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_models")], supported_pt_extensions)
 
-folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], [])
+folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
 
 folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
 

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def execute_prestartup_script():
             print(f"Failed to execute startup-script: {script_path} / {e}")
         return False
 
-    if args.no_custom_node:
+    if args.disable_all_custom_nodes:
         return
 
     node_paths = folder_paths.get_folder_paths("custom_nodes")
@@ -81,7 +81,7 @@ import yaml
 import execution
 import server
 from server import BinaryEventTypes
-from nodes import init_builtin_custom_nodes, init_external_custom_nodes
+from nodes import init_builtin_extra_nodes, init_external_custom_nodes
 import comfy.model_management
 
 def cuda_malloc_warning():
@@ -219,8 +219,8 @@ if __name__ == "__main__":
         for config_path in itertools.chain(*args.extra_model_paths_config):
             load_extra_path_config(config_path)
 
-    init_builtin_custom_nodes()
-    if not args.no_custom_node:
+    init_builtin_extra_nodes()
+    if not args.disable_all_custom_nodes:
         init_external_custom_nodes()
     else:
         logging.info("Skipping loading of custom nodes")

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ import os
 import importlib.util
 import folder_paths
 import time
+from comfy.cli_args import args
+
 
 def execute_prestartup_script():
     def execute_script(script_path):
@@ -17,6 +19,9 @@ def execute_prestartup_script():
         except Exception as e:
             print(f"Failed to execute startup-script: {script_path} / {e}")
         return False
+
+    if args.no_custom_node:
+        return
 
     node_paths = folder_paths.get_folder_paths("custom_nodes")
     for custom_node_path in node_paths:
@@ -76,7 +81,7 @@ import yaml
 import execution
 import server
 from server import BinaryEventTypes
-from nodes import init_custom_nodes
+from nodes import init_builtin_custom_nodes, init_external_custom_nodes
 import comfy.model_management
 
 def cuda_malloc_warning():
@@ -214,7 +219,11 @@ if __name__ == "__main__":
         for config_path in itertools.chain(*args.extra_model_paths_config):
             load_extra_path_config(config_path)
 
-    init_custom_nodes()
+    init_builtin_custom_nodes()
+    if not args.no_custom_node:
+        init_external_custom_nodes()
+    else:
+        logging.info("Skipping loading of custom nodes")
 
     cuda_malloc_warning()
 

--- a/nodes.py
+++ b/nodes.py
@@ -1925,7 +1925,16 @@ def load_custom_node(module_path, ignore=set()):
         logging.warning(f"Cannot import {module_path} module for custom nodes: {e}")
         return False
 
-def load_custom_nodes():
+def init_external_custom_nodes():
+    """
+    Initializes the external custom nodes.
+
+    This function loads custom nodes from the specified folder paths and imports them into the application.
+    It measures the import times for each custom node and logs the results.
+
+    Returns:
+        None
+    """
     base_node_names = set(NODE_CLASS_MAPPINGS.keys())
     node_paths = folder_paths.get_folder_paths("custom_nodes")
     node_import_times = []
@@ -1952,7 +1961,16 @@ def load_custom_nodes():
             logging.info("{:6.1f} seconds{}: {}".format(n[0], import_message, n[1]))
         logging.info("")
 
-def init_custom_nodes():
+def init_builtin_custom_nodes():
+    """
+    Initializes the built-in custom nodes in ComfyUI.
+
+    This function loads the custom node files located in the "comfy_extras" directory and imports them into ComfyUI.
+    If any of the custom node files fail to import, a warning message is logged.
+
+    Returns:
+        None
+    """
     extras_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_extras")
     extras_files = [
         "nodes_latent.py",
@@ -1998,8 +2016,6 @@ def init_custom_nodes():
     for node_file in extras_files:
         if not load_custom_node(os.path.join(extras_dir, node_file)):
             import_failed.append(node_file)
-
-    load_custom_nodes()
 
     if len(import_failed) > 0:
         logging.warning("WARNING: some comfy_extras/ nodes did not import correctly. This may be because they are missing some dependencies.\n")

--- a/nodes.py
+++ b/nodes.py
@@ -1961,12 +1961,12 @@ def init_external_custom_nodes():
             logging.info("{:6.1f} seconds{}: {}".format(n[0], import_message, n[1]))
         logging.info("")
 
-def init_builtin_custom_nodes():
+def init_builtin_extra_nodes():
     """
-    Initializes the built-in custom nodes in ComfyUI.
+    Initializes the built-in extra nodes in ComfyUI.
 
-    This function loads the custom node files located in the "comfy_extras" directory and imports them into ComfyUI.
-    If any of the custom node files fail to import, a warning message is logged.
+    This function loads the extra node files located in the "comfy_extras" directory and imports them into ComfyUI.
+    If any of the extra node files fail to import, a warning message is logged.
 
     Returns:
         None


### PR DESCRIPTION
Loading custom node can greatly slow startup time. During development/testing of ComfyUI, it is often better to use an environment that no custom node is loaded.

This PR adds a `--no-custom-node` flag to allow users/developers skip loading of custom node without removing/renaming the custom_node directory.