### PR TITLE
Add union link connection type support

### DIFF
--- a/comfy_execution/validation.py
+++ b/comfy_execution/validation.py
@@ -1,0 +1,29 @@
+def validate_node_input(
+    received_type: str, input_type: str, strict: bool = False
+) -> bool:
+    """
+    received_type and input_type are both strings of the form "T1,T2,...".
+
+    If strict is True, the input_type must contain the received_type.
+      For example, if received_type is "STRING" and input_type is "STRING,INT",
+      this will return True. But if received_type is "STRING,INT" and input_type is
+      "INT", this will return False.
+
+    If strict is False, the input_type must have overlap with the received_type.
+      For example, if received_type is "STRING,BOOLEAN" and input_type is "STRING,INT",
+      this will return True.
+    """
+    # If the types are exactly the same, we can return immediately
+    if received_type == input_type:
+        return True
+
+    # Split the type strings into sets for comparison
+    received_types = set(t.strip() for t in received_type.split(","))
+    input_types = set(t.strip() for t in input_type.split(","))
+
+    if strict:
+        # In strict mode, all received types must be in the input types
+        return received_types.issubset(input_types)
+    else:
+        # In non-strict mode, there must be at least one type in common
+        return len(received_types.intersection(input_types)) > 0

--- a/comfy_execution/validation.py
+++ b/comfy_execution/validation.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def validate_node_input(
     received_type: str, input_type: str, strict: bool = False
 ) -> bool:

--- a/execution.py
+++ b/execution.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import sys
 import copy
 import logging

--- a/execution.py
+++ b/execution.py
@@ -17,6 +17,7 @@ import comfy.model_management
 from comfy_execution.graph import get_input_info, ExecutionList, DynamicPrompt, ExecutionBlocker
 from comfy_execution.graph_utils import is_link, GraphBuilder
 from comfy_execution.caching import HierarchicalCache, LRUCache, CacheKeySetInputSignature, CacheKeySetID
+from comfy_execution.validation import validate_node_input
 from comfy.cli_args import args
 
 class ExecutionResult(Enum):
@@ -526,35 +527,6 @@ class PromptExecutor:
             self.server.last_node_id = None
             if comfy.model_management.DISABLE_SMART_MEMORY:
                 comfy.model_management.unload_all_models()
-
-
-def validate_node_input(received_type: str, input_type: str, strict: bool = False) -> bool:
-    """
-    received_type and input_type are both strings of the form "T1,T2,...".
-
-    If strict is True, the input_type must contain the received_type.
-      For example, if received_type is "STRING" and input_type is "STRING,INT",
-      this will return True. But if received_type is "STRING,INT" and input_type is
-      "INT", this will return False.
-
-    If strict is False, the input_type must have overlap with the received_type.
-      For example, if received_type is "STRING,BOOLEAN" and input_type is "STRING,INT",
-      this will return True.
-    """
-    # If the types are exactly the same, we can return immediately
-    if received_type == input_type:
-        return True
-
-    # Split the type strings into sets for comparison
-    received_types = set(t.strip() for t in received_type.split(','))
-    input_types = set(t.strip() for t in input_type.split(','))
-
-    if strict:
-        # In strict mode, all received types must be in the input types
-        return received_types.issubset(input_types)
-    else:
-        # In non-strict mode, there must be at least one type in common
-        return len(received_types.intersection(input_types)) > 0
 
 
 def validate_inputs(prompt, item, validated):

