### PR TITLE
Add .github folder to maintainer owner list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,7 @@
 /tests-unit/ @yoland68 @robinjhuang @huchenlei @webfiltered @pythongosssss @ltdrdata @Kosinkadink
 /notebooks/ @yoland68 @robinjhuang @huchenlei @webfiltered @pythongosssss @ltdrdata @Kosinkadink
 /script_examples/ @yoland68 @robinjhuang @huchenlei @webfiltered @pythongosssss @ltdrdata @Kosinkadink
+/.github/ @yoland68 @robinjhuang @huchenlei @webfiltered @pythongosssss @ltdrdata @Kosinkadink
 
 # Python web server
 /api_server/ @yoland68 @robinjhuang @huchenlei @webfiltered @pythongosssss @ltdrdata


### PR DESCRIPTION
This PR adds `.github` folder to maintainer owner list. `.github` folder contains issue templates and github CI configurations.