### PR TITLE
Adding upstream pytorch installation instruction for Intel GPUs to README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This is the command to install the nightly with ROCm 6.2 which might have some p
 2. Launch ComfyUI by running `python main.py`
 
 
-(Option 2) Alternatively, Intel GPUs supported by Intel's Extension for PyTorch (IPEX) can leverage IPEX for improved performance.
+(Option 2) Alternatively, Intel GPUs supported by Intel Extension for PyTorch (IPEX) can leverage IPEX for improved performance.
 
 1. For Intel® Arc™ A-Series Graphics utilizing IPEX, create a conda environment and use the commands below:
 

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ Put your VAE in: models/vae
 ### AMD GPUs (Linux only)
 AMD users can install rocm and pytorch with pip if you don't have it already installed, this is the command to install the stable version:
 
-   ```pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2```
+```pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2```
 
 This is the command to install the nightly with ROCm 6.2 which might have some performance improvements:
 
-   ```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2```
+```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2```
 
 ### Intel GPUs (Windows and Linux)
 

--- a/README.md
+++ b/README.md
@@ -143,11 +143,35 @@ Put your VAE in: models/vae
 ### AMD GPUs (Linux only)
 AMD users can install rocm and pytorch with pip if you don't have it already installed, this is the command to install the stable version:
 
-```pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2```
+   ```pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2```
 
 This is the command to install the nightly with ROCm 6.2 which might have some performance improvements:
 
-```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2```
+   ```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2```
+
+### Intel GPUs (Windows and Linux)
+
+1. Intel Arc GPU users can install native PyTorch with torch.xpu support using pip (currently available in PyTorch nightly builds). More information can be found [here](https://pytorch.org/docs/main/notes/get_start_xpu.html)
+  
+2. To install PyTorch nightly, use the following command:
+
+```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu```
+
+3. Launch ComfyUI by running `python main.py`
+
+
+Alternatively, Intel GPUs supported by Intel's Extension for PyTorch (IPEX) can leverage IPEX for improved performance.
+
+For Intel® Arc™ A-Series Graphics utilizing IPEX, create a conda environment and use the commands below:
+
+```
+conda install libuv
+pip install torch==2.3.1.post0+cxx11.abi torchvision==0.18.1.post0+cxx11.abi torchaudio==2.3.1.post0+cxx11.abi intel-extension-for-pytorch==2.3.110.post0+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/cn/
+```
+
+For other supported Intel GPUs with IPEX, visit [Installation](https://intel.github.io/intel-extension-for-pytorch/index.html#installation?platform=gpu) for more information.
+
+Additional discussion and help can be found [here](https://github.com/comfyanonymous/ComfyUI/discussions/476).
 
 ### NVIDIA
 
@@ -176,17 +200,6 @@ Install the dependencies by opening your terminal inside the ComfyUI folder and:
 After this you should have everything installed and can proceed to running ComfyUI.
 
 ### Others:
-
-#### Intel GPUs
-
-Intel GPU support is available for all Intel GPUs supported by Intel's Extension for Pytorch (IPEX) with the support requirements listed in the [Installation](https://intel.github.io/intel-extension-for-pytorch/index.html#installation?platform=gpu) page. Choose your platform and method of install and follow the instructions. The steps are as follows:
-
-1. Start by installing the drivers or kernel listed or newer in the Installation page of IPEX linked above for Windows and Linux if needed.
-1. Follow the instructions to install [Intel's oneAPI Basekit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html) for your platform.
-1. Install the packages for IPEX using the instructions provided in the Installation page for your platform.
-1. Follow the [ComfyUI manual installation](#manual-install-windows-linux) instructions for Windows and Linux and run ComfyUI normally as described above after everything is installed.
-
-Additional discussion and help can be found [here](https://github.com/comfyanonymous/ComfyUI/discussions/476).
 
 #### Apple Mac silicon
 
@@ -308,4 +321,3 @@ This will use a snapshot of the legacy frontend preserved in the [ComfyUI Legacy
 ### Which GPU should I buy for this?
 
 [See this page for some recommendations](https://github.com/comfyanonymous/ComfyUI/wiki/Which-GPU-should-I-buy-for-ComfyUI)
-

--- a/README.md
+++ b/README.md
@@ -151,18 +151,18 @@ This is the command to install the nightly with ROCm 6.2 which might have some p
 
 ### Intel GPUs (Windows and Linux)
 
-1. Intel Arc GPU users can install native PyTorch with torch.xpu support using pip (currently available in PyTorch nightly builds). More information can be found [here](https://pytorch.org/docs/main/notes/get_start_xpu.html)
+(Option 1) Intel Arc GPU users can install native PyTorch with torch.xpu support using pip (currently available in PyTorch nightly builds). More information can be found [here](https://pytorch.org/docs/main/notes/get_start_xpu.html)
   
-2. To install PyTorch nightly, use the following command:
+1. To install PyTorch nightly, use the following command:
 
 ```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu```
 
-3. Launch ComfyUI by running `python main.py`
+2. Launch ComfyUI by running `python main.py`
 
 
-Alternatively, Intel GPUs supported by Intel's Extension for PyTorch (IPEX) can leverage IPEX for improved performance.
+(Option 2) Alternatively, Intel GPUs supported by Intel's Extension for PyTorch (IPEX) can leverage IPEX for improved performance.
 
-For Intel® Arc™ A-Series Graphics utilizing IPEX, create a conda environment and use the commands below:
+1. For Intel® Arc™ A-Series Graphics utilizing IPEX, create a conda environment and use the commands below:
 
 ```
 conda install libuv


### PR DESCRIPTION
updated and simplfied ComfyUI readme for Intel GPUs.

Intel GPU Support Now Available in PyTorch 2.5 https://pytorch.org/blog/intel-gpu-support-pytorch-2-5/

more info can be found: https://pytorch.org/docs/main/notes/get_start_xpu.html

1. using upstream pytorch nightly builds for Intel Arc GPUs, (Desktop discreet A-Series/B-Series GPUs, Core Ultra-H, Core Ultra Series-2)

```
pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu
```

```
python main.py
```


2. Users can also use Intel® Extension for PyTorch (IPEX) to setup env for ComfyUI. This is device specific for improved performance and requires a conda env.

more info can be found: https://pytorch-extension.intel.com/installation?platform=gpu


oneAPI base toolkit setup is no longer needed starting in IPEX 2.3.110+ , using the pip command to install ipex will also pull the dependent oneAPI packages from pypi.

For Intel® Arc™ A-Series Graphics utilizing IPEX, use the commands below:
```
conda install libuv
pip install torch==2.3.1.post0+cxx11.abi torchvision==0.18.1.post0+cxx11.abi torchaudio==2.3.1.post0+cxx11.abi intel-extension-for-pytorch==2.3.110.post0+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/cn/
```


Screenshot of the updated section:
![image](https://github.com/user-attachments/assets/1a74223f-7653-4324-bbb1-6a3248994617)





Cheers! :)