### PR TITLE
FORCE_SOFT_EMPTY_CACHE env var to enable cache clearing for AMD GPUs

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -25,6 +25,11 @@ import sys
 import platform
 import weakref
 import gc
+import os
+
+
+FORCE_SOFT_EMPTY_CACHE = os.getenv("FORCE_SOFT_EMPTY_CACHE", "0") == "1"
+
 
 class VRAMState(Enum):
     DISABLED = 0    #No vram present: no need to move models to vram
@@ -1061,7 +1066,7 @@ def supports_fp8_compute(device=None):
 
     return True
 
-def soft_empty_cache(force=False):
+def soft_empty_cache(force: bool = FORCE_SOFT_EMPTY_CACHE):
     global cpu_state
     if cpu_state == CPUState.MPS:
         torch.mps.empty_cache()


### PR DESCRIPTION
This PR adds support for the `FORCE_SOFT_EMPTY_CACHE` environment variable to enable cache clearing for AMD GPUs. The logic for cache clearing already exists and is used for NVIDIA GPUs; this change simply extends the same functionality to AMD GPUs when the variable is set.

The feature has been tested for a long time on two AMD video cards, the 7900 GRE and 7900 XTX, using PyTorch versions `2.4.1`, `2.5.1`, and `2.6.0.dev`. In all cases, enabling the cache reset worked without issues.

To maintain stability, the default behavior remains unchanged as this functionality may not be suitable for all AMD GPUs (**as mentioned in an existing comment**). Users can enable this behavior by setting the `FORCE_SOFT_EMPTY_CACHE=1` variable.