### PR TITLE
Moved logic of "post_prompt" endpoint to sub-function, allowed custom "prompt_id"

### DIFF
--- a/server.py
+++ b/server.py
@@ -613,39 +613,12 @@ class PromptServer():
         @routes.post("/prompt")
         async def post_prompt(request):
             logging.info("got prompt")
-            json_data =  await request.json()
-            json_data = self.trigger_on_prompt(json_data)
-
-            if "number" in json_data:
-                number = float(json_data['number'])
-            else:
-                number = self.number
-                if "front" in json_data:
-                    if json_data['front']:
-                        number = -number
-
-                self.number += 1
-
-            if "prompt" in json_data:
-                prompt = json_data["prompt"]
-                valid = execution.validate_prompt(prompt)
-                extra_data = {}
-                if "extra_data" in json_data:
-                    extra_data = json_data["extra_data"]
-
-                if "client_id" in json_data:
-                    extra_data["client_id"] = json_data["client_id"]
-                if valid[0]:
-                    prompt_id = str(uuid.uuid4())
-                    outputs_to_execute = valid[2]
-                    self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute))
-                    response = {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}
-                    return web.json_response(response)
-                else:
-                    logging.warning("invalid prompt: {}".format(valid[1]))
-                    return web.json_response({"error": valid[1], "node_errors": valid[3]}, status=400)
-            else:
-                return web.json_response({"error": "no prompt", "node_errors": []}, status=400)
+            result = self.put_prompt_in_queue(await request.json())
+            if "error" in result:
+                if result.get("node_errors"):
+                    logging.warning("invalid prompt: {}".format(result["error"]))
+                return web.json_response(result, status=400)
+            return web.json_response(result)
 
         @routes.post("/queue")
         async def post_queue(request):
@@ -689,6 +662,38 @@ class PromptServer():
                     self.prompt_queue.delete_history_item(id_to_delete)
 
             return web.Response(status=200)
+
+    def put_prompt_in_queue(self, json_data):
+        json_data = self.trigger_on_prompt(json_data)
+
+        if "number" in json_data:
+            number = float(json_data['number'])
+        else:
+            number = self.number
+            if "front" in json_data:
+                if json_data['front']:
+                    number = -number
+
+            self.number += 1
+
+        if "prompt" in json_data:
+            prompt = json_data["prompt"]
+            valid = execution.validate_prompt(prompt)
+            extra_data = {}
+            if "extra_data" in json_data:
+                extra_data = json_data["extra_data"]
+
+            if "client_id" in json_data:
+                extra_data["client_id"] = json_data["client_id"]
+            if valid[0]:
+                prompt_id = str(uuid.uuid4())
+                outputs_to_execute = valid[2]
+                self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute))
+                return {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}
+            else:
+                return {"error": valid[1], "node_errors": valid[3]}
+        else:
+            return {"error": "no prompt", "node_errors": []}
 
     async def setup(self):
         timeout = aiohttp.ClientTimeout(total=None) # no timeout

--- a/server.py
+++ b/server.py
@@ -686,7 +686,10 @@ class PromptServer():
             if "client_id" in json_data:
                 extra_data["client_id"] = json_data["client_id"]
             if valid[0]:
-                prompt_id = str(uuid.uuid4())
+                if "prompt_id" in json_data:
+                    prompt_id = json_data["prompt_id"]
+                else:
+                    prompt_id = str(uuid.uuid4())
                 outputs_to_execute = valid[2]
                 self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute))
                 return {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}


### PR DESCRIPTION
Relates to [#6114](https://github.com/comfyanonymous/ComfyUI/pull/6114)

The changes do not break backward compatibility, all logic remains the same.

Allows having the class **PromptServer** which is returned by the `start_comfyui` function from the linked PR, without opening a websocket connection, to add tasks for execution to the Comfy engine.

For everything to work together beautifully, there is missing ability to add custom own `event_callback` which will be called at the beginning of the `PromptExecutor.add_message` method, so that without connecting to the websocket you can receive all messages from the Comfy engine and monitor the progress (I already have this locally).

What do you say, @comfyanonymous, should I include this PR in the linked one and add the ability to call the callback in `add_message`, or will we merge both of these PRs, and I will open a third small one? (it depends on the first one because it changes the same files)