### PR TITLE
only append 0 sigma if last sigma isn't already 0

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -305,7 +305,8 @@ def simple_scheduler(model_sampling, steps):
     ss = len(s.sigmas) / steps
     for x in range(steps):
         sigs += [float(s.sigmas[-(1 + int(x * ss))])]
-    sigs += [0.0]
+    if sigs[-1] != 0.0:
+        sigs += [0.0]
     return torch.FloatTensor(sigs)
 
 def ddim_scheduler(model_sampling, steps):
@@ -317,7 +318,8 @@ def ddim_scheduler(model_sampling, steps):
         sigs += [float(s.sigmas[x])]
         x += ss
     sigs = sigs[::-1]
-    sigs += [0.0]
+    if sigs[-1] != 0.0:
+        sigs += [0.0]
     return torch.FloatTensor(sigs)
 
 def normal_scheduler(model_sampling, steps, sgm=False, floor=False):
@@ -334,7 +336,8 @@ def normal_scheduler(model_sampling, steps, sgm=False, floor=False):
     for x in range(len(timesteps)):
         ts = timesteps[x]
         sigs.append(s.sigma(ts))
-    sigs += [0.0]
+    if sigs[-1] != 0.0:
+        sigs += [0.0]
     return torch.FloatTensor(sigs)
 
 def get_mask_aabb(masks):


### PR DESCRIPTION
does what it says on the box; add a check in the simple/normal/ddim schedulers so the final 0 sigma is only appended if `sigmas[-1]` isn't already 0.

useful for some custom/external schedules which *do* actually go to 0 at the end 😄 