### PR TITLE
Make live preview size a configurable launch argument

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -92,7 +92,7 @@ class LatentPreviewMethod(enum.Enum):
 
 parser.add_argument("--preview-method", type=LatentPreviewMethod, default=LatentPreviewMethod.NoPreviews, help="Default preview method for sampler nodes.", action=EnumAction)
 
-parser.add_argument("--preview-size", type=int, default=512, help="Default preview size for sampler nodes.")
+parser.add_argument("--preview-size", type=int, default=512, help="Sets the maximum preview size for sampler nodes.")
 
 cache_group = parser.add_mutually_exclusive_group()
 cache_group.add_argument("--cache-classic", action="store_true", help="Use the old style (aggressive) caching.")

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -92,6 +92,8 @@ class LatentPreviewMethod(enum.Enum):
 
 parser.add_argument("--preview-method", type=LatentPreviewMethod, default=LatentPreviewMethod.NoPreviews, help="Default preview method for sampler nodes.", action=EnumAction)
 
+parser.add_argument("--preview-size", type=int, default=512, help="Default preview size for sampler nodes.")
+
 cache_group = parser.add_mutually_exclusive_group()
 cache_group.add_argument("--cache-classic", action="store_true", help="Use the old style (aggressive) caching.")
 cache_group.add_argument("--cache-lru", type=int, default=0, help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.")

--- a/latent_preview.py
+++ b/latent_preview.py
@@ -2,7 +2,7 @@ import torch
 from PIL import Image
 import struct
 import numpy as np
-from comfy.cli_args import args, LatentPreviewMethod, LatentPreviewSize
+from comfy.cli_args import args, LatentPreviewMethod
 from comfy.taesd.taesd import TAESD
 import comfy.model_management
 import folder_paths

--- a/latent_preview.py
+++ b/latent_preview.py
@@ -2,14 +2,14 @@ import torch
 from PIL import Image
 import struct
 import numpy as np
-from comfy.cli_args import args, LatentPreviewMethod
+from comfy.cli_args import args, LatentPreviewMethod, LatentPreviewSize
 from comfy.taesd.taesd import TAESD
 import comfy.model_management
 import folder_paths
 import comfy.utils
 import logging
 
-MAX_PREVIEW_RESOLUTION = 512
+MAX_PREVIEW_RESOLUTION = args.preview_size
 
 def preview_to_image(latent_image):
         latents_ubyte = (((latent_image + 1.0) / 2.0).clamp(0, 1)  # change scale from -1..1 to 0..1


### PR DESCRIPTION
Adds launch argument to be able to configure live preview size which is quite desirable on large monitors.
The default of 512 will still persist if launch argument `--preview-size` followed by an integer is not set.
Images display workflow of it not being used in first one and second is when set to 768 while generating a 1024 image.

 
![default512](https://github.com/user-attachments/assets/319c6ea8-21dd-4502-ae56-71858425bad7)

![configured768](https://github.com/user-attachments/assets/bcba98bd-8d48-45c2-bad9-4f4aa48792d8)
