### PR TITLE
Fix scipy.stats import when using beta scheduler on API

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -6,7 +6,7 @@ from comfy import model_management
 import math
 import logging
 import comfy.sampler_helpers
-import scipy
+import scipy.stats
 import numpy
 
 def get_area_and_mult(conds, x_in, timestep_in):


### PR DESCRIPTION
Doing `import scipy` does not import `scipy.stats` resulting in the following error when running in API mode:

```
!!! Exception during processing !!! module 'scipy' has no attribute 'stats'
Traceback (most recent call last):
  File "[redacted]i/ComfyUI/execution.py", line 317, in execute
    output_data, output_ui, has_subgraph = get_output_data(obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "[redacted]/ComfyUI/execution.py", line 192, in get_output_data
    return_values = _map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb)
  File "[redacted]/ComfyUI/execution.py", line 169, in _map_node_over_list
    process_inputs(input_dict, i)
  File "[redacted]/ComfyUI/execution.py", line 158, in process_inputs
    results.append(getattr(obj, func)(**inputs))
  File "[redacted]/ComfyUI/comfy_extras/nodes_custom_sampler.py", line 32, in get_sigmas
    sigmas = comfy.samplers.calculate_sigmas(model.get_model_object("model_sampling"), scheduler, total_steps).cpu()
  File "[redacted]/ComfyUI/comfy/samplers.py", line 749, in calculate_sigmas
    sigmas = beta_scheduler(model_sampling, steps)
  File "[redacted]/ComfyUI/comfy/samplers.py", line 358, in beta_scheduler
    ts = numpy.rint(scipy.stats.beta.ppf(ts, alpha, beta) * total_timesteps)
AttributeError: module 'scipy' has no attribute 'stats'
```
Since only scipy.stats is needed, that can be imported instead

Ref: See e.g. https://stackoverflow.com/questions/22108017/cannot-use-scipy-stats