### PR TITLE
remove minimum step count for AYS

### DIFF
--- a/comfy_extras/nodes_align_your_steps.py
+++ b/comfy_extras/nodes_align_your_steps.py
@@ -24,7 +24,7 @@ class AlignYourStepsScheduler:
     def INPUT_TYPES(s):
         return {"required":
                     {"model_type": (["SD1", "SDXL", "SVD"], ),
-                     "steps": ("INT", {"default": 10, "min": 10, "max": 10000}),
+                     "steps": ("INT", {"default": 10, "min": 1, "max": 10000}),
                      "denoise": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
                       }
                }


### PR DESCRIPTION
The 10 step minimum for the AYS scheduler is pointless, it works well at lower steps, like 8 steps, or even 4 steps.

For example, with LCM or DMD2.

Example here: https://i.ibb.co/56CSPMj/image.png