### PR TITLE
Update controlnet.py to fix the default controlnet weight as constant

### DIFF
--- a/comfy/controlnet.py
+++ b/comfy/controlnet.py
@@ -423,7 +423,7 @@ def load_controlnet_hunyuandit(controlnet_data):
 
     latent_format = comfy.latent_formats.SDXL()
     extra_conds = ['text_embedding_mask', 'encoder_hidden_states_t5', 'text_embedding_mask_t5', 'image_meta_size', 'style', 'cos_cis_img', 'sin_cis_img']
-    control = ControlNet(control_model, compression_ratio=1, latent_format=latent_format, load_device=load_device, manual_cast_dtype=manual_cast_dtype, extra_conds=extra_conds, strength_type=StrengthType.LINEAR_UP)
+    control = ControlNet(control_model, compression_ratio=1, latent_format=latent_format, load_device=load_device, manual_cast_dtype=manual_cast_dtype, extra_conds=extra_conds, strength_type=StrengthType.CONSTANT)
     return control
 
 def load_controlnet(ckpt_path, model=None):


### PR DESCRIPTION
The original author intended to design two weighting methods for running controlnet: constant and decay. However, the default is now decay, which prevents the correct invocation of controlnet's weights in the conventional manner. It is recommended that the standard controlnet components continue to use constant control. Special controls like Linear_UP should be placed in nodes similar to 'advanced controlnet', providing additional control options, either constant or Linear_UP. I have trained multiple controlnet models and three HunyuanDiT controlnet models. Using the Linear_UP method to invoke the model results in the weights not being correctly expressed.