### PR TITLE
add_model_folder_path: ensure unique paths by removing duplicates

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -200,6 +200,10 @@ def add_model_folder_path(folder_name: str, full_folder_path: str, is_default: b
     global folder_names_and_paths
     folder_name = map_legacy(folder_name)
     if folder_name in folder_names_and_paths:
+        current_paths = folder_names_and_paths[folder_name][0]
+        if full_folder_path in current_paths:
+            current_paths.remove(full_folder_path)  # Remove the path if it exists
+
         if is_default:
             folder_names_and_paths[folder_name][0].insert(0, full_folder_path)
         else:

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -200,14 +200,17 @@ def add_model_folder_path(folder_name: str, full_folder_path: str, is_default: b
     global folder_names_and_paths
     folder_name = map_legacy(folder_name)
     if folder_name in folder_names_and_paths:
-        current_paths = folder_names_and_paths[folder_name][0]
-        if full_folder_path in current_paths:
-            current_paths.remove(full_folder_path)  # Remove the path if it exists
-
-        if is_default:
-            folder_names_and_paths[folder_name][0].insert(0, full_folder_path)
+        paths, _exts = folder_names_and_paths[folder_name]
+        if full_folder_path in paths:
+            if is_default and paths[0] != full_folder_path:
+                # If the path to the folder is not the first in the list, move it to the beginning.
+                paths.remove(full_folder_path)
+                paths.insert(0, full_folder_path)
         else:
-            folder_names_and_paths[folder_name][0].append(full_folder_path)
+            if is_default:
+                paths.insert(0, full_folder_path)
+            else:
+                paths.append(full_folder_path)
     else:
         folder_names_and_paths[folder_name] = ([full_folder_path], set())
 


### PR DESCRIPTION
The changes are small enough not to complicate the code.

Just added a check if such a path value already exists in `folder_names_and_paths` - then first the old value is deleted and then the new one is added.

Ideally, it would be possible to check whether it is necessary to delete and add at all, but there would be more code, and apparently it will not work faster because of several additional checks and it will become much less readable.