### PR TITLE
add github action to automatically handle stale user support issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           stale-issue-message: 'This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if your issue still isn't solved, and it will be left open. Otherwise, the issue will be closed automatically.'
           days-before-stale: 30

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,23 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    # Run daily at 430 am PT
+    - cron: '30 11 * * *'
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          stale-issue-message: 'This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if it should be left open.'
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: 'Stale'
+          only-labels: 'User Support'
+          exempt-all-assignees: true
+          exempt-all-milestones: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          stale-issue-message: 'This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if it should be left open.'
+          stale-issue-message: 'This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if your issue still isn't solved, and it will be left open. Otherwise, the issue will be closed automatically.'
           days-before-stale: 30
           days-before-close: 7
           stale-issue-label: 'Stale'


### PR DESCRIPTION
This will run daily, scan any issues marked "User Support", and mark them stale if they have had no activity for 30 days (1 month). A stale issue allows 7 days for a user to reply to un-stale it.

if there is no reply, it will look like this:
![image](https://github.com/user-attachments/assets/8946a295-e7cf-409f-a21d-c4a4818c7fcb)

If there is a reply within the 7 day period, it will look like this:
![image](https://github.com/user-attachments/assets/61b4ce54-c976-4abf-85fa-dade1f9fa8cb)

This lets us start cleaning up the old "User Support" issues. Bugs and feature requests will remain open. Anything assigned to a developer or a milestone will remain open.
After it's ran a bit, I'll run a separate process to start marking the old unlabeled issues into "User Support" to let them all either autoclose or be manually kept open, and then we can wipe the backlog of thousands of issues down to a much more manageable size by the end of it.