### PR TITLE
Normalize path returned by /userdata to always use / as separator

### DIFF
--- a/tests-unit/prompt_server_test/user_manager_test.py
+++ b/tests-unit/prompt_server_test/user_manager_test.py
@@ -2,6 +2,7 @@ import pytest
 import os
 from aiohttp import web
 from app.user_manager import UserManager
+from unittest.mock import patch
 
 pytestmark = (
     pytest.mark.asyncio
@@ -53,7 +54,7 @@ async def test_listuserdata_recursive(aiohttp_client, app, tmp_path):
     client = await aiohttp_client(app)
     resp = await client.get("/userdata?dir=test_dir&recurse=true")
     assert resp.status == 200
-    assert set(await resp.json()) == {"file1.txt", os.path.join("subdir", "file2.txt")}
+    assert set(await resp.json()) == {"file1.txt", "subdir/file2.txt"}
 
 
 async def test_listuserdata_full_info(aiohttp_client, app, tmp_path):
@@ -80,7 +81,7 @@ async def test_listuserdata_split_path(aiohttp_client, app, tmp_path):
     resp = await client.get("/userdata?dir=test_dir&recurse=true&split=true")
     assert resp.status == 200
     assert await resp.json() == [
-        [os.path.join("subdir", "file1.txt"), "subdir", "file1.txt"]
+        ["subdir/file1.txt", "subdir", "file1.txt"]
     ]
 
 
@@ -88,3 +89,32 @@ async def test_listuserdata_invalid_directory(aiohttp_client, app):
     client = await aiohttp_client(app)
     resp = await client.get("/userdata?dir=")
     assert resp.status == 400
+
+
+async def test_listuserdata_normalized_separator(aiohttp_client, app, tmp_path):
+    os_sep = "\\"
+    with patch("os.sep", os_sep):
+        with patch("os.path.sep", os_sep):
+            os.makedirs(tmp_path / "test_dir" / "subdir")
+            with open(tmp_path / "test_dir" / "subdir" / "file1.txt", "w") as f:
+                f.write("test content")
+
+            client = await aiohttp_client(app)
+            resp = await client.get("/userdata?dir=test_dir&recurse=true")
+            assert resp.status == 200
+            result = await resp.json()
+            assert len(result) == 1
+            assert "/" in result[0]  # Ensure forward slash is used
+            assert "\\" not in result[0]  # Ensure backslash is not present
+            assert result[0] == "subdir/file1.txt"
+
+            # Test with full_info
+            resp = await client.get(
+                "/userdata?dir=test_dir&recurse=true&full_info=true"
+            )
+            assert resp.status == 200
+            result = await resp.json()
+            assert len(result) == 1
+            assert "/" in result[0]["path"]  # Ensure forward slash is used
+            assert "\\" not in result[0]["path"]  # Ensure backslash is not present
+            assert result[0]["path"] == "subdir/file1.txt"


### PR DESCRIPTION
Dealing with os separator is quite painful in the frontend. This PR normalizes the path returned by `/userdata` endpoint to always use `/` as file separator.