### PR TITLE
Don't cache index.html

### DIFF
--- a/server.py
+++ b/server.py
@@ -127,7 +127,11 @@ class PromptServer():
 
         @routes.get("/")
         async def get_root(request):
-            return web.FileResponse(os.path.join(self.web_root, "index.html"))
+            response = web.FileResponse(os.path.join(self.web_root, "index.html"))
+            response.headers['Cache-Control'] = 'no-cache'
+            response.headers["Pragma"] = "no-cache"
+            response.headers["Expires"] = "0"
+            return response
 
         @routes.get("/embeddings")
         def get_embeddings(self):


### PR DESCRIPTION
If you switch frontend versions while there is no active connection to the server, the browser will use the cached index.html on startup and fail to load. This can happen if you try to use the new frontend for the first time and start the program before opening the webpage. See:

- Comfy-Org/ComfyUI_frontend#291

In general, I think it's better to not cache the entry point.