### PR TITLE
fix non-contiguous tensor saving (from channels-last)

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -627,5 +627,7 @@ def save_checkpoint(output_path, model, clip=None, vae=None, clip_vision=None, m
     sd = model.model.state_dict_for_saving(clip_sd, vae.get_sd(), clip_vision_sd)
     for k in extra_keys:
         sd[k] = extra_keys[k]
+    for k in sd:
+        sd[k] = sd[k].contiguous()
 
     comfy.utils.save_torch_file(sd, output_path, metadata=metadata)


### PR DESCRIPTION
When using `CheckpointSave` with `--force-channels-last`, there's an error: https://github.com/comfyanonymous/ComfyUI/issues/3923

From tensors not being contiguous, as they can't be saved.
This change forces all tensors to be contiguous when saving.

Have validated that:
- This works properly without errors both with and without force-channels-last
- the resultant files are identical
- the resultant files work regardless of whether channels last is set or not

When not using channels-last, the `contiguous()` call is effectively a no-op as the tensors will already be contiguous