### PR TITLE
fix typo in stale-issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if your issue still isn't solved, and it will be left open. Otherwise, the issue will be closed automatically.'
+          stale-issue-message: "This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if your issue still isn't solved, and it will be left open. Otherwise, the issue will be closed automatically."
           days-before-stale: 30
           days-before-close: 7
           stale-issue-label: 'Stale'


### PR DESCRIPTION
The quick text edit to the PR @ https://github.com/comfyanonymous/ComfyUI/pull/4683 included a `'` symbol which broke the singlequotes, so the stale-issues workflow wasn't running, this fixes that.