### PR TITLE
Rename `ImageCrop` to `Image Crop`

### DIFF
--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -187,7 +187,7 @@ class SaveAnimatedPNG:
         return { "ui": { "images": results, "animated": (True,)} }
 
 NODE_CLASS_MAPPINGS = {
-    "ImageCrop": ImageCrop,
+    "Image Crop": ImageCrop,
     "RepeatImageBatch": RepeatImageBatch,
     "ImageFromBatch": ImageFromBatch,
     "SaveAnimatedWEBP": SaveAnimatedWEBP,

--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -187,7 +187,7 @@ class SaveAnimatedPNG:
         return { "ui": { "images": results, "animated": (True,)} }
 
 NODE_CLASS_MAPPINGS = {
-    "Image Crop": ImageCrop,
+    "ImageCrop": ImageCrop,
     "RepeatImageBatch": RepeatImageBatch,
     "ImageFromBatch": ImageFromBatch,
     "SaveAnimatedWEBP": SaveAnimatedWEBP,

--- a/nodes.py
+++ b/nodes.py
@@ -1957,6 +1957,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ImageInvert": "Invert Image",
     "ImagePadForOutpaint": "Pad Image for Outpainting",
     "ImageBatch": "Batch Images",
+    "ImageCrop": "Image Crop",
     # _for_testing
     "VAEDecodeTiled": "VAE Decode (Tiled)",
     "VAEEncodeTiled": "VAE Encode (Tiled)",


### PR DESCRIPTION
Feedback
-
Nodes menu has inconsistency in names, some with spaces between words, other not. i made some minor changes on our local installations (students project). This is something important for the next releases. The actual menu push developers to add their category into the top level, what is not the best option for the users to search for a specific category, if the category exists into various levels.

also, it must be considered that developers would have a guided structure to include their custom nodes packages into existing categories (until the node requires a new one) for consistency and easy search.

Mockup
-
By re-arranging the main node menu, we give to developers a way to inlude their custom nodes in a practical manner.

![menu_comfy_review](https://github.com/user-attachments/assets/22d2809c-be18-4bd5-b4f5-ab273ebaf59b)

Pull request & future development
-
this first pull is about the Image Crop node, to give an overview on my next requests. if accepted, i will work make a complete proposal for this menu. i want to contribute to this project as a developer, mainly because my students are giving me a lot of user feedbacks and i believe it can serve the purpose of the community.
if you want to check my profil: https://www.linkedin.com/in/urieldeveaud/
thank you
