### PR TITLE
add preview 3d node

### DIFF
--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -84,12 +84,38 @@ class Load3DAnimation():
 
         return output_image, output_mask, model_file,
 
+class Preview3D():
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {
+            "model_file": ("STRING", {"default": "", "multiline": False}),
+            "show_grid": ([True, False],),
+            "camera_type": (["perspective", "orthographic"],),
+            "view": (["front", "right", "top", "isometric"],),
+            "material": (["original", "normal", "wireframe", "depth"],),
+            "bg_color": ("STRING", {"default": "#000000", "multiline": False}),
+            "light_intensity": ("INT", {"default": 10, "min": 1, "max": 20, "step": 1}),
+            "up_direction": (["original", "-x", "+x", "-y", "+y", "-z", "+z"],),
+        }}
+
+    OUTPUT_NODE = True
+    RETURN_TYPES = ()
+
+    CATEGORY = "3d"
+
+    FUNCTION = "process"
+
+    def process(self, model_file, **kwargs):
+        return {"ui": {"model_file": [model_file]}, "result": ()}
+
 NODE_CLASS_MAPPINGS = {
     "Load3D": Load3D,
-    "Load3DAnimation": Load3DAnimation
+    "Load3DAnimation": Load3DAnimation,
+    "Preview3D": Preview3D
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "Load3D": "Load 3D",
-    "Load3DAnimation": "Load 3D - Animation"
+    "Load3DAnimation": "Load 3D - Animation",
+    "Preview3D": "Preview 3D"
 }


### PR DESCRIPTION
Even we discussed in https://github.com/comfyanonymous/ComfyUI/pull/5564 that should move this preview 3d into FE, however after investigated, I could not figure out how to do that, the main reason is when execute workflow, comfyUI will validate note mapping here https://github.com/comfyanonymous/ComfyUI/blob/6d1a3f7d00d92b652b986ef69b4337ea0f208a1a/execution.py#L775 but the pure FE node doesn't have such Python Class, I believe we still one BE node here.
Here is a demo video

https://github.com/user-attachments/assets/f2162744-40bb-4d90-8aa8-eec44afa72c1

