### PR TITLE
serve workflow templates from custom_nodes

### DIFF
--- a/app/custom_node_manager.py
+++ b/app/custom_node_manager.py
@@ -15,7 +15,11 @@ class CustomNodeManager:
         @routes.get("/workflow_templates")
         async def get_workflow_templates(request):
             """Returns a web response that contains the map of custom_nodes names and their associated workflow templates. The ones without templates are omitted."""
-            files = glob.glob(os.path.join(folder_paths.get_folder_paths("custom_nodes")[0], '*/example_workflows/*.json'))
+            files = [
+                file
+                for folder in folder_paths.get_folder_paths("custom_nodes")
+                for file in glob.glob(os.path.join(folder, '*/example_workflows/*.json'))
+            ]
             workflow_templates_dict = {} # custom_nodes folder name -> example workflow names
             for file in files:
                 custom_nodes_name = os.path.basename(os.path.dirname(os.path.dirname(file)))

--- a/app/custom_node_manager.py
+++ b/app/custom_node_manager.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+import folder_paths
+import glob
+from aiohttp import web
+
+class CustomNodeManager:
+    """
+    Placeholder to refactor the custom node management features from ComfyUI-Manager.
+    Currently it only contains the custom workflow templates feature.
+    """
+    def add_routes(self, routes, webapp, loadedModules):     
+
+        @routes.get("/workflow_templates")
+        async def get_workflow_templates(request):
+            """Returns a web response that contains the map of custom_nodes names and their associated workflow templates. The ones without templates are omitted."""
+            files = glob.glob(os.path.join(folder_paths.get_folder_paths("custom_nodes")[0], '*/example_workflows/*.json'))
+            workflow_templates_dict = {} # custom_nodes folder name -> example workflow names
+            for file in files:
+                custom_nodes_name = os.path.basename(os.path.dirname(os.path.dirname(file)))
+                workflow_name = os.path.splitext(os.path.basename(file))[0]
+                workflow_templates_dict.setdefault(custom_nodes_name, []).append(workflow_name)
+            return web.json_response(workflow_templates_dict)
+        
+        # Serve workflow templates from custom nodes.
+        for module_name, module_dir in loadedModules:
+            workflows_dir = os.path.join(module_dir, 'example_workflows')
+            if os.path.exists(workflows_dir):
+                webapp.add_routes([web.static('/api/workflow_templates/' + module_name, workflows_dir)])

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -39,10 +39,10 @@ folder_names_and_paths["photomaker"] = ([os.path.join(models_dir, "photomaker")]
 
 folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
 
-output_directory = os.path.join(base_path, "output")
-temp_directory = os.path.join(base_path, "temp")
-input_directory = os.path.join(base_path, "input")
-user_directory = os.path.join(base_path, "user")
+output_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
+temp_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "temp")
+input_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "input")
+user_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "user")
 
 filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
 

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -43,7 +43,6 @@ output_directory = os.path.join(base_path, "output")
 temp_directory = os.path.join(base_path, "temp")
 input_directory = os.path.join(base_path, "input")
 user_directory = os.path.join(base_path, "user")
-custom_nodes_directory = os.path.join(base_path, "custom_nodes")
 
 filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
 

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -39,10 +39,11 @@ folder_names_and_paths["photomaker"] = ([os.path.join(models_dir, "photomaker")]
 
 folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
 
-output_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
-temp_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "temp")
-input_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "input")
-user_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)), "user")
+output_directory = os.path.join(base_path, "output")
+temp_directory = os.path.join(base_path, "temp")
+input_directory = os.path.join(base_path, "input")
+user_directory = os.path.join(base_path, "user")
+custom_nodes_directory = os.path.join(base_path, "custom_nodes")
 
 filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
 

