### PR TITLE
New menu fixes - fix send to workflow

### DIFF
--- a/web/scripts/ui/menu/workflows.js
+++ b/web/scripts/ui/menu/workflows.js
@@ -182,6 +182,11 @@ export class ComfyWorkflowsMenu {
 				 * @param {ComfyWorkflow} workflow
 				 */
 				async function sendToWorkflow(img, workflow) {
+					const openWorkflow = app.workflowManager.openWorkflows.find((w) => w.path === workflow.path);
+					if (openWorkflow) {
+						workflow = openWorkflow;
+					}
+
 					await workflow.load();
 					let options = [];
 					const nodes = app.graph.computeExecutionOrder(false);
@@ -214,7 +219,8 @@ export class ComfyWorkflowsMenu {
 				nodeType.prototype["getExtraMenuOptions"] = function (_, options) {
 					const r = getExtraMenuOptions?.apply?.(this, arguments);
 
-					if (app.ui.settings.getSettingValue("Comfy.UseNewMenu", false) === true) {
+					const setting = app.ui.settings.getSettingValue("Comfy.UseNewMenu", false);
+					if (setting && setting != "Disabled") {
 						const t = /** @type { {imageIndex?: number, overIndex?: number, imgs: string[]} } */ /** @type {any} */ (this);
 						let img;
 						if (t.imageIndex != null) {

--- a/web/style.css
+++ b/web/style.css
@@ -41,7 +41,7 @@ body {
 	background-color: var(--bg-color);
 	color: var(--fg-color);
 	grid-template-columns: auto 1fr auto;
-	grid-template-rows: auto auto 1fr auto;
+	grid-template-rows: auto 1fr auto;
 	min-height: -webkit-fill-available;
 	max-height: -webkit-fill-available;
 	min-width: -webkit-fill-available;
@@ -52,29 +52,34 @@ body {
 	order: 0;
 	grid-column: 1/-1;
 	z-index: 10;
+	display: flex;
+	flex-direction: column;
 }
 
 .comfyui-body-left {
 	order: 1;
 	z-index: 10;
+	display: flex;
 }
 
 #graph-canvas {
 	width: 100%;
 	height: 100%;
 	order: 2;
-	grid-column: 1/-1;
 }
 
 .comfyui-body-right {
 	order: 3;
 	z-index: 10;
+	display: flex;
 }
 
 .comfyui-body-bottom {
 	order: 4;
 	grid-column: 1/-1;
 	z-index: 10;
+	display: flex;
+	flex-direction: column;
 }
 
 .comfy-multiline-input {
@@ -408,8 +413,12 @@ dialog::backdrop {
 	background: rgba(0, 0, 0, 0.5);
 }
 
-.comfy-dialog.comfyui-dialog {
+.comfy-dialog.comfyui-dialog.comfy-modal {
 	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	transform: none;
 }
 
 .comfy-dialog.comfy-modal {

--- a/web/style.css
+++ b/web/style.css
@@ -49,7 +49,7 @@ body {
 }
 
 .comfyui-body-top {
-	order: 0;
+	order: -5;
 	grid-column: 1/-1;
 	z-index: 10;
 	display: flex;
@@ -57,7 +57,7 @@ body {
 }
 
 .comfyui-body-left {
-	order: 1;
+	order: -4;
 	z-index: 10;
 	display: flex;
 }
@@ -65,17 +65,17 @@ body {
 #graph-canvas {
 	width: 100%;
 	height: 100%;
-	order: 2;
+	order: -3;
 }
 
 .comfyui-body-right {
-	order: 3;
+	order: -2;
 	z-index: 10;
 	display: flex;
 }
 
 .comfyui-body-bottom {
-	order: 4;
+	order: -1;
 	grid-column: 1/-1;
 	z-index: 10;
 	display: flex;


### PR DESCRIPTION
## Fix / add "Send To Workflow"
Right click on an image, there should now be a "Send to workflow" option, listing all your saved workflows.  
![image](https://github.com/comfyanonymous/ComfyUI/assets/125205205/1d877251-ade4-42b9-ac1c-19edc75003ae)
You can choose one from here, or the current workflow.  
If a workflow has multiple LoadImage nodes, you can choose the default by including "Input" in the title of the node, else you'll get a prompt to choose which node to use.
![image](https://github.com/comfyanonymous/ComfyUI/assets/125205205/04641e8a-4380-4850-9295-e4a548d35cfd)



## Fix center align of close workflow dialog
Have an unsaved workflow, close it, previously the dialog was misaligned horizontally

## Better support for elements around canvas
May help resolve some issues with other nodes  
Run this to test adding extra elements around the canvas, previously this would totally break the canvas:
```
(() => {
    var el = (txt, bd = "red", bg = "black") => {
            var t = document.createElement("div");
            t.style.background = bg;
            t.style.border = "5px solid " + bd;
            t.style.minWidth = "100px";
            t.style.minHeight = "100px";
            t.textContent = txt;
            return t;
        }
        // Add elements to each edge
        ["Top", "Right", "Bottom", "Left"].forEach(s => {
            app[`body${s}`].append(el(s));
        });

     // Add elements directly to body (these will still be weird, but not break stuff)
    document.body.append(el("Append", "blue", "yellow"));
    document.body.prepend(el("Prepend", "green", "orange"));
})();
```