### PR TITLE
PromptServer: Return `400` for empty `filename` param

### DIFF
--- a/server.py
+++ b/server.py
@@ -329,6 +329,9 @@ class PromptServer():
                 original_ref = json.loads(post.get("original_ref"))
                 filename, output_dir = folder_paths.annotated_filepath(original_ref['filename'])
 
+                if not filename:
+                    return web.Response(status=400)
+
                 # validation for security: prevent accessing arbitrary path
                 if filename[0] == '/' or '..' in filename:
                     return web.Response(status=400)
@@ -369,6 +372,9 @@ class PromptServer():
             if "filename" in request.rel_url.query:
                 filename = request.rel_url.query["filename"]
                 filename,output_dir = folder_paths.annotated_filepath(filename)
+
+                if not filename:
+                    return web.Response(status=400)
 
                 # validation for security: prevent accessing arbitrary path
                 if filename[0] == '/' or '..' in filename:


### PR DESCRIPTION
Prevents noisy errors like this being spit out to the console.
```
Error handling request
Traceback (most recent call last):
  File "C:\comfyui\venv\Lib\site-packages\aiohttp\web_protocol.py", line 452, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\comfyui\venv\Lib\site-packages\aiohttp\web_app.py", line 543, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\comfyui\venv\Lib\site-packages\aiohttp\web_middlewares.py", line 114, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\comfyui\server.py", line 50, in cache_control
    response: web.Response = await handler(request)
                             ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\comfyui\server.py", line 128, in origin_only_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\comfyui\server.py", line 374, in view_image
    if filename[0] == '/' or '..' in filename:
       ~~~~~~~~^^^
IndexError: string index out of range
```

This is reproducible by using something like this [Krita extension](https://github.com/Acly/krita-ai-diffusion), which only sends the image to Krita and doesn't produce a file output, so when the queue entry (normally containing a file) is attempted to be viewed in the frontend, an empty string is passed in for the `filename` parameter, causing this error. Immediately returning `400` when `filename` is empty seems like the correct thing to do here.