### PR TITLE
Add filetype selection to save image

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1578,7 +1578,8 @@ class SaveImage:
         return {
             "required": {
                 "images": ("IMAGE", {"tooltip": "The images to save."}),
-                "filename_prefix": ("STRING", {"default": "ComfyUI", "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."})
+                "filename_prefix": ("STRING", {"default": "ComfyUI", "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."}),
+                "file_type": ("png", "jpg", "webp", "gif")
             },
             "hidden": {
                 "prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"
@@ -1593,7 +1594,7 @@ class SaveImage:
     CATEGORY = "image"
     DESCRIPTION = "Saves the input images to your ComfyUI output directory."
 
-    def save_images(self, images, filename_prefix="ComfyUI", prompt=None, extra_pnginfo=None):
+    def save_images(self, images, file_type, filename_prefix="ComfyUI", prompt=None, extra_pnginfo=None):
         filename_prefix += self.prefix_append
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
         results = list()
@@ -1610,7 +1611,7 @@ class SaveImage:
                         metadata.add_text(x, json.dumps(extra_pnginfo[x]))
 
             filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
-            file = f"{filename_with_batch_num}_{counter:05}_.png"
+            file = f"{filename_with_batch_num}_{counter:05}_.{file_type}"
             img.save(os.path.join(full_output_folder, file), pnginfo=metadata, compress_level=self.compress_level)
             results.append({
                 "filename": file,


### PR DESCRIPTION
#6518 
This adds a filetype selection to the Save Image node so you can choose which format output images will be saved as for convenience. I have tested each format and they all work properly. I'm not sure if metadata works, or if there are any concerns with the implementation `file = f"{filename_with_batch_num}_{counter:05}_.{file_type}"`.

![Screenshot from 2025-01-21 00-19-25](https://github.com/user-attachments/assets/cd77aadb-7b03-4c83-8c68-d621d610acb6)

![Screenshot from 2025-01-21 00-24-51](https://github.com/user-attachments/assets/2cd7a0ac-4810-4817-b11a-97cf9cd420e7)