### PR TITLE
Remove trailing underscore after batch counter for save image output …

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1511,7 +1511,7 @@ class SaveImage:
                         metadata.add_text(x, json.dumps(extra_pnginfo[x]))
 
             filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
-            file = f"{filename_with_batch_num}_{counter:05}_.png"
+            file = f"{filename_with_batch_num}_{counter:05}.png"
             img.save(os.path.join(full_output_folder, file), pnginfo=metadata, compress_level=self.compress_level)
             results.append({
                 "filename": file,


### PR DESCRIPTION
…filename

Not sure if this underscore is somehow used for parsing the file extension at other places but hopefully not.