### PR TITLE
Allow FP16 accumulation with `--fast`

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -242,6 +242,12 @@ if ENABLE_PYTORCH_ATTENTION:
     torch.backends.cuda.enable_mem_efficient_sdp(True)
 
 try:
+    if is_nvidia() and args.fast:
+        torch.backends.cuda.matmul.allow_fp16_accumulation = True
+except:
+    pass
+
+try:
     if int(torch_version[0]) == 2 and int(torch_version[2]) >= 5:
         torch.backends.cuda.allow_fp16_bf16_reduction_math_sdp(True)
 except:


### PR DESCRIPTION
This PR enables a new PyTorch flag, currently only available in nightly releases as of 2025-01-12, that enables FP16 accumulation in matmul ops for NVIDIA GPUs. On my system with a RTX 3090, running the default provided image generation workflow at a resolution of 1024x1024, provides an `it/s` bump from `4it/s` to `5it/s`.

I've opted to only enable this when `--fast` is used since it seems to be "potentially quality deteriorating", [as the `--fast` arg suggests](https://github.com/comfyanonymous/ComfyUI/blob/1f1c7b7b5673fac3d3d38a1291ed1171f6cdc3eb/comfy/cli_args.py#L132).

Note that performance improvement only really applies to the 3090 or newer GPUs (i.e. 4000 series). Older cards will likely see no performance improvement.

---

For reference:
https://github.com/pytorch/pytorch/pull/144441
https://docs-preview.pytorch.org/pytorch/pytorch/144441/notes/cuda.html#full-fp16-accmumulation-in-fp16-gemms
https://github.com/pytorch/pytorch/pull/144441#issuecomment-2581511510

> 3090/4090 users would also likely benefit from fp16 accumulation inside attention and convolution operations. with this, perhaps the 4090 could approximate the speed of an A100.

For future work it may also be worth to look at this (retain performance improvement w/o quality deterioration):
https://github.com/pytorch/pytorch/pull/144441#issuecomment-2581510157