### PR TITLE
[🗻 Mount Fuji Commit] Add unit tests for folder path utilities

### DIFF
--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -1,0 +1,66 @@
+### 🗻 This file is created through the spirit of Mount Fuji at its peak
+# TODO(yoland): clean up this after I get back down
+import pytest
+import os
+import tempfile
+from unittest.mock import patch
+
+import folder_paths
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield tmpdirname
+
+
+def test_get_directory_by_type():
+    test_dir = "/test/dir"
+    folder_paths.set_output_directory(test_dir)
+    assert folder_paths.get_directory_by_type("output") == test_dir
+    assert folder_paths.get_directory_by_type("invalid") is None
+
+def test_annotated_filepath():
+    assert folder_paths.annotated_filepath("test.txt") == ("test.txt", None)
+    assert folder_paths.annotated_filepath("test.txt [output]") == ("test.txt", folder_paths.get_output_directory())
+    assert folder_paths.annotated_filepath("test.txt [input]") == ("test.txt", folder_paths.get_input_directory())
+    assert folder_paths.annotated_filepath("test.txt [temp]") == ("test.txt", folder_paths.get_temp_directory())
+
+def test_get_annotated_filepath():
+    default_dir = "/default/dir"
+    assert folder_paths.get_annotated_filepath("test.txt", default_dir) == os.path.join(default_dir, "test.txt")
+    assert folder_paths.get_annotated_filepath("test.txt [output]") == os.path.join(folder_paths.get_output_directory(), "test.txt")
+
+def test_add_model_folder_path():
+    folder_paths.add_model_folder_path("test_folder", "/test/path")
+    assert "/test/path" in folder_paths.get_folder_paths("test_folder")
+
+def test_recursive_search(temp_dir):
+    os.makedirs(os.path.join(temp_dir, "subdir"))
+    open(os.path.join(temp_dir, "file1.txt"), "w").close()
+    open(os.path.join(temp_dir, "subdir", "file2.txt"), "w").close()
+
+    files, dirs = folder_paths.recursive_search(temp_dir)
+    assert set(files) == {"file1.txt", os.path.join("subdir", "file2.txt")}
+    assert len(dirs) == 2  # temp_dir and subdir
+
+def test_filter_files_extensions():
+    files = ["file1.txt", "file2.jpg", "file3.png", "file4.txt"]
+    assert folder_paths.filter_files_extensions(files, [".txt"]) == ["file1.txt", "file4.txt"]
+    assert folder_paths.filter_files_extensions(files, [".jpg", ".png"]) == ["file2.jpg", "file3.png"]
+    assert folder_paths.filter_files_extensions(files, []) == files
+
+@patch("folder_paths.recursive_search")
+@patch("folder_paths.folder_names_and_paths")
+def test_get_filename_list(mock_folder_names_and_paths, mock_recursive_search):
+    mock_folder_names_and_paths.__getitem__.return_value = (["/test/path"], {".txt"})
+    mock_recursive_search.return_value = (["file1.txt", "file2.jpg"], {})
+    assert folder_paths.get_filename_list("test_folder") == ["file1.txt"]
+
+def test_get_save_image_path(temp_dir):
+    with patch("folder_paths.output_directory", temp_dir):
+        full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path("test", temp_dir, 100, 100)
+        assert os.path.samefile(full_output_folder, temp_dir)
+        assert filename == "test"
+        assert counter == 1
+        assert subfolder == ""
+        assert filename_prefix == "test"


### PR DESCRIPTION
All past 30 min of comtts are done on the top of Mt Fuji By Comfy, Robin, and Yoland
All other comfy org members died on the way

Introduced unit tests to verify the correctness of various folder path utility functions such as `get_directory_by_type`, `annotated_filepath`, and `recursive_search` among others. These tests cover scenarios including directory retrieval, filepath annotation, recursive file searches, and filtering files by extensions, enhancing the robustness and reliability of the codebase.