### PR TITLE
Add a try/catch to skip special file_name values instead of failing to load a node.

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -234,8 +234,12 @@ def recursive_search(directory: str, excluded_dir_names: list[str] | None=None) 
     for dirpath, subdirs, filenames in os.walk(directory, followlinks=True, topdown=True):
         subdirs[:] = [d for d in subdirs if d not in excluded_dir_names]
         for file_name in filenames:
-            relative_path = os.path.relpath(os.path.join(dirpath, file_name), directory)
-            result.append(relative_path)
+            try:
+                relative_path = os.path.relpath(os.path.join(dirpath, file_name), directory)
+                result.append(relative_path)
+            except:
+                logging.warning(f"Warning: Unable to access {file_name}. Skipping this file.")
+                continue
 
         for d in subdirs:
             path: str = os.path.join(dirpath, d)


### PR DESCRIPTION
This guy (points to self) managed to create a file called "nul"* in a windows checkpoints subdirectory. 

This caused all sorts of havoc with many nodes that needed the list of checkpoints when python tried to figure out the relative path to the file. So, might as well check for unexpected problems with computing the file paths here (esp. as this is already done for subdirectory paths in the code block after this one).

* Like CON and PRN, NUL is "special" and should not exist on a Windows filesystem. Supposedly it is not possible to create such a file. However, MINGW64 had no problem creating the file for me when I redirected to nul instead of /dev/null (which would have been correct for MINGW64).
