### PR TITLE
(fix): added "model_type" to photomaker node

### DIFF
--- a/comfy_extras/nodes_photomaker.py
+++ b/comfy_extras/nodes_photomaker.py
@@ -16,6 +16,7 @@ VISION_CONFIG_DICT = {
     "patch_size": 14,
     "projection_dim": 768,
     "hidden_act": "quick_gelu",
+    "model_type": "clip_vision_model",
 }
 
 class MLP(nn.Module):


### PR DESCRIPTION
This commit: https://github.com/comfyanonymous/ComfyUI/commit/8f0009aad0591ceee59a147738aa227187b07898 added the `model_type` field to the CLIP vision configs. However, it seems that the built-in photomaker node still misses this field, resulting in a "missing model_type key in dictionary" error.

This PR fixes the issue, and with this small change, everything works as expected.