### PR TITLE
Sort nodes before saving

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -2033,6 +2033,9 @@ export class ComfyApp {
 		}
 
 		const workflow = graph.serialize();
+		// links are already sorted, but nodes are not
+		workflow["nodes"] = Object.values(workflow["nodes"]).sort((a, b) => a.id - b.id);
+
 		const output = {};
 		// Process nodes in order of execution
 		for (const outerNode of graph.computeExecutionOrder(false)) {


### PR DESCRIPTION
Currently after even a minor modification of the workflow, it's saved in random order. This fix ensures that the nodes are sorted, which minimises the GIT diff after modification. And in general makes sense, given the fact that `links` are already sorted 