--- a/nodes.py
+++ b/nodes.py
@@ -2033,6 +2033,9 @@ NODE_DISPLAY_NAME_MAPPINGS = {
 
 EXTENSION_WEB_DIRS = {}
 
+# Dictionary of successfully loaded module names and associated directories.
+LOADED_MODULE_DIRS = {}
+
 
 def get_module_name(module_path: str) -> str:
     """
@@ -2073,6 +2076,8 @@ def load_custom_node(module_path: str, ignore=set(), module_parent="custom_nodes
         module = importlib.util.module_from_spec(module_spec)
         sys.modules[module_name] = module
         module_spec.loader.exec_module(module)
+
+        LOADED_MODULE_DIRS[module_name] = os.path.abspath(module_dir)
 
         if hasattr(module, "WEB_DIRECTORY") and getattr(module, "WEB_DIRECTORY") is not None:
             web_dir = os.path.abspath(os.path.join(module_dir, getattr(module, "WEB_DIRECTORY")))

--- a/server.py
+++ b/server.py
@@ -714,9 +714,7 @@ class PromptServer():
         self.app.add_routes(self.routes)
 
         for name, dir in nodes.EXTENSION_WEB_DIRS.items():
-            self.app.add_routes([
-                web.static('/extensions/' + urllib.parse.quote(name), dir),
-            ])
+            self.app.add_routes([web.static('/extensions/' + name, dir)])
 
         self.app.add_routes([
             web.static('/', self.web_root),

--- a/server.py
+++ b/server.py
@@ -250,6 +250,16 @@ class PromptServer():
                     name) + "/" + os.path.relpath(f, dir).replace("\\", "/"), files)))
 
             return web.json_response(extensions)
+        
+        @routes.get("/workflow_templates")
+        async def get_workflow_templates(request):
+            files = glob.glob(os.path.join(folder_paths.custom_nodes_directory, '*/example_workflows/*.json'))
+            workflow_templates_dict = {} # custom_nodes folder name -> example workflow names
+            for file in files:
+                custom_nodes_name = os.path.basename(os.path.dirname(os.path.dirname(file)))
+                workflow_name = os.path.splitext(os.path.basename(file))[0]
+                workflow_templates_dict.setdefault(custom_nodes_name, []).append(workflow_name)
+            return web.json_response(workflow_templates_dict)
 
         def get_dir_by_type(dir_type):
             if dir_type is None:

--- a/server.py
+++ b/server.py
@@ -723,6 +723,13 @@ class PromptServer():
         self.app.add_routes(api_routes)
         self.app.add_routes(self.routes)
 
+        # Add routes for workflow templates in custom nodes.
+        for module_name, module_dir in nodes.LOADED_MODULE_DIRS.items():
+            workflows_dir = os.path.join(module_dir, 'example_workflows')
+            if os.path.exists(workflows_dir):
+                self.app.add_routes([web.static('/workflow_templates/' + module_name, workflows_dir)])
+
+        # Add routes from web extensions.
         for name, dir in nodes.EXTENSION_WEB_DIRS.items():
             self.app.add_routes([web.static('/extensions/' + name, dir)])
 

--- a/tests-unit/app_test/custom_node_manager_test.py
+++ b/tests-unit/app_test/custom_node_manager_test.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 from aiohttp import web
 from unittest.mock import patch
 from app.custom_node_manager import CustomNodeManager

--- a/tests-unit/app_test/custom_node_manager_test.py
+++ b/tests-unit/app_test/custom_node_manager_test.py
@@ -1,0 +1,41 @@
+import pytest
+import json
+from aiohttp import web
+from unittest.mock import patch
+from app.custom_node_manager import CustomNodeManager
+
+pytestmark = (
+    pytest.mark.asyncio
+)  # This applies the asyncio mark to all test functions in the module
+
+@pytest.fixture
+def custom_node_manager():
+    return CustomNodeManager()
+
+@pytest.fixture
+def app(custom_node_manager):
+    app = web.Application()
+    routes = web.RouteTableDef()
+    custom_node_manager.add_routes(routes, app, [("ComfyUI-TestExtension1", "ComfyUI-TestExtension1")])
+    app.add_routes(routes)
+    return app
+
+async def test_get_workflow_templates(aiohttp_client, app, tmp_path):
+    client = await aiohttp_client(app)
+    # Setup temporary custom nodes file structure with 1 workflow file
+    custom_nodes_dir = tmp_path / "custom_nodes"
+    example_workflows_dir = custom_nodes_dir / "ComfyUI-TestExtension1" / "example_workflows"
+    example_workflows_dir.mkdir(parents=True)
+    template_file = example_workflows_dir / "workflow1.json"
+    template_file.write_text('')
+
+    with patch('folder_paths.folder_names_and_paths', {
+        'custom_nodes': ([str(custom_nodes_dir)], None)
+    }):
+        response = await client.get('/workflow_templates')
+        assert response.status == 200
+        workflows_dict = await response.json()
+        assert isinstance(workflows_dict, dict)
+        assert "ComfyUI-TestExtension1" in workflows_dict
+        assert isinstance(workflows_dict["ComfyUI-TestExtension1"], list)
+        assert workflows_dict["ComfyUI-TestExtension1"][0] == "workflow1"


### PR DESCRIPTION
This PR prepares the following feature request: https://github.com/Comfy-Org/ComfyUI_frontend/issues/1008
Related frontend PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/2032

Implementation details:
- `@routes.get("/workflow_templates")` - This endpoint returns a map of custom_nodes names and their associated workflow template files. The ones without templates are omitted. Example:
```
{
    "ComfyUI-LTXTricks": [
        "example_ltxv_stg",
        "example_ltx_flow_edit",
        "example_ltx_interpolation",
        "example_ltx_inversion",
        "example_ltx_iv2v",
        "example_ltx_rf_edit"
    ],
    "ComfyUI_Noise": [
        "unsample_example",
        "variations_example"
    ]
}
```
- `LOADED_MODULE_DIRS` where we keep track of all successfully loaded custom_nodes and their directories (even when there is no class mapping and web directory)
- files are served from each custom_nodes's specific subfolder if exists, like this: `custom_nodes/*/example_workflows/*`

Question to reviewers:
- Is serving from the `/example_workflows` folders sufficient or shall we support existing folder structures of popular custom_node repos by allowing `/examples`, `/workflows`, etc.?