### PR TITLE
LoadAudio restores file value from workflow

### DIFF
--- a/web/extensions/core/uploadAudio.js
+++ b/web/extensions/core/uploadAudio.js
@@ -151,9 +151,9 @@ app.registerExtension({
         audioWidget.callback = onAudioWidgetUpdate
 
         // Load saved audio file widget values if restoring from workflow
-        const onGraphConfigured = node.onGraphConfigured;
-        node.onGraphConfigured = () => {
-          onGraphConfigured?.apply(this, arguments)
+        const onAfterGraphConfigured = node.onAfterGraphConfigured;
+        node.onAfterGraphConfigured = () => {
+          onAfterGraphConfigured?.apply(this, arguments)
           if (audioWidget.value) {
             onAudioWidgetUpdate()
           }

--- a/web/extensions/core/uploadAudio.js
+++ b/web/extensions/core/uploadAudio.js
@@ -151,9 +151,9 @@ app.registerExtension({
         audioWidget.callback = onAudioWidgetUpdate
 
         // Load saved audio file widget values if restoring from workflow
-        const onAfterGraphConfigured = node.onAfterGraphConfigured;
-        node.onAfterGraphConfigured = () => {
-          onAfterGraphConfigured?.apply(this, arguments)
+        const onGraphConfigured = node.onGraphConfigured;
+        node.onGraphConfigured = function() {
+          onGraphConfigured?.apply(this, arguments)
           if (audioWidget.value) {
             onAudioWidgetUpdate()
           }

--- a/web/extensions/core/uploadAudio.js
+++ b/web/extensions/core/uploadAudio.js
@@ -150,6 +150,15 @@ app.registerExtension({
         }
         audioWidget.callback = onAudioWidgetUpdate
 
+        // Load saved audio file widget values if restoring from workflow
+        const onGraphConfigured = node.onGraphConfigured;
+        node.onGraphConfigured = () => {
+          onGraphConfigured?.apply(this, arguments)
+          if (audioWidget.value) {
+            onAudioWidgetUpdate()
+          }
+        }
+
         const fileInput = document.createElement("input")
         fileInput.type = "file"
         fileInput.accept = "audio/*"


### PR DESCRIPTION
Currently the LoadAudio node always loads default file, even when a file is specified in the workflow being loaded. See [Comfy-Org/ComfyUI_frontend#85](https://github.com/Comfy-Org/ComfyUI_frontend/issues/85) 

The `widgets_values` are not set when the audio widget is created. So I added `onGraphConfigured` callback which sets the widget value.