### PR TITLE
RFC: Dynamic Typing

### DIFF
--- a/comfy_execution/graph.py
+++ b/comfy_execution/graph.py
@@ -1,4 +1,5 @@
 import nodes
+from typing import Set, Tuple, Dict, List
 
 from comfy_execution.graph_utils import is_link
 
@@ -15,6 +16,7 @@ class DynamicPrompt:
     def __init__(self, original_prompt):
         # The original prompt provided by the user
         self.original_prompt = original_prompt
+        self.node_definitions = DynamicNodeDefinitionCache(self)
         # Any extra pieces of the graph created during execution
         self.ephemeral_prompt = {}
         self.ephemeral_parents = {}
@@ -26,6 +28,9 @@ class DynamicPrompt:
         if node_id in self.original_prompt:
             return self.original_prompt[node_id]
         raise NodeNotFoundError(f"Node {node_id} not found")
+
+    def get_node_definition(self, node_id):
+        return self.node_definitions.get_node_definition(node_id)
 
     def has_node(self, node_id):
         return node_id in self.original_prompt or node_id in self.ephemeral_prompt
@@ -54,8 +59,188 @@ class DynamicPrompt:
     def get_original_prompt(self):
         return self.original_prompt
 
-def get_input_info(class_def, input_name):
-    valid_inputs = class_def.INPUT_TYPES()
+class DynamicNodeDefinitionCache:
+    def __init__(self, dynprompt: DynamicPrompt):
+        self.dynprompt = dynprompt
+        self.definitions = {}
+        self.inputs_from_output_slot = {}
+        self.inputs_from_output_node = {}
+
+    def get_node_definition(self, node_id):
+        if node_id not in self.definitions:
+            node = self.dynprompt.get_node(node_id)
+            if node is None:
+                return None
+            class_type = node["class_type"]
+            definition = node_class_info(class_type)
+            self.definitions[node_id] = definition
+        return self.definitions[node_id]
+
+    def get_constant_type(self, value):
+        if isinstance(value, (int, float)):
+            return "INT,FLOAT"
+        elif isinstance(value, str):
+            return "STRING"
+        elif isinstance(value, bool):
+            return "BOOL"
+        else:
+            return None
+
+    def get_input_output_types(self, node_id) -> Tuple[Dict[str, str], Dict[str, List[str]]]:
+        node = self.dynprompt.get_node(node_id)
+        input_types: Dict[str, str] = {}
+        for input_name, input_data in node["inputs"].items():
+            if is_link(input_data):
+                from_node_id, from_socket = input_data
+                if from_socket < len(self.definitions[from_node_id]["output_name"]):
+                    input_types[input_name] = self.definitions[from_node_id]["output"][from_socket]
+                else:
+                    input_types[input_name] = "*"
+            else:
+                constant_type = self.get_constant_type(input_data)
+                if constant_type is not None:
+                    input_types[input_name] = constant_type
+        output_types: Dict[str, List[str]] = {}
+        for index in range(len(self.definitions[node_id]["output_name"])):
+            output_name = self.definitions[node_id]["output_name"][index]
+            if (node_id, index) not in self.inputs_from_output_slot:
+                continue
+            for (to_node_id, to_input_name) in self.inputs_from_output_slot[(node_id, index)]:
+                if output_name not in output_types:
+                    output_types[output_name] = []
+                if to_input_name in self.definitions[to_node_id]["input"]["required"]:
+                    output_types[output_name].append(self.definitions[to_node_id]["input"]["required"][to_input_name][0])
+                elif to_input_name in self.definitions[to_node_id]["input"]["optional"]:
+                    output_types[output_name].append(self.definitions[to_node_id]["input"]["optional"][to_input_name][0])
+                else:
+                    output_types[output_name].append("*")
+        return input_types, output_types
+
+    def resolve_dynamic_definitions(self, node_id_set: Set[str]):
+        entangled = {}
+        # Pre-fill with class info. Also, build a lookup table for output nodes
+        for node_id in node_id_set:
+            node = self.dynprompt.get_node(node_id)
+            class_type = node["class_type"]
+            self.definitions[node_id] = node_class_info(class_type)
+            for input_name, input_data in node["inputs"].items():
+                if is_link(input_data):
+                    input_tuple = tuple(input_data)
+                    if input_tuple not in self.inputs_from_output_slot:
+                        self.inputs_from_output_slot[input_tuple] = []
+                    self.inputs_from_output_slot[input_tuple].append((node_id, input_name))
+                    if input_tuple[0] not in self.inputs_from_output_node:
+                        self.inputs_from_output_node[input_tuple[0]] = []
+                    self.inputs_from_output_node[input_tuple[0]].append((node_id, input_name))
+                    _, _, extra_info = get_input_info(self.definitions[node_id], input_name)
+                    if extra_info is not None and extra_info.get("entangleTypes", False):
+                        from_node_id = input_data[0]
+                        if node_id not in entangled:
+                            entangled[node_id] = []
+                        if from_node_id not in entangled:
+                            entangled[from_node_id] = []
+
+                        entangled[node_id].append((from_node_id, input_name))
+                        entangled[from_node_id].append((node_id, input_name))
+
+        # Evaluate node info
+        to_resolve = node_id_set.copy()
+        updated = {}
+        while len(to_resolve) > 0:
+            node_id = to_resolve.pop()
+            node = self.dynprompt.get_node(node_id)
+            class_type = node["class_type"]
+            class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
+            if hasattr(class_def, "resolve_dynamic_types"):
+                entangled_types = {}
+                for (entangled_id, entangled_name) in entangled.get(node_id, []):
+                    entangled_def = self.get_node_definition(entangled_id)
+                    if entangled_def is None:
+                        continue
+                    input_types = {}
+                    output_types = {}
+                    for input_category, input_list in entangled_def["input"].items():
+                        for input_name, input_info in input_list.items():
+                            if isinstance(input_info, tuple) or input_category != "hidden":
+                                input_types[input_name] = input_info[0]
+                    for i in range(len(entangled_def["output"])):
+                        output_name = entangled_def["output_name"][i]
+                        output_types[output_name] = entangled_def["output"][i]
+
+                    if entangled_name not in entangled_types:
+                        entangled_types[entangled_name] = []
+                    entangled_types[entangled_name].append({
+                        "node_id": entangled_id,
+                        "input_types": input_types,
+                        "output_types": output_types
+                    })
+
+                input_types, output_types = self.get_input_output_types(node_id)
+                dynamic_info = class_def.resolve_dynamic_types(
+                    input_types=input_types,
+                    output_types=output_types,
+                    entangled_types=entangled_types
+                )
+                old_info = self.definitions[node_id].copy()
+                self.definitions[node_id].update(dynamic_info)
+                updated[node_id] = self.definitions[node_id]
+                # We changed the info, so we potentially need to resolve adjacent and entangled nodes
+                if old_info != self.definitions[node_id]:
+                    for (entangled_node_id, _) in entangled.get(node_id, []):
+                        if entangled_node_id in node_id_set:
+                            to_resolve.add(entangled_node_id)
+                    for i in range(len(self.definitions[node_id]["output"])):
+                        for (output_node_id, _) in self.inputs_from_output_slot.get((node_id, i), []):
+                            if output_node_id in node_id_set:
+                                to_resolve.add(output_node_id)
+                    for _, input_data in node["inputs"].items():
+                        if is_link(input_data):
+                            if input_data[0] in node_id_set:
+                                to_resolve.add(input_data[0])
+                    for (to_node_id, _) in self.inputs_from_output_node.get(node_id, []):
+                        if to_node_id in node_id_set:
+                            to_resolve.add(to_node_id)
+                    # Because this run may have changed the number of outputs, we may need to run it again
+                    # in order to get those outputs passed as output_types.
+                    to_resolve.add(node_id)
+        return updated
+
+def node_class_info(node_class):
+    if node_class not in nodes.NODE_CLASS_MAPPINGS:
+        return None
+    obj_class = nodes.NODE_CLASS_MAPPINGS[node_class]
+    info = {}
+    info['input'] = obj_class.INPUT_TYPES()
+    info['input_order'] = {key: list(value.keys()) for (key, value) in obj_class.INPUT_TYPES().items()}
+    info['output'] = obj_class.RETURN_TYPES
+    info['output_is_list'] = obj_class.OUTPUT_IS_LIST if hasattr(obj_class, 'OUTPUT_IS_LIST') else [False] * len(obj_class.RETURN_TYPES)
+    info['output_name'] = obj_class.RETURN_NAMES if hasattr(obj_class, 'RETURN_NAMES') else info['output']
+    info['name'] = node_class
+    info['display_name'] = nodes.NODE_DISPLAY_NAME_MAPPINGS[node_class] if node_class in nodes.NODE_DISPLAY_NAME_MAPPINGS.keys() else node_class
+    info['description'] = obj_class.DESCRIPTION if hasattr(obj_class,'DESCRIPTION') else ''
+    info['python_module'] = getattr(obj_class, "RELATIVE_PYTHON_MODULE", "nodes")
+    info['category'] = 'sd'
+    if hasattr(obj_class, 'OUTPUT_NODE') and obj_class.OUTPUT_NODE == True:
+        info['output_node'] = True
+    else:
+        info['output_node'] = False
+
+    if hasattr(obj_class, 'CATEGORY'):
+        info['category'] = obj_class.CATEGORY
+
+    if hasattr(obj_class, 'OUTPUT_TOOLTIPS'):
+        info['output_tooltips'] = obj_class.OUTPUT_TOOLTIPS
+
+    if getattr(obj_class, "DEPRECATED", False):
+        info['deprecated'] = True
+    if getattr(obj_class, "EXPERIMENTAL", False):
+        info['experimental'] = True
+
+    return info
+
+
+def get_input_info(node_info, input_name):
+    valid_inputs = node_info["input"]
     input_info = None
     input_category = None
     if "required" in valid_inputs and input_name in valid_inputs["required"]:
