### PR TITLE
Fix task.status.status_str caused by #2666

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -492,9 +492,9 @@ class PromptExecutor:
                     break
 
                 result, error, ex = execute(self.server, dynamic_prompt, self.caches, node_id, extra_data, executed, prompt_id, execution_list, pending_subgraph_results)
+                self.success = result == ExecutionResult.SUCCESS
                 if result == ExecutionResult.FAILURE:
                     self.handle_execution_error(prompt_id, dynamic_prompt.original_prompt, current_outputs, executed, error, ex)
-                    self.success = False
                     break
                 elif result == ExecutionResult.PENDING:
                     execution_list.unstage_node_execution()

--- a/execution.py
+++ b/execution.py
@@ -450,7 +450,7 @@ class PromptExecutor:
                 "current_outputs": list(current_outputs),
             }
             self.add_message("execution_error", mes, broadcast=False)
-        
+
     def execute(self, prompt, prompt_id, extra_data={}, execute_outputs=[]):
         nodes.interrupt_processing(False)
 
@@ -494,6 +494,7 @@ class PromptExecutor:
                 result, error, ex = execute(self.server, dynamic_prompt, self.caches, node_id, extra_data, executed, prompt_id, execution_list, pending_subgraph_results)
                 if result == ExecutionResult.FAILURE:
                     self.handle_execution_error(prompt_id, dynamic_prompt.original_prompt, current_outputs, executed, error, ex)
+                    self.success = False
                     break
                 elif result == ExecutionResult.PENDING:
                     execution_list.unstage_node_execution()

--- a/execution.py
+++ b/execution.py
@@ -492,7 +492,7 @@ class PromptExecutor:
                     break
 
                 result, error, ex = execute(self.server, dynamic_prompt, self.caches, node_id, extra_data, executed, prompt_id, execution_list, pending_subgraph_results)
-                self.success = result == ExecutionResult.SUCCESS
+                self.success = result != ExecutionResult.FAILURE
                 if result == ExecutionResult.FAILURE:
                     self.handle_execution_error(prompt_id, dynamic_prompt.original_prompt, current_outputs, executed, error, ex)
                     break


### PR DESCRIPTION
#2666 introduced an enum status indicator as result, which replaces previous `self.success` flag. However the previous `self.success` flag is send as `status_str` to the frontend via API. This causes frontend assigns wrong task status. This PR fixes this issue.

