### PR TITLE
Add utils/ to web server developer codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@
 # Python web server
 /api_server/ @yoland68 @robinjhuang @huchenlei @webfiltered @pythongosssss @ltdrdata
 /app/ @yoland68 @robinjhuang @huchenlei @webfiltered @pythongosssss @ltdrdata
+/utils/ @yoland68 @robinjhuang @huchenlei @webfiltered @pythongosssss @ltdrdata
 
 # Frontend assets
 /web/ @huchenlei @webfiltered @pythongosssss @yoland68 @robinjhuang


### PR DESCRIPTION
Make web server developers own `/utils/` directory.