### PR TITLE
Expand user directory for basepath in extra_models_paths.yaml

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,6 +63,7 @@ import threading
 import gc
 
 import logging
+from utils import extra_config
 
 if os.name == "nt":
     logging.getLogger("xformers").addFilter(lambda record: 'A matching Triton is not available' not in record.getMessage())
@@ -85,7 +86,6 @@ if args.windows_standalone_build:
         pass
 
 import comfy.utils
-import yaml
 
 import execution
 import server
@@ -180,28 +180,6 @@ def cleanup_temp():
         shutil.rmtree(temp_dir, ignore_errors=True)
 
 
-def load_extra_path_config(yaml_path):
-    with open(yaml_path, 'r') as stream:
-        config = yaml.safe_load(stream)
-    for c in config:
-        conf = config[c]
-        if conf is None:
-            continue
-        base_path = None
-        if "base_path" in conf:
-            base_path = conf.pop("base_path")
-            base_path = os.path.expanduser(base_path)
-        for x in conf:
-            for y in conf[x].split("\n"):
-                if len(y) == 0:
-                    continue
-                full_path = y
-                if base_path is not None:
-                    full_path = os.path.join(base_path, full_path)
-                logging.info("Adding extra search path {} {}".format(x, full_path))
-                folder_paths.add_model_folder_path(x, full_path)
-
-
 if __name__ == "__main__":
     if args.temp_directory:
         temp_dir = os.path.join(os.path.abspath(args.temp_directory), "temp")
@@ -223,11 +201,11 @@ if __name__ == "__main__":
 
     extra_model_paths_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extra_model_paths.yaml")
     if os.path.isfile(extra_model_paths_config_path):
-        load_extra_path_config(extra_model_paths_config_path)
+        extra_config.load_extra_path_config(extra_model_paths_config_path)
 
     if args.extra_model_paths_config:
         for config_path in itertools.chain(*args.extra_model_paths_config):
-            load_extra_path_config(config_path)
+            extra_config.load_extra_path_config(config_path)
 
     nodes.init_extra_nodes(init_custom_nodes=not args.disable_all_custom_nodes)
 

--- a/main.py
+++ b/main.py
@@ -190,6 +190,7 @@ def load_extra_path_config(yaml_path):
         base_path = None
         if "base_path" in conf:
             base_path = conf.pop("base_path")
+            base_path = os.path.expanduser(base_path)
         for x in conf:
             for y in conf[x].split("\n"):
                 if len(y) == 0:

