### PR TITLE
Fix DoRA alpha

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -11,7 +11,6 @@ from comfy.types import UnetWrapperFunction
 
 def weight_decompose(dora_scale, weight, lora_diff, alpha, strength):
     dora_scale = comfy.model_management.cast_to_device(dora_scale, weight.device, torch.float32)
-    lora_diff *= alpha
     weight_calc = weight + lora_diff.type(weight.dtype)
     weight_norm = (
         weight_calc.transpose(0, 1)
@@ -22,9 +21,9 @@ def weight_decompose(dora_scale, weight, lora_diff, alpha, strength):
     )
 
     weight_calc *= (dora_scale / weight_norm).type(weight.dtype)
-    if strength != 1.0:
+    if strength != 1.0 or alpha != 1.0:
         weight_calc -= weight
-        weight += strength * (weight_calc)
+        weight += strength * alpha * weight_calc
     else:
         weight[:] = weight_calc
     return weight


### PR DESCRIPTION
This change improves the DoRA implementation by moving the alpha application to after the weight_norm.

This aligns with A1111 allowing DoRA authors to target both platforms.

Example DoRA:
[extremely_detailed_v2.zip](https://github.com/user-attachments/files/16058648/extremely_detailed_v2.zip)

Base image (no DoRA)
![image](https://github.com/comfyanonymous/ComfyUI/assets/56453727/11441ba7-3a4e-4d86-a3a9-1874f437c46e)

Before patch (attached DoRA same seed)
![image](https://github.com/comfyanonymous/ComfyUI/assets/56453727/0a61e11e-77ce-4604-9c6a-82db77132ef2)
(identity changed)

After patch
![image](https://github.com/comfyanonymous/ComfyUI/assets/56453727/b55a10bb-6d94-430a-bc94-46121f0aa480)
purrfect