### PR TITLE
Add strength input to Differential Diffusion

### DIFF
--- a/comfy_extras/nodes_differential_diffusion.py
+++ b/comfy_extras/nodes_differential_diffusion.py
@@ -5,19 +5,27 @@ import torch
 class DifferentialDiffusion():
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {"model": ("MODEL", ),
-                            }}
+        return {
+            "required": {
+                "model": ("MODEL", ),
+                "strength": ("FLOAT", {
+                    "default": 1.0,
+                    "min": 0.0,
+                    "max": 1.0
+                }),
+            }
+        }
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply"
     CATEGORY = "_for_testing"
     INIT = False
 
-    def apply(self, model):
+    def apply(self, model, strength=1.0):
         model = model.clone()
-        model.set_model_denoise_mask_function(self.forward)
-        return (model,)
+        model.set_model_denoise_mask_function(lambda *args, **kwargs: self.forward(*args, **kwargs, strength=strength))
+        return (model, )
 
-    def forward(self, sigma: torch.Tensor, denoise_mask: torch.Tensor, extra_options: dict):
+    def forward(self, sigma: torch.Tensor, denoise_mask: torch.Tensor, extra_options: dict, strength: float):
         model = extra_options["model"]
         step_sigmas = extra_options["sigmas"]
         sigma_to = model.inner_model.model_sampling.sigma_min
@@ -31,7 +39,13 @@ class DifferentialDiffusion():
 
         threshold = (current_ts - ts_to) / (ts_from - ts_to)
 
-        return (denoise_mask >= threshold).to(denoise_mask.dtype)
+        # Generate the binary mask based on the threshold
+        binary_mask = (denoise_mask >= threshold).to(denoise_mask.dtype)
+
+        # Blend binary mask with the original denoise_mask using strength
+        blended_mask = strength * binary_mask + (1 - strength) * denoise_mask
+
+        return blended_mask
 
 
 NODE_CLASS_MAPPINGS = {

--- a/comfy_extras/nodes_differential_diffusion.py
+++ b/comfy_extras/nodes_differential_diffusion.py
@@ -43,9 +43,11 @@ class DifferentialDiffusion():
         binary_mask = (denoise_mask >= threshold).to(denoise_mask.dtype)
 
         # Blend binary mask with the original denoise_mask using strength
-        blended_mask = strength * binary_mask + (1 - strength) * denoise_mask
-
-        return blended_mask
+        if strength and strength < 1:
+            blended_mask = strength * binary_mask + (1 - strength) * denoise_mask
+            return blended_mask
+        else:
+            return binary_mask
 
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
Hi,

The Differential Diffusion node from #2876 is awesome for inpainting tasks, but the effect is too strong at times. It is challenging to use when generating a subject that has little in common with the original.

Even at a denoising strength of 100%, Differential Diffusion often overwhelms the prompt. But if we blend the adjusted binary mask with the original, we can find a sweet spot. The example below was performed with Euler/Beta, 4 steps, 100% denoising strength. Model is flux1-dev.sft with distillation LoRAs for speed.

![differential_diffusion_strength](https://github.com/user-attachments/assets/151413eb-ed58-4d50-92a7-bb05dcb99e6f)

50-75% Differential Diffusion strength feels a lot more usable in practice than 100%. Here's one more comparison if you'll indulge me:

<img src=https://github.com/user-attachments/assets/a5ad045d-5ab8-423a-a5e7-524a09a7353b width=300>

The prompt was "Donald Trump." That guy in the middle looks like he'd be fun at parties, but he's definitely not Trump.