### PR TITLE
Add Locale-based and Custom dt (datetime) variables 

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -245,7 +245,8 @@ def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height
         input = input.replace("%width%", str(image_width))
         input = input.replace("%height%", str(image_height))
 
-        input = input.replace("%dt%", time.strftime("%Y-%m-%d_%H:%M:%S", now))  # Emulate ISO 8601 format
+        # Notes: %x is date format based on Locale, %X is time format based on Locale.
+        input = input.replace("%dt%", time.strftime("%x_%X", now))
         now = time.localtime()
         regex_dt_fmt = re.compile("%dt:.*%")
         if regex_dt_fmt.search(input):

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -247,7 +247,7 @@ def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height
 
         # Notes: %x is date format based on Locale, %X is time format based on Locale.
         input = input.replace("%dt%", time.strftime("%x_%X", now))
-        input = input.replace("%dt:iso%", time.strftime("%Y-%m-%dT%H:%M:%S%z", now)
+        input = input.replace("%dt:iso%", time.strftime("%Y-%m-%dT%H:%M:%S%z", now))
         now = time.localtime()
         regex_dt_fmt = re.compile("%dt:.*%")
         if regex_dt_fmt.search(input):

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -245,14 +245,9 @@ def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height
         input = input.replace("%width%", str(image_width))
         input = input.replace("%height%", str(image_height))
 
+        input = input.replace("%dt%", time.strftime("%Y-%m-%d_%H:%M:%S", now))  # Emulate ISO 8601 format
         now = time.localtime()
-
-        regex_dt = re.compile("%dt%")
         regex_dt_fmt = re.compile("%dt:.*%")
-
-        if regex_dt.search(input):
-            input = input.replace("%dt%", time.strftime("%Y-%m-%d_%H:%M:%S", now))  # Emulate ISO 8601 format
-        
         if regex_dt_fmt.search(input):
             for match in regex_dt_fmt.findall(input):
                 fmt = match.split(':', '1')[1].rstrip('%')

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -247,6 +247,7 @@ def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height
 
         # Notes: %x is date format based on Locale, %X is time format based on Locale.
         input = input.replace("%dt%", time.strftime("%x_%X", now))
+        input = input.replace("%dt:iso%", time.strftime("%Y-%m-%dT%H:%M:%S%z", now)
         now = time.localtime()
         regex_dt_fmt = re.compile("%dt:.*%")
         if regex_dt_fmt.search(input):

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -1,3 +1,4 @@
+import re
 import os
 import time
 import logging
@@ -243,6 +244,20 @@ def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height
     def compute_vars(input, image_width, image_height):
         input = input.replace("%width%", str(image_width))
         input = input.replace("%height%", str(image_height))
+
+        now = time.localtime()
+
+        regex_dt = re.compile("%dt%")
+        regex_dt_fmt = re.compile("%dt:.*%")
+
+        if regex_dt.search(input):
+            input = input.replace("%dt%", time.strftime("%Y-%m-%d_%H:%M:%S", now))  # Emulate ISO 8601 format
+        
+        if regex_dt_fmt.search(input):
+            for match in regex_dt_fmt.findall(input):
+                fmt = match.split(':', '1')[1].rstrip('%')
+                input = input.replace(match, time.strftime(fmt, now))
+        
         return input
 
     filename_prefix = compute_vars(filename_prefix, image_width, image_height)


### PR DESCRIPTION
In similar form to https://github.com/comfyanonymous/ComfyUI/pull/4030 which allows custom time variables in parsing, this adds the ability to have *complex* time formats defined, or to rely on the international [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) time standards for the timestamp.

This adds three replaceable variables (one which we'll need regex for) as replaceable variables:

 - `%dt%` - Replaces with a locale-driven timestamp in the format `[DATE]_[TIME]` using the locale of the system and Python's ability to use locale based detection
 - `%dt:iso%` - Replaces with ISO-format compatible date-time output `YYYY-mm-ddTHH:MM:SS-00:00` (where `-00:00` is the Timezone Offset) (which would be like `2024-07-17T14:10:14-0400`)
 - `%dt:FMT%` - Where `FMT` is specified in here, parses this as a Pythonic / `strftime` parseable time format string. `%dt:%Y-%m-%d%` for instance would be replaced by `YYYY-mm-dd` (`2024-07-16`).
 
 This is a more technical version of what's in #4030 for those who need more fine tuned control of output formats, etc.  (This could be implemented also for image save paths, etc. if needed, for saving in filenames and paths too).