### PR TITLE
Add route to list model types

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -6,7 +6,7 @@ from comfy import model_management
 import math
 import logging
 import comfy.sampler_helpers
-import scipy
+import scipy.stats
 import numpy
 
 def get_area_and_mult(conds, x_in, timestep_in):

--- a/server.py
+++ b/server.py
@@ -155,6 +155,10 @@ class PromptServer():
         def get_embeddings(self):
             embeddings = folder_paths.get_filename_list("embeddings")
             return web.json_response(list(map(lambda a: os.path.splitext(a)[0], embeddings)))
+        
+        @routes.get("/models")
+        def list_model_types(request):
+            return web.json_response(list(folder_paths.folder_names_and_paths))
 
         @routes.get("/models/{folder}")
         async def get_models(request):

--- a/server.py
+++ b/server.py
@@ -158,7 +158,9 @@ class PromptServer():
         
         @routes.get("/models")
         def list_model_types(request):
-            return web.json_response(list(folder_paths.folder_names_and_paths))
+            model_types = list(folder_paths.folder_names_and_paths.keys())
+
+            return web.json_response(model_types)
 
         @routes.get("/models/{folder}")
         async def get_models(request):


### PR DESCRIPTION
Adds a route to list all valid model types as a JSON list.

This will benefit those working with the api as it will allow for an easy way to list model types.

I have seen people in the past request a feature like this ( such as #830 ) and this adds it in a safe and simple way.