### PR TITLE
very simple strong-cache on model list

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -307,7 +307,7 @@ def get_filename_list(folder_name: str) -> list[str]:
         out = get_filename_list_(folder_name)
         global filename_list_cache
         filename_list_cache[folder_name] = out
-        cache_helper.set(folder_name, out)
+    cache_helper.set(folder_name, out)
     return list(out[0])
 
 def get_save_image_path(filename_prefix: str, output_dir: str, image_width=0, image_height=0) -> tuple[str, str, int, str, str]:

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -52,12 +52,16 @@ class CacheHelper:
     """
     def __init__(self):
         self.cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
+        self.active = False
 
     def get(self, key: str, default=None) -> tuple[list[str], dict[str, float], float]:
+        if not self.active:
+            return default
         return self.cache.get(key, default)
     
     def set(self, key: str, value: tuple[list[str], dict[str, float], float]) -> None:
-        self.cache[key] = value
+        if self.active:
+            self.cache[key] = value
 
     def clear(self):
         self.cache.clear()

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -46,6 +46,24 @@ user_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "user
 
 filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
 
+class CacheHelper:
+    """
+    Helper class for managing file list cache data.
+    """
+    def __init__(self):
+        self.cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
+
+    def get(self, key: str, default=None) -> tuple[list[str], dict[str, float], float]:
+        return self.cache.get(key, default)
+    
+    def set(self, key: str, value: tuple[list[str], dict[str, float], float]) -> None:
+        self.cache[key] = value
+
+    def clear(self):
+        self.cache.clear()
+
+cache_helper = CacheHelper()
+
 extension_mimetypes_cache = {
     "webp" : "image",
 }
@@ -257,6 +275,10 @@ def get_filename_list_(folder_name: str) -> tuple[list[str], dict[str, float], f
     return sorted(list(output_list)), output_folders, time.perf_counter()
 
 def cached_filename_list_(folder_name: str) -> tuple[list[str], dict[str, float], float] | None:
+    strong_cache = cache_helper.get(folder_name)
+    if strong_cache is not None:
+        return strong_cache
+    
     global filename_list_cache
     global folder_names_and_paths
     folder_name = map_legacy(folder_name)
@@ -285,6 +307,7 @@ def get_filename_list(folder_name: str) -> list[str]:
         out = get_filename_list_(folder_name)
         global filename_list_cache
         filename_list_cache[folder_name] = out
+        cache_helper.set(folder_name, out)
     return list(out[0])
 
 def get_save_image_path(filename_prefix: str, output_dir: str, image_width=0, image_height=0) -> tuple[str, str, int, str, str]:

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -66,6 +66,14 @@ class CacheHelper:
     def clear(self):
         self.cache.clear()
 
+    def __enter__(self):
+        self.active = True
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.active = False
+        self.clear()
+
 cache_helper = CacheHelper()
 
 extension_mimetypes_cache = {

--- a/server.py
+++ b/server.py
@@ -552,17 +552,15 @@ class PromptServer():
 
         @routes.get("/object_info")
         async def get_object_info(request):
-            folder_paths.cache_helper.clear()
-            folder_paths.cache_helper.active = True
-            out = {}
-            for x in nodes.NODE_CLASS_MAPPINGS:
-                try:
-                    out[x] = node_info(x)
-                except Exception as e:
-                    logging.error(f"[ERROR] An error occurred while retrieving information for the '{x}' node.")
-                    logging.error(traceback.format_exc())
-            folder_paths.cache_helper.active = False
-            return web.json_response(out)
+            with folder_paths.cache_helper:
+                out = {}
+                for x in nodes.NODE_CLASS_MAPPINGS:
+                    try:
+                        out[x] = node_info(x)
+                    except Exception as e:
+                        logging.error(f"[ERROR] An error occurred while retrieving information for the '{x}' node.")
+                        logging.error(traceback.format_exc())
+                return web.json_response(out)
 
         @routes.get("/object_info/{node_class}")
         async def get_object_info_node(request):

--- a/server.py
+++ b/server.py
@@ -552,6 +552,7 @@ class PromptServer():
 
         @routes.get("/object_info")
         async def get_object_info(request):
+            folder_paths.cache_helper.clear()
             out = {}
             for x in nodes.NODE_CLASS_MAPPINGS:
                 try:

--- a/server.py
+++ b/server.py
@@ -553,6 +553,7 @@ class PromptServer():
         @routes.get("/object_info")
         async def get_object_info(request):
             folder_paths.cache_helper.clear()
+            folder_paths.cache_helper.active = True
             out = {}
             for x in nodes.NODE_CLASS_MAPPINGS:
                 try:
@@ -560,6 +561,7 @@ class PromptServer():
                 except Exception as e:
                     logging.error(f"[ERROR] An error occurred while retrieving information for the '{x}' node.")
                     logging.error(traceback.format_exc())
+            folder_paths.cache_helper.active = False
             return web.json_response(out)
 
         @routes.get("/object_info/{node_class}")


### PR DESCRIPTION
This is based on the same work as https://github.com/comfyanonymous/ComfyUI/pull/4968 but a much simpler and more agreeable approach: when object_info is hit, use a strong cache to ensure each model list is read exactly once, rather than once per node - ie skip the cache validation *within the current call*, until the next object_info hit.

Currently only `/object_info` triggers a cache clear, but it can be made to apply to `/object_info/{x}` and `/models/{x}` as well if desired. (I'd argue that strong caching in those subcalls is desired, as only `/object_info` is intended as a 'refresh' - though also a separate dedicated `/refresh` route would be preferred imo)

For this code I made a nice lil subclass helper doodle to reduce the amount of chaotic global variable pollution in that file a bit.

The practical result is, in the ultra-high-latency test env I set up, time to read `/object_info` using just this cache PR alone reduces from 70 seconds to 23 seconds.

The cache hit/miss pattern of a pure default comfy with no custom nodes for `/object_info` is:
```
cache hit for controlnet
cache miss for style_models
cache hit for style_models
cache miss for clip_vision
cache hit for clip_vision
cache hit for checkpoints
cache hit for checkpoints
cache miss for gligen
cache hit for gligen
cache miss for configs
cache hit for checkpoints
cache hit for configs
cache hit for checkpoints
cache hit for loras
cache hit for loras
cache miss for hypernetworks
cache hit for hypernetworks
cache miss for upscale_models
cache hit for upscale_models
cache hit for checkpoints
cache hit for checkpoints
cache miss for photomaker
cache hit for photomaker
cache hit for clip
cache hit for clip
cache hit for clip
cache hit for clip
cache hit for controlnet
cache miss for style_models
cache hit for style_models
cache miss for clip_vision
cache hit for clip_vision
cache hit for checkpoints
cache hit for checkpoints
cache miss for gligen
cache hit for gligen
cache miss for configs
cache hit for checkpoints
cache hit for configs
cache hit for checkpoints
cache hit for loras
cache hit for loras
cache miss for hypernetworks
cache hit for hypernetworks
cache miss for upscale_models
cache hit for upscale_models
cache hit for checkpoints
cache hit for checkpoints
cache miss for photomaker
cache hit for loras
cache miss for hypernetworks
cache hit for hypernetworks
cache miss for upscale_models
cache hit for upscale_models
cache miss for upscale_models
cache hit for upscale_models
cache hit for checkpoints
cache hit for checkpoints
cache miss for photomaker
cache hit for photomaker
cache hit for clip
cache hit for clip
cache hit for clip
cache hit for clip
cache hit for clip
cache hit for clip
```