### PR TITLE
add node ConditioningTimestepInterpolate

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -276,11 +276,8 @@ class ConditioningTimestepInterpolate:
 
     CATEGORY = "advanced/conditioning"
 
-
     def interpolate_conds(self, conditioning_1, conditioning_2, interval_range):
-        
         num_intervals = int(1 / interval_range)
-
         conditioning_1_intervals = []
         conditioning_2_intervals = []
 

--- a/nodes.py
+++ b/nodes.py
@@ -288,6 +288,10 @@ class ConditioningTimestepInterpolate:
             start = i * interval_range
             end = (i + 1) * interval_range
 
+            # Ensure the last interval ends exactly at 1.0
+            if i == num_intervals - 1:
+                end = 1.0
+
             if i % 2 == 0:
                 conditioning_1_intervals.append(node_helpers.conditioning_set_values(conditioning_1, {"start_percent": start, "end_percent": end}))
             else:


### PR DESCRIPTION
Adds node for interpolating between two conditionings at a set interval.
Simplifies something that would otherwise require over 30 nodes ifor generating an image interpolating every step for 20 steps with currently available Core nodes. 
It also mimics prompt editing from A1111 webui that did similar thing.