### PR TITLE
Attempt to fix hooks using first keyframe at first step of second sampler

### DIFF
--- a/comfy/hooks.py
+++ b/comfy/hooks.py
@@ -432,8 +432,12 @@ class HookKeyframeGroup:
             return False
         prev_index = self._current_index
         prev_strength = self._current_strength
-        # if met guaranteed steps, look for next keyframe in case need to switch
-        if self._current_used_steps >= self._current_keyframe.guarantee_steps:
+        if (
+            # if met guaranteed steps, look for next keyframe in case need to switch
+            self._current_used_steps >= self._current_keyframe.guarantee_steps
+            # handle case where guarantee_steps is 1 at first keyframe, but later steps have already occurred
+            or bool(self._current_keyframe == self.keyframes[0] and self.keyframes[1].start_t >= curr_t)
+        ):
             # if has next index, loop through and see if need to switch
             if self.has_index(self._current_index+1):
                 for i in range(self._current_index+1, len(self.keyframes)):


### PR DESCRIPTION
Attempts to resolve #6183 

This fixes the issue where hooks incorrectly use the first keyframe during the first step of a second sampler pass as described in the original issue's workflow. Workflows that sample through all sigmas are not affected by this change.

Unfortunately, I don't believe this resolves the issue entirely, as it still has to invoke the ModelPatcher at the first step of the second sampler pass when it should not be necessary, and while the results are much closer to being identical than before, it still is ever so slightly off. Regardless, I'm opening this PR for further dissection and maybe as a temporary fix until it is properly resolved.

<details><summary>Result of this PR (compare to result 1 in the aforementioned issue)</summary>
<p>

![ComfyUI_temp_oluux_00001_](https://github.com/user-attachments/assets/5b0f60c5-dee8-41ea-9563-a5add7e96936)

</p>
</details>  