### PR TITLE
Temporarily pin numpy < 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ psutil
 kornia>=0.7.1
 spandrel
 soundfile
+
+#temporary
+numpy<2


### PR DESCRIPTION
Transformers, spandrel and potentially other dependencies are not compatible with numpy 2.0 yet. Causes problems with stable releases and other user reported issues.

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.1 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
Traceback (most recent call last):  File "D:\a\ComfyUI\ComfyUI_windows_portable\ComfyUI\main.py", line 86, in <module>
    import execution
  File "D:\a\ComfyUI\ComfyUI_windows_portable\ComfyUI\execution.py", line 12, in <module>
    import nodes
  File "D:\a\ComfyUI\ComfyUI_windows_portable\ComfyUI\nodes.py", line 21, in <module>
    import comfy.diffusers_load
  File "D:\a\ComfyUI\ComfyUI_windows_portable\ComfyUI\comfy\diffusers_load.py", line 3, in <module>
    import comfy.sd
  File "D:\a\ComfyUI\ComfyUI_windows_portable\ComfyUI\comfy\sd.py", line 5, in <module>
    from comfy import model_management
  File "D:\a\ComfyUI\ComfyUI_windows_portable\ComfyUI\comfy\model_management.py", line 119, in <module>
    total_vram = get_total_memory(get_torch_device()) / (1024 * 1024)
  File "D:\a\ComfyUI\ComfyUI_windows_portable\ComfyUI\comfy\model_management.py", line 83, in get_torch_device
    return torch.device("cpu")
D:\a\ComfyUI\ComfyUI_windows_portable\ComfyUI\comfy\model_management.py:83: UserWarning: Failed to initialize NumPy: _ARRAY_API not found (Triggered internally at ..\torch\csrc\utils\tensor_numpy.cpp:84.)
  return torch.device("cpu")
```

https://github.com/comfyanonymous/ComfyUI/actions/runs/10119732183/job/27988564526

Fixes https://github.com/comfyanonymous/ComfyUI/issues/3794