--- a/tests-unit/execution_test/validate_node_input_test.py
+++ b/tests-unit/execution_test/validate_node_input_test.py
@@ -1,0 +1,75 @@
+import pytest
+from execution import validate_node_input
+
+
+def test_exact_match():
+    """Test cases where types match exactly"""
+    assert validate_node_input("STRING", "STRING")
+    assert validate_node_input("STRING,INT", "STRING,INT")
+    assert (
+        validate_node_input("INT,STRING", "STRING,INT")
+    )  # Order shouldn't matter
+
+
+def test_strict_mode():
+    """Test strict mode validation"""
+    # Should pass - received type is subset of input type
+    assert validate_node_input("STRING", "STRING,INT", strict=True)
+    assert validate_node_input("INT", "STRING,INT", strict=True)
+    assert validate_node_input("STRING,INT", "STRING,INT,BOOLEAN", strict=True)
+
+    # Should fail - received type is not subset of input type
+    assert not validate_node_input("STRING,INT", "STRING", strict=True)
+    assert not validate_node_input("STRING,BOOLEAN", "STRING", strict=True)
+    assert not validate_node_input("INT,BOOLEAN", "STRING,INT", strict=True)
+
+
+def test_non_strict_mode():
+    """Test non-strict mode validation (default behavior)"""
+    # Should pass - types have overlap
+    assert validate_node_input("STRING,BOOLEAN", "STRING,INT")
+    assert validate_node_input("STRING,INT", "INT,BOOLEAN")
+    assert validate_node_input("STRING", "STRING,INT")
+
+    # Should fail - no overlap in types
+    assert not validate_node_input("BOOLEAN", "STRING,INT")
+    assert not validate_node_input("FLOAT", "STRING,INT")
+    assert not validate_node_input("FLOAT,BOOLEAN", "STRING,INT")
+
+
+def test_whitespace_handling():
+    """Test that whitespace is handled correctly"""
+    assert validate_node_input("STRING, INT", "STRING,INT")
+    assert validate_node_input("STRING,INT", "STRING, INT")
+    assert validate_node_input(" STRING , INT ", "STRING,INT")
+    assert validate_node_input("STRING,INT", " STRING , INT ")
+
+
+def test_empty_strings():
+    """Test behavior with empty strings"""
+    assert validate_node_input("", "")
+    assert not validate_node_input("STRING", "")
+    assert not validate_node_input("", "STRING")
+
+
+def test_single_vs_multiple():
+    """Test single type against multiple types"""
+    assert validate_node_input("STRING", "STRING,INT,BOOLEAN")
+    assert validate_node_input("STRING,INT,BOOLEAN", "STRING", strict=False)
+    assert not validate_node_input("STRING,INT,BOOLEAN", "STRING", strict=True)
+
+
+@pytest.mark.parametrize(
+    "received,input_type,strict,expected",
+    [
+        ("STRING", "STRING", False, True),
+        ("STRING,INT", "STRING,INT", False, True),
+        ("STRING", "STRING,INT", True, True),
+        ("STRING,INT", "STRING", True, False),
+        ("BOOLEAN", "STRING,INT", False, False),
+        ("STRING,BOOLEAN", "STRING,INT", False, True),
+    ],
+)
+def test_parametrized_cases(received, input_type, strict, expected):
+    """Parametrized test cases for various scenarios"""
+    assert validate_node_input(received, input_type, strict) == expected

--- a/tests-unit/execution_test/validate_node_input_test.py
+++ b/tests-unit/execution_test/validate_node_input_test.py
@@ -1,5 +1,5 @@
 import pytest
-from execution import validate_node_input
+from comfy_execution.validation import validate_node_input
 
 
 def test_exact_match():


### PR DESCRIPTION
Requested by @Kosinkadink 

Supports running workflow with union types, i.e. types separated with comma like `T1,T2,...`. The frontend code (litegraph) already supports the connection of it. It's the backend validation failing blocking this feature to be properly used.

Before:
![image](https://github.com/user-attachments/assets/a8f7e2c7-7653-4f1e-afb1-c2b3380fc742)

After:
![image](https://github.com/user-attachments/assets/22e8b8ae-851f-4efe-8f63-8d72a052bf6e)

### Reproduction workflow
[UnionTest.json](https://github.com/user-attachments/files/17937955/UnionTest.json)

Required custom nodes:
- https://github.com/Comfy-Org/ComfyUI_devtools
- https://github.com/WASasquatch/was-node-suite-comfyui