### PR TITLE
Save output node ID in file metadata

### DIFF
--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -121,6 +121,7 @@ def insert_or_replace_vorbis_comment(flac_io, comment_dict):
 
 class SaveAudio:
     def __init__(self):
+        self.id: str
         self.output_dir = folder_paths.get_output_directory()
         self.type = "output"
         self.prefix_append = ""
@@ -151,6 +152,7 @@ class SaveAudio:
             if extra_pnginfo is not None:
                 for x in extra_pnginfo:
                     metadata[x] = json.dumps(extra_pnginfo[x])
+            metadata["output_node_id"] = self.id
 
         for (batch_number, waveform) in enumerate(audio["waveform"].cpu()):
             filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))

--- a/execution.py
+++ b/execution.py
@@ -287,6 +287,7 @@ def execute(server, dynprompt, caches, current_item, extra_data, executed, promp
             obj = caches.objects.get(unique_id)
             if obj is None:
                 obj = class_def()
+                obj.id = unique_id
                 caches.objects.set(unique_id, obj)
 
             if hasattr(obj, "check_lazy_status"):

--- a/nodes.py
+++ b/nodes.py
@@ -1472,6 +1472,7 @@ class KSamplerAdvanced:
 
 class SaveImage:
     def __init__(self):
+        self.id: str
         self.output_dir = folder_paths.get_output_directory()
         self.type = "output"
         self.prefix_append = ""
@@ -1512,6 +1513,7 @@ class SaveImage:
                 if extra_pnginfo is not None:
                     for x in extra_pnginfo:
                         metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+                metadata.add_text("output_node_id", self.id)
 
             filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
             file = f"{filename_with_batch_num}_{counter:05}_.png"


### PR DESCRIPTION
I'm working on solving a [feature request](https://github.com/Comfy-Org/ComfyUI_frontend/issues/497) that involves a small backend modification. In short, the goal is to display the dropped file in the node it was saved by.

To make this work I allow nodes to access their own unique id's and then modify `SaveImage`, `SaveAudio` to write it in metadata.

Related frontend PR: [link](https://github.com/Comfy-Org/ComfyUI_frontend/pull/1150), which depends on this PR to work.

Implementation details:
- nodes can access their unique IDs in the `id` field
- output nodes like `SaveImage`, `SaveAudio`, `Preview...` etc. utilize this to serialize ID in the metadata

For reviewers:
- Please confirm whether the ID I'm using in `execution.py` is correct as there were multiple IDs related to the node. Looks like they are all the same.