### PR TITLE
Add timestamp to execution messages

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -400,8 +400,8 @@ class PromptExecutor:
                     self.handle_execution_error(prompt_id, prompt, current_outputs, executed, error, ex)
                     break
             else:
-                # Only execute when while ends without break
-                self.add_message("execution_end", { "prompt_id": prompt_id }, broadcast=False)
+                # Only execute when the while-loop ends without break
+                self.add_message("execution_success", { "prompt_id": prompt_id }, broadcast=False)
 
             for x in executed:
                 self.old_prompt[x] = copy.deepcopy(prompt[x])

--- a/execution.py
+++ b/execution.py
@@ -399,6 +399,9 @@ class PromptExecutor:
                 if self.success is not True:
                     self.handle_execution_error(prompt_id, prompt, current_outputs, executed, error, ex)
                     break
+            else:
+                # Only execute when while ends without break
+                self.add_message("execution_end", { "prompt_id": prompt_id }, broadcast=False)
 
             for x in executed:
                 self.old_prompt[x] = copy.deepcopy(prompt[x])

--- a/execution.py
+++ b/execution.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import threading
 import heapq
+import time
 import traceback
 import inspect
 from typing import List, Literal, NamedTuple, Optional
@@ -283,7 +284,11 @@ class PromptExecutor:
         self.success = True
         self.old_prompt = {}
 
-    def add_message(self, event, data, broadcast: bool):
+    def add_message(self, event, data: dict, broadcast: bool):
+        data = {
+            **data,
+            "timestamp": int(time.time() * 1000),
+        }
         self.status_messages.append((event, data))
         if self.server.client_id is not None or broadcast:
             self.server.send_sync(event, data, self.server.client_id)


### PR DESCRIPTION
Timestamp is necessary for the frontend to display the duration of a workflow task. The timestamp cannot be calculated on client side on receving these messages as the persisted value for `/history` endpoint need to have the timestamp as well for correct history item duration display.

This PR also adds a `execution_success` message to mark the successful end of the task.





