### PR TITLE
Improve the log time function for 10 minute + renders

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,7 +183,13 @@ def prompt_worker(q, server_instance):
 
             current_time = time.perf_counter()
             execution_time = current_time - execution_start_time
-            logging.info("Prompt executed in {:.2f} seconds".format(execution_time))
+            
+            # Log Time in a more readable way after 10 minutes
+            if execution_time > 600:
+                execution_time = time.strftime("%H:%M:%S", time.gmtime(execution_time))
+                logging.info("Prompt executed in", execution_time)
+            else:
+                logging.info("Prompt executed in {:.2f} seconds".format(execution_time))
 
         flags = q.get_flags()
         free_memory = flags.get("free_memory", False)

--- a/main.py
+++ b/main.py
@@ -187,7 +187,7 @@ def prompt_worker(q, server_instance):
             # Log Time in a more readable way after 10 minutes
             if execution_time > 600:
                 execution_time = time.strftime("%H:%M:%S", time.gmtime(execution_time))
-                logging.info("Prompt executed in", execution_time)
+                logging.info(f"Prompt executed in {execution_time}")
             else:
                 logging.info("Prompt executed in {:.2f} seconds".format(execution_time))
 


### PR DESCRIPTION
While seeing the output on seconds is useful when they get longer ( which will start to happen more often since video models are here ) the total time gets a bit complicated to read on.

Specially for people leaving Comfy rendering overnight.

I hope this helps