### PR TITLE
"unload_models" flag when creating a task

### DIFF
--- a/main.py
+++ b/main.py
@@ -166,6 +166,14 @@ def prompt_worker(q, server_instance):
         queue_item = q.get(timeout=timeout)
         if queue_item is not None:
             item, item_id = queue_item
+
+            if item[3].get("unload_models"):
+                # For those cases where the flag is set, to clear memory before execution
+                comfy.model_management.unload_all_models()
+                gc.collect()
+                comfy.model_management.soft_empty_cache()
+                last_gc_collect = time.perf_counter()
+
             execution_start_time = time.perf_counter()
             prompt_id = item[1]
             server_instance.last_prompt_id = prompt_id


### PR DESCRIPTION
When might this be needed:

1. When you have a heavy workflow and want to run it in clean environment.
2. When several people use a server with Comfy and pressing the "Clear memory" button in the front-end does not guarantee that at that moment someone else will not add a task before yours.
3. For use via API, for example, you have a server with Comfy and you want to measure how many memory are consumed by the workflow - you will also need this flag then, because if the server is not purely for testing, but in production - see point 2.
4. For clear and easy benchmarks using API.

We use something similar in our project, but since now we want to reduce the amount of different code between us and Comfy, I hope this PR will be accepted.

If I need to update the documentation somewhere - point your finger..


P.S: about point 3, to save info about how many memory are consumed by the workflow - if such feature is needed for someone I can create a separate PR.

