### PR TITLE
Add support for custom load order of external nodes

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2027,10 +2027,30 @@ def init_external_custom_nodes():
     base_node_names = set(NODE_CLASS_MAPPINGS.keys())
     node_paths = folder_paths.get_folder_paths("custom_nodes")
     node_import_times = []
+
+    # Path to the file specifying the load order for custom modules.
+    # Each line in the file should represent a module name.
+    module_order_path = 'custom_nodes/custom_load_order.txt'
+
+    # If the file exists, read module names from it; otherwise, use an empty list.
+    if os.path.exists(module_order_path):
+        with open(module_order_path, 'r') as file:
+            ordered_modules = [line.strip() for line in file]
+    else:
+        ordered_modules = []
+
+    # Create a dictionary that maps module names to their index in 'ordered_modules'.
+    # Modules not in this list will be assigned 'inf' to load them last.
+    order_map = {name: i for i, name in enumerate(ordered_modules)}
+
     for custom_node_path in node_paths:
         possible_modules = os.listdir(os.path.realpath(custom_node_path))
         if "__pycache__" in possible_modules:
             possible_modules.remove("__pycache__")
+
+        # Sort modules based on their order in 'order_map'.
+        # Modules without an entry are sorted to load after those listed.
+        possible_modules.sort(key=lambda x: order_map.get(x, float('inf')))
 
         for possible_module in possible_modules:
             module_path = os.path.join(custom_node_path, possible_module)


### PR DESCRIPTION
# Pull Request: Add Custom Module Load Order for External Nodes

## Summary
This pull request introduces a new feature to support custom load ordering for external custom nodes. It adds the ability to read a module load order from a text file (`custom_load_order.txt`) and load custom nodes based on that order. This feature enhances the flexibility of module imports by allowing users to define the order in which custom nodes are loaded.

## Changes Introduced
1. **Introduction of `module_order_path`**:
    - A new variable `module_order_path` has been added, which points to a file (`custom_nodes/custom_load_order.txt`). This file contains a list of custom modules to be loaded in a specific order. Each line in the file represents the name of a module.
    
   ```python
   +    module_order_path = 'custom_nodes/custom_load_order.txt'
   ```

2. **Reading the Custom Load Order File**:
    - The code checks if the file exists at `module_order_path`. If it does, it reads the contents, stripping any excess whitespace, and stores each line (module name) in the list `ordered_modules`. If the file is not found, an empty list (`ordered_modules`) is initialized, meaning no specific order is applied.
    
   ```python
   +    if os.path.exists(module_order_path):
   +        with open(module_order_path, 'r') as file:
   +            ordered_modules = [line.strip() for line in file]
   +    else:
   +        ordered_modules = []
   ```

3. **Creating `order_map` for Sorting**:
    - A dictionary `order_map` is created to map module names to their index in the `ordered_modules` list. This mapping allows for efficient sorting of modules during the loading process.
    - If a module is not listed in `custom_load_order.txt`, it is assigned a default value of `float('inf')`, which ensures it will be loaded after the explicitly ordered modules.
    
   ```python
   +    order_map = {name: i for i, name in enumerate(ordered_modules)}
   ```

4. **Sorting Custom Modules by Defined Order**:
    - The list of custom modules (`possible_modules`) is sorted according to the indices defined in `order_map`. Modules that are listed in the order file are loaded first, and any modules not listed are loaded afterwards.
    
   ```python
   +        possible_modules.sort(key=lambda x: order_map.get(x, float('inf')))
   ```

## Reason for the Changes
These changes address the need to control the loading order of external custom nodes in the application. Previously, there was no mechanism to enforce a specific load order, which could lead to unpredictable behavior when certain modules conflict with others. By introducing an optional load order via a configurable text file, users can ensure that modules are loaded in a particular sequence if desired.

## Impact
- **Flexibility**: Users can now define a specific load order for custom nodes, improving the customization and stability of node loading.
- **Backward Compatibility**: If no custom load order file is provided, the application defaults to loading modules in an arbitrary order as before, ensuring backward compatibility.

## Example Usage
To use this feature, create a file at `custom_nodes/custom_load_order.txt` with the following content, where each line is the name of a custom module:

```txt
moduleA
moduleB
moduleC
```

Modules will be loaded in the order specified in this file. Any module not included will be loaded afterward, in no particular order.

## Testing
- Tested the changes with and without the `custom_load_order.txt` file.
- Verified that modules load in the order specified when the file is present.
- Ensured that the system falls back to default behavior when the file is missing or empty.

## Future Enhancements
- The `re` module could be leveraged to add pattern-based matching for more advanced load ordering in the future, such as wildcard-based module selection.
