### PR TITLE
Update nodes.py so VAEDecode falls back to a tiled method if GPU runs out of memory

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -280,11 +280,14 @@ class VAEDecode:
     CATEGORY = "latent"
     DESCRIPTION = "Decodes latent images back into pixel space images."
 
-    def decode(self, vae, samples):
-        images = vae.decode(samples["samples"])
-        if len(images.shape) == 5: #Combine batches
-            images = images.reshape(-1, images.shape[-3], images.shape[-2], images.shape[-1])
-        return (images, )
+    def decode(self, vae, samples, tile_size=512):
+        try:
+            images = vae.decode(samples["samples"])
+            if len(images.shape) == 5: #Combine batches
+                images = images.reshape(-1, images.shape[-3], images.shape[-2], images.shape[-1])
+            return (images, )
+        except (MemoryError, RuntimeError) as e:
+            return (vae.decode_tiled(samples["samples"], tile_x=tile_size // 8, tile_y=tile_size // 8, ), )
 
 class VAEDecodeTiled:
     @classmethod


### PR DESCRIPTION
## Issue

As the title suggests, if the GPU runs out of VRAM during a VAEDecode event, then the entire queued prompt fails. With as many enhancements as ComfyUI has received over the last months, it is all but certain that this failure should no longer exist.

## Solution
I have introduced a small change to the VAEDecode node so that it will fallback to a tiled decode process should the GPU run out of memory.

## How to test
Run a sufficiently large image generation on a GPU with 8GB of VRAM or less. VAEDecode node will fail due to lack of GPU memory, especially on an AMD GPU that does not support rocm.

## Potential side effects or concerns
The VAEDecode node has changed significantly to include batches, which is fine, however the tiled decoding method does not include such support. There is a possibility that the tiled method may fail here. I haven't been able to find any instances where it would fail with simple image generations. In these cases, it may be that the user is simply trying to do too much and should instead switch to a device that has a GPU with more VRAM.