### PR TITLE
add internal /folder_paths route

### DIFF
--- a/api_server/routes/internal/internal_routes.py
+++ b/api_server/routes/internal/internal_routes.py
@@ -1,6 +1,6 @@
 from aiohttp import web
 from typing import Optional
-from folder_paths import models_dir, user_directory, output_directory
+from folder_paths import models_dir, user_directory, output_directory, folder_names_and_paths
 from api_server.services.file_service import FileService
 import app.logger
 
@@ -35,6 +35,13 @@ class InternalRoutes:
         @self.routes.get('/logs')
         async def get_logs(request):
             return web.json_response(app.logger.get_logs())
+
+        @self.routes.get('/folder_paths')
+        async def get_folder_paths(request):
+            response = {}
+            for key in folder_names_and_paths:
+                response[key] = folder_names_and_paths[key][0]
+            return web.json_response(response)
 
     def get_app(self):
         if self._app is None:


### PR DESCRIPTION
returns a json maps of folder paths

Looks something like:

```
{
  "checkpoints": [
    "Z:\\Stable-Diffusion",
    "C:\\GitHub\\ComfyUI_windows_portable\\ComfyUI\\models\\checkpoints",
    "C:\\GitHub\\ComfyUI_windows_portable\\ComfyUI\\output\\checkpoints"
  ],
  "configs": [
    "C:\\GitHub\\ComfyUI_windows_portable\\ComfyUI\\models\\configs"
  ],
  "loras": [
    "Z:\\Lora",
    "C:\\GitHub\\ComfyUI_windows_portable\\ComfyUI\\models\\loras",
    "C:\\GitHub\\ComfyUI_windows_portable\\ComfyUI\\output\\loras"
  ],
  etc...
}
```

this is for the frontend model downloader to be able to see available paths and have the user select one

pairs with https://github.com/comfyanonymous/ComfyUI/pull/4979 to allow config to set which one comes first