### PR TITLE
Add front end change guard

### DIFF
--- a/.github/workflows/front-end-guard.yml
+++ b/.github/workflows/front-end-guard.yml
@@ -12,6 +12,8 @@ jobs:
   commentIfWebChanges:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Direct FrontEnd Change') }}
+    permissions:
+      pull-requests: "write"
     steps:
       - name: Post comment on PR and apply label
         uses: actions/github-script@v6
@@ -22,7 +24,7 @@ jobs:
 
             // Add comment
             const message = "No direct changes are allowed in the web/ directory."
-              "Please submit the change to https://github.com/Comfy-Org/ComfyUI_frontend";
+              "Please submit changes to https://github.com/Comfy-Org/ComfyUI_frontend instead";
             github.rest.issues.createComment({
               issue_number: issue_number,
               owner: context.repo.owner,

--- a/.github/workflows/front-end-guard.yml
+++ b/.github/workflows/front-end-guard.yml
@@ -23,8 +23,7 @@ jobs:
             const issue_number = context.issue.number;
 
             // Add comment
-            const message = "No direct changes are allowed in the web/ directory."
-              "Please submit changes to https://github.com/Comfy-Org/ComfyUI_frontend instead";
+            const message = "No direct changes are allowed in the web/ directory. Please submit changes to https://github.com/Comfy-Org/ComfyUI_frontend instead";
             github.rest.issues.createComment({
               issue_number: issue_number,
               owner: context.repo.owner,

--- a/.github/workflows/front-end-guard.yml
+++ b/.github/workflows/front-end-guard.yml
@@ -1,0 +1,38 @@
+# Guard any changes under web/ directory
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - "web/**"
+
+jobs:
+  commentIfWebChanges:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Direct FrontEnd Change') }}
+    steps:
+      - name: Post comment on PR and apply label
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issue_number = context.issue.number;
+
+            // Add comment
+            const message = "No direct changes are allowed in the web/ directory."
+              "Please submit the change to https://github.com/Comfy-Org/ComfyUI_frontend";
+            github.rest.issues.createComment({
+              issue_number: issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });
+            // Apply label
+            github.rest.issues.addLabels({
+              issue_number: issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Direct FrontEnd Change']
+            });


### PR DESCRIPTION
Auto label & comment on change under `web/`, as we are migrating to TS repo: https://github.com/Comfy-Org/ComfyUI_frontend

@comfyanonymous Please change github action config to grant action accessibility to add label & comment on PR.

Test PR: https://github.com/comfyanonymous/ComfyUI/pull/4012