### PR TITLE
feat: ✨ add a method to extend convertable widget types

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -12,6 +12,12 @@ export function getWidgetConfig(slot) {
 	return slot.widget[CONFIG] ?? slot.widget[GET_CONFIG]();
 }
 
+export function addValidType(type) {
+    if (!VALID_TYPES.includes(type)) {
+        VALID_TYPES.push(type);
+    }
+}
+
 function getConfig(widgetName) {
 	const { nodeData } = this.constructor;
 	return nodeData?.input?.required[widgetName] ?? nodeData?.input?.optional?.[widgetName];


### PR DESCRIPTION
re of #3657 (I can't reopen it because I'm constantly force-pushing my edits)

Currently when creating custom types the mechanism to convert from/to widget/input isn't considering them.
This allows extension developers to extend the "convertible types"