### PR TITLE
Add sampler_pre_cfg_function

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -57,6 +57,12 @@ def set_model_options_post_cfg_function(model_options, post_cfg_function, disabl
         model_options["disable_cfg1_optimization"] = True
     return model_options
 
+def set_model_options_pre_cfg_function(model_options, pre_cfg_function, disable_cfg1_optimization=False):
+    model_options["sampler_pre_cfg_function"] = model_options.get("sampler_pre_cfg_function", []) + [pre_cfg_function]
+    if disable_cfg1_optimization:
+        model_options["disable_cfg1_optimization"] = True
+    return model_options
+
 class ModelPatcher:
     def __init__(self, model, load_device, offload_device, size=0, current_device=None, weight_inplace_update=False):
         self.size = size
@@ -129,6 +135,9 @@ class ModelPatcher:
 
     def set_model_sampler_post_cfg_function(self, post_cfg_function, disable_cfg1_optimization=False):
         self.model_options = set_model_options_post_cfg_function(self.model_options, post_cfg_function, disable_cfg1_optimization)
+
+    def set_model_sampler_pre_cfg_function(self, pre_cfg_function, disable_cfg1_optimization=False):
+        self.model_options = set_model_options_pre_cfg_function(self.model_options, pre_cfg_function, disable_cfg1_optimization)
 
     def set_model_unet_function_wrapper(self, unet_wrapper_function: UnetWrapperFunction):
         self.model_options["model_function_wrapper"] = unet_wrapper_function

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -275,6 +275,12 @@ def sampling_function(model, x, timestep, uncond, cond, cond_scale, model_option
 
     conds = [cond, uncond_]
     out = calc_cond_batch(model, conds, x, timestep, model_options)
+
+    for fn in model_options.get("sampler_pre_cfg_function", []):
+        args = {"conds":conds, "conds_out": out, "cond_scale": cond_scale, "timestep": timestep,
+                "input": x, "sigma": timestep, "model": model, "model_options": model_options}
+        out  = fn(args)
+
     return cfg_function(model, out[0], out[1], cond_scale, x, timestep, model_options=model_options, cond=cond, uncond=uncond_)
 
 


### PR DESCRIPTION
Hello!

I am submitting this pull request to add an iterable pre-CFG function entry in the model options.

This modification will enable reworking the predictions before the CFG function, allowing for a wide range of possibilities.

For example, in [this node](https://github.com/Extraltodeus/Uncond-Zero-for-ComfyUI/blob/28ef8d78cf7c54cb6b73a8cb6bf70a37ef15816f/nodes.py#L23), I subtract something from the previous step to make everything sharper. It would be convenient to be able to do it beforehand as it is not required to do this particular modification within the CFG function.

Additionally, this will allow adding "on the fly" options like perp-neg without requiring a guider. The theoretical function could modify the predictions as needed and then return them seamlessly, enabling this capability without exclusively using the CFG function.
