### PR TITLE
alternative to `load_checkpoint_guess_config` that accepts a loaded state dict

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -500,16 +500,14 @@ def load_checkpoint(config_path=None, ckpt_path=None, output_vae=True, output_cl
 
 def load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True):
     sd = comfy.utils.load_torch_file(ckpt_path)
-    return load_state_dict_guess_config(sd, output_vae, output_clip, output_clipvision, embedding_directory, output_model)
+    return load_state_dict_guess_config(sd, ckpt_path, output_vae, output_clip, output_clipvision, embedding_directory, output_model)
 
-def load_state_dict_guess_config(sd, output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True):
-    sd_keys = sd.keys()
+def load_state_dict_guess_config(sd, ckpt_path="<memory>", output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True):
     clip = None
     clipvision = None
     vae = None
     model = None
     model_patcher = None
-    clip_target = None
 
     diffusion_model_prefix = model_detection.unet_prefix_from_state_dict(sd)
     parameters = comfy.utils.calculate_parameters(sd, diffusion_model_prefix)

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -500,6 +500,9 @@ def load_checkpoint(config_path=None, ckpt_path=None, output_vae=True, output_cl
 
 def load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True):
     sd = comfy.utils.load_torch_file(ckpt_path)
+    return load_state_dict_guess_config(sd, output_vae, output_clip, output_clipvision, embedding_directory, output_model)
+
+def load_state_dict_guess_config(sd, output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True):
     sd_keys = sd.keys()
     clip = None
     clipvision = None


### PR DESCRIPTION
In comfy-mecha the Merger node creates a state dict in memory without passing by the file system. Currently I need to duplicate the function `comfy.sd.load_checkpoint_guess_config()` to the nodepack code because it takes a path as input but I need to pass a state dict instead.

The alternative solution to copying the function is to temporarily monkey patch `comfy.utils.load_torch_file`, but this solution is as brittle as copying the function to the nodepack code.

I think the best solution is to create a new function `load_state_dict_guess_config()` and keep the other one for backwards compatibility or ease of use.

I have been told that some functions under `comfy.sd` are deprecated, if this one is also deprecated then I would appreciate some guidance on the best way to do this!