### PR TITLE
[Security] Fix potential XSS on /view

### DIFF
--- a/server.py
+++ b/server.py
@@ -460,7 +460,21 @@ class PromptServer():
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
                                                 headers={"Content-Disposition": f"filename=\"{filename}\""})
                     else:
-                        return web.FileResponse(file, headers={"Content-Disposition": f"filename=\"{filename}\""})
+                        # Get content type from mimetype, defaulting to 'application/octet-stream'
+                        content_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+
+                        # For security, force certain extensions to download instead of display
+                        file_extension = os.path.splitext(filename)[1].lower()
+                        if file_extension in {'.html', '.htm', '.js', '.css'}:
+                            content_type = 'application/octet-stream'  # Forces download
+
+                        return web.FileResponse(
+                            file,
+                            headers={
+                                "Content-Disposition": f"filename=\"{filename}\"",
+                                "Content-Type": content_type
+                            }
+                        )
 
             return web.Response(status=404)
 


### PR DESCRIPTION
This PR prevents html/htm/js/css files being served as web page for code execution.

## Reproduction steps
- Put a index.html file with random content in `ComfyUI/output` folder
- Run ComfyUI
- Type `http://localhost:8188/api/view?filename=index.html&type=output&subfolder=` in browser nav bar
- Observe that the page is getting loaded. With the patch, you should observe that the html file is being downloaded instead.

## Note
During testing, make sure that you disable browser cache between different testing procedures.
