### PR TITLE
Reduce repeated calls of get_immediate_node_signature in cache

### DIFF
--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -67,6 +67,7 @@ class CacheKeySetInputSignature(CacheKeySet):
         super().__init__(dynprompt, node_ids, is_changed_cache)
         self.dynprompt = dynprompt
         self.is_changed_cache = is_changed_cache
+        self.immediate_node_signature = {}
         self.add_keys(node_ids)
 
     def include_node_id_in_input(self) -> bool:
@@ -94,6 +95,8 @@ class CacheKeySetInputSignature(CacheKeySet):
         if not dynprompt.has_node(node_id):
             # This node doesn't exist -- we can't cache it.
             return [float("NaN")]
+        if node_id in self.immediate_node_signature:    # reduce repeated calls of ancestors
+            return self.immediate_node_signature[node_id]
         node = dynprompt.get_node(node_id)
         class_type = node["class_type"]
         class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
@@ -108,6 +111,7 @@ class CacheKeySetInputSignature(CacheKeySet):
                 signature.append((key,("ANCESTOR", ancestor_index, ancestor_socket)))
             else:
                 signature.append((key, inputs[key]))
+        self.immediate_node_signature[node_id] = signature
         return signature
 
     # This function returns a list of all ancestors of the given node. The order of the list is


### PR DESCRIPTION
`CacheKeySetInputSignature.get_immediate_node_signature` is called multiple times for the same node as ancestors of different nodes.

Most nodes are fine, but when there are time-consuming operations in `class_def.INPUT_TYPES()`, such as `get_filename_list`, the performance of `cache.set_prompt` becomes quite bad on machines with poor disk performance.

On one of my devices, `set_prompt` of `caches.outputs` and `caches.ui` took 500+ms before modification, and it would be worse if there were more time-consuming nodes. This PR reduces the time to 80ms on average