### PR TITLE
Add download_path for model downloading progress report.

### DIFF
--- a/server.py
+++ b/server.py
@@ -586,7 +586,9 @@ class PromptServer():
         @routes.post("/internal/models/download")
         async def download_handler(request):
             async def report_progress(filename: str, status: DownloadModelStatus):
-                await self.send_json("download_progress", status.to_dict())
+                payload = status.to_dict()
+                payload['download_path'] = filename
+                await self.send_json("download_progress", payload)
 
             data = await request.json()
             url = data.get('url')


### PR DESCRIPTION
Adding a new field `download_path`. Needed by frontend to report progress for all files being downloaded.

<img width="668" alt="Screenshot 2024-08-26 at 5 03 39 PM" src="https://github.com/user-attachments/assets/b11a01d1-a8fa-4e4d-a075-3e71c07f01e2">

