### PR TITLE
Add support for setting type password

### DIFF
--- a/web/scripts/ui/settings.js
+++ b/web/scripts/ui/settings.js
@@ -276,6 +276,22 @@ export class ComfySettingsDialog extends ComfyDialog {
 								]),
 							]);
 							break;
+						case "password":
+							element = $el("tr", [
+								labelCell,
+								$el("td", [
+									$el("input", {
+										value,
+										id: htmlID,
+										type: "password",
+										oninput: (e) => {
+											setter(e.target.value);
+										},
+										...attrs,
+									}),
+								]),
+							]);
+							break;
 						case "text":
 						default:
 							if (type !== "text") {


### PR DESCRIPTION
This PR is to add support for settings of type "password". This can be useful for custom node developers, whose nodes require to configure some secrets (API keys...).