### PR TITLE
Frontend Manager: avoid redundant gh calls for static versions

### DIFF
--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -168,6 +168,7 @@ class FrontendManager:
             Path(cls.CUSTOM_FRONTENDS_ROOT) / provider.folder_name / semantic_version
         )
         if not os.path.exists(web_root):
+            # Use tmp path until complete to avoid path exists check passing from interrupted downloads
             tmp_path = web_root + ".tmp"
             try:
                 os.makedirs(tmp_path, exist_ok=True)

--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -151,6 +151,15 @@ class FrontendManager:
             return cls.DEFAULT_FRONTEND_PATH
 
         repo_owner, repo_name, version = cls.parse_version_string(version_string)
+
+        if version.startswith("v"):
+            expected_path = str(Path(cls.CUSTOM_FRONTENDS_ROOT) / f"{repo_owner}_{repo_name}" / version.lstrip("v"))
+            if os.path.exists(expected_path):
+                logging.info(f"Using existing copy of specific frontend version tag: {repo_owner}/{repo_name}@{version}")
+                return expected_path
+
+        logging.info(f"Initializing frontend: {repo_owner}/{repo_name}@{version}, requesting version details from GitHub...")
+
         provider = provider or FrontEndProvider(repo_owner, repo_name)
         release = provider.get_release(version)
 
@@ -159,16 +168,21 @@ class FrontendManager:
             Path(cls.CUSTOM_FRONTENDS_ROOT) / provider.folder_name / semantic_version
         )
         if not os.path.exists(web_root):
+            tmp_path = web_root + ".tmp"
+            if os.path.exists(tmp_path):
+                os.rmdir(tmp_path)
             try:
-                os.makedirs(web_root, exist_ok=True)
+                os.makedirs(tmp_path, exist_ok=True)
                 logging.info(
                     "Downloading frontend(%s) version(%s) to (%s)",
                     provider.folder_name,
                     semantic_version,
-                    web_root,
+                    tmp_path,
                 )
                 logging.debug(release)
-                download_release_asset_zip(release, destination_path=web_root)
+                download_release_asset_zip(release, destination_path=tmp_path)
+                if os.listdir(tmp_path):
+                    os.rename(tmp_path, web_root)
             finally:
                 # Clean up the directory if it is empty, i.e. the download failed
                 if not os.listdir(web_root):

--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -169,8 +169,6 @@ class FrontendManager:
         )
         if not os.path.exists(web_root):
             tmp_path = web_root + ".tmp"
-            if os.path.exists(tmp_path):
-                os.rmdir(tmp_path)
             try:
                 os.makedirs(tmp_path, exist_ok=True)
                 logging.info(


### PR DESCRIPTION
Reduces the risk of errors like this:
![image](https://github.com/user-attachments/assets/48ffd67c-23d0-4bcd-a15a-0c2fd0fc5137)

By avoiding makings call to github API if the frontend is already downloaded locally for a specific version anyway. Only not-yet-installed versions or `latest` still makes github API calls this way.
The check is a very simple - if you're not default, and have a version starting with "v", you want a specific frontend version, so we can just check that specific folder exists, and use it if so.

Prior to this PR, this type of error could potentially happen at any time when launching comfy, from either GitHub API limits like the user above saw, or from network connectivity issues, or etc.
The API limit error risk was increased by the fact that the existing code reads a list of all versions by making multiple API calls in sequence, ie it may eat more API calls that needed. There's potential for further improvement here by way of removing that full-list-read and replacing it with a direct single version check.
Note that a fresh install with an undownloaded specific version still needs to connect to github to load that version, so that users actual case is not necessarily cured other than by waiting for the api limit to drop.

Also reports a notice in logs when github calls are happening (feels weird that that was happening silently before now)

Also moves the download to a folder with a `.tmp` suffix until everything's extracted as otherwise you can CTRL+C the comfy window while it's downloading and get stuck in a state where comfyui thinks its has the frontend downloaded but it doesn't actually.