### PR TITLE
improve: add missing folder paths in extra_model_paths template

### DIFF
--- a/extra_model_paths.yaml.example
+++ b/extra_model_paths.yaml.example
@@ -30,10 +30,17 @@ a111:
 #     clip_vision: models/clip_vision/
 #     configs: models/configs/
 #     controlnet: models/controlnet/
+#     diffusers: models/diffusers/
 #     embeddings: models/embeddings/
+#     gligen: models/gligen/
+#     hypernetworks: models/hypernetworks/
 #     loras: models/loras/
+#     photomaker: models/photomaker/
+#     style_models: models/style_models/
+#     unet: models/unet/
 #     upscale_models: models/upscale_models/
 #     vae: models/vae/
+#     vae_approx: models/vae_approx/
 
 #other_ui:
 #    base_path: path/to/ui


### PR DESCRIPTION
Some items are missing from the extra_model_path template, which often leads to situations where users are unsure if they can use it.

https://github.com/comfyanonymous/ComfyUI/issues/4342
https://github.com/comfyanonymous/ComfyUI/issues/4353