@@ -84,9 +269,7 @@ class TopologicalSort:
         self.blocking = {} # Which nodes are blocked by this node
 
     def get_input_info(self, unique_id, input_name):
-        class_type = self.dynprompt.get_node(unique_id)["class_type"]
-        class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
-        return get_input_info(class_def, input_name)
+        return get_input_info(self.dynprompt.get_node_definition(unique_id), input_name)
 
     def make_input_strong_link(self, to_node_id, to_input):
         inputs = self.dynprompt.get_node(to_node_id)["inputs"]
@@ -197,11 +380,8 @@ class ExecutionList(TopologicalSort):
         # for a PreviewImage to display a result as soon as it can
         # Some other heuristics could probably be used here to improve the UX further.
         def is_output(node_id):
-            class_type = self.dynprompt.get_node(node_id)["class_type"]
-            class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
-            if hasattr(class_def, 'OUTPUT_NODE') and class_def.OUTPUT_NODE == True:
-                return True
-            return False
+            node_def = self.dynprompt.get_node_definition(node_id)
+            return node_def['output_node']
 
         for node_id in node_list:
             if is_output(node_id):

--- a/comfy_execution/node_utils.py
+++ b/comfy_execution/node_utils.py
@@ -1,0 +1,173 @@
+import re
+from typing import Optional, Tuple
+
+# This decorator can be used to enable a "template" syntax for types in a node.
+#
+# Dynamic Types
+# When specifying a type for an input or output, you can wrap an arbitrary string in angle brackets to indicate that it is dynamic. For example, the type "<FOO>" will be the equivalent of "*" (with the commonly used hacks) with the caveat that all inputs/outputs with the same template name ("FOO" in this case) must have the same type. Use multiple different template names if you want to allow types to differ. Note that this only applies within a single instance of a node -- different nodes can have different type resolutions
+#
+# Wrapping Types
+# Rather than using JUST a template type, you can also use a template type with a wrapping type. For example, if you have a node that takes two inputs with the types "<FOO>" and "Accumulation<FOO>" respectively, any output can be connected to the "<FOO>" input. Once that input has a value (let's say an IMAGE), the other input will resolve as well (to Accumulation<IMAGE> in this example).
+#
+# Variadic Inputs
+# Sometimes, you want a node to take a dynamic number of inputs. To do this, create an input value that has a name followed by a number sign and a string (e.g. "input#COUNT"). This will cause additional inputs to be added and removed as the user attaches to those sockets. The string after the '#' can be used to ensure that you have the same number of sockets for two different inputs. For example, having inputs named "image#FOO" and "mask#BAR" will allow the number of images and the number of masks to dynamically increase independently. Having inputs named "image#FOO" and "mask#FOO" will ensure that there are the same number of images as masks.
+#
+# Variadic Input - Same Type
+# If you want to have a variadic input with a dynamic type, you can combine the two. For example, if you have an input named "input#COUNT" with the type "<FOO>", you can attach multiple inputs to that socket. Once you attach a value to one of the inputs, all of the other inputs will resolve to the same type. This is useful for nodes that take a dynamic number of inputs of the same type.
+#
+# Variadic Input - Different Types
+# If you want to have a variadic input with a dynamic type, you can combine the two. For example, if you have an input named "input#COUNT" with the type "<FOO#COUNT>", each socket for the input can have a different type. (Internally, this is equivalent to making the type <FOO1> where 1 is the index of this input.)
+#
+# Restrictions
+# - All dynamic inputs must have `"forceInput": True` due to frontend reasons that will hopefully be resolved before merging.
+
+def TemplateTypeSupport():
+    def decorator(cls):
+        old_input_types = getattr(cls, "INPUT_TYPES")
+        def new_input_types(cls):
+            old_types = old_input_types()
+            new_types = {
+                "required": {},
+                "optional": {},
+                "hidden": old_types.get("hidden", {}),
+            }
+            for category in ["required", "optional"]:
+                if category not in old_types:
+                    continue
+                for key, value in old_types[category].items():
+                    new_types[category][replace_variadic_suffix(key, 1)] = (template_to_type(value[0]),) + value[1:]
+            return new_types
+        setattr(cls, "INPUT_TYPES", classmethod(new_input_types))
+        old_outputs = getattr(cls, "RETURN_TYPES")
+        setattr(cls, "RETURN_TYPES", tuple(template_to_type(x) for x in old_outputs))
+
+        def resolve_dynamic_types(cls, input_types, output_types, entangled_types):
+            original_inputs = old_input_types()
+
+            # Step 1 - Find all variadic groups and determine their maximum used index
+            variadic_group_map = {}
+            max_group_index = {}
+            for category in ["required", "optional"]:
+                for key, value in original_inputs.get(category, {}).items():
+                    root, group = determine_variadic_group(key)
+                    if root is not None and group is not None:
+                        variadic_group_map[root] = group
+            for type_map in [input_types, output_types]:
+                for key in type_map.keys():
+                    root, index = determine_variadic_suffix(key)
+                    if root is not None and index is not None:
+                        if root in variadic_group_map:
+                            group = variadic_group_map[root]
+                            max_group_index[group] = max(max_group_index.get(group, 0), index)
+
+            # Step 2 - Create variadic arguments
+            variadic_inputs = {
+                "required": {},
+                "optional": {},
+            }
+            for category in ["required", "optional"]:
+                for key, value in original_inputs.get(category, {}).items():
+                    root, group = determine_variadic_group(key)
+                    if root is None or group is None:
+                        # Copy it over as-is
+                        variadic_inputs[category][key] = value
+                    else:
+                        for i in range(1, max_group_index.get(group, 0) + 2):
+                            # Also replace any variadic suffixes in the type (for use with templates)
+                            input_type = value[0]
+                            if isinstance(input_type, str):
+                                input_type = replace_variadic_suffix(input_type, i)
+                            variadic_inputs[category][replace_variadic_suffix(key, i)] = (input_type,value[1])
+
+            # Step 3 - Resolve template arguments
+            resolved = {}
+            for category in ["required", "optional"]:
+                for key, value in variadic_inputs[category].items():
+                    if key in input_types:
+                        tkey, tvalue = determine_template_value(value[0], input_types[key])
+                        if tkey is not None and tvalue is not None:
+                            resolved[tkey] = type_intersection(resolved.get(tkey, "*"), tvalue)
+            for i in range(len(old_outputs)):
+                output_name = cls.RETURN_NAMES[i]
+                if output_name in output_types:
+                    for output_type in output_types[output_name]:
+                        tkey, tvalue = determine_template_value(old_outputs[i], output_type)
+                        if tkey is not None and tvalue is not None:
+                            resolved[tkey] = type_intersection(resolved.get(tkey, "*"), tvalue)
+
+            # Step 4 - Replace templates with resolved types
+            final_inputs = {
+                "required": {},
+                "optional": {},
+                "hidden": original_inputs.get("hidden", {}),
+            }
+            for category in ["required", "optional"]:
+                for key, value in variadic_inputs[category].items():
+                    final_inputs[category][key] = (template_to_type(value[0], resolved),) + value[1:]
+            outputs = (template_to_type(x, resolved) for x in old_outputs)
+            return {
+                "input": final_inputs,
+                "output": tuple(outputs),
+                "output_name": cls.RETURN_NAMES,
+                "dynamic_counts": max_group_index,
+            }
+        setattr(cls, "resolve_dynamic_types", classmethod(resolve_dynamic_types))
+        return cls
+    return decorator
+
+def type_intersection(a: str, b: str) -> str:
+    if a == "*":
+        return b
+    if b == "*":
+        return a
+    if a == b:
+        return a
+    aset = set(a.split(','))
+    bset = set(b.split(','))
+    intersection = aset.intersection(bset)
+    if len(intersection) == 0:
+        return "*"
+    return ",".join(intersection)
+
+naked_template_regex = re.compile(r"^<(.+)>$")
+qualified_template_regex = re.compile(r"^(.+)<(.+)>$")
+variadic_template_regex = re.compile(r"([^<]+)#([^>]+)")
+variadic_suffix_regex =   re.compile(r"([^<]+)(\d+)")
+
+empty_lookup = {}
+def template_to_type(template, key_lookup=empty_lookup):
+    templ_match = naked_template_regex.match(template)
+    if templ_match:
+        return key_lookup.get(templ_match.group(1), "*")
+    templ_match = qualified_template_regex.match(template)
+    if templ_match:
+        resolved = key_lookup.get(templ_match.group(2), "*")
+        return qualified_template_regex.sub(r"\1<%s>" % resolved, template)
+    return template
+
+# Returns the 'key' and 'value' of the template (if any)
+def determine_template_value(template: str, actual_type: str) -> Tuple[Optional[str], Optional[str]]:
+    templ_match = naked_template_regex.match(template)
+    if templ_match:
+        return templ_match.group(1), actual_type
+    templ_match = qualified_template_regex.match(template)
+    actual_match = qualified_template_regex.match(actual_type)
+    if templ_match and actual_match and templ_match.group(1) == actual_match.group(1):
+        return templ_match.group(2), actual_match.group(2)
+    return None, None
+
+def determine_variadic_group(template: str) -> Tuple[Optional[str], Optional[str]]:
+    variadic_match = variadic_template_regex.match(template)
+    if variadic_match:
+        return variadic_match.group(1), variadic_match.group(2)
+    return None, None
+
+def replace_variadic_suffix(template: str, index: int) -> str:
+    return variadic_template_regex.sub(lambda match: match.group(1) + str(index), template)
+
+def determine_variadic_suffix(template: str) -> Tuple[Optional[str], Optional[int]]:
+    variadic_match = variadic_suffix_regex.match(template)
+    if variadic_match:
+        return variadic_match.group(1), int(variadic_match.group(2))
+    return None, None
+


