### PR TITLE
Pytorch XPU check overhaul and other small XPU backend changes

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -44,8 +44,10 @@ cpu_state = CPUState.GPU
 
 total_vram = 0
 
+torch_version = torch.version.__version__
+
 lowvram_available = True
-xpu_available = False
+xpu_available = int(torch_version[0]) < 2 or (int(torch_version[0]) == 2 and int(torch_version[2]) <= 4)
 
 if args.deterministic:
     logging.info("Using deterministic algorithms for pytorch")
@@ -66,10 +68,10 @@ if args.directml is not None:
 
 try:
     import intel_extension_for_pytorch as ipex
-    if torch.xpu.is_available():
-        xpu_available = True
+    _ = torch.xpu.device_count()
+    xpu_available = torch.xpu.is_available()
 except:
-    pass
+    xpu_available = xpu_available or (hasattr(torch, "xpu") and torch.xpu.is_available())
 
 try:
     if torch.backends.mps.is_available():
@@ -189,7 +191,6 @@ VAE_DTYPES = [torch.float32]
 
 try:
     if is_nvidia():
-        torch_version = torch.version.__version__
         if int(torch_version[0]) >= 2:
             if ENABLE_PYTORCH_ATTENTION == False and args.use_split_cross_attention == False and args.use_quad_cross_attention == False:
                 ENABLE_PYTORCH_ATTENTION = True
@@ -321,8 +322,9 @@ class LoadedModel:
                 self.model_unload()
                 raise e
 
-        if is_intel_xpu() and not args.disable_ipex_optimize:
-            self.real_model = ipex.optimize(self.real_model.eval(), graph_mode=True, concat_linear=True)
+        if is_intel_xpu() and not args.disable_ipex_optimize and self.real_model is not None:
+            with torch.no_grad():
+                self.real_model = ipex.optimize(self.real_model.eval(), inplace=True, graph_mode=True, concat_linear=True)
 
         self.weights_loaded = True
         return self.real_model


### PR DESCRIPTION
Per the upstream policy outlined [here](https://dev-discuss.pytorch.org/t/intel-gpu-enabling-status-and-feature-plan/2389), Intel will be making available their XPU support into Pytorch proper with version 2.5 which includes their new Xe GPUs and therefore, Intel's Extension for Pytorch (IPEX) will become optional. In order to prepare for this, I am updating how ComfyUI checks for IPEX support. Complicating this is the fact that in the [Pytorch 2.4 release notes](https://pytorch.org/blog/pytorch2-4/), Intel has made XPU support available as a prototype for anyone that makes a custom build of v2.4 with some environment and command arguments passed in.
Therefore, this support was a bit tricky to implement but after doing some research, it seems like making similar changes made to transformers in their [import utils](https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py) to support this transition will allow supporting these edge cases and more which is what I have implemented here. I considered changing the readme to reflect the above change but I think that can be changed at a later date when Pytorch 2.5 comes out.
The other change I did was to put in some more optimizations regarding `ipex.optimize` where I turn on the inplace optimization variable to true, add in no_grad and check for if the model is null to avoid uselessly setting optimizations and avoiding errors in custom nodes that one can encounter.