### PR TITLE
save_checkpoint VAE optional

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -668,7 +668,8 @@ def save_checkpoint(output_path, model, clip=None, vae=None, clip_vision=None, m
 
     model_management.load_models_gpu(load_models, force_patch_weights=True)
     clip_vision_sd = clip_vision.get_sd() if clip_vision is not None else None
-    sd = model.model.state_dict_for_saving(clip_sd, vae.get_sd(), clip_vision_sd)
+    vae = vae.get_sd() if vae is not None else None
+    sd = model.model.state_dict_for_saving(clip_sd, vae, clip_vision_sd)
     for k in extra_keys:
         sd[k] = extra_keys[k]
 


### PR DESCRIPTION
Make VAE optional in save_checkpoint. Function argument has vae=None, but you call a method on the vae object without checking first if it is None.