### PR TITLE
In inner_sample, change "sigmas" to "sample_sigmas"

### DIFF
--- a/comfy/hooks.py
+++ b/comfy/hooks.py
@@ -442,7 +442,7 @@ class HookKeyframeGroup:
             return False
         if curr_t == self._curr_t:
             return False
-        max_sigma = torch.max(transformer_options["sigmas"])
+        max_sigma = torch.max(transformer_options["sample_sigmas"])
         prev_index = self._current_index
         prev_strength = self._current_strength
         # if met guaranteed steps, look for next keyframe in case need to switch

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -849,7 +849,7 @@ class CFGGuider:
         self.conds = process_conds(self.inner_model, noise, self.conds, device, latent_image, denoise_mask, seed)
 
         extra_model_options = comfy.model_patcher.create_model_options_clone(self.model_options)
-        extra_model_options.setdefault("transformer_options", {})["sigmas"] = sigmas
+        extra_model_options.setdefault("transformer_options", {})["sample_sigmas"] = sigmas
         extra_args = {"model_options": extra_model_options, "seed": seed}
 
         executor = comfy.patcher_extension.WrapperExecutor.new_class_executor(


### PR DESCRIPTION
In _calc_cond_batch, "sigmas" on transformer_options is written with the value of t, which is only the current step's sigma (and this PR does not change it). In inner_sample, there is another "sigmas" assigned to transformer_options earlier that is intended to have all the sigmas used for the current sampling run (i.e. all the steps that will be run).

When I added that inner_sample "sigmas", I did not notice the string was already used inside _calc_cond_batch, so third-party nodes that were intending to use the full sample sigmas do not work as intended since those values end up not being exposed anywhere.

So this PR just changes the "sigmas" assigned to transformer_options in inner_sample to "sample_sigmas" to make sure there is no overlap in the name. In the long term, we should have a class defined somewhere that keeps track of all the possible vanilla entries to transformer_options to avoid accidental clashes.