### PR TITLE
feat: return import_failed from init_extra_nodes function

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2129,3 +2129,5 @@ def init_extra_nodes(init_custom_nodes=True):
         else:
             logging.warning("Please do a: pip install -r requirements.txt")
         logging.warning("")
+    
+    return import_failed


### PR DESCRIPTION
modified `init_extra_nodes` function to return the `import_failed` list. This change allows the upstream callers (`main`) to decide about the extra node state.
e.g., fail if a node failed to load; as some custom nodes might leave comfy in a bad state