### PR TITLE
resolve relative paths in YAML configuration for extra model paths

### DIFF
--- a/utils/extra_config.py
+++ b/utils/extra_config.py
@@ -24,5 +24,8 @@ def load_extra_path_config(yaml_path):
                 full_path = y
                 if base_path is not None:
                     full_path = os.path.join(base_path, full_path)
+                elif not os.path.isabs(full_path):
+                    yaml_dir = os.path.dirname(os.path.abspath(yaml_path))
+                    full_path = os.path.abspath(os.path.join(yaml_dir, y))
                 logging.info("Adding extra search path {} {}".format(x, full_path))
                 folder_paths.add_model_folder_path(x, full_path, is_default)


### PR DESCRIPTION
This PR updates the `load_extra_path_config` function to properly handle relative paths in YAML configuration files.

Relative paths are now resolved relative to the directory containing the YAML file.

### Changes:

- Added a check using `os.path.isabs` to determine whether a path is relative or absolute.
- Relative paths are resolved using the directory of the YAML file when `base_path` is not specified.

This PR introduces minimal changes and only affects cases where `base_path` is not set. 
As far as I know, there are no breaking changes. 

