### PR TITLE
Fix loadGraphData func call

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -2314,14 +2314,14 @@ export class ComfyApp {
 				} else if(this.isApiJson(jsonContent)) {
 					this.loadApiJson(jsonContent, fileName);
 				} else {
-					await this.loadGraphData(jsonContent, true, fileName);
+					await this.loadGraphData(jsonContent, true, true, fileName);
 				}
 			};
 			reader.readAsText(file);
 		} else if (file.name?.endsWith(".latent") || file.name?.endsWith(".safetensors")) {
 			const info = await getLatentMetadata(file);
 			if (info.workflow) {
-				await this.loadGraphData(JSON.parse(info.workflow), true, fileName);
+				await this.loadGraphData(JSON.parse(info.workflow), true, true, fileName);
 			} else if (info.prompt) {
 				this.loadApiJson(JSON.parse(info.prompt));
 			} else {


### PR DESCRIPTION
The issue was originally introduced by https://github.com/comfyanonymous/ComfyUI/pull/3112.

`ComfyApp.loadGraphData` accepts 4 positional arguments, with the last one being the fileName string. This PR fixes 2 call sites that passing fileName as the 3rd argument.

@pythongosssss PTAL

