### PR TITLE
Add ws.close() to the websocket examples

### DIFF
--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -154,7 +154,7 @@ prompt["3"]["inputs"]["seed"] = 5
 ws = websocket.WebSocket()
 ws.connect("ws://{}/ws?clientId={}".format(server_address, client_id))
 images = get_images(ws, prompt)
-
+ws.close() # for in case this example is used in an environment where it will be repeatedly called, like in a Gradio app. otherwise, you'll randomly receive connection timeouts
 #Commented out code to display the output images:
 
 # for node_id in images:

--- a/script_examples/websockets_api_example_ws_images.py
+++ b/script_examples/websockets_api_example_ws_images.py
@@ -147,7 +147,7 @@ prompt["3"]["inputs"]["seed"] = 5
 ws = websocket.WebSocket()
 ws.connect("ws://{}/ws?clientId={}".format(server_address, client_id))
 images = get_images(ws, prompt)
-
+ws.close() # for in case this example is used in an environment where it will be repeatedly called, like in a Gradio app. otherwise, you'll randomly receive connection timeouts
 #Commented out code to display the output images:
 
 # for node_id in images:


### PR DESCRIPTION
Within the examples scripts, it doesn't really do anything since they are one-shot scripts that end on completion, but if people build and expand off the scripts by adding in a function like:
```python
def get_prompt_images(prompt):
    global preview_image #for storing latent previews
    ws = websocket.WebSocket()
    ws.connect("ws://{}/ws?clientId={}".format(server_address, client_id), timeout=5,)
    images = get_images(ws, prompt)
    outputs = []
    for node_id in images:
        for image_data in images[node_id]:
            image = Image.open(io.BytesIO(image_data))
            outputs.append(image)
    ws.close()
    return outputs
```
Then it's necessary to include the `ws.close()` since this function will get called mutliple times and because each time it's called, a new random `str(uuid.uuid4())` will be called. If they aren't closed each time, then ComfyUI will probably think it still has a ton of open connections to clients or something and eventually it causes timeouts. Adding this fixes it and it won't harm the websocket examples by being there.

I also plan on mocking up a simple stripped down Gradio example, that also includes latent previews, but I'll add it as a new script example.