### PR TITLE
Change Save Image default value

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1578,7 +1578,7 @@ class SaveImage:
         return {
             "required": {
                 "images": ("IMAGE", {"tooltip": "The images to save."}),
-                "filename_prefix": ("STRING", {"default": "ComfyUI", "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."})
+                "filename_prefix": ("STRING", {"default": "%date:yyyy-MM-dd%/%date:hhmmss%", "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."})
             },
             "hidden": {
                 "prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"


### PR DESCRIPTION
Set a more useful default filename for the **Save Image** node. Sample output path would be: **output/2025-01-07/190401_00001_.png**

Sorting the folder by name will also sort them chronologically.

_Note thate "00001_" is a suffix added by ComfyUI itself.