### PR TITLE
Change browser test CI python to 3.8

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -32,7 +32,7 @@ jobs:
         node-version: lts/*
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.8'
     - name: Install requirements
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Downgrade browser test CI to use python 3.8 to capture compatibility issues. Any errors during startup will be capture and reported in the browser test CI.