### PR TITLE
Load only needed custom-nodes by passing it as cli args

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -178,6 +178,8 @@ parser.add_argument(
 
 parser.add_argument("--user-directory", type=is_valid_directory, default=None, help="Set the ComfyUI user directory with an absolute path.")
 
+parser.add_argument('--custom-nodes', type=str, nargs='*', help='Specify which custom nodes to load')
+
 if comfy.options.args_parsing:
     args = parser.parse_args()
 else:

--- a/main.py
+++ b/main.py
@@ -258,7 +258,14 @@ def start_comfyui(asyncio_loop=None):
     prompt_server = server.PromptServer(asyncio_loop)
     q = execution.PromptQueue(prompt_server)
 
-    nodes.init_extra_nodes(init_custom_nodes=not args.disable_all_custom_nodes)
+    # Parse requested custom nodes from args
+    requested_nodes = None
+    if args.custom_nodes:
+        requested_nodes = [node.strip() for nodes in args.custom_nodes for node in nodes.split(',')]
+        logging.info(f"Loading only requested custom nodes: {requested_nodes}")
+
+    nodes.init_extra_nodes(init_custom_nodes=not args.disable_all_custom_nodes, 
+                          requested_nodes=requested_nodes)
 
     cuda_malloc_warning()
 


### PR DESCRIPTION
Our custom_nodes are becoming heavier and heavier.

to reduce the app's startup time, I suggest using this arg option.

Here is an example of usage.

```sh
python main.py --custom-nodes comfyui-impact-pack ComfyUI-Manager ComfyUI_Comfyroll_CustomNodes ComfyUI_ADV_CLIP_emb bilbox-comfyui cg-use-everywhere
```