### PR TITLE
Add Batch Size Argument for EmptyLatentAudio and WAV File Format Option for SaveAudio

### DIFF
--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -16,14 +16,13 @@ class EmptyLatentAudio:
 
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {"seconds": ("FLOAT", {"default": 47.6, "min": 1.0, "max": 1000.0, "step": 0.1})}}
+        return {"required": {"seconds": ("FLOAT", {"default": 47.6, "min": 1.0, "max": 1000.0, "step": 0.1}), "batch_size": ("INT", {"default": 1, "min": 1, "max": 16, "step": 1})}}
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "generate"
 
     CATEGORY = "latent/audio"
 
-    def generate(self, seconds):
-        batch_size = 1
+    def generate(self, seconds, batch_size):
         length = round((seconds * 44100 / 2048) / 2) * 2
         latent = torch.zeros([batch_size, 64, length], device=self.device)
         return ({"samples":latent, "type": "audio"}, )


### PR DESCRIPTION
This merge request introduces two new features for the audio tools:

1. **Batch Size Argument for `EmptyLatentAudio`:**  
   This feature allows users to specify the batch size when creating empty latent audio with the `EmptyLatentAudio` node. Can be used for making one-shot (drum) samples.

2. **WAV File Format Option for `SaveAudio`:**  
   A new option to save audio files in WAV format has been added to the `SaveAudio` node. This change enables users to save audio files in the widely used WAV format, making integration with other audio tools easier, instead of relying only on FLAC.

#### Changes

- Added a `batch_size` argument to the `EmptyLatentAudio` node.
- Updated the `SaveAudio` node to support saving audio files in WAV format.

#### Benefits

- **Improved flexibility and scalability:**  
  The batch size argument allows users to create larger batch sizes to be used to create one-shot samples or more variations.

- **Broader file format support:**  
  The WAV format is commonly used in many audio processing workflows and has better support in DAWs. Adding support for it helps increase compatibility with various applications and use cases.

#### Testing

- Both features have been tested to ensure they work as expected, and no existing functionality was affected.

Please review and let me know if any additional changes are needed. Thank you!