### PR TITLE
Allow setting http proxy in Windows updater

### DIFF
--- a/.ci/update_windows/update.py
+++ b/.ci/update_windows/update.py
@@ -5,10 +5,10 @@ import os
 import shutil
 import filecmp
 
-def pull(repo, remote_name='origin', branch='master'):
+def pull(repo, remote_name='origin', branch='master', proxy=None):
     for remote in repo.remotes:
         if remote.name == remote_name:
-            remote.fetch()
+            remote.fetch(proxy=proxy)
             remote_master_id = repo.lookup_reference('refs/remotes/origin/%s' % (branch)).target
             merge_result, _ = repo.merge_analysis(remote_master_id)
             # Up to date, do nothing
@@ -46,6 +46,14 @@ def pull(repo, remote_name='origin', branch='master'):
 
 pygit2.option(pygit2.GIT_OPT_SET_OWNER_VALIDATION, 0)
 repo_path = str(sys.argv[1])
+proxy = None
+if '--proxy' in sys.argv:
+    proxy_index = sys.argv.index('--proxy')
+    if proxy_index + 1 < len(sys.argv):
+        proxy = sys.argv[proxy_index + 1]
+        if len(proxy)<=0:
+            proxy = None
+
 repo = pygit2.Repository(repo_path)
 ident = pygit2.Signature('comfyui', 'comfy@ui')
 try:
@@ -73,7 +81,7 @@ else:
     repo.checkout(ref)
 
 print("pulling latest changes")  # noqa: T201
-pull(repo)
+pull(repo, proxy=proxy)
 
 if "--stable" in sys.argv:
     def latest_tag(repo):

--- a/.ci/update_windows/update_comfyui.bat
+++ b/.ci/update_windows/update_comfyui.bat
@@ -1,8 +1,10 @@
 @echo off
-..\python_embeded\python.exe .\update.py ..\ComfyUI\
+:: Set the http proxy here like `set proxy="http://127.0.0.1:888/"`. No spacebar allowed.
+set proxy=""
+..\python_embeded\python.exe .\update.py ..\ComfyUI\ --proxy %proxy%
 if exist update_new.py (
   move /y update_new.py update.py
   echo Running updater again since it got updated.
-  ..\python_embeded\python.exe .\update.py ..\ComfyUI\ --skip_self_update
+  ..\python_embeded\python.exe .\update.py ..\ComfyUI\ --skip_self_update --proxy %proxy%
 )
 if "%~1"=="" pause

--- a/.ci/update_windows/update_comfyui_stable.bat
+++ b/.ci/update_windows/update_comfyui_stable.bat
@@ -1,8 +1,10 @@
 @echo off
-..\python_embeded\python.exe .\update.py ..\ComfyUI\ --stable
+:: Set the http proxy here like `set proxy="http://127.0.0.1:888/"`. No spacebar allowed.
+set proxy=""
+..\python_embeded\python.exe .\update.py ..\ComfyUI\ --proxy %proxy% --stable
 if exist update_new.py (
   move /y update_new.py update.py
   echo Running updater again since it got updated.
-  ..\python_embeded\python.exe .\update.py ..\ComfyUI\ --skip_self_update --stable
+  ..\python_embeded\python.exe .\update.py ..\ComfyUI\ --skip_self_update --proxy %proxy% --stable
 )
 if "%~1"=="" pause


### PR DESCRIPTION
A manual way of setting HTTP proxy in `pygit2` used in updater.

Or simply just use `proxy=True` for automatic proxy.
![image](https://github.com/user-attachments/assets/876a4a1d-7177-4ec9-87b8-cd46ad4d2abd)

May fix https://github.com/comfyanonymous/ComfyUI/issues/6288