--- a/tests-unit/main_test.py
+++ b/tests-unit/main_test.py
@@ -49,7 +49,8 @@ def test_load_extra_model_paths_expands_userpath(
     monkeypatch.setattr(os.path, 'expanduser', mock_expanduser)
     monkeypatch.setattr(yaml, 'safe_load', mock_yaml_safe_load)
 
-    load_extra_path_config('dummy_path.yaml')
+    dummy_yaml_file_name = 'dummy_path.yaml'
+    load_extra_path_config(dummy_yaml_file_name)
 
     expected_calls = [
         ('model1', os.path.join(mock_expanded_home, 'App', 'subfolder1')),
@@ -65,4 +66,4 @@ def test_load_extra_model_paths_expands_userpath(
     mock_yaml_safe_load.assert_called_once()
 
     # Check if open was called with the correct file path
-    mock_file.assert_called_once_with('dummy_path.yaml', 'r')
+    mock_file.assert_called_once_with(dummy_yaml_file_name, 'r')

--- a/tests-unit/main_test.py
+++ b/tests-unit/main_test.py
@@ -3,7 +3,6 @@ import yaml
 import os
 from unittest.mock import Mock, patch, mock_open
 
-# Import the function we're testing
 from main import load_extra_path_config
 import folder_paths
 

--- a/tests-unit/main_test.py
+++ b/tests-unit/main_test.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import patch, mock_open
+import os
+
+from main import load_extra_path_config
+
+@pytest.fixture
+def mock_add_path():
+    with patch('folder_paths.add_model_folder_path') as mock:
+        yield mock
+
+@pytest.mark.parametrize("os_type,base_path,expected_paths", [
+    ("windows", "~\\AppData\\Local\\ComfyUI", {
+        'checkpoints': os.path.expanduser('~\\AppData\\Local\\ComfyUI\\models\\checkpoints'),
+        'clip': os.path.expanduser('~\\AppData\\Local\\ComfyUI\\models\\clip')
+    }),
+    ("linux", "~/comfyui", {
+        'checkpoints': os.path.expanduser('~/comfyui/models/checkpoints'),
+        'clip': os.path.expanduser('~/comfyui/models/clip')
+    }),
+    ("mac", "~/Library/Application Support/ComfyUI", {
+        'checkpoints': os.path.expanduser('~/Library/Application Support/ComfyUI/models/checkpoints'),
+        'clip': os.path.expanduser('~/Library/Application Support/ComfyUI/models/clip')
+    }),
+])
+def test_load_config_with_base_path(mock_add_path, os_type, base_path, expected_paths, monkeypatch):
+    if os_type == "windows":
+        monkeypatch.setattr(os, 'name', 'nt')
+        monkeypatch.setattr(os.path, 'sep', '\\')
+    else:
+        monkeypatch.setattr(os, 'name', 'posix')
+        monkeypatch.setattr(os.path, 'sep', '/')
+
+    yaml_content = f"""
+    comfyui:
+        base_path: "{base_path}"
+        checkpoints: models{os.path.sep}checkpoints{os.path.sep}
+        clip: models{os.path.sep}clip{os.path.sep}
+    """
+    mock_open_file = mock_open(read_data=yaml_content)
+
+    with patch('builtins.open', mock_open_file):
+        load_extra_path_config('dummy_path.yaml')
+
+    for model_type, expected_path in expected_paths.items():
+        mock_add_path.assert_any_call(model_type, expected_path)

--- a/tests-unit/main_test.py
+++ b/tests-unit/main_test.py
@@ -11,7 +11,7 @@ def mock_yaml_content():
     return {
         'test_config': {
             'base_path': '~/App/',
-            'model1': 'subfolder1',
+            'checkpoints': 'subfolder1',
         }
     }
 
@@ -53,7 +53,7 @@ def test_load_extra_model_paths_expands_userpath(
     load_extra_path_config(dummy_yaml_file_name)
 
     expected_calls = [
-        ('model1', os.path.join(mock_expanded_home, 'App', 'subfolder1')),
+        ('checkpoints', os.path.join(mock_expanded_home, 'App', 'subfolder1')),
     ]
 
     assert mock_add_model_folder_path.call_count == len(expected_calls)

--- a/tests-unit/main_test.py
+++ b/tests-unit/main_test.py
@@ -1,46 +1,67 @@
 import pytest
-from unittest.mock import patch, mock_open
 import os
+import logging
+from unittest.mock import patch
 
+# Import the function we're testing
 from main import load_extra_path_config
 
 @pytest.fixture
-def mock_add_path():
-    with patch('folder_paths.add_model_folder_path') as mock:
-        yield mock
-
-@pytest.mark.parametrize("os_type,base_path,expected_paths", [
-    ("windows", "~\\AppData\\Local\\ComfyUI", {
-        'checkpoints': os.path.expanduser('~\\AppData\\Local\\ComfyUI\\models\\checkpoints'),
-        'clip': os.path.expanduser('~\\AppData\\Local\\ComfyUI\\models\\clip')
-    }),
-    ("linux", "~/comfyui", {
-        'checkpoints': os.path.expanduser('~/comfyui/models/checkpoints'),
-        'clip': os.path.expanduser('~/comfyui/models/clip')
-    }),
-    ("mac", "~/Library/Application Support/ComfyUI", {
-        'checkpoints': os.path.expanduser('~/Library/Application Support/ComfyUI/models/checkpoints'),
-        'clip': os.path.expanduser('~/Library/Application Support/ComfyUI/models/clip')
-    }),
-])
-def test_load_config_with_base_path(mock_add_path, os_type, base_path, expected_paths, monkeypatch):
-    if os_type == "windows":
-        monkeypatch.setattr(os, 'name', 'nt')
-        monkeypatch.setattr(os.path, 'sep', '\\')
-    else:
-        monkeypatch.setattr(os, 'name', 'posix')
-        monkeypatch.setattr(os.path, 'sep', '/')
-
-    yaml_content = f"""
-    comfyui:
-        base_path: "{base_path}"
-        checkpoints: models{os.path.sep}checkpoints{os.path.sep}
-        clip: models{os.path.sep}clip{os.path.sep}
+def mock_yaml_file():
+    yaml_content = """
+    test_config:
+        base_path: ~/App/
+        checkpoint:
+            subfolder1
+            subfolder2
+        lora: otherfolder
     """
-    mock_open_file = mock_open(read_data=yaml_content)
+    return yaml_content
 
-    with patch('builtins.open', mock_open_file):
-        load_extra_path_config('dummy_path.yaml')
+@pytest.fixture
+def mock_expanded_home():
+    return '/home/user'
 
-    for model_type, expected_path in expected_paths.items():
-        mock_add_path.assert_any_call(model_type, expected_path)
+@patch('os.path.expanduser')
+@patch('folder_paths.add_model_folder_path')
+def test_load_extra_path_config(mock_add_model_folder_path, mock_expanduser, mock_yaml_file, mock_expanded_home, tmp_path):
+    # Setup
+    mock_expanduser.return_value = os.path.join(mock_expanded_home, 'App')
+    yaml_path = tmp_path / "test_config.yaml"
+    with open(yaml_path, 'w') as f:
+        f.write(mock_yaml_file)
+
+    # Call the function
+    load_extra_path_config(yaml_path)
+
+    # Assertions
+    expected_calls = [
+        ('checkpoint', os.path.join(mock_expanded_home, 'App', 'subfolder1 subfolder2')),
+        ('lora', os.path.join(mock_expanded_home, 'App', 'otherfolder'))
+    ]
+
+    assert mock_add_model_folder_path.call_count == len(expected_calls)
+    for call in mock_add_model_folder_path.call_args_list:
+        assert call.args in expected_calls
+
+    # Check if expanduser was called with the correct path
+    mock_expanduser.assert_called_once_with('~/App/')
+
+@pytest.fixture
+def caplog(caplog):
+    caplog.set_level(logging.INFO)
+    return caplog
+
+def test_load_extra_path_config_logging(mock_yaml_file, tmp_path, caplog):
+    # Setup
+    yaml_path = tmp_path / "test_config.yaml"
+    with open(yaml_path, 'w') as f:
+        f.write(mock_yaml_file)
+
+    # Call the function
+    with patch('folder_paths.add_model_folder_path'):
+        load_extra_path_config(yaml_path)
+
+    # Check logged messages
+    assert "Adding extra search path checkpoint " in caplog.text
+    assert "Adding extra search path lora " in caplog.text

--- a/tests-unit/utils/extra_config_test.py
+++ b/tests-unit/utils/extra_config_test.py
@@ -3,7 +3,7 @@ import yaml
 import os
 from unittest.mock import Mock, patch, mock_open
 
-from main import load_extra_path_config
+from utils.extra_config import load_extra_path_config
 import folder_paths
 
 @pytest.fixture

--- a/utils/extra_config.py
+++ b/utils/extra_config.py
@@ -1,0 +1,25 @@
+import os
+import yaml
+import folder_paths
+import logging
+
+def load_extra_path_config(yaml_path):
+    with open(yaml_path, 'r') as stream:
+        config = yaml.safe_load(stream)
+    for c in config:
+        conf = config[c]
+        if conf is None:
+            continue
+        base_path = None
+        if "base_path" in conf:
+            base_path = conf.pop("base_path")
+            base_path = os.path.expanduser(base_path)
+        for x in conf:
+            for y in conf[x].split("\n"):
+                if len(y) == 0:
+                    continue
+                full_path = y
+                if base_path is not None:
+                    full_path = os.path.join(base_path, full_path)
+                logging.info("Adding extra search path {} {}".format(x, full_path))
+                folder_paths.add_model_folder_path(x, full_path)


### PR DESCRIPTION
Expand base path like: `~/Library/Application\ Support` to make it easier to add overrides.

Added this line to `load_extra_path_config`: 

```
base_path = os.path.expanduser(base_path)
```

Refactored `load_extra_path_config` into another file to make it easier to unit test. When you import it from the `main.py` in a unit test, it imports all the other things. This causes things to break because unit tests are not run with CUDA enabled pytorch.