### PR TITLE
Fix/webp exif little endian

### DIFF
--- a/web/scripts/pnginfo.js
+++ b/web/scripts/pnginfo.js
@@ -134,6 +134,7 @@ export function getWebpMetadata(file) {
 						let index = value.indexOf(':');
 						txt_chunks[value.slice(0, index)] = value.slice(index + 1);
 					}
+					break;
 				}
 
 				offset += 8 + chunk_length;

--- a/web/scripts/pnginfo.js
+++ b/web/scripts/pnginfo.js
@@ -49,7 +49,7 @@ export function getPngMetadata(file) {
 
 function parseExifData(exifData) {
 	// Check for the correct TIFF header (0x4949 for little-endian or 0x4D4D for big-endian)
-	const isLittleEndian = new Uint16Array(exifData.slice(0, 2))[0] === 0x4949;
+	const isLittleEndian = String.fromCharCode(...exifData.slice(0, 2)) === "II";
 
 	// Function to read 16-bit and 32-bit integers from binary data
 	function readInt(offset, isLittleEndian, length) {


### PR DESCRIPTION
## Background
I noticed that comfy UI could not read workflows from webp files that were processed and resaved by the image library I was using. The main difference seemed to be that it was using a little endian EXIF byte order, and after some debugging of comfy I found this issue. 

I brought this problem up on the [discord](https://discord.com/channels/1218270712402415686/1244085343905648691/1263911527602192534) and got this fix confirmed as desirable.

## Fixes
### Fix for isLittleEndian flag in parseExifData used for extracting workflows from webp files
The original code was comparing the expected hex value to an array instead of an int.  
You could replace it with
```
readInt(0, true, 2) === 0x4949
```
which works, but I elected to convert it and compare it to its string value "II" ("MM" for big endian) because it felt more intuitive than a mystery hex value and is in line with how the EXIF chunk header is identified on line 127.

### Break out of parsing after first EXIF chunk
For some reason I also got errors with the loop termination logic at line 124, it would return an offset slightly below the value of webp.length. I did not deep dive into this issue, but after consulting the specification of [webp](https://developers.google.com/speed/webp/docs/riff_container#extended_file_format) it specifies only one EXIF chunk, and after some mild research it seemed like it was considered reasonable if not best practice to only read the first EXIF chunk provided. So I added a break after the first EXIF chunk is extracted to just make things a little more robust and that solved my issue.


## Example Images

I have provided two images, original.webp and output-original.webp, original.webp being the one I got from comfy that imported fine before my fixes and output-original.webp which is a version I ran through the image library I am using making no intentional alterations to the EXIF data, which doesn't work before this change and does afterwards.

Apparently github doesn't support webp files so I put them in a zip, if you prefer another format let me know

[example images.zip](https://github.com/user-attachments/files/16316230/example.images.zip)
