### PR TITLE
Automatically link the Comfy CI page on PRs

### DIFF
--- a/.github/workflows/pullrequest-ci-run.yml
+++ b/.github/workflows/pullrequest-ci-run.yml
@@ -35,3 +35,19 @@ jobs:
           torch_version: ${{ matrix.torch_version }}
           google_credentials: ${{ secrets.GCS_SERVICE_ACCOUNT_JSON }}
           comfyui_flags: ${{ matrix.flags }}
+          use_prior_commit: 'true'
+  comment:
+    if: ${{ github.event.label.name == 'Run-CI-Test' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '(Automated Bot Message) CI Tests are running, you can view the results at https://ci.comfy.org/?branch=${{ github.event.pull_request.number }}%2Fmerge'
+            })


### PR DESCRIPTION
Updates the Pull Request CI action that triggers when you add the `Run-CI-Test` to now automatically comment a link to the CI dashboard (I think yoland requested this somewhere last week)

(also use_prior_commit because the the final commit on a PR in a github action is an automerge instead of the real last commit)

Bot messages show up like so:
![image](https://github.com/user-attachments/assets/e43aa79f-8ced-4d98-88b3-7f980aba8268)

And will have a message like:
> (Automated Bot Message) CI Tests are running, you can view the results at https://ci.comfy.org/?branch=4260%2Fmerge


(Yes it's `context.issue.number` in the github-script but `github.event.pull_request.number` in the workflow, don't even ask me why idek, but I did test this and that's how it has to be to work)