### PR TITLE
Allow POST `/userdata/{file}` endpoint to return full file info

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -234,6 +234,8 @@ class UserManager():
             - file: The target file path (URL encoded if necessary).
 
             Returns:
+            - 400: If 'file' parameter is missing.
+            - 403: If the requested path is not allowed.
             - 409: If overwrite=false and the file already exists.
             - 200: JSON response with either:
                   - Full file information (if full_info=true)

--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -22,7 +22,7 @@ class FileInfo(TypedDict):
 
 def get_file_info(path: str, relative_to: str) -> FileInfo:
     return {
-        "path": os.path.relpath(path, relative_to),
+        "path": os.path.relpath(path, relative_to).replace(os.sep, '/'),
         "size": os.path.getsize(path),
         "modified": os.path.getmtime(path)
     }
@@ -178,11 +178,10 @@ class UserManager():
                 pattern = os.path.join(glob.escape(path), '*')
 
             def process_full_path(full_path: str) -> FileInfo | str | list[str]:
-                full_path = full_path.replace(os.sep, '/')
                 if full_info:
                     return get_file_info(full_path, path)
 
-                rel_path = os.path.relpath(full_path, path)
+                rel_path = os.path.relpath(full_path, path).replace(os.sep, '/')
                 if split_path:
                     return [rel_path] + rel_path.split('/')
 

--- a/tests-unit/prompt_server_test/user_manager_test.py
+++ b/tests-unit/prompt_server_test/user_manager_test.py
@@ -14,7 +14,7 @@ def user_manager(tmp_path):
     um = UserManager()
     um.get_request_user_filepath = lambda req, file, **kwargs: os.path.join(
         tmp_path, file
-    )
+    ) if file else tmp_path
     return um
 
 


### PR DESCRIPTION
This PR makes POST `/userdata/{file}` and POST `/userdata/{file}/move/{dest}` accept an extra optional param `full_info` so that the updated full file info (size and last modified timestamp) is returned to the caller. Without the param, the return value would be the file path string.

This can save the frontend an extra GET `/userdata` call to update the size and last modified info.