### PR TITLE
Active workflow use primary fg color

### DIFF
--- a/web/scripts/ui/menu/menu.css
+++ b/web/scripts/ui/menu/menu.css
@@ -330,6 +330,7 @@
 
 .comfyui-workflows-open .active {
 	font-weight: bold;
+	color: var(--primary-fg);
 }
 
 .comfyui-workflows-favorites:empty {
@@ -415,6 +416,10 @@
 	background-color: transparent;
 	color: var(--fg-color);
 	padding: 2px 4px;
+}
+
+.comfyui-workflows-tree-file.active .comfyui-workflows-file-action {
+	color: var(--primary-fg);
 }
 
 .lg ~ .comfyui-workflows-popup .comfyui-workflows-tree-file:not(:hover) .comfyui-workflows-file-action {


### PR DESCRIPTION
Made active workflow entry use primary fg color. Before / After:

![before](https://github.com/user-attachments/assets/d7a20a3c-b263-4e3d-bac5-718989196c5f)

![after](https://github.com/user-attachments/assets/347b431d-50d0-4122-9d64-e1914f4e3aae)

I tested it on all the built-in color themes.