### PR TITLE
fix --cuda-device arg for AMD/HIP devices

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,7 +70,9 @@ if os.name == "nt":
 
 if __name__ == "__main__":
     if args.cuda_device is not None:
+        if 
         os.environ['CUDA_VISIBLE_DEVICES'] = str(args.cuda_device)
+        os.environ['HIP_VISIBLE_DEVICES'] = str(args.cuda_device)
         logging.info("Set cuda device to: {}".format(args.cuda_device))
 
     if args.deterministic:

--- a/main.py
+++ b/main.py
@@ -70,7 +70,6 @@ if os.name == "nt":
 
 if __name__ == "__main__":
     if args.cuda_device is not None:
-        if 
         os.environ['CUDA_VISIBLE_DEVICES'] = str(args.cuda_device)
         os.environ['HIP_VISIBLE_DEVICES'] = str(args.cuda_device)
         logging.info("Set cuda device to: {}".format(args.cuda_device))


### PR DESCRIPTION
concerning #5585
CUDA_VISIBLE_DEVICES is ignored for HIP devices/backend. Instead it uses HIP_VISIBLE_DEVICES. Setting this environment variable has no side effect for CUDA/NVIDIA so it can safely be set in any case and vice versa.