### PR TITLE
High quality Stable Cascade Stage C previews via previewer.safetensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ To use a textual inversion concepts/embeddings in a text prompt put them in the 
 
 Use ```--preview-method auto``` to enable previews.
 
-The default installation includes a fast latent preview method that's low-resolution. To enable higher-quality previews with [TAESD](https://github.com/madebyollin/taesd), download the [taesd_decoder.pth, taesdxl_decoder.pth, taesd3_decoder.pth and taef1_decoder.pth](https://github.com/madebyollin/taesd/) and place them in the `models/vae_approx` folder. Once they're installed, restart ComfyUI and launch it with `--preview-method taesd` to enable high-quality previews.
+The default installation includes a fast latent preview method that's low-resolution. To enable higher-quality previews with [TAESD](https://github.com/madebyollin/taesd) or the Stable Cascade previewer, download [taesd_decoder.pth, taesdxl_decoder.pth, taesd3_decoder.pth and taef1_decoder.pth](https://github.com/madebyollin/taesd/) and/or [previewer.safetensors](https://huggingface.co/stabilityai/stable-cascade/resolve/main/previewer.safetensors) and place them in the `models/vae_approx` folder. Once they're installed, restart ComfyUI and launch it with `--preview-method taesd` to enable high-quality previews.
 
 ## How to use TLS/SSL?
 Generate a self-signed certificate (not appropriate for shared/production use) and key by running the command: `openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname"`

--- a/comfy/latent_formats.py
+++ b/comfy/latent_formats.py
@@ -95,6 +95,7 @@ class SC_Prior(LatentFormat):
             [ 0.0542,  0.1545,  0.1325],
             [-0.0352, -0.1672, -0.2541]
         ]
+    taesd_decoder_name = "previewer.safetensors"
 
 class SC_B(LatentFormat):
     def __init__(self):


### PR DESCRIPTION
This enables higher-quality previews for Stable Cascade.

It seems to be reasonably fast, too; during my testing speed drops from about 4.2 it/s to ~4 it/s, and you can actually see what it's generating unlike the pixely mess that the latent2rgb method provides.

I don't really like that the previewer filename is used to detect which method to use, but it fits with what the code is currently doing anyway.

The mini-decoder preview method option should probably be generalized somehow rather than calling it "taesd" 