### PR TITLE
Add TPU/XLA devices support for ComfyUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,25 @@ You can install ComfyUI in Apple Mac silicon (M1 or M2) with any recent macOS ve
 
 ```pip install torch-directml``` Then you can launch ComfyUI with: ```python main.py --directml```
 
+#### TPU/XLA Devices
+Users with TPU/XLA devices can install the PyTorch XLA stable build with the following command:
+
+```pip install torch~=2.5.0 torch_xla[tpu]~=2.5.0 -f https://storage.googleapis.com/libtpu-releases/index.html```
+
+This is the command to install the nightly 2.6.0 which might have some performance improvements:
+
+```
+pip3 install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+pip install 'torch_xla[tpu] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0.dev-cp310-cp310-linux_x86_64.whl' -f https://storage.googleapis.com/libtpu-releases/index.html
+```
+
+<!-- tell them to install tpu-info if memory info is needed -->
+To get memory info for TPU devices, install the [tpu-info](https://github.com/AI-Hypercomputer/cloud-accelerator-diagnostics/tree/main/tpu_info) package with the following command:
+
+```pip install tpu-info```
+
+
+
 # Running
 
 ```python main.py```

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ pip3 install --pre torch torchvision --index-url https://download.pytorch.org/wh
 pip install 'torch_xla[tpu] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0.dev-cp310-cp310-linux_x86_64.whl' -f https://storage.googleapis.com/libtpu-releases/index.html
 ```
 
-<!-- tell them to install tpu-info if memory info is needed -->
+
 To get memory info for TPU devices, install the [tpu-info](https://github.com/AI-Hypercomputer/cloud-accelerator-diagnostics/tree/main/tpu_info) package with the following command:
 
 ```pip install tpu-info```

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -9,6 +9,7 @@ class EnumAction(argparse.Action):
     """
     Argparse action for handling Enums
     """
+
     def __init__(self, **kwargs):
         # Pop off the type value
         enum_type = kwargs.pop("type", None)
@@ -36,53 +37,170 @@ class EnumAction(argparse.Action):
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("--listen", type=str, default="127.0.0.1", metavar="IP", nargs="?", const="0.0.0.0,::", help="Specify the IP address to listen on (default: 127.0.0.1). You can give a list of ip addresses by separating them with a comma like: 127.2.2.2,127.3.3.3 If --listen is provided without an argument, it defaults to 0.0.0.0,:: (listens on all ipv4 and ipv6)")
+parser.add_argument(
+    "--listen",
+    type=str,
+    default="127.0.0.1",
+    metavar="IP",
+    nargs="?",
+    const="0.0.0.0,::",
+    help="Specify the IP address to listen on (default: 127.0.0.1). You can give a list of ip addresses by separating them with a comma like: 127.2.2.2,127.3.3.3 If --listen is provided without an argument, it defaults to 0.0.0.0,:: (listens on all ipv4 and ipv6)",
+)
 parser.add_argument("--port", type=int, default=8188, help="Set the listen port.")
-parser.add_argument("--tls-keyfile", type=str, help="Path to TLS (SSL) key file. Enables TLS, makes app accessible at https://... requires --tls-certfile to function")
-parser.add_argument("--tls-certfile", type=str, help="Path to TLS (SSL) certificate file. Enables TLS, makes app accessible at https://... requires --tls-keyfile to function")
-parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
-parser.add_argument("--max-upload-size", type=float, default=100, help="Set the maximum upload size in MB.")
+parser.add_argument(
+    "--tls-keyfile",
+    type=str,
+    help="Path to TLS (SSL) key file. Enables TLS, makes app accessible at https://... requires --tls-certfile to function",
+)
+parser.add_argument(
+    "--tls-certfile",
+    type=str,
+    help="Path to TLS (SSL) certificate file. Enables TLS, makes app accessible at https://... requires --tls-keyfile to function",
+)
+parser.add_argument(
+    "--enable-cors-header",
+    type=str,
+    default=None,
+    metavar="ORIGIN",
+    nargs="?",
+    const="*",
+    help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.",
+)
+parser.add_argument(
+    "--max-upload-size",
+    type=float,
+    default=100,
+    help="Set the maximum upload size in MB.",
+)
 
-parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
-parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory.")
-parser.add_argument("--temp-directory", type=str, default=None, help="Set the ComfyUI temp directory (default is in the ComfyUI directory).")
-parser.add_argument("--input-directory", type=str, default=None, help="Set the ComfyUI input directory.")
-parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")
-parser.add_argument("--disable-auto-launch", action="store_true", help="Disable auto launching the browser.")
-parser.add_argument("--cuda-device", type=int, default=None, metavar="DEVICE_ID", help="Set the id of the cuda device this instance will use.")
+parser.add_argument(
+    "--extra-model-paths-config",
+    type=str,
+    default=None,
+    metavar="PATH",
+    nargs="+",
+    action="append",
+    help="Load one or more extra_model_paths.yaml files.",
+)
+parser.add_argument(
+    "--output-directory",
+    type=str,
+    default=None,
+    help="Set the ComfyUI output directory.",
+)
+parser.add_argument(
+    "--temp-directory",
+    type=str,
+    default=None,
+    help="Set the ComfyUI temp directory (default is in the ComfyUI directory).",
+)
+parser.add_argument(
+    "--input-directory", type=str, default=None, help="Set the ComfyUI input directory."
+)
+parser.add_argument(
+    "--auto-launch",
+    action="store_true",
+    help="Automatically launch ComfyUI in the default browser.",
+)
+parser.add_argument(
+    "--disable-auto-launch",
+    action="store_true",
+    help="Disable auto launching the browser.",
+)
+parser.add_argument(
+    "--cuda-device",
+    type=int,
+    default=None,
+    metavar="DEVICE_ID",
+    help="Set the id of the cuda device this instance will use.",
+)
 cm_group = parser.add_mutually_exclusive_group()
-cm_group.add_argument("--cuda-malloc", action="store_true", help="Enable cudaMallocAsync (enabled by default for torch 2.0 and up).")
-cm_group.add_argument("--disable-cuda-malloc", action="store_true", help="Disable cudaMallocAsync.")
+cm_group.add_argument(
+    "--cuda-malloc",
+    action="store_true",
+    help="Enable cudaMallocAsync (enabled by default for torch 2.0 and up).",
+)
+cm_group.add_argument(
+    "--disable-cuda-malloc", action="store_true", help="Disable cudaMallocAsync."
+)
 
 
 fp_group = parser.add_mutually_exclusive_group()
-fp_group.add_argument("--force-fp32", action="store_true", help="Force fp32 (If this makes your GPU work better please report it).")
+fp_group.add_argument(
+    "--force-fp32",
+    action="store_true",
+    help="Force fp32 (If this makes your GPU work better please report it).",
+)
 fp_group.add_argument("--force-fp16", action="store_true", help="Force fp16.")
 
 fpunet_group = parser.add_mutually_exclusive_group()
-fpunet_group.add_argument("--bf16-unet", action="store_true", help="Run the UNET in bf16. This should only be used for testing stuff.")
-fpunet_group.add_argument("--fp16-unet", action="store_true", help="Store unet weights in fp16.")
-fpunet_group.add_argument("--fp8_e4m3fn-unet", action="store_true", help="Store unet weights in fp8_e4m3fn.")
-fpunet_group.add_argument("--fp8_e5m2-unet", action="store_true", help="Store unet weights in fp8_e5m2.")
+fpunet_group.add_argument(
+    "--bf16-unet",
+    action="store_true",
+    help="Run the UNET in bf16. This should only be used for testing stuff.",
+)
+fpunet_group.add_argument(
+    "--fp16-unet", action="store_true", help="Store unet weights in fp16."
+)
+fpunet_group.add_argument(
+    "--fp8_e4m3fn-unet", action="store_true", help="Store unet weights in fp8_e4m3fn."
+)
+fpunet_group.add_argument(
+    "--fp8_e5m2-unet", action="store_true", help="Store unet weights in fp8_e5m2."
+)
 
 fpvae_group = parser.add_mutually_exclusive_group()
-fpvae_group.add_argument("--fp16-vae", action="store_true", help="Run the VAE in fp16, might cause black images.")
-fpvae_group.add_argument("--fp32-vae", action="store_true", help="Run the VAE in full precision fp32.")
+fpvae_group.add_argument(
+    "--fp16-vae",
+    action="store_true",
+    help="Run the VAE in fp16, might cause black images.",
+)
+fpvae_group.add_argument(
+    "--fp32-vae", action="store_true", help="Run the VAE in full precision fp32."
+)
 fpvae_group.add_argument("--bf16-vae", action="store_true", help="Run the VAE in bf16.")
 
 parser.add_argument("--cpu-vae", action="store_true", help="Run the VAE on the CPU.")
 
 fpte_group = parser.add_mutually_exclusive_group()
-fpte_group.add_argument("--fp8_e4m3fn-text-enc", action="store_true", help="Store text encoder weights in fp8 (e4m3fn variant).")
-fpte_group.add_argument("--fp8_e5m2-text-enc", action="store_true", help="Store text encoder weights in fp8 (e5m2 variant).")
-fpte_group.add_argument("--fp16-text-enc", action="store_true", help="Store text encoder weights in fp16.")
-fpte_group.add_argument("--fp32-text-enc", action="store_true", help="Store text encoder weights in fp32.")
+fpte_group.add_argument(
+    "--fp8_e4m3fn-text-enc",
+    action="store_true",
+    help="Store text encoder weights in fp8 (e4m3fn variant).",
+)
+fpte_group.add_argument(
+    "--fp8_e5m2-text-enc",
+    action="store_true",
+    help="Store text encoder weights in fp8 (e5m2 variant).",
+)
+fpte_group.add_argument(
+    "--fp16-text-enc", action="store_true", help="Store text encoder weights in fp16."
+)
+fpte_group.add_argument(
+    "--fp32-text-enc", action="store_true", help="Store text encoder weights in fp32."
+)
 
-parser.add_argument("--force-channels-last", action="store_true", help="Force channels last format when inferencing the models.")
+parser.add_argument(
+    "--force-channels-last",
+    action="store_true",
+    help="Force channels last format when inferencing the models.",
+)
 
-parser.add_argument("--directml", type=int, nargs="?", metavar="DIRECTML_DEVICE", const=-1, help="Use torch-directml.")
+parser.add_argument(
+    "--directml",
+    type=int,
+    nargs="?",
+    metavar="DIRECTML_DEVICE",
+    const=-1,
+    help="Use torch-directml.",
+)
 
-parser.add_argument("--disable-ipex-optimize", action="store_true", help="Disables ipex.optimize when loading models with Intel GPUs.")
+parser.add_argument(
+    "--disable-ipex-optimize",
+    action="store_true",
+    help="Disables ipex.optimize when loading models with Intel GPUs.",
+)
+
 
 class LatentPreviewMethod(enum.Enum):
     NoPreviews = "none"
@@ -90,56 +208,164 @@ class LatentPreviewMethod(enum.Enum):
     Latent2RGB = "latent2rgb"
     TAESD = "taesd"
 
-parser.add_argument("--preview-method", type=LatentPreviewMethod, default=LatentPreviewMethod.NoPreviews, help="Default preview method for sampler nodes.", action=EnumAction)
 
-parser.add_argument("--preview-size", type=int, default=512, help="Sets the maximum preview size for sampler nodes.")
+parser.add_argument(
+    "--preview-method",
+    type=LatentPreviewMethod,
+    default=LatentPreviewMethod.NoPreviews,
+    help="Default preview method for sampler nodes.",
+    action=EnumAction,
+)
+
+parser.add_argument(
+    "--preview-size",
+    type=int,
+    default=512,
+    help="Sets the maximum preview size for sampler nodes.",
+)
 
 cache_group = parser.add_mutually_exclusive_group()
-cache_group.add_argument("--cache-classic", action="store_true", help="Use the old style (aggressive) caching.")
-cache_group.add_argument("--cache-lru", type=int, default=0, help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.")
+cache_group.add_argument(
+    "--cache-classic",
+    action="store_true",
+    help="Use the old style (aggressive) caching.",
+)
+cache_group.add_argument(
+    "--cache-lru",
+    type=int,
+    default=0,
+    help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.",
+)
 
 attn_group = parser.add_mutually_exclusive_group()
-attn_group.add_argument("--use-split-cross-attention", action="store_true", help="Use the split cross attention optimization. Ignored when xformers is used.")
-attn_group.add_argument("--use-quad-cross-attention", action="store_true", help="Use the sub-quadratic cross attention optimization . Ignored when xformers is used.")
-attn_group.add_argument("--use-pytorch-cross-attention", action="store_true", help="Use the new pytorch 2.0 cross attention function.")
+attn_group.add_argument(
+    "--use-split-cross-attention",
+    action="store_true",
+    help="Use the split cross attention optimization. Ignored when xformers is used.",
+)
+attn_group.add_argument(
+    "--use-quad-cross-attention",
+    action="store_true",
+    help="Use the sub-quadratic cross attention optimization . Ignored when xformers is used.",
+)
+attn_group.add_argument(
+    "--use-pytorch-cross-attention",
+    action="store_true",
+    help="Use the new pytorch 2.0 cross attention function.",
+)
 
 parser.add_argument("--disable-xformers", action="store_true", help="Disable xformers.")
 
 upcast = parser.add_mutually_exclusive_group()
-upcast.add_argument("--force-upcast-attention", action="store_true", help="Force enable attention upcasting, please report if it fixes black images.")
-upcast.add_argument("--dont-upcast-attention", action="store_true", help="Disable all upcasting of attention. Should be unnecessary except for debugging.")
+upcast.add_argument(
+    "--force-upcast-attention",
+    action="store_true",
+    help="Force enable attention upcasting, please report if it fixes black images.",
+)
+upcast.add_argument(
+    "--dont-upcast-attention",
+    action="store_true",
+    help="Disable all upcasting of attention. Should be unnecessary except for debugging.",
+)
 
 
 vram_group = parser.add_mutually_exclusive_group()
-vram_group.add_argument("--gpu-only", action="store_true", help="Store and run everything (text encoders/CLIP models, etc... on the GPU).")
-vram_group.add_argument("--highvram", action="store_true", help="By default models will be unloaded to CPU memory after being used. This option keeps them in GPU memory.")
-vram_group.add_argument("--normalvram", action="store_true", help="Used to force normal vram use if lowvram gets automatically enabled.")
-vram_group.add_argument("--lowvram", action="store_true", help="Split the unet in parts to use less vram.")
-vram_group.add_argument("--novram", action="store_true", help="When lowvram isn't enough.")
-vram_group.add_argument("--cpu", action="store_true", help="To use the CPU for everything (slow).")
+vram_group.add_argument(
+    "--gpu-only",
+    action="store_true",
+    help="Store and run everything (text encoders/CLIP models, etc... on the GPU).",
+)
+vram_group.add_argument(
+    "--highvram",
+    action="store_true",
+    help="By default models will be unloaded to CPU memory after being used. This option keeps them in GPU memory.",
+)
+vram_group.add_argument(
+    "--normalvram",
+    action="store_true",
+    help="Used to force normal vram use if lowvram gets automatically enabled.",
+)
+vram_group.add_argument(
+    "--lowvram", action="store_true", help="Split the unet in parts to use less vram."
+)
+vram_group.add_argument(
+    "--novram", action="store_true", help="When lowvram isn't enough."
+)
+vram_group.add_argument(
+    "--cpu", action="store_true", help="To use the CPU for everything (slow)."
+)
 
-parser.add_argument("--reserve-vram", type=float, default=None, help="Set the amount of vram in GB you want to reserve for use by your OS/other software. By default some amount is reverved depending on your OS.")
+parser.add_argument(
+    "--reserve-vram",
+    type=float,
+    default=None,
+    help="Set the amount of vram in GB you want to reserve for use by your OS/other software. By default some amount is reverved depending on your OS.",
+)
 
 
-parser.add_argument("--default-hashing-function", type=str, choices=['md5', 'sha1', 'sha256', 'sha512'], default='sha256', help="Allows you to choose the hash function to use for duplicate filename / contents comparison. Default is sha256.")
+parser.add_argument(
+    "--default-hashing-function",
+    type=str,
+    choices=["md5", "sha1", "sha256", "sha512"],
+    default="sha256",
+    help="Allows you to choose the hash function to use for duplicate filename / contents comparison. Default is sha256.",
+)
 
-parser.add_argument("--disable-smart-memory", action="store_true", help="Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.")
-parser.add_argument("--deterministic", action="store_true", help="Make pytorch use slower deterministic algorithms when it can. Note that this might not make images deterministic in all cases.")
-parser.add_argument("--fast", action="store_true", help="Enable some untested and potentially quality deteriorating optimizations.")
+parser.add_argument(
+    "--disable-smart-memory",
+    action="store_true",
+    help="Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.",
+)
+parser.add_argument(
+    "--deterministic",
+    action="store_true",
+    help="Make pytorch use slower deterministic algorithms when it can. Note that this might not make images deterministic in all cases.",
+)
+parser.add_argument(
+    "--fast",
+    action="store_true",
+    help="Enable some untested and potentially quality deteriorating optimizations.",
+)
 
-parser.add_argument("--dont-print-server", action="store_true", help="Don't print server output.")
-parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test for CI.")
-parser.add_argument("--windows-standalone-build", action="store_true", help="Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup).")
+parser.add_argument(
+    "--dont-print-server", action="store_true", help="Don't print server output."
+)
+parser.add_argument(
+    "--quick-test-for-ci", action="store_true", help="Quick test for CI."
+)
+parser.add_argument(
+    "--windows-standalone-build",
+    action="store_true",
+    help="Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup).",
+)
 
-parser.add_argument("--disable-metadata", action="store_true", help="Disable saving prompt metadata in files.")
-parser.add_argument("--disable-all-custom-nodes", action="store_true", help="Disable loading all custom nodes.")
+parser.add_argument(
+    "--disable-metadata",
+    action="store_true",
+    help="Disable saving prompt metadata in files.",
+)
+parser.add_argument(
+    "--disable-all-custom-nodes",
+    action="store_true",
+    help="Disable loading all custom nodes.",
+)
 
-parser.add_argument("--multi-user", action="store_true", help="Enables per-user storage.")
+parser.add_argument(
+    "--multi-user", action="store_true", help="Enables per-user storage."
+)
 
-parser.add_argument("--verbose", default='INFO', const='DEBUG', nargs="?", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], help='Set the logging level')
+parser.add_argument(
+    "--verbose",
+    default="INFO",
+    const="DEBUG",
+    nargs="?",
+    choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    help="Set the logging level",
+)
 
-parser.add_argument("--xla", action="store_true", help="To use the XLA devices for everything.")
-# parser.add_argument("--xla_fsdp", action="store_true", help="To use the XLA devices with FSDP for everything.")
+parser.add_argument(
+    "--xla", action="store_true", help="To use the XLA devices for everything."
+)
 
 # The default built-in provider hosted under web/
 DEFAULT_VERSION_STRING = "comfyanonymous/ComfyUI@latest"
@@ -158,6 +384,7 @@ parser.add_argument(
     """,
 )
 
+
 def is_valid_directory(path: Optional[str]) -> Optional[str]:
     """Validate if the given path is a directory."""
     if path is None:
@@ -167,6 +394,7 @@ def is_valid_directory(path: Optional[str]) -> Optional[str]:
         raise argparse.ArgumentTypeError(f"{path} is not a valid directory.")
     return path
 
+
 parser.add_argument(
     "--front-end-root",
     type=is_valid_directory,
@@ -174,7 +402,12 @@ parser.add_argument(
     help="The local filesystem path to the directory where the frontend is located. Overrides --front-end-version.",
 )
 
-parser.add_argument("--user-directory", type=is_valid_directory, default=None, help="Set the ComfyUI user directory with an absolute path.")
+parser.add_argument(
+    "--user-directory",
+    type=is_valid_directory,
+    default=None,
+    help="Set the ComfyUI user directory with an absolute path.",
+)
 
 if comfy.options.args_parsing:
     args = parser.parse_args()

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -9,7 +9,6 @@ class EnumAction(argparse.Action):
     """
     Argparse action for handling Enums
     """
-
     def __init__(self, **kwargs):
         # Pop off the type value
         enum_type = kwargs.pop("type", None)
@@ -37,170 +36,53 @@ class EnumAction(argparse.Action):
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument(
-    "--listen",
-    type=str,
-    default="127.0.0.1",
-    metavar="IP",
-    nargs="?",
-    const="0.0.0.0,::",
-    help="Specify the IP address to listen on (default: 127.0.0.1). You can give a list of ip addresses by separating them with a comma like: 127.2.2.2,127.3.3.3 If --listen is provided without an argument, it defaults to 0.0.0.0,:: (listens on all ipv4 and ipv6)",
-)
+parser.add_argument("--listen", type=str, default="127.0.0.1", metavar="IP", nargs="?", const="0.0.0.0,::", help="Specify the IP address to listen on (default: 127.0.0.1). You can give a list of ip addresses by separating them with a comma like: 127.2.2.2,127.3.3.3 If --listen is provided without an argument, it defaults to 0.0.0.0,:: (listens on all ipv4 and ipv6)")
 parser.add_argument("--port", type=int, default=8188, help="Set the listen port.")
-parser.add_argument(
-    "--tls-keyfile",
-    type=str,
-    help="Path to TLS (SSL) key file. Enables TLS, makes app accessible at https://... requires --tls-certfile to function",
-)
-parser.add_argument(
-    "--tls-certfile",
-    type=str,
-    help="Path to TLS (SSL) certificate file. Enables TLS, makes app accessible at https://... requires --tls-keyfile to function",
-)
-parser.add_argument(
-    "--enable-cors-header",
-    type=str,
-    default=None,
-    metavar="ORIGIN",
-    nargs="?",
-    const="*",
-    help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.",
-)
-parser.add_argument(
-    "--max-upload-size",
-    type=float,
-    default=100,
-    help="Set the maximum upload size in MB.",
-)
+parser.add_argument("--tls-keyfile", type=str, help="Path to TLS (SSL) key file. Enables TLS, makes app accessible at https://... requires --tls-certfile to function")
+parser.add_argument("--tls-certfile", type=str, help="Path to TLS (SSL) certificate file. Enables TLS, makes app accessible at https://... requires --tls-keyfile to function")
+parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
+parser.add_argument("--max-upload-size", type=float, default=100, help="Set the maximum upload size in MB.")
 
-parser.add_argument(
-    "--extra-model-paths-config",
-    type=str,
-    default=None,
-    metavar="PATH",
-    nargs="+",
-    action="append",
-    help="Load one or more extra_model_paths.yaml files.",
-)
-parser.add_argument(
-    "--output-directory",
-    type=str,
-    default=None,
-    help="Set the ComfyUI output directory.",
-)
-parser.add_argument(
-    "--temp-directory",
-    type=str,
-    default=None,
-    help="Set the ComfyUI temp directory (default is in the ComfyUI directory).",
-)
-parser.add_argument(
-    "--input-directory", type=str, default=None, help="Set the ComfyUI input directory."
-)
-parser.add_argument(
-    "--auto-launch",
-    action="store_true",
-    help="Automatically launch ComfyUI in the default browser.",
-)
-parser.add_argument(
-    "--disable-auto-launch",
-    action="store_true",
-    help="Disable auto launching the browser.",
-)
-parser.add_argument(
-    "--cuda-device",
-    type=int,
-    default=None,
-    metavar="DEVICE_ID",
-    help="Set the id of the cuda device this instance will use.",
-)
+parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
+parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory.")
+parser.add_argument("--temp-directory", type=str, default=None, help="Set the ComfyUI temp directory (default is in the ComfyUI directory).")
+parser.add_argument("--input-directory", type=str, default=None, help="Set the ComfyUI input directory.")
+parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")
+parser.add_argument("--disable-auto-launch", action="store_true", help="Disable auto launching the browser.")
+parser.add_argument("--cuda-device", type=int, default=None, metavar="DEVICE_ID", help="Set the id of the cuda device this instance will use.")
 cm_group = parser.add_mutually_exclusive_group()
-cm_group.add_argument(
-    "--cuda-malloc",
-    action="store_true",
-    help="Enable cudaMallocAsync (enabled by default for torch 2.0 and up).",
-)
-cm_group.add_argument(
-    "--disable-cuda-malloc", action="store_true", help="Disable cudaMallocAsync."
-)
+cm_group.add_argument("--cuda-malloc", action="store_true", help="Enable cudaMallocAsync (enabled by default for torch 2.0 and up).")
+cm_group.add_argument("--disable-cuda-malloc", action="store_true", help="Disable cudaMallocAsync.")
 
 
 fp_group = parser.add_mutually_exclusive_group()
-fp_group.add_argument(
-    "--force-fp32",
-    action="store_true",
-    help="Force fp32 (If this makes your GPU work better please report it).",
-)
+fp_group.add_argument("--force-fp32", action="store_true", help="Force fp32 (If this makes your GPU work better please report it).")
 fp_group.add_argument("--force-fp16", action="store_true", help="Force fp16.")
 
 fpunet_group = parser.add_mutually_exclusive_group()
-fpunet_group.add_argument(
-    "--bf16-unet",
-    action="store_true",
-    help="Run the UNET in bf16. This should only be used for testing stuff.",
-)
-fpunet_group.add_argument(
-    "--fp16-unet", action="store_true", help="Store unet weights in fp16."
-)
-fpunet_group.add_argument(
-    "--fp8_e4m3fn-unet", action="store_true", help="Store unet weights in fp8_e4m3fn."
-)
-fpunet_group.add_argument(
-    "--fp8_e5m2-unet", action="store_true", help="Store unet weights in fp8_e5m2."
-)
+fpunet_group.add_argument("--bf16-unet", action="store_true", help="Run the UNET in bf16. This should only be used for testing stuff.")
+fpunet_group.add_argument("--fp16-unet", action="store_true", help="Store unet weights in fp16.")
+fpunet_group.add_argument("--fp8_e4m3fn-unet", action="store_true", help="Store unet weights in fp8_e4m3fn.")
+fpunet_group.add_argument("--fp8_e5m2-unet", action="store_true", help="Store unet weights in fp8_e5m2.")
 
 fpvae_group = parser.add_mutually_exclusive_group()
-fpvae_group.add_argument(
-    "--fp16-vae",
-    action="store_true",
-    help="Run the VAE in fp16, might cause black images.",
-)
-fpvae_group.add_argument(
-    "--fp32-vae", action="store_true", help="Run the VAE in full precision fp32."
-)
+fpvae_group.add_argument("--fp16-vae", action="store_true", help="Run the VAE in fp16, might cause black images.")
+fpvae_group.add_argument("--fp32-vae", action="store_true", help="Run the VAE in full precision fp32.")
 fpvae_group.add_argument("--bf16-vae", action="store_true", help="Run the VAE in bf16.")
 
 parser.add_argument("--cpu-vae", action="store_true", help="Run the VAE on the CPU.")
 
 fpte_group = parser.add_mutually_exclusive_group()
-fpte_group.add_argument(
-    "--fp8_e4m3fn-text-enc",
-    action="store_true",
-    help="Store text encoder weights in fp8 (e4m3fn variant).",
-)
-fpte_group.add_argument(
-    "--fp8_e5m2-text-enc",
-    action="store_true",
-    help="Store text encoder weights in fp8 (e5m2 variant).",
-)
-fpte_group.add_argument(
-    "--fp16-text-enc", action="store_true", help="Store text encoder weights in fp16."
-)
-fpte_group.add_argument(
-    "--fp32-text-enc", action="store_true", help="Store text encoder weights in fp32."
-)
+fpte_group.add_argument("--fp8_e4m3fn-text-enc", action="store_true", help="Store text encoder weights in fp8 (e4m3fn variant).")
+fpte_group.add_argument("--fp8_e5m2-text-enc", action="store_true", help="Store text encoder weights in fp8 (e5m2 variant).")
+fpte_group.add_argument("--fp16-text-enc", action="store_true", help="Store text encoder weights in fp16.")
+fpte_group.add_argument("--fp32-text-enc", action="store_true", help="Store text encoder weights in fp32.")
 
-parser.add_argument(
-    "--force-channels-last",
-    action="store_true",
-    help="Force channels last format when inferencing the models.",
-)
+parser.add_argument("--force-channels-last", action="store_true", help="Force channels last format when inferencing the models.")
 
-parser.add_argument(
-    "--directml",
-    type=int,
-    nargs="?",
-    metavar="DIRECTML_DEVICE",
-    const=-1,
-    help="Use torch-directml.",
-)
+parser.add_argument("--directml", type=int, nargs="?", metavar="DIRECTML_DEVICE", const=-1, help="Use torch-directml.")
 
-parser.add_argument(
-    "--disable-ipex-optimize",
-    action="store_true",
-    help="Disables ipex.optimize when loading models with Intel GPUs.",
-)
-
+parser.add_argument("--disable-ipex-optimize", action="store_true", help="Disables ipex.optimize when loading models with Intel GPUs.")
 
 class LatentPreviewMethod(enum.Enum):
     NoPreviews = "none"
@@ -208,164 +90,56 @@ class LatentPreviewMethod(enum.Enum):
     Latent2RGB = "latent2rgb"
     TAESD = "taesd"
 
+parser.add_argument("--preview-method", type=LatentPreviewMethod, default=LatentPreviewMethod.NoPreviews, help="Default preview method for sampler nodes.", action=EnumAction)
 
-parser.add_argument(
-    "--preview-method",
-    type=LatentPreviewMethod,
-    default=LatentPreviewMethod.NoPreviews,
-    help="Default preview method for sampler nodes.",
-    action=EnumAction,
-)
-
-parser.add_argument(
-    "--preview-size",
-    type=int,
-    default=512,
-    help="Sets the maximum preview size for sampler nodes.",
-)
+parser.add_argument("--preview-size", type=int, default=512, help="Sets the maximum preview size for sampler nodes.")
 
 cache_group = parser.add_mutually_exclusive_group()
-cache_group.add_argument(
-    "--cache-classic",
-    action="store_true",
-    help="Use the old style (aggressive) caching.",
-)
-cache_group.add_argument(
-    "--cache-lru",
-    type=int,
-    default=0,
-    help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.",
-)
+cache_group.add_argument("--cache-classic", action="store_true", help="Use the old style (aggressive) caching.")
+cache_group.add_argument("--cache-lru", type=int, default=0, help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.")
 
 attn_group = parser.add_mutually_exclusive_group()
-attn_group.add_argument(
-    "--use-split-cross-attention",
-    action="store_true",
-    help="Use the split cross attention optimization. Ignored when xformers is used.",
-)
-attn_group.add_argument(
-    "--use-quad-cross-attention",
-    action="store_true",
-    help="Use the sub-quadratic cross attention optimization . Ignored when xformers is used.",
-)
-attn_group.add_argument(
-    "--use-pytorch-cross-attention",
-    action="store_true",
-    help="Use the new pytorch 2.0 cross attention function.",
-)
+attn_group.add_argument("--use-split-cross-attention", action="store_true", help="Use the split cross attention optimization. Ignored when xformers is used.")
+attn_group.add_argument("--use-quad-cross-attention", action="store_true", help="Use the sub-quadratic cross attention optimization . Ignored when xformers is used.")
+attn_group.add_argument("--use-pytorch-cross-attention", action="store_true", help="Use the new pytorch 2.0 cross attention function.")
 
 parser.add_argument("--disable-xformers", action="store_true", help="Disable xformers.")
 
 upcast = parser.add_mutually_exclusive_group()
-upcast.add_argument(
-    "--force-upcast-attention",
-    action="store_true",
-    help="Force enable attention upcasting, please report if it fixes black images.",
-)
-upcast.add_argument(
-    "--dont-upcast-attention",
-    action="store_true",
-    help="Disable all upcasting of attention. Should be unnecessary except for debugging.",
-)
+upcast.add_argument("--force-upcast-attention", action="store_true", help="Force enable attention upcasting, please report if it fixes black images.")
+upcast.add_argument("--dont-upcast-attention", action="store_true", help="Disable all upcasting of attention. Should be unnecessary except for debugging.")
 
 
 vram_group = parser.add_mutually_exclusive_group()
-vram_group.add_argument(
-    "--gpu-only",
-    action="store_true",
-    help="Store and run everything (text encoders/CLIP models, etc... on the GPU).",
-)
-vram_group.add_argument(
-    "--highvram",
-    action="store_true",
-    help="By default models will be unloaded to CPU memory after being used. This option keeps them in GPU memory.",
-)
-vram_group.add_argument(
-    "--normalvram",
-    action="store_true",
-    help="Used to force normal vram use if lowvram gets automatically enabled.",
-)
-vram_group.add_argument(
-    "--lowvram", action="store_true", help="Split the unet in parts to use less vram."
-)
-vram_group.add_argument(
-    "--novram", action="store_true", help="When lowvram isn't enough."
-)
-vram_group.add_argument(
-    "--cpu", action="store_true", help="To use the CPU for everything (slow)."
-)
+vram_group.add_argument("--gpu-only", action="store_true", help="Store and run everything (text encoders/CLIP models, etc... on the GPU).")
+vram_group.add_argument("--highvram", action="store_true", help="By default models will be unloaded to CPU memory after being used. This option keeps them in GPU memory.")
+vram_group.add_argument("--normalvram", action="store_true", help="Used to force normal vram use if lowvram gets automatically enabled.")
+vram_group.add_argument("--lowvram", action="store_true", help="Split the unet in parts to use less vram.")
+vram_group.add_argument("--novram", action="store_true", help="When lowvram isn't enough.")
+vram_group.add_argument("--cpu", action="store_true", help="To use the CPU for everything (slow).")
 
-parser.add_argument(
-    "--reserve-vram",
-    type=float,
-    default=None,
-    help="Set the amount of vram in GB you want to reserve for use by your OS/other software. By default some amount is reverved depending on your OS.",
-)
+parser.add_argument("--reserve-vram", type=float, default=None, help="Set the amount of vram in GB you want to reserve for use by your OS/other software. By default some amount is reverved depending on your OS.")
 
 
-parser.add_argument(
-    "--default-hashing-function",
-    type=str,
-    choices=["md5", "sha1", "sha256", "sha512"],
-    default="sha256",
-    help="Allows you to choose the hash function to use for duplicate filename / contents comparison. Default is sha256.",
-)
+parser.add_argument("--default-hashing-function", type=str, choices=['md5', 'sha1', 'sha256', 'sha512'], default='sha256', help="Allows you to choose the hash function to use for duplicate filename / contents comparison. Default is sha256.")
 
-parser.add_argument(
-    "--disable-smart-memory",
-    action="store_true",
-    help="Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.",
-)
-parser.add_argument(
-    "--deterministic",
-    action="store_true",
-    help="Make pytorch use slower deterministic algorithms when it can. Note that this might not make images deterministic in all cases.",
-)
-parser.add_argument(
-    "--fast",
-    action="store_true",
-    help="Enable some untested and potentially quality deteriorating optimizations.",
-)
+parser.add_argument("--disable-smart-memory", action="store_true", help="Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.")
+parser.add_argument("--deterministic", action="store_true", help="Make pytorch use slower deterministic algorithms when it can. Note that this might not make images deterministic in all cases.")
+parser.add_argument("--fast", action="store_true", help="Enable some untested and potentially quality deteriorating optimizations.")
 
-parser.add_argument(
-    "--dont-print-server", action="store_true", help="Don't print server output."
-)
-parser.add_argument(
-    "--quick-test-for-ci", action="store_true", help="Quick test for CI."
-)
-parser.add_argument(
-    "--windows-standalone-build",
-    action="store_true",
-    help="Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup).",
-)
+parser.add_argument("--dont-print-server", action="store_true", help="Don't print server output.")
+parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test for CI.")
+parser.add_argument("--windows-standalone-build", action="store_true", help="Windows standalone build: Enable convenient things that most people using the standalone windows build will probably enjoy (like auto opening the page on startup).")
 
-parser.add_argument(
-    "--disable-metadata",
-    action="store_true",
-    help="Disable saving prompt metadata in files.",
-)
-parser.add_argument(
-    "--disable-all-custom-nodes",
-    action="store_true",
-    help="Disable loading all custom nodes.",
-)
+parser.add_argument("--disable-metadata", action="store_true", help="Disable saving prompt metadata in files.")
+parser.add_argument("--disable-all-custom-nodes", action="store_true", help="Disable loading all custom nodes.")
 
-parser.add_argument(
-    "--multi-user", action="store_true", help="Enables per-user storage."
-)
+parser.add_argument("--multi-user", action="store_true", help="Enables per-user storage.")
 
-parser.add_argument(
-    "--verbose",
-    default="INFO",
-    const="DEBUG",
-    nargs="?",
-    choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-    help="Set the logging level",
-)
+parser.add_argument("--verbose", default='INFO', const='DEBUG', nargs="?", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], help='Set the logging level')
 
-parser.add_argument(
-    "--xla", action="store_true", help="To use the XLA devices for everything."
-)
+parser.add_argument("--xla", action="store_true", help="To use the XLA devices for everything.")
+
 
 # The default built-in provider hosted under web/
 DEFAULT_VERSION_STRING = "comfyanonymous/ComfyUI@latest"
@@ -384,7 +158,6 @@ parser.add_argument(
     """,
 )
 
-
 def is_valid_directory(path: Optional[str]) -> Optional[str]:
     """Validate if the given path is a directory."""
     if path is None:
@@ -394,7 +167,6 @@ def is_valid_directory(path: Optional[str]) -> Optional[str]:
         raise argparse.ArgumentTypeError(f"{path} is not a valid directory.")
     return path
 
-
 parser.add_argument(
     "--front-end-root",
     type=is_valid_directory,
@@ -402,12 +174,7 @@ parser.add_argument(
     help="The local filesystem path to the directory where the frontend is located. Overrides --front-end-version.",
 )
 
-parser.add_argument(
-    "--user-directory",
-    type=is_valid_directory,
-    default=None,
-    help="Set the ComfyUI user directory with an absolute path.",
-)
+parser.add_argument("--user-directory", type=is_valid_directory, default=None, help="Set the ComfyUI user directory with an absolute path.")
 
 if comfy.options.args_parsing:
     args = parser.parse_args()

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -138,6 +138,9 @@ parser.add_argument("--multi-user", action="store_true", help="Enables per-user 
 
 parser.add_argument("--verbose", default='INFO', const='DEBUG', nargs="?", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], help='Set the logging level')
 
+parser.add_argument("--xla", action="store_true", help="To use the XLA devices for everything.")
+# parser.add_argument("--xla_fsdp", action="store_true", help="To use the XLA devices with FSDP for everything.")
+
 # The default built-in provider hosted under web/
 DEFAULT_VERSION_STRING = "comfyanonymous/ComfyUI@latest"
 

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -23,19 +23,29 @@ from comfy.cli_args import args
 import torch
 import sys
 import platform
+import importlib.util
+
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
 
 class VRAMState(Enum):
-    DISABLED = 0    #No vram present: no need to move models to vram
-    NO_VRAM = 1     #Very low vram: enable all the options to save vram
+    DISABLED = 0  # No vram present: no need to move models to vram
+    NO_VRAM = 1  # Very low vram: enable all the options to save vram
     LOW_VRAM = 2
     NORMAL_VRAM = 3
     HIGH_VRAM = 4
-    SHARED = 5      #No dedicated vram: memory shared between CPU and GPU but models still need to be moved between both.
+    SHARED = 5  # No dedicated vram: memory shared between CPU and GPU but models still need to be moved between both.
+
 
 class CPUState(Enum):
     GPU = 0
     CPU = 1
     MPS = 2
+    XLA = 3
+
 
 # Determine VRAM State
 vram_state = VRAMState.NORMAL_VRAM
@@ -48,7 +58,10 @@ xpu_available = False
 torch_version = ""
 try:
     torch_version = torch.version.__version__
-    xpu_available = (int(torch_version[0]) < 2 or (int(torch_version[0]) == 2 and int(torch_version[2]) <= 4)) and torch.xpu.is_available()
+    xpu_available = (
+        int(torch_version[0]) < 2
+        or (int(torch_version[0]) == 2 and int(torch_version[2]) <= 4)
+    ) and torch.xpu.is_available()
 except:
     pass
 
@@ -60,22 +73,43 @@ if args.deterministic:
 directml_enabled = False
 if args.directml is not None:
     import torch_directml
+
     directml_enabled = True
     device_index = args.directml
     if device_index < 0:
         directml_device = torch_directml.device()
     else:
         directml_device = torch_directml.device(device_index)
-    logging.info("Using directml with device: {}".format(torch_directml.device_name(device_index)))
+    logging.info(
+        "Using directml with device: {}".format(
+            torch_directml.device_name(device_index)
+        )
+    )
     # torch_directml.disable_tiled_resources(True)
-    lowvram_available = False #TODO: need to find a way to get free memory in directml before this can be enabled by default.
+    lowvram_available = False  # TODO: need to find a way to get free memory in directml before this can be enabled by default.
 
 try:
     import intel_extension_for_pytorch as ipex
+
     _ = torch.xpu.device_count()
     xpu_available = torch.xpu.is_available()
 except:
-    xpu_available = xpu_available or (hasattr(torch, "xpu") and torch.xpu.is_available())
+    xpu_available = xpu_available or (
+        hasattr(torch, "xpu") and torch.xpu.is_available()
+    )
+
+XLA_AVAILABLE = False
+if args.xla or args.xla_fsdp:
+    try:
+        XLA_AVAILABLE = importlib.util.find_spec("torch_xla") is not None
+        xla_version = importlib_metadata.version("torch_xla")
+        logging.info(f"PyTorch XLA version {xla_version} available.")
+        import torch_xla as xla
+        import torch_xla.core.xla_model as xm
+
+    except ImportError:
+        raise ImportError("PyTorch XLA not installed.")
+
 
 try:
     if torch.backends.mps.is_available():
@@ -87,6 +121,18 @@ except:
 if args.cpu:
     cpu_state = CPUState.CPU
 
+if (args.xla or args.xla_fsdp) and XLA_AVAILABLE:
+    cpu_state = CPUState.XLA
+
+
+def get_xla_memory_info(dev):
+    # xm.get_memory_info(dev) only has bytes_limit and bytes_used
+    mem_reserved = xm.get_memory_info(dev)["bytes_used"]
+    # minus 1GB for safety
+    mem_total = xm.get_memory_info(dev)["bytes_limit"]
+    return (mem_reserved, mem_total)
+
+
 def is_intel_xpu():
     global cpu_state
     global xpu_available
@@ -94,6 +140,7 @@ def is_intel_xpu():
         if xpu_available:
             return True
     return False
+
 
 def get_torch_device():
     global directml_enabled
@@ -105,32 +152,37 @@ def get_torch_device():
         return torch.device("mps")
     if cpu_state == CPUState.CPU:
         return torch.device("cpu")
+    if cpu_state == CPUState.XLA:
+        return xla.device()
     else:
         if is_intel_xpu():
             return torch.device("xpu", torch.xpu.current_device())
         else:
             return torch.device(torch.cuda.current_device())
 
+
 def get_total_memory(dev=None, torch_total_too=False):
     global directml_enabled
     if dev is None:
         dev = get_torch_device()
 
-    if hasattr(dev, 'type') and (dev.type == 'cpu' or dev.type == 'mps'):
+    if hasattr(dev, "type") and (dev.type == "cpu" or dev.type == "mps"):
         mem_total = psutil.virtual_memory().total
         mem_total_torch = mem_total
     else:
         if directml_enabled:
-            mem_total = 1024 * 1024 * 1024 #TODO
+            mem_total = 1024 * 1024 * 1024  # TODO
             mem_total_torch = mem_total
         elif is_intel_xpu():
             stats = torch.xpu.memory_stats(dev)
-            mem_reserved = stats['reserved_bytes.all.current']
+            mem_reserved = stats["reserved_bytes.all.current"]
             mem_total_torch = mem_reserved
             mem_total = torch.xpu.get_device_properties(dev).total_memory
+        elif cpu_state == CPUState.XLA:
+            mem_total_torch, mem_total = get_xla_memory_info(dev)
         else:
             stats = torch.cuda.memory_stats(dev)
-            mem_reserved = stats['reserved_bytes.all.current']
+            mem_reserved = stats["reserved_bytes.all.current"]
             _, mem_total_cuda = torch.cuda.mem_get_info(dev)
             mem_total_torch = mem_reserved
             mem_total = mem_total_cuda
@@ -140,9 +192,12 @@ def get_total_memory(dev=None, torch_total_too=False):
     else:
         return mem_total
 
+
 total_vram = get_total_memory(get_torch_device()) / (1024 * 1024)
 total_ram = psutil.virtual_memory().total / (1024 * 1024)
-logging.info("Total VRAM {:0.0f} MB, total RAM {:0.0f} MB".format(total_vram, total_ram))
+logging.info(
+    "Total VRAM {:0.0f} MB, total RAM {:0.0f} MB".format(total_vram, total_ram)
+)
 
 try:
     logging.info("pytorch version: {}".format(torch_version))
@@ -162,6 +217,7 @@ else:
     try:
         import xformers
         import xformers.ops
+
         XFORMERS_IS_AVAILABLE = True
         try:
             XFORMERS_IS_AVAILABLE = xformers._has_cpp_library
@@ -171,13 +227,18 @@ else:
             XFORMERS_VERSION = xformers.version.__version__
             logging.info("xformers version: {}".format(XFORMERS_VERSION))
             if XFORMERS_VERSION.startswith("0.0.18"):
-                logging.warning("\nWARNING: This version of xformers has a major bug where you will get black images when generating high resolution images.")
-                logging.warning("Please downgrade or upgrade xformers to a different version.\n")
+                logging.warning(
+                    "\nWARNING: This version of xformers has a major bug where you will get black images when generating high resolution images."
+                )
+                logging.warning(
+                    "Please downgrade or upgrade xformers to a different version.\n"
+                )
                 XFORMERS_ENABLED_VAE = False
         except:
             pass
     except:
         XFORMERS_IS_AVAILABLE = False
+
 
 def is_nvidia():
     global cpu_state
@@ -185,6 +246,7 @@ def is_nvidia():
         if torch.version.cuda:
             return True
     return False
+
 
 ENABLE_PYTORCH_ATTENTION = False
 if args.use_pytorch_cross_attention:
@@ -196,12 +258,23 @@ VAE_DTYPES = [torch.float32]
 try:
     if is_nvidia():
         if int(torch_version[0]) >= 2:
-            if ENABLE_PYTORCH_ATTENTION == False and args.use_split_cross_attention == False and args.use_quad_cross_attention == False:
+            if (
+                ENABLE_PYTORCH_ATTENTION == False
+                and args.use_split_cross_attention == False
+                and args.use_quad_cross_attention == False
+            ):
                 ENABLE_PYTORCH_ATTENTION = True
-            if torch.cuda.is_bf16_supported() and torch.cuda.get_device_properties(torch.cuda.current_device()).major >= 8:
+            if (
+                torch.cuda.is_bf16_supported()
+                and torch.cuda.get_device_properties(torch.cuda.current_device()).major
+                >= 8
+            ):
                 VAE_DTYPES = [torch.bfloat16] + VAE_DTYPES
     if is_intel_xpu():
-        if args.use_split_cross_attention == False and args.use_quad_cross_attention == False:
+        if (
+            args.use_split_cross_attention == False
+            and args.use_quad_cross_attention == False
+        ):
             ENABLE_PYTORCH_ATTENTION = True
 except:
     pass
@@ -241,8 +314,9 @@ if lowvram_available:
         vram_state = set_vram_to
 
 
-if cpu_state != CPUState.GPU:
+if cpu_state != CPUState.GPU and cpu_state != CPUState.XLA:
     vram_state = VRAMState.DISABLED
+
 
 if cpu_state == CPUState.MPS:
     vram_state = VRAMState.SHARED
@@ -254,20 +328,24 @@ DISABLE_SMART_MEMORY = args.disable_smart_memory
 if DISABLE_SMART_MEMORY:
     logging.info("Disabling smart memory management")
 
+
 def get_torch_device_name(device):
-    if hasattr(device, 'type'):
+    if hasattr(device, "type"):
         if device.type == "cuda":
             try:
                 allocator_backend = torch.cuda.get_allocator_backend()
             except:
                 allocator_backend = ""
-            return "{} {} : {}".format(device, torch.cuda.get_device_name(device), allocator_backend)
+            return "{} {} : {}".format(
+                device, torch.cuda.get_device_name(device), allocator_backend
+            )
         else:
             return "{}".format(device.type)
     elif is_intel_xpu():
         return "{} {}".format(device, torch.xpu.get_device_name(device))
     else:
         return "CUDA {}: {}".format(device, torch.cuda.get_device_name(device))
+
 
 try:
     logging.info("Device: {}".format(get_torch_device_name(get_torch_device())))
@@ -277,6 +355,7 @@ except:
 
 current_loaded_models = []
 
+
 def module_size(module):
     module_mem = 0
     sd = module.state_dict()
@@ -284,6 +363,7 @@ def module_size(module):
         t = sd[k]
         module_mem += t.nelement() * t.element_size()
     return module_mem
+
 
 class LoadedModel:
     def __init__(self, model):
@@ -320,15 +400,30 @@ class LoadedModel:
             self.model_use_more_vram(use_more_vram)
         else:
             try:
-                self.real_model = self.model.patch_model(device_to=patch_model_to, lowvram_model_memory=lowvram_model_memory, load_weights=load_weights, force_patch_weights=force_patch_weights)
+                self.real_model = self.model.patch_model(
+                    device_to=patch_model_to,
+                    lowvram_model_memory=lowvram_model_memory,
+                    load_weights=load_weights,
+                    force_patch_weights=force_patch_weights,
+                )
             except Exception as e:
                 self.model.unpatch_model(self.model.offload_device)
                 self.model_unload()
                 raise e
 
-        if is_intel_xpu() and not args.disable_ipex_optimize and 'ipex' in globals() and self.real_model is not None:
+        if (
+            is_intel_xpu()
+            and not args.disable_ipex_optimize
+            and "ipex" in globals()
+            and self.real_model is not None
+        ):
             with torch.no_grad():
-                self.real_model = ipex.optimize(self.real_model.eval(), inplace=True, graph_mode=True, concat_linear=True)
+                self.real_model = ipex.optimize(
+                    self.real_model.eval(),
+                    inplace=True,
+                    graph_mode=True,
+                    concat_linear=True,
+                )
 
         self.weights_loaded = True
         return self.real_model
@@ -341,10 +436,14 @@ class LoadedModel:
     def model_unload(self, memory_to_free=None, unpatch_weights=True):
         if memory_to_free is not None:
             if memory_to_free < self.model.loaded_size():
-                freed = self.model.partially_unload(self.model.offload_device, memory_to_free)
+                freed = self.model.partially_unload(
+                    self.model.offload_device, memory_to_free
+                )
                 if freed >= memory_to_free:
                     return False
-        self.model.unpatch_model(self.model.offload_device, unpatch_weights=unpatch_weights)
+        self.model.unpatch_model(
+            self.model.offload_device, unpatch_weights=unpatch_weights
+        )
         self.model.model_patches_to(self.model.offload_device)
         self.weights_loaded = self.weights_loaded and not unpatch_weights
         self.real_model = None
@@ -356,12 +455,14 @@ class LoadedModel:
     def __eq__(self, other):
         return self.model is other.model
 
+
 def use_more_memory(extra_memory, loaded_models, device):
     for m in loaded_models:
         if m.device == device:
             extra_memory -= m.model_use_more_vram(extra_memory)
             if extra_memory <= 0:
                 break
+
 
 def offloaded_memory(loaded_models, device):
     offloaded_mem = 0
@@ -370,21 +471,31 @@ def offloaded_memory(loaded_models, device):
             offloaded_mem += m.model_offloaded_memory()
     return offloaded_mem
 
+
 WINDOWS = any(platform.win32_ver())
 
 EXTRA_RESERVED_VRAM = 400 * 1024 * 1024
 if WINDOWS:
-    EXTRA_RESERVED_VRAM = 600 * 1024 * 1024 #Windows is higher because of the shared vram issue
+    EXTRA_RESERVED_VRAM = (
+        600 * 1024 * 1024
+    )  # Windows is higher because of the shared vram issue
 
 if args.reserve_vram is not None:
     EXTRA_RESERVED_VRAM = args.reserve_vram * 1024 * 1024 * 1024
-    logging.debug("Reserving {}MB vram for other applications.".format(EXTRA_RESERVED_VRAM / (1024 * 1024)))
+    logging.debug(
+        "Reserving {}MB vram for other applications.".format(
+            EXTRA_RESERVED_VRAM / (1024 * 1024)
+        )
+    )
+
 
 def extra_reserved_memory():
     return EXTRA_RESERVED_VRAM
 
+
 def minimum_inference_memory():
     return (1024 * 1024 * 1024) * 0.8 + extra_reserved_memory()
+
 
 def unload_model_clones(model, unload_weights_only=True, force_unload=True):
     to_unload = []
@@ -417,16 +528,24 @@ def unload_model_clones(model, unload_weights_only=True, force_unload=True):
 
     return unload_weight
 
+
 def free_memory(memory_required, device, keep_loaded=[]):
     unloaded_model = []
     can_unload = []
     unloaded_models = []
 
-    for i in range(len(current_loaded_models) -1, -1, -1):
+    for i in range(len(current_loaded_models) - 1, -1, -1):
         shift_model = current_loaded_models[i]
         if shift_model.device == device:
             if shift_model not in keep_loaded:
-                can_unload.append((-shift_model.model_offloaded_memory(), sys.getrefcount(shift_model.model), shift_model.model_memory(), i))
+                can_unload.append(
+                    (
+                        -shift_model.model_offloaded_memory(),
+                        sys.getrefcount(shift_model.model),
+                        shift_model.model_memory(),
+                        i,
+                    )
+                )
                 shift_model.currently_used = False
 
     for x in sorted(can_unload):
@@ -437,7 +556,9 @@ def free_memory(memory_required, device, keep_loaded=[]):
             if free_mem > memory_required:
                 break
             memory_to_free = memory_required - free_mem
-        logging.debug(f"Unloading {current_loaded_models[i].model.model.__class__.__name__}")
+        logging.debug(
+            f"Unloading {current_loaded_models[i].model.model.__class__.__name__}"
+        )
         if current_loaded_models[i].model_unload(memory_to_free):
             unloaded_model.append(i)
 
@@ -448,12 +569,21 @@ def free_memory(memory_required, device, keep_loaded=[]):
         soft_empty_cache()
     else:
         if vram_state != VRAMState.HIGH_VRAM:
-            mem_free_total, mem_free_torch = get_free_memory(device, torch_free_too=True)
+            mem_free_total, mem_free_torch = get_free_memory(
+                device, torch_free_too=True
+            )
             if mem_free_torch > mem_free_total * 0.25:
                 soft_empty_cache()
     return unloaded_models
 
-def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimum_memory_required=None, force_full_load=False):
+
+def load_models_gpu(
+    models,
+    memory_required=0,
+    force_patch_weights=False,
+    minimum_memory_required=None,
+    force_full_load=False,
+):
     global vram_state
 
     inference_memory = minimum_inference_memory()
@@ -461,7 +591,9 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
     if minimum_memory_required is None:
         minimum_memory_required = extra_mem
     else:
-        minimum_memory_required = max(inference_memory, minimum_memory_required + extra_reserved_memory())
+        minimum_memory_required = max(
+            inference_memory, minimum_memory_required + extra_reserved_memory()
+        )
 
     models = set(models)
 
@@ -478,8 +610,12 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
 
         if loaded_model_index is not None:
             loaded = current_loaded_models[loaded_model_index]
-            if loaded.should_reload_model(force_patch_weights=force_patch_weights): #TODO: cleanup this model reload logic
-                current_loaded_models.pop(loaded_model_index).model_unload(unpatch_weights=True)
+            if loaded.should_reload_model(
+                force_patch_weights=force_patch_weights
+            ):  # TODO: cleanup this model reload logic
+                current_loaded_models.pop(loaded_model_index).model_unload(
+                    unpatch_weights=True
+                )
                 loaded = None
             else:
                 loaded.currently_used = True
@@ -494,35 +630,57 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
         devs = set(map(lambda a: a.device, models_already_loaded))
         for d in devs:
             if d != torch.device("cpu"):
-                free_memory(extra_mem + offloaded_memory(models_already_loaded, d), d, models_already_loaded)
+                free_memory(
+                    extra_mem + offloaded_memory(models_already_loaded, d),
+                    d,
+                    models_already_loaded,
+                )
                 free_mem = get_free_memory(d)
                 if free_mem < minimum_memory_required:
-                    logging.info("Unloading models for lowram load.") #TODO: partial model unloading when this case happens, also handle the opposite case where models can be unlowvramed.
+                    logging.info(
+                        "Unloading models for lowram load."
+                    )  # TODO: partial model unloading when this case happens, also handle the opposite case where models can be unlowvramed.
                     models_to_load = free_memory(minimum_memory_required, d)
                     logging.info("{} models unloaded.".format(len(models_to_load)))
                 else:
-                    use_more_memory(free_mem - minimum_memory_required, models_already_loaded, d)
+                    use_more_memory(
+                        free_mem - minimum_memory_required, models_already_loaded, d
+                    )
         if len(models_to_load) == 0:
             return
 
-    logging.info(f"Loading {len(models_to_load)} new model{'s' if len(models_to_load) > 1 else ''}")
+    logging.info(
+        f"Loading {len(models_to_load)} new model{'s' if len(models_to_load) > 1 else ''}"
+    )
 
     total_memory_required = {}
     for loaded_model in models_to_load:
-        unload_model_clones(loaded_model.model, unload_weights_only=True, force_unload=False) #unload clones where the weights are different
-        total_memory_required[loaded_model.device] = total_memory_required.get(loaded_model.device, 0) + loaded_model.model_memory_required(loaded_model.device)
+        unload_model_clones(
+            loaded_model.model, unload_weights_only=True, force_unload=False
+        )  # unload clones where the weights are different
+        total_memory_required[loaded_model.device] = total_memory_required.get(
+            loaded_model.device, 0
+        ) + loaded_model.model_memory_required(loaded_model.device)
 
     for loaded_model in models_already_loaded:
-        total_memory_required[loaded_model.device] = total_memory_required.get(loaded_model.device, 0) + loaded_model.model_memory_required(loaded_model.device)
+        total_memory_required[loaded_model.device] = total_memory_required.get(
+            loaded_model.device, 0
+        ) + loaded_model.model_memory_required(loaded_model.device)
 
     for loaded_model in models_to_load:
-        weights_unloaded = unload_model_clones(loaded_model.model, unload_weights_only=False, force_unload=False) #unload the rest of the clones where the weights can stay loaded
+        weights_unloaded = unload_model_clones(
+            loaded_model.model, unload_weights_only=False, force_unload=False
+        )  # unload the rest of the clones where the weights can stay loaded
         if weights_unloaded is not None:
             loaded_model.weights_loaded = not weights_unloaded
 
     for device in total_memory_required:
         if device != torch.device("cpu"):
-            free_memory(total_memory_required[device] * 1.1 + extra_mem, device, models_already_loaded)
+            free_memory(
+                total_memory_required[device] * 1.1 + extra_mem,
+                device,
+                models_already_loaded,
+            )
 
     for loaded_model in models_to_load:
         model = loaded_model.model
@@ -532,31 +690,51 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
         else:
             vram_set_state = vram_state
         lowvram_model_memory = 0
-        if lowvram_available and (vram_set_state == VRAMState.LOW_VRAM or vram_set_state == VRAMState.NORMAL_VRAM) and not force_full_load:
+        if (
+            lowvram_available
+            and (
+                vram_set_state == VRAMState.LOW_VRAM
+                or vram_set_state == VRAMState.NORMAL_VRAM
+            )
+            and not force_full_load
+        ):
             model_size = loaded_model.model_memory_required(torch_dev)
             current_free_mem = get_free_memory(torch_dev)
-            lowvram_model_memory = max(64 * (1024 * 1024), (current_free_mem - minimum_memory_required), min(current_free_mem * 0.4, current_free_mem - minimum_inference_memory()))
-            if model_size <= lowvram_model_memory: #only switch to lowvram if really necessary
+            lowvram_model_memory = max(
+                64 * (1024 * 1024),
+                (current_free_mem - minimum_memory_required),
+                min(
+                    current_free_mem * 0.4,
+                    current_free_mem - minimum_inference_memory(),
+                ),
+            )
+            if (
+                model_size <= lowvram_model_memory
+            ):  # only switch to lowvram if really necessary
                 lowvram_model_memory = 0
 
         if vram_set_state == VRAMState.NO_VRAM:
             lowvram_model_memory = 64 * 1024 * 1024
 
-        cur_loaded_model = loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
+        cur_loaded_model = loaded_model.model_load(
+            lowvram_model_memory, force_patch_weights=force_patch_weights
+        )
         current_loaded_models.insert(0, loaded_model)
-
 
     devs = set(map(lambda a: a.device, models_already_loaded))
     for d in devs:
         if d != torch.device("cpu"):
             free_mem = get_free_memory(d)
             if free_mem > minimum_memory_required:
-                use_more_memory(free_mem - minimum_memory_required, models_already_loaded, d)
+                use_more_memory(
+                    free_mem - minimum_memory_required, models_already_loaded, d
+                )
     return
 
 
 def load_model_gpu(model):
     return load_models_gpu([model])
+
 
 def loaded_models(only_currently_used=False):
     output = []
@@ -568,22 +746,26 @@ def loaded_models(only_currently_used=False):
         output.append(m.model)
     return output
 
+
 def cleanup_models(keep_clone_weights_loaded=False):
     to_delete = []
     for i in range(len(current_loaded_models)):
-        #TODO: very fragile function needs improvement
+        # TODO: very fragile function needs improvement
         num_refs = sys.getrefcount(current_loaded_models[i].model)
         if num_refs <= 2:
             if not keep_clone_weights_loaded:
                 to_delete = [i] + to_delete
-            #TODO: find a less fragile way to do this.
-            elif sys.getrefcount(current_loaded_models[i].real_model) <= 3: #references from .real_model + the .model
+            # TODO: find a less fragile way to do this.
+            elif (
+                sys.getrefcount(current_loaded_models[i].real_model) <= 3
+            ):  # references from .real_model + the .model
                 to_delete = [i] + to_delete
 
     for i in to_delete:
         x = current_loaded_models.pop(i)
         x.model_unload()
         del x
+
 
 def dtype_size(dtype):
     dtype_size = 4
@@ -594,15 +776,17 @@ def dtype_size(dtype):
     else:
         try:
             dtype_size = dtype.itemsize
-        except: #Old pytorch doesn't have .itemsize
+        except:  # Old pytorch doesn't have .itemsize
             pass
     return dtype_size
+
 
 def unet_offload_device():
     if vram_state == VRAMState.HIGH_VRAM:
         return get_torch_device()
     else:
         return torch.device("cpu")
+
 
 def unet_inital_load_device(parameters, dtype):
     torch_dev = get_torch_device()
@@ -622,10 +806,16 @@ def unet_inital_load_device(parameters, dtype):
     else:
         return cpu_dev
 
-def maximum_vram_for_weights(device=None):
-    return (get_total_memory(device) * 0.88 - minimum_inference_memory())
 
-def unet_dtype(device=None, model_params=0, supported_dtypes=[torch.float16, torch.bfloat16, torch.float32]):
+def maximum_vram_for_weights(device=None):
+    return get_total_memory(device) * 0.88 - minimum_inference_memory()
+
+
+def unet_dtype(
+    device=None,
+    model_params=0,
+    supported_dtypes=[torch.float16, torch.bfloat16, torch.float32],
+):
     if model_params < 0:
         model_params = 1000000000000000000000
     if args.bf16_unet:
@@ -647,7 +837,9 @@ def unet_dtype(device=None, model_params=0, supported_dtypes=[torch.float16, tor
         pass
 
     if fp8_dtype is not None:
-        if supports_fp8_compute(device): #if fp8 compute is supported the casting is most likely not expensive
+        if supports_fp8_compute(
+            device
+        ):  # if fp8 compute is supported the casting is most likely not expensive
             return fp8_dtype
 
         free_model_memory = maximum_vram_for_weights(device)
@@ -655,7 +847,9 @@ def unet_dtype(device=None, model_params=0, supported_dtypes=[torch.float16, tor
             return fp8_dtype
 
     for dt in supported_dtypes:
-        if dt == torch.float16 and should_use_fp16(device=device, model_params=model_params):
+        if dt == torch.float16 and should_use_fp16(
+            device=device, model_params=model_params
+        ):
             if torch.float16 in supported_dtypes:
                 return torch.float16
         if dt == torch.bfloat16 and should_use_bf16(device, model_params=model_params):
@@ -663,17 +857,26 @@ def unet_dtype(device=None, model_params=0, supported_dtypes=[torch.float16, tor
                 return torch.bfloat16
 
     for dt in supported_dtypes:
-        if dt == torch.float16 and should_use_fp16(device=device, model_params=model_params, manual_cast=True):
+        if dt == torch.float16 and should_use_fp16(
+            device=device, model_params=model_params, manual_cast=True
+        ):
             if torch.float16 in supported_dtypes:
                 return torch.float16
-        if dt == torch.bfloat16 and should_use_bf16(device, model_params=model_params, manual_cast=True):
+        if dt == torch.bfloat16 and should_use_bf16(
+            device, model_params=model_params, manual_cast=True
+        ):
             if torch.bfloat16 in supported_dtypes:
                 return torch.bfloat16
 
     return torch.float32
 
+
 # None means no manual cast
-def unet_manual_cast(weight_dtype, inference_device, supported_dtypes=[torch.float16, torch.bfloat16, torch.float32]):
+def unet_manual_cast(
+    weight_dtype,
+    inference_device,
+    supported_dtypes=[torch.float16, torch.bfloat16, torch.float32],
+):
     if weight_dtype == torch.float32:
         return None
 
@@ -694,11 +897,13 @@ def unet_manual_cast(weight_dtype, inference_device, supported_dtypes=[torch.flo
 
     return torch.float32
 
+
 def text_encoder_offload_device():
     if args.gpu_only:
         return get_torch_device()
     else:
         return torch.device("cpu")
+
 
 def text_encoder_device():
     if args.gpu_only:
@@ -710,6 +915,7 @@ def text_encoder_device():
             return torch.device("cpu")
     else:
         return torch.device("cpu")
+
 
 def text_encoder_initial_device(load_device, offload_device, model_size=0):
     if load_device == offload_device or model_size <= 1024 * 1024 * 1024:
@@ -724,6 +930,7 @@ def text_encoder_initial_device(load_device, offload_device, model_size=0):
         return load_device
     else:
         return offload_device
+
 
 def text_encoder_dtype(device=None):
     if args.fp8_e4m3fn_text_enc:
@@ -747,16 +954,19 @@ def intermediate_device():
     else:
         return torch.device("cpu")
 
+
 def vae_device():
     if args.cpu_vae:
         return torch.device("cpu")
     return get_torch_device()
+
 
 def vae_offload_device():
     if args.gpu_only:
         return get_torch_device()
     else:
         return torch.device("cpu")
+
 
 def vae_dtype(device=None, allowed_dtypes=[]):
     global VAE_DTYPES
@@ -775,12 +985,14 @@ def vae_dtype(device=None, allowed_dtypes=[]):
 
     return VAE_DTYPES[0]
 
+
 def get_autocast_device(dev):
-    if hasattr(dev, 'type'):
+    if hasattr(dev, "type"):
         return dev.type
     return "cuda"
 
-def supports_dtype(device, dtype): #TODO
+
+def supports_dtype(device, dtype):  # TODO
     if dtype == torch.float32:
         return True
     if is_device_cpu(device):
@@ -791,12 +1003,13 @@ def supports_dtype(device, dtype): #TODO
         return True
     return False
 
-def supports_cast(device, dtype): #TODO
+
+def supports_cast(device, dtype):  # TODO
     if dtype == torch.float32:
         return True
     if dtype == torch.float16:
         return True
-    if directml_enabled: #TODO: test this
+    if directml_enabled:  # TODO: test this
         return False
     if dtype == torch.bfloat16:
         return True
@@ -807,6 +1020,7 @@ def supports_cast(device, dtype): #TODO
     if dtype == torch.float8_e5m2:
         return True
     return False
+
 
 def pick_weight_dtype(dtype, fallback_dtype, device=None):
     if dtype is None:
@@ -819,16 +1033,20 @@ def pick_weight_dtype(dtype, fallback_dtype, device=None):
 
     return dtype
 
+
 def device_supports_non_blocking(device):
     if is_device_mps(device):
-        return False #pytorch bug? mps doesn't support non blocking
+        return False  # pytorch bug? mps doesn't support non blocking
     if is_intel_xpu():
         return False
-    if args.deterministic: #TODO: figure out why deterministic breaks non blocking from gpu to cpu (previews)
+    if (
+        args.deterministic
+    ):  # TODO: figure out why deterministic breaks non blocking from gpu to cpu (previews)
         return False
     if directml_enabled:
         return False
     return True
+
 
 def device_should_use_non_blocking(device):
     if not device_supports_non_blocking(device):
@@ -836,12 +1054,14 @@ def device_should_use_non_blocking(device):
     return False
     # return True #TODO: figure out why this causes memory issues on Nvidia and possibly others
 
+
 def force_channels_last():
     if args.force_channels_last:
         return True
 
-    #TODO
+    # TODO
     return False
+
 
 def cast_to(weight, dtype=None, device=None, non_blocking=False, copy=False):
     if device is None or weight.device == device:
@@ -854,9 +1074,12 @@ def cast_to(weight, dtype=None, device=None, non_blocking=False, copy=False):
     r.copy_(weight, non_blocking=non_blocking)
     return r
 
+
 def cast_to_device(tensor, device, dtype, copy=False):
     non_blocking = device_supports_non_blocking(device)
-    return cast_to(tensor, dtype=dtype, device=device, non_blocking=non_blocking, copy=copy)
+    return cast_to(
+        tensor, dtype=dtype, device=device, non_blocking=non_blocking, copy=copy
+    )
 
 
 def xformers_enabled():
@@ -878,25 +1101,30 @@ def xformers_enabled_vae():
 
     return XFORMERS_ENABLED_VAE
 
+
 def pytorch_attention_enabled():
     global ENABLE_PYTORCH_ATTENTION
     return ENABLE_PYTORCH_ATTENTION
 
+
 def pytorch_attention_flash_attention():
     global ENABLE_PYTORCH_ATTENTION
     if ENABLE_PYTORCH_ATTENTION:
-        #TODO: more reliable way of checking for flash attention?
-        if is_nvidia(): #pytorch flash attention only works on Nvidia
+        # TODO: more reliable way of checking for flash attention?
+        if is_nvidia():  # pytorch flash attention only works on Nvidia
             return True
         if is_intel_xpu():
             return True
     return False
 
+
 def force_upcast_attention_dtype():
     upcast = args.force_upcast_attention
     try:
         macos_version = tuple(int(n) for n in platform.mac_ver()[0].split("."))
-        if (14, 5) <= macos_version <= (15, 2):  # black image bug on recent versions of macOS
+        if (
+            (14, 5) <= macos_version <= (15, 2)
+        ):  # black image bug on recent versions of macOS
             upcast = True
     except:
         pass
@@ -905,29 +1133,36 @@ def force_upcast_attention_dtype():
     else:
         return None
 
+
 def get_free_memory(dev=None, torch_free_too=False):
     global directml_enabled
     if dev is None:
         dev = get_torch_device()
 
-    if hasattr(dev, 'type') and (dev.type == 'cpu' or dev.type == 'mps'):
+    if hasattr(dev, "type") and (dev.type == "cpu" or dev.type == "mps"):
         mem_free_total = psutil.virtual_memory().available
         mem_free_torch = mem_free_total
     else:
         if directml_enabled:
-            mem_free_total = 1024 * 1024 * 1024 #TODO
+            mem_free_total = 1024 * 1024 * 1024  # TODO
             mem_free_torch = mem_free_total
         elif is_intel_xpu():
             stats = torch.xpu.memory_stats(dev)
-            mem_active = stats['active_bytes.all.current']
-            mem_reserved = stats['reserved_bytes.all.current']
+            mem_active = stats["active_bytes.all.current"]
+            mem_reserved = stats["reserved_bytes.all.current"]
             mem_free_torch = mem_reserved - mem_active
-            mem_free_xpu = torch.xpu.get_device_properties(dev).total_memory - mem_reserved
+            mem_free_xpu = (
+                torch.xpu.get_device_properties(dev).total_memory - mem_reserved
+            )
             mem_free_total = mem_free_xpu + mem_free_torch
+        elif cpu_state == CPUState.XLA:
+            mem_reserved, mem_total = get_xla_memory_info(dev)
+            mem_free_total = mem_total - mem_reserved
+            mem_free_torch = mem_free_total
         else:
             stats = torch.cuda.memory_stats(dev)
-            mem_active = stats['active_bytes.all.current']
-            mem_reserved = stats['reserved_bytes.all.current']
+            mem_active = stats["active_bytes.all.current"]
+            mem_reserved = stats["reserved_bytes.all.current"]
             mem_free_cuda, _ = torch.cuda.mem_get_info(dev)
             mem_free_torch = mem_reserved - mem_active
             mem_free_total = mem_free_cuda + mem_free_torch
@@ -937,30 +1172,44 @@ def get_free_memory(dev=None, torch_free_too=False):
     else:
         return mem_free_total
 
+
 def cpu_mode():
     global cpu_state
     return cpu_state == CPUState.CPU
+
+
+def xla_mode():
+    global cpu_state
+    return cpu_state == CPUState.XLA
+
 
 def mps_mode():
     global cpu_state
     return cpu_state == CPUState.MPS
 
+
 def is_device_type(device, type):
-    if hasattr(device, 'type'):
-        if (device.type == type):
+    if hasattr(device, "type"):
+        if device.type == type:
             return True
     return False
 
+
 def is_device_cpu(device):
-    return is_device_type(device, 'cpu')
+    return is_device_type(device, "cpu")
+
 
 def is_device_mps(device):
-    return is_device_type(device, 'mps')
+    return is_device_type(device, "mps")
+
 
 def is_device_cuda(device):
-    return is_device_type(device, 'cuda')
+    return is_device_type(device, "cuda")
 
-def should_use_fp16(device=None, model_params=0, prioritize_performance=True, manual_cast=False):
+
+def should_use_fp16(
+    device=None, model_params=0, prioritize_performance=True, manual_cast=False
+):
     global directml_enabled
 
     if device is not None:
@@ -983,6 +1232,9 @@ def should_use_fp16(device=None, model_params=0, prioritize_performance=True, ma
     if mps_mode():
         return True
 
+    if xla_mode():
+        return True
+
     if cpu_mode():
         return False
 
@@ -999,14 +1251,31 @@ def should_use_fp16(device=None, model_params=0, prioritize_performance=True, ma
     if props.major < 6:
         return False
 
-    #FP16 is confirmed working on a 1080 (GP104) and on latest pytorch actually seems faster than fp32
-    nvidia_10_series = ["1080", "1070", "titan x", "p3000", "p3200", "p4000", "p4200", "p5000", "p5200", "p6000", "1060", "1050", "p40", "p100", "p6", "p4"]
+    # FP16 is confirmed working on a 1080 (GP104) and on latest pytorch actually seems faster than fp32
+    nvidia_10_series = [
+        "1080",
+        "1070",
+        "titan x",
+        "p3000",
+        "p3200",
+        "p4000",
+        "p4200",
+        "p5000",
+        "p5200",
+        "p6000",
+        "1060",
+        "1050",
+        "p40",
+        "p100",
+        "p6",
+        "p4",
+    ]
     for x in nvidia_10_series:
         if x in props.name.lower():
             if WINDOWS or manual_cast:
                 return True
             else:
-                return False #weird linux behavior where fp32 is faster
+                return False  # weird linux behavior where fp32 is faster
 
     if manual_cast:
         free_model_memory = maximum_vram_for_weights(device)
@@ -1016,17 +1285,33 @@ def should_use_fp16(device=None, model_params=0, prioritize_performance=True, ma
     if props.major < 7:
         return False
 
-    #FP16 is just broken on these cards
-    nvidia_16_series = ["1660", "1650", "1630", "T500", "T550", "T600", "MX550", "MX450", "CMP 30HX", "T2000", "T1000", "T1200"]
+    # FP16 is just broken on these cards
+    nvidia_16_series = [
+        "1660",
+        "1650",
+        "1630",
+        "T500",
+        "T550",
+        "T600",
+        "MX550",
+        "MX450",
+        "CMP 30HX",
+        "T2000",
+        "T1000",
+        "T1200",
+    ]
     for x in nvidia_16_series:
         if x in props.name:
             return False
 
     return True
 
-def should_use_bf16(device=None, model_params=0, prioritize_performance=True, manual_cast=False):
+
+def should_use_bf16(
+    device=None, model_params=0, prioritize_performance=True, manual_cast=False
+):
     if device is not None:
-        if is_device_cpu(device): #TODO ? bf16 works on CPU but is extremely slow
+        if is_device_cpu(device):  # TODO ? bf16 works on CPU but is extremely slow
             return False
 
     if device is not None:
@@ -1040,6 +1325,9 @@ def should_use_bf16(device=None, model_params=0, prioritize_performance=True, ma
         return False
 
     if mps_mode():
+        return True
+
+    if xla_mode():
         return True
 
     if cpu_mode():
@@ -1061,7 +1349,11 @@ def should_use_bf16(device=None, model_params=0, prioritize_performance=True, ma
 
     return False
 
+
 def supports_fp8_compute(device=None):
+    if XLA_AVAILABLE:
+        return True
+
     if not is_nvidia():
         return False
 
@@ -1073,14 +1365,17 @@ def supports_fp8_compute(device=None):
     if props.minor < 9:
         return False
 
-    if int(torch_version[0]) < 2 or (int(torch_version[0]) == 2 and int(torch_version[2]) < 3):
+    if int(torch_version[0]) < 2 or (
+        int(torch_version[0]) == 2 and int(torch_version[2]) < 3
+    ):
         return False
 
     if WINDOWS:
-        if (int(torch_version[0]) == 2 and int(torch_version[2]) < 4):
+        if int(torch_version[0]) == 2 and int(torch_version[2]) < 4:
             return False
 
     return True
+
 
 def soft_empty_cache(force=False):
     global cpu_state
@@ -1089,38 +1384,50 @@ def soft_empty_cache(force=False):
     elif is_intel_xpu():
         torch.xpu.empty_cache()
     elif torch.cuda.is_available():
-        if force or is_nvidia(): #This seems to make things worse on ROCm so I only do it for cuda
+        if (
+            force or is_nvidia()
+        ):  # This seems to make things worse on ROCm so I only do it for cuda
             torch.cuda.empty_cache()
             torch.cuda.ipc_collect()
+
 
 def unload_all_models():
     free_memory(1e30, get_torch_device())
 
 
-def resolve_lowvram_weight(weight, model, key): #TODO: remove
-    print("WARNING: The comfy.model_management.resolve_lowvram_weight function will be removed soon, please stop using it.")
+def resolve_lowvram_weight(weight, model, key):  # TODO: remove
+    print(
+        "WARNING: The comfy.model_management.resolve_lowvram_weight function will be removed soon, please stop using it."
+    )
     return weight
 
-#TODO: might be cleaner to put this somewhere else
+
+# TODO: might be cleaner to put this somewhere else
 import threading
+
 
 class InterruptProcessingException(Exception):
     pass
 
+
 interrupt_processing_mutex = threading.RLock()
 
 interrupt_processing = False
+
+
 def interrupt_current_processing(value=True):
     global interrupt_processing
     global interrupt_processing_mutex
     with interrupt_processing_mutex:
         interrupt_processing = value
 
+
 def processing_interrupted():
     global interrupt_processing
     global interrupt_processing_mutex
     with interrupt_processing_mutex:
         return interrupt_processing
+
 
 def throw_exception_if_processing_interrupted():
     global interrupt_processing

--- a/latent_preview.py
+++ b/latent_preview.py
@@ -146,9 +146,7 @@ def prepare_callback(model, steps, x0_output_dict=None):
         pbar.update_absolute(step + 1, total_steps, preview_bytes)
         if args.xla or args.xla_fsdp:
             import torch_xla as xla
-            import torch_xla.core.xla_model as xm
 
-            logging.info(f"Step {step + 1}/{total_steps}")
             xla.sync()
 
     return callback

--- a/latent_preview.py
+++ b/latent_preview.py
@@ -144,9 +144,12 @@ def prepare_callback(model, steps, x0_output_dict=None):
         if previewer:
             preview_bytes = previewer.decode_latent_to_preview_image(preview_format, x0)
         pbar.update_absolute(step + 1, total_steps, preview_bytes)
-        if args.xla or args.xla_fsdp:
+
+        if args.xla or args.xla_spmd:
             import torch_xla as xla
 
             xla.sync()
+
+        pbar.update_absolute(step + 1, total_steps, preview_bytes)
 
     return callback


### PR DESCRIPTION
This PR adds support for TPU/XLA devices in ComfyUI. users can enable by adding the command line arg `--xla`

- Update README about support for TPU/XLA devices.
- Detects TPU/XLA device, and memory information.
- Add `torch_xla.sync()/xm.mark_step()` for the callback after every sampling step when using TPU devices. This is needed to execute the XLA current graph.

Tested on TPU v3 with [ComfyUI-MochiWrapper](https://github.com/kijai/ComfyUI-MochiWrapper) models.

a reference image with sampling settings/seed/etc.
![image](https://github.com/user-attachments/assets/cde9ff7c-84a2-402e-aa86-4d5b6608f10b)


