### PR TITLE
Revert download to .tmp in frontend_management

### DIFF
--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -168,20 +168,16 @@ class FrontendManager:
             Path(cls.CUSTOM_FRONTENDS_ROOT) / provider.folder_name / semantic_version
         )
         if not os.path.exists(web_root):
-            # Use tmp path until complete to avoid path exists check passing from interrupted downloads
-            tmp_path = web_root + ".tmp"
             try:
-                os.makedirs(tmp_path, exist_ok=True)
+                os.makedirs(web_root, exist_ok=True)
                 logging.info(
                     "Downloading frontend(%s) version(%s) to (%s)",
                     provider.folder_name,
                     semantic_version,
-                    tmp_path,
+                    web_root,
                 )
                 logging.debug(release)
-                download_release_asset_zip(release, destination_path=tmp_path)
-                if os.listdir(tmp_path):
-                    os.rename(tmp_path, web_root)
+                download_release_asset_zip(release, destination_path=web_root)
             finally:
                 # Clean up the directory if it is empty, i.e. the download failed
                 if not os.listdir(web_root):


### PR DESCRIPTION
Partially revert https://github.com/comfyanonymous/ComfyUI/pull/5152

In electron build, the downloaded file ownership can be taken by the electron app, and cause rename to fail.

```
Device: cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync
[2024-10-25 17:14:15.902] [error] stderr: Using pytorch cross attention
[2024-10-25 17:14:17.258] [error] stderr: Initializing frontend: Comfy-Org/ComfyUI_frontend@latest, requesting version details from GitHub...
[2024-10-25 17:14:17.452] [error] stderr: Downloading frontend(Comfy-Org_ComfyUI_frontend) version(1.3.22) to (D:\electron\assets\ComfyUI\web_custom_versions\Comfy-Org_ComfyUI_frontend\1.3.22.tmp)
[2024-10-25 17:14:18.642] [error] stderr: Failed to initialize frontend: [WinError 3] The system cannot find the path specified: 'D:\\electron\\assets\\ComfyUI\\web_custom_versions\\Comfy-Org_ComfyUI_frontend\\1.3.22'
Falling back to the default frontend.
[2024-10-25 17:14:18.643] [error] stderr: [Prompt Server] web root: D:\electron\assets\ComfyUI\web
```

Overall we probably don't want to introduce an extra step that can easily fail to prevent something that is more rare to fail.