### PR TITLE
add 'is_default' to model paths config

### DIFF
--- a/extra_model_paths.yaml.example
+++ b/extra_model_paths.yaml.example
@@ -25,6 +25,8 @@ a111:
 
 #comfyui:
 #     base_path: path/to/comfyui/
+#     # You can use is_default to mark that these folders should be listed first, and used as the default dirs for eg downloads
+#     #is_default: true
 #     checkpoints: models/checkpoints/
 #     clip: models/clip/
 #     clip_vision: models/clip_vision/

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -195,11 +195,14 @@ def exists_annotated_filepath(name) -> bool:
     return os.path.exists(filepath)
 
 
-def add_model_folder_path(folder_name: str, full_folder_path: str) -> None:
+def add_model_folder_path(folder_name: str, full_folder_path: str, is_default: bool = False) -> None:
     global folder_names_and_paths
     folder_name = map_legacy(folder_name)
     if folder_name in folder_names_and_paths:
-        folder_names_and_paths[folder_name][0].append(full_folder_path)
+        if is_default:
+            folder_names_and_paths[folder_name][0].insert(0, full_folder_path)
+        else:
+            folder_names_and_paths[folder_name][0].append(full_folder_path)
     else:
         folder_names_and_paths[folder_name] = ([full_folder_path], set())
 

--- a/tests-unit/utils/extra_config_test.py
+++ b/tests-unit/utils/extra_config_test.py
@@ -71,7 +71,7 @@ def test_load_extra_model_paths_expands_userpath(
     load_extra_path_config(dummy_yaml_file_name)
 
     expected_calls = [
-        ('checkpoints', os.path.join(mock_expanded_home, 'App', 'subfolder1')),
+        ('checkpoints', os.path.join(mock_expanded_home, 'App', 'subfolder1', False)),
     ]
 
     assert mock_add_model_folder_path.call_count == len(expected_calls)

--- a/tests-unit/utils/extra_config_test.py
+++ b/tests-unit/utils/extra_config_test.py
@@ -71,7 +71,7 @@ def test_load_extra_model_paths_expands_userpath(
     load_extra_path_config(dummy_yaml_file_name)
 
     expected_calls = [
-        ('checkpoints', os.path.join(mock_expanded_home, 'App', 'subfolder1', False)),
+        ('checkpoints', os.path.join(mock_expanded_home, 'App', 'subfolder1'), False),
     ]
 
     assert mock_add_model_folder_path.call_count == len(expected_calls)

--- a/tests-unit/utils/extra_config_test.py
+++ b/tests-unit/utils/extra_config_test.py
@@ -111,7 +111,7 @@ def test_load_extra_model_paths_expands_appdata(
 
     expected_base_path = 'C:/Users/TestUser/AppData/Roaming/ComfyUI'
     expected_calls = [
-        ('checkpoints', os.path.join(expected_base_path, 'models/checkpoints')),
+        ('checkpoints', os.path.join(expected_base_path, 'models/checkpoints'), False),
     ]
 
     assert mock_add_model_folder_path.call_count == len(expected_calls)

--- a/utils/extra_config.py
+++ b/utils/extra_config.py
@@ -14,6 +14,9 @@ def load_extra_path_config(yaml_path):
         if "base_path" in conf:
             base_path = conf.pop("base_path")
             base_path = os.path.expandvars(os.path.expanduser(base_path))
+        is_default = False
+        if "is_default" in conf:
+            is_default = conf.pop("is_default")
         for x in conf:
             for y in conf[x].split("\n"):
                 if len(y) == 0:
@@ -22,4 +25,4 @@ def load_extra_path_config(yaml_path):
                 if base_path is not None:
                     full_path = os.path.join(base_path, full_path)
                 logging.info("Adding extra search path {} {}".format(x, full_path))
-                folder_paths.add_model_folder_path(x, full_path)
+                folder_paths.add_model_folder_path(x, full_path, is_default)


### PR DESCRIPTION
Very simple, just add `is_default: true` in a block within `extra_model_paths.yaml` and it will insert those folders at the front of the list rather than the end, preceding even the ComfyUI default folder.

This allows automatic installations to define a clear default that will be used particularly for things like the model downloader (which would then be in turn user overridable in the frontend settings to pick a preference when desired)