### PR TITLE
Fix module name for comfy extra nodes

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1889,9 +1889,9 @@ EXTENSION_WEB_DIRS = {}
 
 def load_custom_node(module_path, ignore=set()):
     module_name = os.path.basename(module_path)
+    # Drop '.py' file extension
     if os.path.isfile(module_path):
-        sp = os.path.splitext(module_path)
-        module_name = sp[0]
+        module_name = os.path.splitext(module_name)[0]
     try:
         logging.debug("Trying to load custom node {}".format(module_path))
         if os.path.isfile(module_path):


### PR DESCRIPTION
Related PR: https://github.com/comfyanonymous/ComfyUI/pull/3936

The code was originally added by https://github.com/comfyanonymous/ComfyUI/commit/8c4ccb55d16c7528ab143ef50c640dd86891e18f

The original PR does not explain the operation on module name. I believe the original intention here is to drop the '.py' file extension on module_name. However, the original code does this on full 'module_path', which resulted `cls.__module__` being set to full file path.