### PR TITLE
load ltx loras trained with finetrainers

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -401,9 +401,9 @@ def model_lora_keys_unet(model, key_map={}):
 
     if isinstance(model, comfy.model_base.LTXV):
         for k in sdk:
-            if k.startswith("transformer.") and k.endswith(".weight"): #Official Mochi lora format
-                key_lora = k[len("transformer."):-len(".weight")]
-                key_map["{}".format(key_lora)] = k
+            if k.startswith("diffusion_model.") and k.endswith(".weight"):
+                key_lora = k[len("diffusion_model."):-len(".weight")]
+                key_map["transformer.{}".format(key_lora)] = k
 
     return key_map
 

--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -388,6 +388,14 @@ def model_lora_keys_unet(model, key_map={}):
                 key_map["{}".format(key_lora)] = k
 
     if isinstance(model, comfy.model_base.HunyuanVideo):
+        diffusers_keys = comfy.utils.flux_to_diffusers(model.model_config.unet_config, output_prefix="diffusion_model.")
+        for j in diffusers_keys:
+            if j.endswith(".weight"):
+                to = diffusers_keys[j]
+                key_map["transformer.{}".format(j[:-len(".weight")])] = to #simpletrainer and probably regular diffusers flux lora format
+                key_map["lycoris_{}".format(j[:-len(".weight")].replace(".", "_"))] = to #simpletrainer lycoris
+                key_map["lora_transformer_{}".format(j[:-len(".weight")].replace(".", "_"))] = to #onetrainer
+        
         for k in sdk:
             if k.startswith("diffusion_model.") and k.endswith(".weight"):
                 # diffusion-pipe lora format
@@ -398,7 +406,7 @@ def model_lora_keys_unet(model, key_map={}):
                 key_lora = key_lora[len("diffusion_model."):-len(".weight")]
                 key_map["transformer.{}".format(key_lora)] = k
                 key_map["diffusion_model.{}".format(key_lora)] = k  # Old loras
-
+    
     if isinstance(model, comfy.model_base.LTXV):
         for k in sdk:
             if k.startswith("diffusion_model.") and k.endswith(".weight"):

--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -64,6 +64,7 @@ def load_lora(lora, to_load, log_missing=True):
         diffusers3_lora = "{}.lora.up.weight".format(x)
         mochi_lora = "{}.lora_B".format(x)
         transformers_lora = "{}.lora_linear_layer.up.weight".format(x)
+        ltx_lora = "transformer.{}.lora_B.weight".format(x)
         A_name = None
 
         if regular_lora in lora.keys():
@@ -89,6 +90,10 @@ def load_lora(lora, to_load, log_missing=True):
         elif transformers_lora in lora.keys():
             A_name = transformers_lora
             B_name ="{}.lora_linear_layer.down.weight".format(x)
+            mid_name = None
+        elif ltx_lora in lora.keys():
+            A_name = ltx_lora
+            B_name = "transformer.{}.lora_A.weight".format(x)
             mid_name = None
 
         if A_name is not None:

--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -64,7 +64,6 @@ def load_lora(lora, to_load, log_missing=True):
         diffusers3_lora = "{}.lora.up.weight".format(x)
         mochi_lora = "{}.lora_B".format(x)
         transformers_lora = "{}.lora_linear_layer.up.weight".format(x)
-        ltx_lora = "transformer.{}.lora_B.weight".format(x)
         A_name = None
 
         if regular_lora in lora.keys():
@@ -90,10 +89,6 @@ def load_lora(lora, to_load, log_missing=True):
         elif transformers_lora in lora.keys():
             A_name = transformers_lora
             B_name ="{}.lora_linear_layer.down.weight".format(x)
-            mid_name = None
-        elif ltx_lora in lora.keys():
-            A_name = ltx_lora
-            B_name = "transformer.{}.lora_A.weight".format(x)
             mid_name = None
 
         if A_name is not None:
@@ -403,6 +398,12 @@ def model_lora_keys_unet(model, key_map={}):
                 key_lora = key_lora[len("diffusion_model."):-len(".weight")]
                 key_map["transformer.{}".format(key_lora)] = k
                 key_map["diffusion_model.{}".format(key_lora)] = k  # Old loras
+
+    if isinstance(model, comfy.model_base.LTXV):
+        for k in sdk:
+            if k.startswith("transformer.") and k.endswith(".weight"): #Official Mochi lora format
+                key_lora = k[len("transformer."):-len(".weight")]
+                key_map["{}".format(key_lora)] = k
 
     return key_map
 


### PR DESCRIPTION
Hi
I've been playing around with finetuning LTX-Video using [finetrainers](https://github.com/a-r-r-o-w/finetrainers), and by default the loras won't load in ComfyUI. I noticed the naming of the keys were slightly different, having a "transformer." prepended.

`transformer.transformer_blocks.0.attn1.to_k.lora_A.weight`

This PR makes them recognized by ComfyUI, but I have no idea whether it's a viable solution, if it applies to other loras than these, or if it should be fixed elsewhere.