### PR TITLE
Fix CI ref

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         repository: "comfyanonymous/ComfyUI"
         path: "ComfyUI"
+        ref: ${{ github.head_ref }}
     - name: Checkout ComfyUI_frontend
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         repository: "comfyanonymous/ComfyUI"
         path: "ComfyUI"
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.event.pull_request.head.ref || github.ref }}
     - name: Checkout ComfyUI_frontend
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Example CI https://github.com/comfyanonymous/ComfyUI/actions/runs/9742396196/job/26883627645
![image](https://github.com/comfyanonymous/ComfyUI/assets/20929282/65a5adb3-7e67-40e7-8957-a329c2de3080)
![image](https://github.com/comfyanonymous/ComfyUI/assets/20929282/f0e06f3a-5fbf-4fa2-9ed5-e4589cd1bd74)

The browsertest CI is checking out ComfyUI from master by default. This PR fixes this issue by specifying head_ref so that CI works correctly in PRs.