### PR TITLE
Add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ extra_model_paths.yaml
 .vscode/
 .idea/
 venv/
+.venv/
 /web/extensions/*
 !/web/extensions/logging.js.example
 !/web/extensions/core/


### PR DESCRIPTION
Creating a virtual environment in VSCode creates a .venv/ directory. This adds it to the .gitignore to avoid 10,000+ changes detected by source control.