### PR DESCRIPTION
# RFC: Dynamic Typing
This Draft PR contains a proposal and initial implementation for adding official support for dynamic inputs/outputs to ComfyUI. This is intended to remove the UX barriers to adding "Loop", "Switch", and other nodes to the default ComfyUI.

https://github.com/user-attachments/assets/2404dd32-178b-4faf-a535-578164c8a329

## Functionality
The primary goal of this design is two-fold:
1. Dynamic Typing - Enable the enforcement of interrelated type constraints when using the equivalent of `"*"` inputs and outputs.
2. Variadic Inputs/Outputs - Officially support nodes with a variable number of inputs and outputs.

## Why current solutions aren't sufficient
### Use of `"*"` types
The most common solution to the lack of dynamic typing is to use `"*"` types. While this functions properly, the user experience is far from ideal. Once you're using a wildcard type, nothing is preventing you from connecting incompatible sockets. When you do make a mistake, the result is a Python error in some node (that may not even be the node where the issue occurred).

### Custom Frontend Extensions - Dynamic Types
While I haven't seen it done, a custom frontend extension can technically enforce its own type constraints in the UI. While this would work with a single custom node pack in isolation, the propagation of node types through multiple dynamically typed nodes would cause issues. If we're going to start including nodes (like While Loops) in the base ComfyUI, we need a system that allows different node packs to play well with each other.

