### PR TITLE
fix: 🐛 limit loadImage dropdown to supported formats

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -9,6 +9,7 @@ import math
 import time
 import random
 import logging
+from pathlib import Path
 
 from PIL import Image, ImageOps, ImageSequence, ImageFile
 from PIL.PngImagePlugin import PngInfo
@@ -1523,8 +1524,9 @@ class PreviewImage(SaveImage):
 class LoadImage:
     @classmethod
     def INPUT_TYPES(s):
-        input_dir = folder_paths.get_input_directory()
-        files = [f for f in os.listdir(input_dir) if os.path.isfile(os.path.join(input_dir, f))]
+        input_dir = Path(folder_paths.get_input_directory())
+        pillow_formats = {ext.lower() for ext in Image.registered_extensions().keys()}
+        files = sorted([f.name for f in input_dir.iterdir() if f.is_file() and f.suffix.lower() in pillow_formats])
         return {"required":
                     {"image": (sorted(files), {"image_upload": True})},
                 }


### PR DESCRIPTION
This limits the dropdown of the LoadImage to only display formats it can load:
```sh
{'.grib', '.jpx', '.ico', '.jpg', '.bw', '.fli', '.jfif', '.mpg', '.pxr', '.pgm', '.sgi', '
.ras', '.bufr', '.dcx', '.tiff', '.pcx', '.ppm', '.msp', '.jpf', '.pnm', '.h5', '.jpeg', '.
vda', '.cur', '.ftc', '.flc', '.tga', '.im', '.mpo', '.bmp', '.palm', '.xpm', '.pcd', '.iim
', '.j2k', '.jpc', '.ps', '.fit', '.blp', '.tif', '.rgb', '.hdf', '.wmf', '.webp', '.gif', 
'.vst', '.mpeg', '.eps', '.icb', '.jpe', '.jp2', '.dds', '.pdf', '.emf', '.icns', '.fits', 
'.apng', '.gbr', '.rgba', '.dib', '.psd', '.png', '.ftu', '.pbm', '.xbm', '.j2c', '.qoi'} 
```


This is because extensions like VHS upload videos to `input`, other audio extensions too and these video/audio get listed in loadImage