### PR TITLE
Use raw dir name to serve static web content

### DIFF
--- a/server.py
+++ b/server.py
@@ -714,9 +714,7 @@ class PromptServer():
         self.app.add_routes(self.routes)
 
         for name, dir in nodes.EXTENSION_WEB_DIRS.items():
-            self.app.add_routes([
-                web.static('/extensions/' + urllib.parse.quote(name), dir),
-            ])
+            self.app.add_routes([web.static('/extensions/' + name, dir)])
 
         self.app.add_routes([
             web.static('/', self.web_root),


### PR DESCRIPTION
The `urllib.parse.quote(name)` was added in 

https://github.com/comfyanonymous/ComfyUI/commit/9b1d5a587cee63771c1184d0942093bf64b54d96#diff-791d4d41d3718d15d49180f3aacc8370b8cab07383f0d35b2713651cc0adfe46R511

However, it is causing issue if there are special characters in the name, such as `@`.