### PR TITLE
Add `DS_Store` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv/
 /user/
 *.log
 web_custom_versions/
+.DS_Store


### PR DESCRIPTION
Because macos dont have prebuild packages we have to build it from the repo.
In macos OS create extra usless files that we don't want to commit