### Custom Frontend Extensions - Variadic Inputs
Custom frontend extensions are frequently used (along with a `kwargs` argument) to allow for a dynamic number of inputs. The issue is that the backend knows nothing at all about these inputs. This means that any functionality that relies on input flags (like lazy evaluation) can't work with these inputs without terrifying hacks (like looking at the callstack to return different results from `INPUT_TYPES` depending on the caller).

# Design Goals
There were a couple goals going into this:
1. Make the common cases clean and easy to implement for node authors.
2. Make the less common (and more complicated cases -- like `End While` loops needing types that match the linked `Begin While` node) possible to implement.
3. Don't require the default frontend (or custom frontend extensions) for this functionality.
4. Use a syntax that allows front-ends (particularly the default front-end) to do type resolution in the 99% case without a round trip to the back-end. (Note - this is not yet implemented.)
5. Allow front-ends to gracefully fall back to letting the back-end perform type resolution in an efficient way (either because an alternative front-end hasn't implemented full type resolution or because there's a case the front-end can't handle).
6. Don't break existing nodes. If people want to keep using `"*"` types, they don't need to change anything.

I know that Goal 5 is going to be the most controversial due to the extra call to the back-end, but I believe that it's necessary if we don't want to end up with the ComfyUI back-end being tied inextricably to the default front-end.

# Architecture Overview
In order to accomplish the above goals, I've implemented this using a number of layers. The top layer is the easiest to use for custom node authors, but is also the least flexible. Custom nodes that require more complicated behavior can use the same API that the higher layers are built on top of.

## Layer 1 - Template Type Syntax
Template type syntax can be activated by using the `@TemplateTypeSupport` decorator imported from `confy_execution.node_utils`. The functionality it supports is:

1. Dynamic input/output types (e.g. `<T>`)
2. Wrapped input/output types (e.g. `ACCUMULATION<T>`)
3. Dynamic number of inputs with the same type
4. Dynamic number of inputs with different types

### Dynamic Types
When specifying a type for an input or output, you can wrap an arbitrary string in angle brackets to indicate that it is dynamic. For example, the type `<FOO>` will be the equivalent of `*` (with the commonly used hacks) with the caveat that all inputs/outputs with the same template name (`FOO` in this case) must have the same type. Use multiple different template names if you want to allow types to differ. Note that this only applies within a single instance of a node -- different nodes can have different type resolutions
```python
from comfy_execution.node_utils import TemplateTypeSupport

@TemplateTypeSupport()
class SimpleSwitch:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {
                "switch": ("BOOLEAN",),
                "on_false": ("<T>", {}),
                "on_true": ("<T>", {}),
            },
        }

    RETURN_TYPES = ("<T>",)
    RETURN_NAMES = ("result",)
    FUNCTION = "switch"

    CATEGORY = "Examples"

    def switch(self, switch, on_false = None, on_true = None):
        value = on_true if switch else on_false
        return (value,)
```

### Wrapped Types
Rather than using JUST a template type, you can also use a template type with a wrapping type. For example, if you have a node that takes two inputs with the types `<FOO>` and `ACCUMULATION<FOO>`, any output can be connected to the `<FOO>` input. Once that input has a value (let's say an `IMAGE`), the other input will resolve as well (to `ACCUMULATION<IMAGE>` in this example).

```python
@TemplateTypeSupport()
class AccumulateNode:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {
                "to_add": ("<T>", {}),
            },
            "optional": {
                "accumulation": ("ACCUMULATION<T>", {}),
            },
        }

    RETURN_TYPES = ("ACCUMULATION<T>",)
    RETURN_NAMES = ("accumulation",)
    FUNCTION = "accumulate"

    CATEGORY = "Examples"

    def accumulate(self, to_add, accumulation = None):
        if accumulation is None:
            value = [to_add]
        else:
            value = accumulation["accum"] + [to_add]
        return ({"accum": value},)
```

### Dynamic Input Count (Same Type)
Sometimes, you want a node to take a dynamic number of inputs. To do this, create an input value that has a name followed by a number sign and a string (e.g. `input#COUNT`). This will cause additional inputs to be added and removed as the user attaches to those sockets. The string after the '#' can be used to ensure that you have the same number of sockets for two different inputs. For example, having inputs named `image#FOO` and `mask#BAR` will allow the number of images and the number of masks to dynamically increase independently. Having inputs named `image#FOO` and `mask#FOO` will ensure that there are the same number of images as masks.

The current dynamic count can be accessed from the node definition.

```python
@TemplateTypeSupport()
class MakeListNode:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {},
            "optional": {
                "value#COUNT": ("<T>", {}),
            },
            "hidden": {
                "node_def": "NODE_DEFINITION",
            },
        }

    RETURN_TYPES = ("<T>",)
    RETURN_NAMES = ("list",)
    FUNCTION = "make_list"
    OUTPUT_IS_LIST = (True,)

    CATEGORY = "Examples"

    def make_list(self, node_def, **kwargs):
        result = []
        for i in range(node_def.get("dynamic_counts", {}).get("COUNT", 0)):
            if "value%d" % i in kwargs:
                result.append(kwargs["value%d" % i])
        return (result,)
```

### Dynamic Input Count (Different Types)
If you want to have a variadic input with a dynamic type, you can combine the syntax for the two. For example, if you have an input named `"input#COUNT"` with the type `"<FOO#COUNT>"`, each socket for the input can have a different type. (Internally, this is equivalent to making the type `<FOO1>` where 1 is the index of this input.)

```python
@TemplateTypeSupport()
class ConcatAsString:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {},
            "optional": {
                "value#COUNT": ("<T#COUNT>", {}),
            },
            "hidden": {
                "node_def": "NODE_DEFINITION",
            },
        }

    RETURN_TYPES = ("STRING",)
    RETURN_NAMES = ("string",)
    FUNCTION = "concat"

    CATEGORY = "Examples"

    def concat(self, node_def, **kwargs):
        inputs = []
        for i in range(node_def.get("dynamic_counts", {}).get("COUNT", 0)):
            if "value%d" % i in kwargs:
                inputs.append(kwargs["value%d" % i])
        return ("\n".join(str(obj) for obj in objects_list))
```

## Layer 2 - `resolve_dynamic_types`
Behind the scenes, Layer 1 (TemplateType syntax) is implemented using Layer 2. For the more complicated cases where TemplateType syntax is insufficient, custom nodes can use Layer 2 as well.

Layer 2 is used by defining a class function named `resolve_dynamic_types` on your node. This function can only make use of the following information when determining what inputs/outputs it should have:
1. What the types are of outputs which are connected to this node's inputs (contained in the `input_types` argument)
2. What the types are of inputs which are connected to this node's outputs (contained in the `output_types` argument)
3. The input/output types of a node which is "entangled" via a direct connection on a socket defined as `"entangleTypes": True`.

The return value of `resolve_dynamic_types` should be a dictionary in the form:
```python
return {
    "input": {
        # Same format as the return value of INPUT_TYPES
        "required": {}
    },
    "output": ("IMAGE", "MASK"),
    "output_name": ("My Image", "My Mask"),
}
```

### Example
Here's an example of a 'switch' node.

```python
from comfy_execution.node_utils import type_intersection
class SimpleSwitch:
    @classmethod
    def INPUT_TYPES(cls):
        return {
            "required": {
                "switch": ("BOOLEAN",),
                "on_false": ("*", {"forceInput": True}),
                "on_true": ("*", {"forceInput": True}),
            },
        }

    @classmethod
    def resolve_dynamic_types(cls, input_types, output_types, entangled_types):
        resolved_type = "*"
        if "on_false" in input_types:
            resolved_type = type_intersection(resolved_type, input_types["on_false"])
        if "on_true" in input_types:
            resolved_type = type_intersection(resolved_type, input_types["on_true"])
        if "result" in output_types:
            # Note that output_types contains a list of types since outputs can be connected
            # to multiple inputs.
            for output_type in output_types["result"]:
                resolved_type = type_intersection(resolved_type, output_type)

        return {
            "input": {
                # Same format as the return value of INPUT_TYPES
                "required": {
                    "switch": ("BOOLEAN",),
                    "on_false": (resolved_type, {"forceInput": True}),
                    "on_true": (resolved_type, {"forceInput": True}),
                },
            },
            "output": (resolved_type,),
            "output_name": ("result",),
        }

    RETURN_TYPES = ("*",)
    RETURN_NAMES = ("result",)
    FUNCTION = "switch"

    CATEGORY = "Examples"

    def switch(self, switch, on_false = None, on_true = None):
        value = on_true if switch else on_false
        return (value,)
```

Note - I don't currently try to handle "unstable" `resolve_dynamic_types` functions. While it would be relatively easy to cause unstable configurations to "fail", identifying the exact node responsible to give a useful error message would be a lot more difficult.

## Layer 3 (Internal) - Node Definitions
### Back-end
Internally to the ComfyUI back-end, I've turned the "node definition" (as returned from the `/object_info` endpoint) into a first-class object. Instead of directly calling `INPUT_TYPES` in multiple places, the execution engine makes use of a node definition that is calculated and cached at the beginning of execution (or as part of node expansion in the case of nodes that are created at runtime).

Theoretically, this could be extended in the future to making any other part of the node definition dynamic (e.g. whether it's an `OUTPUT_NODE`).

These node definitions are iteratively settled across the graph, with a maximum of `O(sockets)` iterations (though you'd have to try hard to actually approach that). The same function is used for both resolving types in response to `/resolve_dynamic_types` requests and prior to the beginning of execution, ensuring that the two are consistent.

### Front-end
The frontend now hits the `/resolve_dynamic_types` endpoint each time edges are created or removed from the graph. This call is non-blocking, but type changes and the addition/removal of inputs/outputs won't occur until it completes. My hope is that by implementing something like the TemplateType syntax on the default front-end, we can make 99% of these calls no-ops.

# Areas For Improvement
While my back-end changes are solid and could be code reviewed today, my front-end changes are hacky and would almost certainly need some attention from someone who has more experience with the front-end. While I'm posting this PR Draft now to start getting input, there are the following areas for improvement (mostly on the front-end):

1. Dynamic inputs currently require `"forceInput": True` as I'm not currently creating/destroying widgets as appropriate. This also means that Primitives nodes won't connect to them.
2. I added a `displayOrder` option for inputs. This is just intended to sort inputs on the front-end, but it doesn't seem to always work.
3. Improved error handling when a custom node defines an unstable `resolve_dynamic_types` function. (Right now, it'll just infinitely loop.)
4. Implementation of TemplateType syntax (or whatever syntax we land on) on the front-end to avoid the round trip time for most use-cases.
