### PR TITLE
Add Flux model support for InstantX style controlnet residuals

### DIFF
--- a/comfy/ldm/flux/controlnet_xlabs.py
+++ b/comfy/ldm/flux/controlnet_xlabs.py
@@ -82,7 +82,7 @@ class ControlNetFlux(Flux):
             block_res_sample = controlnet_block(block_res_sample)
             controlnet_block_res_samples = controlnet_block_res_samples + (block_res_sample,)
 
-        return {"output": (controlnet_block_res_samples * 10)[:19]}
+        return {"input": (controlnet_block_res_samples * 10)[:19]}
 
     def forward(self, x, timesteps, context, y, guidance=None, hint=None, **kwargs):
         hint = hint * 2.0 - 1.0

--- a/comfy/ldm/flux/model.py
+++ b/comfy/ldm/flux/model.py
@@ -133,9 +133,9 @@ class Flux(nn.Module):
         if self.params.guidance_embed:
             if guidance is None:
                 raise ValueError("Didn't get guidance strength for guidance distilled model.")
-            vec.add_(self.guidance_in(timestep_embedding(guidance, 256).to(img.dtype)))
+            vec = vec + self.guidance_in(timestep_embedding(guidance, 256).to(img.dtype))
 
-        vec.add_(self.vector_in(y))
+        vec = vec + self.vector_in(y)
         txt = self.txt_in(txt)
 
         ids = torch.cat((txt_ids, img_ids), dim=1)

--- a/comfy/ldm/flux/model.py
+++ b/comfy/ldm/flux/model.py
@@ -15,7 +15,6 @@ from .layers import (
 )
 
 from einops import rearrange, repeat
-import numpy as np
 import comfy.ldm.common_dit
 
 @dataclass
@@ -32,6 +31,7 @@ class FluxParams:
     theta: int
     qkv_bias: bool
     guidance_embed: bool
+
 
 class Flux(nn.Module):
     """
@@ -106,9 +106,9 @@ class Flux(nn.Module):
         if self.params.guidance_embed:
             if guidance is None:
                 raise ValueError("Didn't get guidance strength for guidance distilled model.")
-            vec.add_(self.guidance_in(timestep_embedding(guidance, 256).to(img.dtype)))
+            vec = vec + self.guidance_in(timestep_embedding(guidance, 256).to(img.dtype))
 
-        vec.add_(self.vector_in(y))
+        vec = vec + self.vector_in(y)
         txt = self.txt_in(txt)
 
         ids = torch.cat((txt_ids, img_ids), dim=1)


### PR DESCRIPTION
This updates the Flux model with the possibility of processing InstantX style Flux controlnet residuals which apply to both single and double blocks. 

I would like to have this merged since I have ported the InstantX union controlnet to comfyui, which produces output in this format. I will first distribute it as a custom node but can later create a pull request to merge it as well.