### PR TITLE
add load 3d node support

### DIFF
--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -1,0 +1,116 @@
+import nodes
+import folder_paths
+import os
+
+def normalize_path(path):
+    return path.replace('\\', '/')
+
+class Load3D():
+    @classmethod
+    def INPUT_TYPES(s):
+        input_dir = os.path.join(folder_paths.get_input_directory(), "3d")
+
+        os.makedirs(input_dir, exist_ok=True)
+
+        files = [normalize_path(os.path.join("3d", f)) for f in os.listdir(input_dir) if f.endswith(('.gltf', '.glb', '.obj', '.mtl', '.fbx', '.stl'))]
+
+        return {"required": {
+            "model_file": (sorted(files), {"file_upload": True}),
+            "image": ("LOAD_3D", {}),
+            "width": ("INT", {"default": 1024, "min": 1, "max": 4096, "step": 1}),
+            "height": ("INT", {"default": 1024, "min": 1, "max": 4096, "step": 1}),
+            "show_grid": ([True, False],),
+            "camera_type": (["perspective", "orthographic"],),
+            "view": (["front", "right", "top", "isometric"],),
+            "material": (["original", "normal", "wireframe", "depth"],),
+            "bg_color": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFF, "step": 1, "display": "color"}),
+            "light_intensity": ("INT", {"default": 10, "min": 1, "max": 20, "step": 1}),
+            "up_direction": (["original", "-x", "+x", "-y", "+y", "-z", "+z"],),
+        }}
+
+    RETURN_TYPES = ("IMAGE", "MASK", "STRING")
+    RETURN_NAMES = ("image", "mask", "mesh_path")
+
+    FUNCTION = "process"
+
+    CATEGORY = "3d"
+
+    def process(self, model_file, image, **kwargs):
+        imagepath = folder_paths.get_annotated_filepath(image)
+
+        load_image_node = nodes.LoadImage()
+
+        output_image, output_mask = load_image_node.load_image(image=imagepath)
+
+        return output_image, output_mask, model_file,
+
+class Load3DAnimation():
+    @classmethod
+    def INPUT_TYPES(s):
+        input_dir = os.path.join(folder_paths.get_input_directory(), "3d")
+
+        os.makedirs(input_dir, exist_ok=True)
+
+        files = [normalize_path(os.path.join("3d", f)) for f in os.listdir(input_dir) if f.endswith(('.gltf', '.glb', '.fbx'))]
+
+        return {"required": {
+            "model_file": (sorted(files), {"file_upload": True}),
+            "image": ("LOAD_3D_ANIMATION", {}),
+            "width": ("INT", {"default": 1024, "min": 1, "max": 4096, "step": 1}),
+            "height": ("INT", {"default": 1024, "min": 1, "max": 4096, "step": 1}),
+            "show_grid": ([True, False],),
+            "camera_type": (["perspective", "orthographic"],),
+            "view": (["front", "right", "top", "isometric"],),
+            "material": (["original", "normal", "wireframe", "depth"],),
+            "bg_color": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFF, "step": 1, "display": "color"}),
+            "light_intensity": ("INT", {"default": 10, "min": 1, "max": 20, "step": 1}),
+            "up_direction": (["original", "-x", "+x", "-y", "+y", "-z", "+z"],),
+            "animation_speed": (["0.1", "0.5", "1", "1.5", "2"], {"default": "1"}),
+        }}
+
+    RETURN_TYPES = ("IMAGE", "MASK", "STRING")
+    RETURN_NAMES = ("image", "mask", "mesh_path")
+
+    FUNCTION = "process"
+
+    CATEGORY = "3d"
+
+    def process(self, model_file, image, **kwargs):
+        imagepath = folder_paths.get_annotated_filepath(image)
+
+        load_image_node = nodes.LoadImage()
+
+        output_image, output_mask = load_image_node.load_image(image=imagepath)
+
+        return output_image, output_mask, model_file,
+
+class Preview3D():
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {
+            "model_file": ("STRING", {"default": "", "multiline": False}),
+            "image": ("PREVIEW_3D", {}),
+            "show_grid": ([True, False],),
+            "camera_type": (["perspective", "orthographic"],),
+            "view": (["front", "right", "top", "isometric"],),
+            "material": (["original", "normal", "wireframe", "depth"],),
+            "bg_color": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFF, "step": 1, "display": "color"}),
+            "light_intensity": ("INT", {"default": 10, "min": 1, "max": 20, "step": 1}),
+            "up_direction": (["original", "-x", "+x", "-y", "+y", "-z", "+z"],),
+        }}
+
+    RETURN_TYPES = ()
+
+    CATEGORY = "3d"
+
+NODE_CLASS_MAPPINGS = {
+    "Load3D": Load3D,
+    "Load3DAnimation": Load3DAnimation,
+    "Preview3D": Preview3D
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "Load3D": "Load 3D",
+    "Load3DAnimation": "Load 3D - Animation",
+    "Preview3D": "Preview 3D"
+}

--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -84,33 +84,12 @@ class Load3DAnimation():
 
         return output_image, output_mask, model_file,
 
-class Preview3D():
-    @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {
-            "model_file": ("STRING", {"default": "", "multiline": False}),
-            "image": ("PREVIEW_3D", {}),
-            "show_grid": ([True, False],),
-            "camera_type": (["perspective", "orthographic"],),
-            "view": (["front", "right", "top", "isometric"],),
-            "material": (["original", "normal", "wireframe", "depth"],),
-            "bg_color": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFF, "step": 1, "display": "color"}),
-            "light_intensity": ("INT", {"default": 10, "min": 1, "max": 20, "step": 1}),
-            "up_direction": (["original", "-x", "+x", "-y", "+y", "-z", "+z"],),
-        }}
-
-    RETURN_TYPES = ()
-
-    CATEGORY = "3d"
-
 NODE_CLASS_MAPPINGS = {
     "Load3D": Load3D,
-    "Load3DAnimation": Load3DAnimation,
-    "Preview3D": Preview3D
+    "Load3DAnimation": Load3DAnimation
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "Load3D": "Load 3D",
-    "Load3DAnimation": "Load 3D - Animation",
-    "Preview3D": "Preview 3D"
+    "Load3DAnimation": "Load 3D - Animation"
 }

--- a/nodes.py
+++ b/nodes.py
@@ -2149,6 +2149,7 @@ def init_builtin_extra_nodes():
         "nodes_slg.py",
         "nodes_lt.py",
         "nodes_hooks.py",
+        "nodes_load_3d.py",
     ]
 
     import_failed = []


### PR DESCRIPTION
Hi,
I implment a node to load local 3d models, here is FE change:
https://github.com/Comfy-Org/ComfyUI_frontend/pull/1563

which needs this BE changes.

here are the introduction video as your reference:
1. basic load feature

https://github.com/user-attachments/assets/f9f1a7f4-5bd2-4a96-b9d7-681b2d7f68f3

3. showGrid, cameraType, View

https://github.com/user-attachments/assets/3c539495-6a35-49eb-84fc-14d5dd8c55c4

5. material, lightIntensity

https://github.com/user-attachments/assets/dbc4dd0b-d387-4ec0-b276-5e966ccc6794

7. fbx and animation

https://github.com/user-attachments/assets/a615f99a-7555-477c-beb4-d1d885bf093b

9. up-direction

https://github.com/user-attachments/assets/40e9f61a-91cf-4e7a-8b62-e3dd1a59e9d5

11. multi-models (video file is too big)
12. supported-formats (video file is too big)
13. preview-3d-node

https://github.com/user-attachments/assets/ec69325a-78ea-43b6-beaf-acc568f37505