### PR TITLE
Skip state check hook on first load

### DIFF
--- a/web/scripts/changeTracker.js
+++ b/web/scripts/changeTracker.js
@@ -173,9 +173,11 @@ export class ChangeTracker {
 		const onNodeAdded = LiteGraph.LGraph.prototype.onNodeAdded;
 		LiteGraph.LGraph.prototype.onNodeAdded = function () {
 			const v = onNodeAdded?.apply(this, arguments);
-			const ct = changeTracker();
-			if (!ct.isOurLoad) {
-				ct.checkState();
+			if (!app?.configuringGraph) {
+				const ct = changeTracker();
+				if (!ct.isOurLoad) {
+					ct.checkState();
+				}
 			}
 			return v;
 		};


### PR DESCRIPTION
This `onNodeAdded` hook fixed #3885 well but it's running unnecessarily for every node in the workflow on startup. It's having a noticeable effect on startup time. This change adds check for `app.configuringGraph` flag to tell if the graph is loading or not.