### PR TITLE
Resize control if there is a tensor size mismatch

### DIFF
--- a/comfy/ldm/modules/diffusionmodules/openaimodel.py
+++ b/comfy/ldm/modules/diffusionmodules/openaimodel.py
@@ -358,6 +358,8 @@ def apply_control(h, control, name):
         ctrl = control[name].pop()
         if ctrl is not None:
             try:
+                if ctrl.shape[2] != h.shape[2] or ctrl.shape[3] != h.shape[3]:
+                    ctrl = F.interpolate(ctrl.float(), size=(h.shape[2], h.shape[3]), mode="bicubic", align_corners=False).to(h.dtype)
                 h += ctrl
             except:
                 logging.warning("warning control could not be applied {} {}".format(h.shape, ctrl.shape))


### PR DESCRIPTION
Fixes PatchModelAddDownscale when used with controlnets, and possibly some other nodes doing similar things as well.

Fixes #3022

I'm not sure if there's a situation where the operation can fail after this, so I didn't remove the try/except