### PR TITLE
Replace use of .view with .reshape

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -250,7 +250,7 @@ def fp8_linear(self, input):
         return None
 
     if len(input.shape) == 3:
-        inn = input.view(-1, input.shape[2]).to(dtype)
+        inn = input.reshape(-1, input.shape[2]).to(dtype)
         non_blocking = comfy.model_management.device_supports_non_blocking(input.device)
         w = cast_to(self.weight, device=input.device, non_blocking=non_blocking).t()
 
@@ -259,7 +259,7 @@ def fp8_linear(self, input):
         else:
             o, _ = torch._scaled_mm(inn, w, out_dtype=input.dtype)
 
-        return o.view((-1, input.shape[1], self.weight.shape[0]))
+        return o.reshape((-1, input.shape[1], self.weight.shape[0]))
     return None
 
 class fp8_ops(manual_cast):


### PR DESCRIPTION
When generating images with fp8_e4_m3 Flux and batch size >1, using --fast, ComfyUI throws a "view size is not compatible with input tensor's size and stride" error pointing at the first of these two calls to view.

As reshape is semantically equivalent to view except for working on a broader set of inputs, there should be no downside to changing this. The only difference is that it clones the underlying data in cases where .view would error out. I have confirmed that the output still looks as expected, but cannot confirm that no mutable use is made of the tensors anywhere.