### PR TITLE
Increase maximum macOS version to 15.0.1 when forcing upcast attention

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -899,7 +899,7 @@ def force_upcast_attention_dtype():
     upcast = args.force_upcast_attention
     try:
         macos_version = tuple(int(n) for n in platform.mac_ver()[0].split("."))
-        if (14, 5) <= macos_version < (14, 7):  # black image bug on recent versions of MacOS
+        if (14, 5) <= macos_version <= (15, 0, 1):  # black image bug on recent versions of macOS
             upcast = True
     except:
         pass


### PR DESCRIPTION
As of the latest version of macOS (15.0.1), the `--force-upcast-attention` flag is required to fix a "black image" bug (#3521). Similar to #4548, this PR checks whether the macOS version is affected and automatically forces upcast attention.