### PR TITLE
[proof of concept] async model file listing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ transformers>=4.28.1
 tokenizers>=0.13.3
 sentencepiece
 safetensors>=0.4.2
+aiofiles
 aiohttp
 pyyaml
 Pillow


### PR DESCRIPTION
This is a messy proof of concept: using [aiofiles](https://github.com/Tinche/aiofiles/), handle model listing and cache validation with async parallelization, to make high-latency drives list models fast.

I tested by running ComfyUI in Tokyo accessing a model folder in Los Angeles via SMB.

Key timings:
- before anything: ~70s to read `object_info`
- cache code disabled, no further edits: ~25s
- asyncfiles listing, with cache validation disabled: ~8s
- asyncfiles listing, asyncfiles cache validation enabled: ~28s
- async cache validation only: ~23s

All times above are +/- a pretty wide range, latency was not constant, but an order of magnitude smaller than most of those jumps.

This code undoubtedly has side effects (I haven't tested symlinks for example), not to mention requires a new dependency, and adds significant complexity. So the main question is, is the case of high-latency drive reads worth the trouble of merging and maintaining this messier model listing code?

I will be building and submitting a separate, more easily agreeable PR, to buff up the caching code soon