### PR TITLE
Add error message on unsupported control type in union controlnet

### DIFF
--- a/comfy/cldm/cldm.py
+++ b/comfy/cldm/cldm.py
@@ -13,6 +13,7 @@ from ..ldm.modules.diffusionmodules.util import (
 from ..ldm.modules.attention import SpatialTransformer
 from ..ldm.modules.diffusionmodules.openaimodel import UNetModel, TimestepEmbedSequential, ResBlock, Downsample
 from ..ldm.util import exists
+from .control_types import UNION_CONTROLNET_TYPES
 from collections import OrderedDict
 import comfy.ops
 from comfy.ldm.modules.attention import optimized_attention
@@ -389,6 +390,18 @@ class ControlNet(nn.Module):
         guided_hint = None
         if self.control_add_embedding is not None: #Union Controlnet
             control_type = kwargs.get("control_type", [])
+
+            if any([c >= self.num_control_type for c in control_type]):
+                max_type = max(control_type)
+                max_type_name = {
+                    v: k for k, v in UNION_CONTROLNET_TYPES.items()
+                }[max_type]
+                raise ValueError(
+                    f"Control type {max_type_name}({max_type}) is out of range for the number of control types" +
+                    f"({self.num_control_type}) supported.\n" +
+                    "Please consider using the ProMax ControlNet Union model.\n" +
+                    "https://huggingface.co/xinsir/controlnet-union-sdxl-1.0/tree/main"
+                )
 
             emb += self.control_add_embedding(control_type, emb.dtype, emb.device)
             if len(control_type) > 0:

--- a/comfy/cldm/control_types.py
+++ b/comfy/cldm/control_types.py
@@ -1,0 +1,11 @@
+UNION_CONTROLNET_TYPES = {
+    "auto": -1,
+    "openpose": 0,
+    "depth": 1,
+    "hed/pidi/scribble/ted": 2,
+    "canny/lineart/anime_lineart/mlsd": 3,
+    "normal": 4,
+    "segment": 5,
+    "tile": 6,
+    "repaint": 7,
+}

--- a/comfy_extras/nodes_controlnet.py
+++ b/comfy_extras/nodes_controlnet.py
@@ -1,14 +1,4 @@
-
-UNION_CONTROLNET_TYPES = {"auto": -1,
-                          "openpose": 0,
-                          "depth": 1,
-                          "hed/pidi/scribble/ted": 2,
-                          "canny/lineart/anime_lineart/mlsd": 3,
-                          "normal": 4,
-                          "segment": 5,
-                          "tile": 6,
-                          "repaint": 7,
-                        }
+from comfy.cldm.control_types import UNION_CONTROLNET_TYPES
 
 class SetUnionControlNetType:
     @classmethod


### PR DESCRIPTION
Related Issue: 
https://github.com/comfyanonymous/ComfyUI/issues/4068

This PR adds a more meaningful error message when user pick the wrong controlnet model.

![image](https://github.com/user-attachments/assets/8091f0d4-72c8-466c-9b3f-8059d24dbe9a)

Repro workflow:
[controlnet_union_tile_xl.json](https://github.com/user-attachments/files/16334046/controlnet_union_tile_xl.json)
