### PR TITLE
allow current timestamp in save image prefix

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -243,9 +243,17 @@ def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height
     def compute_vars(input, image_width, image_height):
         input = input.replace("%width%", str(image_width))
         input = input.replace("%height%", str(image_height))
+        now = time.localtime()
+        input = input.replace("%year%", str(now.tm_year))
+        input = input.replace("%month%", str(now.tm_mon).zfill(2))
+        input = input.replace("%day%", str(now.tm_mday).zfill(2))
+        input = input.replace("%hour%", str(now.tm_hour).zfill(2))
+        input = input.replace("%minute%", str(now.tm_min).zfill(2))
+        input = input.replace("%second%", str(now.tm_sec).zfill(2))
         return input
 
-    filename_prefix = compute_vars(filename_prefix, image_width, image_height)
+    if "%" in filename_prefix:
+        filename_prefix = compute_vars(filename_prefix, image_width, image_height)
 
     subfolder = os.path.dirname(os.path.normpath(filename_prefix))
     filename = os.path.basename(os.path.normpath(filename_prefix))


### PR DESCRIPTION
Example:
![image](https://github.com/user-attachments/assets/00c81e2b-a869-478a-85f9-cbfb3e93809a)

Just set filename prefix to eg `%year%-%month%-%day%/ComfyUI`,
this will save as eg `ComfyUI/output/2024-07-15/ComfyUI_00001_.png`

Supercedes #3402 but with cleaner code and a more configurable usage

The benefit is, of course, more ways to organize files.

Arguably more vars would be useful, eg prompt and wotnot, but that would require text processing nodes linking together, which is possible with some custom node packs.
Date/time however is easily inserted directly.

I also added an `if "%" in filename_prefix:` guard to prevent redundant calculations when the user doesn't want them.