### PR TITLE
Fix Hook Keyframe 'guarantee_steps' behavior and add 'sigmas'

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -919,11 +919,12 @@ class ModelPatcher:
     def set_hook_mode(self, hook_mode: comfy.hooks.EnumHookMode):
         self.hook_mode = hook_mode
 
-    def prepare_hook_patches_current_keyframe(self, t: torch.Tensor, hook_group: comfy.hooks.HookGroup):
+    def prepare_hook_patches_current_keyframe(self, t: torch.Tensor, hook_group: comfy.hooks.HookGroup, model_options: dict[str]):
         curr_t = t[0]
         reset_current_hooks = False
+        transformer_options = model_options.get("transformer_options", {})
         for hook in hook_group.hooks:
-            changed = hook.hook_keyframe.prepare_current_keyframe(curr_t=curr_t)
+            changed = hook.hook_keyframe.prepare_current_keyframe(curr_t=curr_t, transformer_options=transformer_options)
             # if keyframe changed, remove any cached HookGroups that contain hook with the same hook_ref;
             # this will cause the weights to be recalculated when sampling
             if changed:


### PR DESCRIPTION
This PR adds a 'sigmas' entry into ```transformer_options``` so that downstream code can know the full scope of the current sampling run.

This makes it possible to fix the inconsistency in hook keyframe behavior when sampling is split across different sampling nodes, or if a node's sampling code splits it across multiple calls.
https://github.com/comfyanonymous/ComfyUI/issues/6183
https://github.com/comfyanonymous/ComfyUI/pull/6185