### PR TITLE
Fix issue where using DisableNoise or disabling add_noise results in non-deterministic generations

### DIFF
--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -315,15 +315,6 @@ class SamplerDPMAdaptative:
                                                               "s_noise":s_noise })
         return (sampler, )
 
-class Noise_EmptyNoise:
-    def __init__(self):
-        self.seed = 0
-
-    def generate_noise(self, input_latent):
-        latent_image = input_latent["samples"]
-        return torch.zeros(latent_image.shape, dtype=latent_image.dtype, layout=latent_image.layout, device="cpu")
-
-
 class Noise_RandomNoise:
     def __init__(self, seed):
         self.seed = seed
@@ -360,7 +351,7 @@ class SamplerCustom:
         latent = latent_image
         latent_image = latent["samples"]
         if not add_noise:
-            noise = Noise_EmptyNoise().generate_noise(latent)
+            raise ValueError("add_noise must be enabled")
         else:
             noise = Noise_RandomNoise(noise_seed).generate_noise(latent)
 
@@ -480,7 +471,7 @@ class DisableNoise:
     CATEGORY = "sampling/custom_sampling/noise"
 
     def get_noise(self):
-        return (Noise_EmptyNoise(),)
+        raise RuntimeError("DisableNoise cannot be used")
 
 
 class RandomNoise(DisableNoise):

--- a/nodes.py
+++ b/nodes.py
@@ -1348,7 +1348,7 @@ class KSamplerAdvanced:
     def INPUT_TYPES(s):
         return {"required":
                     {"model": ("MODEL",),
-                    "add_noise": (["enable", "disable"], ),
+                    "add_noise": (["enable"], ),
                     "noise_seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
                     "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                     "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0, "step":0.1, "round": 0.01}),
@@ -1373,8 +1373,8 @@ class KSamplerAdvanced:
         if return_with_leftover_noise == "enable":
             force_full_denoise = False
         disable_noise = False
-        if add_noise == "disable":
-            disable_noise = True
+        if add_noise != "enable":
+            raise ValueError("add_noise must be enabled")
         return common_ksampler(model, noise_seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise=denoise, disable_noise=disable_noise, start_step=start_at_step, last_step=end_at_step, force_full_denoise=force_full_denoise)
 
 class SaveImage:


### PR DESCRIPTION
ComfyUI currently has a bug where disabling `add_noise` in samplers or using a `DisableNoise` node simply does not seed the RNG at all, resulting in non-deterministic generations. #4518 aims to fix that problem by actually seeding the RNG even when adding noise is disabled. this pull takes a slightly different approach: we throw an error when the user attempts to disable noise rather than proceeding anyway and erroneously ignoring the seed.

this pull could also be changed to simply remove the `DisableNoise` node and `add_noise` parameters but i thought it would be a bit more friendly to let people load existing workflows.

closes #2833 