### PR TITLE
[SECURITY] Hard-enforce ultralytics <= 8.3.40.

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,23 @@ import folder_paths
 import time
 from comfy.cli_args import args
 from app.logger import setup_logger
+from packaging.version import Version
+
+
+# Security: Hard-pin ultralytics to 8.3.40, enforce as a test during ComfyUI startup. If ultralytics exists, 8.3.40 is last "okay" version.
+# Refer to following:
+# - https://github.com/ultralytics/ultralytics/issues/18027
+# - https://blog.comfy.org/comfyui-statement-on-the-ultralytics-crypto-miner-situation/
+try:
+    from ultralytics import __version__ as ultralytics_version
+    if Version(ultralytics_version) > Version('8.3.40'):
+        raise EnvironmentError("[SECURITY ALERT] Unsafe malicious versions of Ultralytics detected, last known good version 8.3.40.")
+except ModuleNotFound:
+    pass
+except Exception:
+    raise
+    
+    
 
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI which should already have no communication with the internet, they are for custom nodes.


### PR DESCRIPTION
A decision was made to hard-enforce ultralytics versions to 8.3.40 internally in response to the cryptominer hijack of Ultralytics on PyPI.

As a result, however, there's an issue where custom modules may still depend on and specify a higher version of Ultralytics in their requirements.  Because of the severity of this issue and risk, I propose adding a hard test on Ultralytics' version string to make sure that the version is 8.3.40 or lower in accordance with this recent security problem.

Refer to https://github.com/ultralytics/ultralytics/issues/18027 and https://blog.comfy.org/comfyui-statement-on-the-ultralytics-crypto-miner-situation/ as well for reasoning.