### PR TITLE
Add spellcheck option to Multiline widget and set to false by default

### DIFF
--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -245,6 +245,7 @@ function addMultilineWidget(node, name, opts, app) {
 	inputEl.className = "comfy-multiline-input";
 	inputEl.value = opts.defaultVal;
 	inputEl.placeholder = opts.placeholder || name;
+	inputEl.spellcheck = opts.spellcheck || false;
 
 	const widget = node.addDOMWidget(name, "customtext", inputEl, {
 		getValue() {


### PR DESCRIPTION
Red squigglies were annoying me in my XY lists, so this change turns off spellcheck in multiline input widgets by default. If desired, spellcheck can be toggled on for individual nodes in the node inputs options:

`"text_input":  ("STRING", {"default":"", "multiline": True, "spellcheck": True}),`