### PR TITLE
Automatically detect and set zero terminal SNR

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -682,6 +682,12 @@ def load_state_dict_guess_config(sd, output_vae=True, output_clip=True, output_c
 
     if output_model:
         model_patcher = comfy.model_patcher.ModelPatcher(model, load_device=load_device, offload_device=model_management.unet_offload_device())
+        if model_config.ztsnr:
+            class ModelSamplingAdvanced(comfy.model_sampling.ModelSamplingDiscrete, comfy.model_sampling.V_PREDICTION):
+                pass
+            model_sampling = ModelSamplingAdvanced(model.model_config)
+            model_sampling.set_sigmas(comfy.utils.rescale_zero_terminal_snr_sigmas(model_sampling.sigmas))
+            model_patcher.add_object_patch("model_sampling", model_sampling)
         if inital_load_device != torch.device("cpu"):
             logging.info("loaded straight to GPU")
             model_management.load_models_gpu([model_patcher], force_full_load=True)

--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -197,6 +197,8 @@ class SDXL(supported_models_base.BASE):
                 self.sampling_settings["sigma_min"] = float(state_dict["edm_vpred.sigma_min"].item())
             return model_base.ModelType.V_PREDICTION_EDM
         elif "v_pred" in state_dict:
+            if "ztsnr" in state_dict:
+                self.ztsnr = True
             return model_base.ModelType.V_PREDICTION
         else:
             return model_base.ModelType.EPS

--- a/comfy/supported_models_base.py
+++ b/comfy/supported_models_base.py
@@ -40,6 +40,7 @@ class BASE:
     clip_vision_prefix = None
     noise_aug_config = None
     sampling_settings = {}
+    ztsnr = False
     latent_format = latent_formats.LatentFormat
     vae_key_prefix = ["first_stage_model."]
     text_encoder_key_prefix = ["cond_stage_model."]


### PR DESCRIPTION
Adds support for models that contain a `ztsnr` key (and `v_pred` key) in the state_dict to automatically enable this feature.
Example model: https://civitai.com/models/833294?modelVersionId=1046043

Open for suggestions on how to better accomplish this, but I wanted to at least have a starting point to make this known.