### PR TITLE
Nodes using UNIQUE_ID as input are NOT_IDEMPOTENT

### DIFF
--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -98,7 +98,7 @@ class CacheKeySetInputSignature(CacheKeySet):
         class_type = node["class_type"]
         class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
         signature = [class_type, self.is_changed_cache.get(node_id)]
-        if self.include_node_id_in_input() or (hasattr(class_def, "NOT_IDEMPOTENT") and class_def.NOT_IDEMPOTENT):
+        if self.include_node_id_in_input() or (hasattr(class_def, "NOT_IDEMPOTENT") and class_def.NOT_IDEMPOTENT) or "UNIQUE_ID" in class_def.INPUT_TYPES().get("hidden", {}).values():
             signature.append(node_id)
         inputs = node["inputs"]
         for key in sorted(inputs.keys()):


### PR DESCRIPTION
As suggested by @ltdrdata, we can automatically consider nodes that take
the UNIQUE_ID hidden input to be NOT_IDEMPOTENT. This will likely just save
some custom node authors from frustration as they try to figure out why nodes
are sharing output.