### PR TITLE
add a get models list api route

### DIFF
--- a/server.py
+++ b/server.py
@@ -142,6 +142,14 @@ class PromptServer():
             embeddings = folder_paths.get_filename_list("embeddings")
             return web.json_response(list(map(lambda a: os.path.splitext(a)[0], embeddings)))
 
+        @routes.get("/models/{folder}")
+        async def get_models(request):
+            folder = request.match_info.get("folder", None)
+            if not folder in folder_paths.folder_names_and_paths:
+                return web.Response(status=404)
+            files = folder_paths.get_filename_list(folder)
+            return web.json_response(list(map(lambda a: os.path.splitext(a)[0], files)))
+
         @routes.get("/extensions")
         async def get_extensions(request):
             files = glob.glob(os.path.join(

--- a/server.py
+++ b/server.py
@@ -148,7 +148,7 @@ class PromptServer():
             if not folder in folder_paths.folder_names_and_paths:
                 return web.Response(status=404)
             files = folder_paths.get_filename_list(folder)
-            return web.json_response(list(map(lambda a: os.path.splitext(a)[0], files)))
+            return web.json_response(files)
 
         @routes.get("/extensions")
         async def get_extensions(request):


### PR DESCRIPTION
For example `wget http://127.0.0.1:8188/models/checkpoints`  returns `["sd_xl_base_1.0.safetensors", "sd_xl_refiner_1.0.safetensors", "v1-5-pruned-emaonly.ckpt"]`

the `if not folder in folder_paths.folder_names_and_paths:` check is a pretty tight whitelist, that's only path types defined explicitly by model-paths config or custom nodes -- anything that's not a predetermined path yields a 404

The existing route `/embeddings` can arguably be deprecated or removed in favor of `/models/embeddings` to yield near-identical results (but with file extensions added)
