### PR TITLE
Use relative path for custom/extra node module name

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1889,9 +1889,9 @@ EXTENSION_WEB_DIRS = {}
 
 def load_custom_node(module_path, ignore=set()):
     module_name = os.path.basename(module_path)
+    # Drop '.py' file extension
     if os.path.isfile(module_path):
-        sp = os.path.splitext(module_path)
-        module_name = sp[0]
+        module_name = os.path.splitext(module_name)[0]
     try:
         logging.debug("Trying to load custom node {}".format(module_path))
         if os.path.isfile(module_path):

--- a/nodes.py
+++ b/nodes.py
@@ -1887,11 +1887,33 @@ NODE_DISPLAY_NAME_MAPPINGS = {
 
 EXTENSION_WEB_DIRS = {}
 
-def load_custom_node(module_path, ignore=set()):
-    module_name = os.path.basename(module_path)
-    # Drop '.py' file extension
+
+def get_module_name(module_path: str) -> str:
+    """
+    Returns the module name based on the given module path.
+    Examples:
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node.py") -> "custom_nodes.my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node") -> "custom_nodes.my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node/") -> "custom_nodes.my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node/__init__.py") -> "custom_nodes.my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node/__init__") -> "custom_nodes.my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node/__init__/") -> "custom_nodes.my_custom_node"
+        get_module_name("C:/Users/username/ComfyUI/custom_nodes/my_custom_node.disabled") -> "custom_nodes.my
+
+    Args:
+        module_path (str): The path of the module.
+
+    Returns:
+        str: The module name.
+    """
+    relative_path = os.path.relpath(module_path, folder_paths.base_path)
     if os.path.isfile(module_path):
-        module_name = os.path.splitext(module_name)[0]
+        relative_path = os.path.splitext(relative_path)[0]
+    return relative_path.replace(os.sep, '.')
+
+
+def load_custom_node(module_path, ignore=set()):
+    module_name = get_module_name(module_path)
     try:
         logging.debug("Trying to load custom node {}".format(module_path))
         if os.path.isfile(module_path):


### PR DESCRIPTION
Related PR: #3943

Previously the module name of imported custom node is set as filename / directoryname, which can cause potential name conflict.

Imagine you have both `comfy_extras/audio_nodes.py` and `custom_nodes/audio_nodes/`. They both resolve to the same module name `audio_nodes` which can cause issue.

This PR makes module name relative path to the ComfyUI root folder so that this situation does not happen.

I can add some unit tests if the unit test infrastructure setup in https://github.com/comfyanonymous/ComfyUI/pull/3897 is merged.