### PR TITLE
Ignore more network related errors during websocket communication.

### DIFF
--- a/server.py
+++ b/server.py
@@ -40,7 +40,7 @@ class BinaryEventTypes:
 async def send_socket_catch_exception(function, message):
     try:
         await function(message)
-    except (aiohttp.ClientError, aiohttp.ClientPayloadError, ConnectionResetError) as err:
+    except (aiohttp.ClientError, aiohttp.ClientPayloadError, ConnectionResetError, BrokenPipeError, ConnectionError) as err:
         logging.warning("send error: {}".format(err))
 
 def get_comfyui_version():


### PR DESCRIPTION
Intermittent network issues during Websocket communication should not crash ComfyUi main process.