### PR TITLE
Disable audio widget trying to get previews

### DIFF
--- a/web/extensions/core/uploadAudio.js
+++ b/web/extensions/core/uploadAudio.js
@@ -17,7 +17,6 @@ function getResourceURL(subfolder, filename, type = "input") {
     "filename=" + encodeURIComponent(filename),
     "type=" + type,
     "subfolder=" + subfolder,
-    app.getPreviewFormatParam().substring(1),
     app.getRandParam().substring(1)
   ].join("&")
 


### PR DESCRIPTION
The audio player widget is breaking when a preview format is specified. See [Comfy-Org/ComfyUI_frontend#141](https://github.com/Comfy-Org/ComfyUI_frontend/issues/141). When no preview format is set, `getPreviewFormatParam()` returns `""` so it doesn't cause an error.

I just removed the preview param from the widget's request to api/view, because I don't think audio previews will be implemented.