### PR TITLE
Flux torch compile fix

### DIFF
--- a/comfy/ldm/flux/model.py
+++ b/comfy/ldm/flux/model.py
@@ -151,8 +151,8 @@ class Flux(nn.Module):
         h_len = ((h + (patch_size // 2)) // patch_size)
         w_len = ((w + (patch_size // 2)) // patch_size)
         img_ids = torch.zeros((h_len, w_len, 3), device=x.device, dtype=x.dtype)
-        img_ids[..., 1] = img_ids[..., 1] + torch.linspace(0, h_len - 1, steps=h_len, device=x.device, dtype=x.dtype)[:, None]
-        img_ids[..., 2] = img_ids[..., 2] + torch.linspace(0, w_len - 1, steps=w_len, device=x.device, dtype=x.dtype)[None, :]
+        img_ids[:, :, 1] = torch.linspace(0, h_len - 1, steps=h_len, device=x.device, dtype=x.dtype).unsqueeze(1)
+        img_ids[:, :, 2] = torch.linspace(0, w_len - 1, steps=w_len, device=x.device, dtype=x.dtype).unsqueeze(0)
         img_ids = repeat(img_ids, "h w c -> b (h w) c", b=bs)
 
         txt_ids = torch.zeros((bs, context.shape[1], 3), device=x.device, dtype=x.dtype)


### PR DESCRIPTION
This fixes torch.compile with GGUF on flux1. (Also might fix bf16 but I can't test on volta). Based on a quick test the results are 1:1.
Ref: https://github.com/city96/ComfyUI-GGUF/issues/118

- Changed `[...]` to `[:, :]` since we know how many dimensions `img_ids` has.
- Removed the addition since `img_ids` is zeros anyway
- Changed `[None]` to unsqueeze
