### PR TITLE
Added to the websockets_api_example.py to show how to decode latent previews from the binary stream

### DIFF
--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -38,6 +38,12 @@ def get_images(ws, prompt):
                 if data['node'] is None and data['prompt_id'] == prompt_id:
                     break #Execution is done
         else:
+            # If you want to be able to decode the binary stream for latent previews, here is how you can do it:
+            # event = struct.unpack(">I", out[:4])[0]
+            # image_data = out[8:]
+            # if event == 1:
+                # bytesIO = BytesIO(image_data)
+                # preview_image = Image.open(bytesIO) # This is your preview in PIL image format, store it in a global
             continue #previews are binary data
 
     history = get_history(prompt_id)[prompt_id]

--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -39,11 +39,8 @@ def get_images(ws, prompt):
                     break #Execution is done
         else:
             # If you want to be able to decode the binary stream for latent previews, here is how you can do it:
-            # event = struct.unpack(">I", out[:4])[0]
-            # image_data = out[8:]
-            # if event == 1:
-                # bytesIO = BytesIO(image_data)
-                # preview_image = Image.open(bytesIO) # This is your preview in PIL image format, store it in a global
+            # bytesIO = BytesIO(out[8:])
+            # preview_image = Image.open(bytesIO) # This is your preview in PIL image format, store it in a global
             continue #previews are binary data
 
     history = get_history(prompt_id)[prompt_id]


### PR DESCRIPTION
After wasting a ton of time trying to do this a different way, it turned out to be extremely simple to pull off after I finally figured out that the start of the stream had an extra 4 bytes added to it, so the image data was at [8:] and not [4:]. I guess the websockets_api_example_ws_images.py example kind of addresses this with the images_output.append(out[8:]) line? But it's handled differently overall, so I'm not going to mess with that example file.

Here's an example of it working with a Gradio app:
![image](https://github.com/user-attachments/assets/ad2365b3-615a-4042-902a-8ea2f45ed606)

Thanks @asagi4 for making me requestion my previous approach, causing me to do a bunch of digging!

