### PR TITLE
Add folder path tracking for unets and minor fix

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -14,8 +14,9 @@ folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
 base_path = os.path.dirname(os.path.realpath(__file__))
 models_dir = os.path.join(base_path, "models")
 folder_names_and_paths["checkpoints"] = ([os.path.join(models_dir, "checkpoints")], supported_pt_extensions)
-folder_names_and_paths["configs"] = ([os.path.join(models_dir, "configs")], [".yaml"])
+folder_names_and_paths["configs"] = ([os.path.join(models_dir, "configs")], {".yaml"})
 
+folder_names_and_paths["unet"] = ([os.path.join(models_dir, "unet")], supported_pt_extensions)
 folder_names_and_paths["loras"] = ([os.path.join(models_dir, "loras")], supported_pt_extensions)
 folder_names_and_paths["vae"] = ([os.path.join(models_dir, "vae")], supported_pt_extensions)
 folder_names_and_paths["clip"] = ([os.path.join(models_dir, "clip")], supported_pt_extensions)
@@ -23,7 +24,7 @@ folder_names_and_paths["diffusion_models"] = ([os.path.join(models_dir, "unet"),
 folder_names_and_paths["clip_vision"] = ([os.path.join(models_dir, "clip_vision")], supported_pt_extensions)
 folder_names_and_paths["style_models"] = ([os.path.join(models_dir, "style_models")], supported_pt_extensions)
 folder_names_and_paths["embeddings"] = ([os.path.join(models_dir, "embeddings")], supported_pt_extensions)
-folder_names_and_paths["diffusers"] = ([os.path.join(models_dir, "diffusers")], ["folder"])
+folder_names_and_paths["diffusers"] = ([os.path.join(models_dir, "diffusers")], {"folder"})
 folder_names_and_paths["vae_approx"] = ([os.path.join(models_dir, "vae_approx")], supported_pt_extensions)
 
 folder_names_and_paths["controlnet"] = ([os.path.join(models_dir, "controlnet"), os.path.join(models_dir, "t2i_adapter")], supported_pt_extensions)


### PR DESCRIPTION
- Add tracking for `unet` folder (mostly related to storing flux models)
- Fix type conflict for variable `folder_names_and_paths` (mypy flags this)