### PR TITLE
Fix nondeterministic results when add_noise==disable

### DIFF
--- a/comfy/sample.py
+++ b/comfy/sample.py
@@ -5,15 +5,18 @@ import comfy.utils
 import numpy as np
 import logging
 
-def prepare_noise(latent_image, seed, noise_inds=None):
+def prepare_noise(latent_image, seed, noise_inds=None, disable_noise=False):
     """
     creates random noise given a latent image and a seed.
     optional arg skip can be used to skip and discard x number of noise generations for a given seed
     """
     generator = torch.manual_seed(seed)
+    if disable_noise:
+        return torch.zeros(latent_image.size(), dtype=latent_image.dtype, layout=latent_image.layout, device="cpu")
+
     if noise_inds is None:
         return torch.randn(latent_image.size(), dtype=latent_image.dtype, layout=latent_image.layout, generator=generator, device="cpu")
-    
+
     unique_inds, inverse = np.unique(noise_inds, return_inverse=True)
     noises = []
     for i in range(unique_inds[-1]+1):

--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -397,7 +397,7 @@ class Noise_EmptyNoise:
 
     def generate_noise(self, input_latent):
         latent_image = input_latent["samples"]
-        return torch.zeros(latent_image.shape, dtype=latent_image.dtype, layout=latent_image.layout, device="cpu")
+        return comfy.sample.prepare_noise(latent_image, self.seed, disable_noise=True)
 
 
 class Noise_RandomNoise:

--- a/nodes.py
+++ b/nodes.py
@@ -1381,11 +1381,8 @@ def common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, 
     latent_image = latent["samples"]
     latent_image = comfy.sample.fix_empty_latent_channels(model, latent_image)
 
-    if disable_noise:
-        noise = torch.zeros(latent_image.size(), dtype=latent_image.dtype, layout=latent_image.layout, device="cpu")
-    else:
-        batch_inds = latent["batch_index"] if "batch_index" in latent else None
-        noise = comfy.sample.prepare_noise(latent_image, seed, batch_inds)
+    batch_inds = latent["batch_index"] if "batch_index" in latent else None
+    noise = comfy.sample.prepare_noise(latent_image, seed, batch_inds, disable_noise)
 
     noise_mask = None
     if "noise_mask" in latent:


### PR DESCRIPTION
Images generated by `KSampler (Advanced)` and `SamplerCustom` nodes are nondeterministic when `add_noise` is set to False.
Seems like we need to call `torch.manual_seed(seed)` before sampling in order to get deterministic results.

You can reproduce this problem by generating multiple times the same image with a fixed seed on ancestral sampler without adding initial noise.

This PR fixes that issue by moving all `torch.zeros` calls inside `prepare_noise` function right after setting torch seed.