### PR TITLE
Fix SDXL generating black images when using --fast (fp8_ops)

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -269,7 +269,7 @@ def fp8_linear(self, input):
 
         if scale_input is None:
             scale_input = torch.ones((), device=input.device, dtype=torch.float32)
-            inn = input.reshape(-1, input.shape[2]).to(dtype)
+            inn = torch.clamp(input, min=-448, max=448).reshape(-1, input.shape[2]).to(dtype)
         else:
             scale_input = scale_input.to(input.device)
             inn = (input * (1.0 / scale_input).to(input.dtype)).reshape(-1, input.shape[2]).to(dtype)


### PR DESCRIPTION
#### Description

Currently, if you attempt to use a SDXL *(PonyXL somehow works...)* checkpoint with `fp8_ops`, it will cause `NaN` in the latent, which results in black images. This is caused by the `input` overflowing the value range of `float8_e4m3fn`, and can be fixed by adding a clamp with the range set to `-448` ~ `448`, without too much quality degradation.

> **Source for the Range**: https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html <br>
> - **E4M3** - it consists of 1 sign bit, 4 exponent bits and 3 bits of mantissa. It can store values up to **+/-448**

#### Code Changes

- Added `torch.clamp` at [L272](https://github.com/comfyanonymous/ComfyUI/blob/v0.3.7/comfy/ops.py#L272)

#### Related Issue
- #4572 

<hr>

#### Benchmark

- Generate a `1024x1024` image using **SDXL** checkpoint on a **RTX 4070 Ti S**:
    - **fp16:** `4.56 it/s`
    - **float8_e4m3fn_fast:** `5.68 it/s`

#### Example Workflow

<p align="center">
<img src="https://github.com/user-attachments/assets/42298f13-ccfd-4872-9385-21d1c83d6ea2" width=512>
</p>

<hr>

#### misc.

- Unsure if [L275](https://github.com/comfyanonymous/ComfyUI/blob/v0.3.7/comfy/ops.py#L275) should also be clamped
- Doing `torch.clamp` is significantly faster than checking for `torch.min` or `torch.max`