### PR TITLE
extended python compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
 import comfy.options
 comfy.options.enable_args_parsing()
 
-import os
 import importlib.util
 import folder_paths
 import time


### PR DESCRIPTION
I've been messing around with newer python versions than the original venv is using, which broke ComfyUI by failing to import the comfy module. This small change will make it run and find the module with other python versions than the original installations intended to use. Doesn't seem to affect anything else or have any negative changes in general, so why not add it to the main branch so everybody who likes to mess around like me doesn't have to fix the issue of not finding the comfy module :)