### PR TITLE
resolved issue with black and white images in nodes_mask.py

### DIFF
--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -5,7 +5,19 @@ import comfy.utils
 
 from nodes import MAX_RESOLUTION
 
+def tensor_to_rgb(img):
+    # convert from bw to rgb : cwh -> bchw
+    if img.shape[1] != 3:
+        if len(img.shape) == 3:
+            img = img.unsqueeze(0)
+        img = img.permute(0, 1, 3, 2).repeat(1, 3, 1, 1)
+    
+    return img 
+
 def composite(destination, source, x, y, mask = None, multiplier = 8, resize_source = False):
+    destination = tensor_to_rgb(destination)
+    source = tensor_to_rgb(source)
+    
     source = source.to(destination.device)
     if resize_source:
         source = torch.nn.functional.interpolate(source, size=(destination.shape[2], destination.shape[3]), mode="bilinear")


### PR DESCRIPTION
Nodes that use the composite function accept both bw `1:w:h` and rgb `b:3:h:w` images as input. Both formats correctly display in the image preview node, however, the formats have transposed HW and incompatible C dimensions, which throws an error in nodes that attempt to composite them.

This is the normal format for PIL to create an image from a single channel numpy array such as a mask if `.convert("RGB")` is not used. This is a fairly common omission, as it does not impact preview behavior, and compositing of the mask preview over an RGB image was not a common workflow task.

However, with the introduction of UnionControlnet, compositing of mask previews is however now a common operation as it is part of creating a conditioning image for `repaint` union operations.  

The resultant image will pass through most image nodes without issue when converted back into a tensor, and will display properly in preview nodes, but will not composite properly with an "RGB" image. This can make it confusing for users as to where and what the source of the error is.   

This change introduces a function that checks if a tensor is in the PIL b&w shape `1:w:h` and converts to the RGB shape `b:3:h:w` so that composite operations do not unexpectedly fail while the image preview displays an image successfully. 

An alternative solution is to make it so that image inputs only accept tensors of shape `b:3:h:w`, instead of also accepting `1:w:h` and `b:1:w:h` images.  

