### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui"
+description = ""
+version = "1.0.0"
+license = {file = "LICENSE"}
+dependencies = ["torch", "torchsde", "torchvision", "torchaudio", "einops", "transformers>=4.28.1", "tokenizers>=0.13.3", "sentencepiece", "safetensors>=0.4.2", "aiohttp", "pyyaml", "Pillow", "scipy", "tqdm", "psutil", "#non essential dependencies:", "kornia>=0.7.1", "spandrel", "soundfile"]
+
+[project.urls]
+Repository = "https://github.com/comfyanonymous/ComfyUI"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI"
+Icon = ""


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

Eventually, the registry will be integrated as a backend for the UI-manager where all nodes will go through a security scan. Nodes that pass these checks will have a verification flag (✅) beside their name on the UI-manager. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!