### PR TITLE
Lint and fix undefined names (2/N)

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,6 +112,7 @@ def cuda_malloc_warning():
             logging.warning("\nWARNING: this card most likely does not support cuda-malloc, if you get \"CUDA error\" please run ComfyUI with: --disable-cuda-malloc\n")
 
 def prompt_worker(q, server):
+    current_time: float = 0.0
     e = execution.PromptExecutor(server, lru_size=args.cache_lru)
     last_gc_collect = 0
     need_gc = False


### PR DESCRIPTION
`current_time` in line 124 is referenced before assignment. Logic wise this can never happen as `need_gc` is set to `False`, but it is triggering the static check on F821.