### PR TITLE
execution.py: Fix prompt_worker thread error handling

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -496,8 +496,15 @@ class PromptExecutor:
                 if error is not None:
                     self.handle_execution_error(prompt_id, dynamic_prompt.original_prompt, current_outputs, executed, error, ex)
                     break
-
-                result, error, ex = execute(self.server, dynamic_prompt, self.caches, node_id, extra_data, executed, prompt_id, execution_list, pending_subgraph_results)
+                try:
+                    result, error, ex = execute(self.server, dynamic_prompt, self.caches, node_id, extra_data, executed, prompt_id, execution_list, pending_subgraph_results)
+                except Exception as e:
+                    typ, _, tb = sys.exc_info()
+                    exception_type = full_type_name(typ)
+                    logging.error(f"Unexpected error occurred, during nested error handling: {e}, please open an issue on github.")
+                    logging.error(traceback.format_exc())
+                    self.add_message("execution_error", {"prompt_id": prompt_id}, broadcast=True)
+                    break
                 self.success = result != ExecutionResult.FAILURE
                 if result == ExecutionResult.FAILURE:
                     self.handle_execution_error(prompt_id, dynamic_prompt.original_prompt, current_outputs, executed, error, ex)


### PR DESCRIPTION
If something raises inside `execution.execute` function's except - thread will die due to unhandled error. I faced problem because of a bug in `torch==2.3.1` - tensor's `__str__` method raised unhandled error. To face the same symptoms you can mock `execution.format_value` to raise any Exception. 
Please, check my PR properly, I'm not familiar with ComfyUI's messages exchange protocol between frontend and backend. 