### PR TITLE
Add format metadata to CLIP save to make compatible with diffusers sa…

### DIFF
--- a/comfy_extras/nodes_model_merging.py
+++ b/comfy_extras/nodes_model_merging.py
@@ -264,6 +264,7 @@ class CLIPSave:
 
         metadata = {}
         if not args.disable_metadata:
+            metadata["format"] = "pt"
             metadata["prompt"] = prompt_info
             if extra_pnginfo is not None:
                 for x in extra_pnginfo:


### PR DESCRIPTION
…fetensors loading

Currently the saved CLIP models lack the necessary metadata specifying pytorch format needed to load CLIP models with diffusers.
This PR enables users to take the saved clip model and use as text encoder model in diffusers.