### PR TITLE
Fix loadGraphData call during restore

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -1599,7 +1599,7 @@ export class ComfyApp {
 				if (json) {
 					const workflow = JSON.parse(json);
 					const workflowName = getStorageValue("Comfy.PreviousWorkflow");
-					await this.loadGraphData(workflow, true, workflowName);
+					await this.loadGraphData(workflow, true, true, workflowName);
 					return true;
 				}
 			};


### PR DESCRIPTION
Same issue and same fix as #3918. This one is preventing the view from being restored when refreshing page. 

`loadGraphData`:

https://github.com/comfyanonymous/ComfyUI/blob/bb663bcd6c81a4395100c5f8527a221037d366f8/web/scripts/app.js#L1852-L1859

The call to `loadGraphData` when trying to restore workflow:

https://github.com/comfyanonymous/ComfyUI/blob/bb663bcd6c81a4395100c5f8527a221037d366f8/web/scripts/app.js#L1601-L1602

`workflowName` can be empty string when not using saved workflow, making restore_view false implicitly.