### PR TITLE
(fix): UserManager: allow unencoded "{file}" parameter

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -211,6 +211,57 @@ class UserManager():
 
             return path
 
+        @routes.post("/userdata/{file}/move/{dest}")
+        async def move_userdata(request):
+            """
+            Move or rename a user data file.
+
+            This endpoint handles moving or renaming files within a user's data directory, with options for
+            controlling overwrite behavior and response format.
+
+            Path Parameters:
+            - file: The source file path (URL encoded if necessary)
+            - dest: The destination file path (URL encoded if necessary)
+
+            Query Parameters:
+            - overwrite (optional): If "false", prevents overwriting existing files. Defaults to "true".
+            - full_info (optional): If "true", returns detailed file information (path, size, modified time).
+                                  If "false", returns only the relative file path.
+
+            Returns:
+            - 400: If either 'file' or 'dest' parameter is missing
+            - 403: If either requested path is not allowed
+            - 404: If the source file does not exist
+            - 409: If overwrite=false and the destination file already exists
+            - 200: JSON response with either:
+                  - Full file information (if full_info=true)
+                  - Relative file path (if full_info=false)
+            """
+            source = get_user_data_path(request, check_exists=True)
+            if not isinstance(source, str):
+                return source
+
+            dest = get_user_data_path(request, check_exists=False, param="dest")
+            if not isinstance(source, str):
+                return dest
+
+            overwrite = request.query.get("overwrite", 'true') != "false"
+            full_info = request.query.get('full_info', 'false').lower() == "true"
+
+            if not overwrite and os.path.exists(dest):
+                return web.Response(status=409, text="File already exists")
+
+            logging.info(f"moving '{source}' -> '{dest}'")
+            shutil.move(source, dest)
+
+            user_path = self.get_request_user_filepath(request, None)
+            if full_info:
+                resp = get_file_info(dest, user_path)
+            else:
+                resp = os.path.relpath(dest, user_path)
+
+            return web.json_response(resp)
+
         @routes.get("/userdata/{file:.+}")
         async def getuserdata(request):
             path = get_user_data_path(request, check_exists=True)
@@ -277,54 +328,3 @@ class UserManager():
             os.remove(path)
 
             return web.Response(status=204)
-
-        @routes.post("/userdata/{file}/move/{dest}")
-        async def move_userdata(request):
-            """
-            Move or rename a user data file.
-
-            This endpoint handles moving or renaming files within a user's data directory, with options for
-            controlling overwrite behavior and response format.
-
-            Path Parameters:
-            - file: The source file path (URL encoded if necessary)
-            - dest: The destination file path (URL encoded if necessary)
-
-            Query Parameters:
-            - overwrite (optional): If "false", prevents overwriting existing files. Defaults to "true".
-            - full_info (optional): If "true", returns detailed file information (path, size, modified time).
-                                  If "false", returns only the relative file path.
-
-            Returns:
-            - 400: If either 'file' or 'dest' parameter is missing
-            - 403: If either requested path is not allowed
-            - 404: If the source file does not exist
-            - 409: If overwrite=false and the destination file already exists
-            - 200: JSON response with either:
-                  - Full file information (if full_info=true)
-                  - Relative file path (if full_info=false)
-            """
-            source = get_user_data_path(request, check_exists=True)
-            if not isinstance(source, str):
-                return source
-
-            dest = get_user_data_path(request, check_exists=False, param="dest")
-            if not isinstance(source, str):
-                return dest
-
-            overwrite = request.query.get("overwrite", 'true') != "false"
-            full_info = request.query.get('full_info', 'false').lower() == "true"
-
-            if not overwrite and os.path.exists(dest):
-                return web.Response(status=409, text="File already exists")
-
-            logging.info(f"moving '{source}' -> '{dest}'")
-            shutil.move(source, dest)
-
-            user_path = self.get_request_user_filepath(request, None)
-            if full_info:
-                resp = get_file_info(dest, user_path)
-            else:
-                resp = os.path.relpath(dest, user_path)
-
-            return web.json_response(resp)

--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -211,7 +211,7 @@ class UserManager():
 
             return path
 
-        @routes.get("/userdata/{file}")
+        @routes.get("/userdata/{file:.+}")
         async def getuserdata(request):
             path = get_user_data_path(request, check_exists=True)
             if not isinstance(path, str):
@@ -219,7 +219,7 @@ class UserManager():
 
             return web.FileResponse(path)
 
-        @routes.post("/userdata/{file}")
+        @routes.post("/userdata/{file:.+}")
         async def post_userdata(request):
             """
             Upload or update a user data file.
@@ -268,7 +268,7 @@ class UserManager():
 
             return web.json_response(resp)
 
-        @routes.delete("/userdata/{file}")
+        @routes.delete("/userdata/{file:.+}")
         async def delete_userdata(request):
             path = get_user_data_path(request, check_exists=True)
             if not isinstance(path, str):


### PR DESCRIPTION
We encountered issues while deploying ComfyUI behind `NGINX`, as file-related endpoints do not work reliably. According to the standard, there is no explicit requirement specifying which parts of a URL should be encoded and which should not. As a result, any proxy server may modify the request:

`http://127.0.0.1:8188/api/userdata/workflows%2Fphoto_stickers2.json?overwrite=false&full_info=true`

to:

`http://127.0.0.1:8188/api/userdata/workflows/photo_stickers2.json?overwrite=false&full_info=true`

This change causes the server to return a `405 Method Not Allowed` status.

With the modifications we applied, this issue is resolved (we primarily tested this with the "Save Workflow" button, where we initially noticed the error).

It is worth noting that the `move_userdata` endpoint will still not work because it requires two file paths as **path** parameters. It would be more reliable to rewrite `move_userdata` endpoint to accept those parameters as POST data or headers(like in WebDAV), which aligns better with common practices.


Edited: moved `move_userdata` before other `/userdata` endpoints that have greedy quantifier in the path.
