### PR TITLE
Allow override of folder_paths.base_path via env var

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -11,7 +11,8 @@ supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.bin', '.pth', '.safetenso
 
 folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
 
-base_path = os.path.dirname(os.path.realpath(__file__))
+env_base_path = os.environ.get("COMFYUI_FOLDERS_BASE_PATH")
+base_path = os.path.dirname(os.path.realpath(__file__)) if env_base_path is None else env_base_path
 models_dir = os.path.join(base_path, "models")
 folder_names_and_paths["checkpoints"] = ([os.path.join(models_dir, "checkpoints")], supported_pt_extensions)
 folder_names_and_paths["configs"] = ([os.path.join(models_dir, "configs")], [".yaml"])


### PR DESCRIPTION
- Allows the configuration of the default ComfyUI folders via environment variable.
- Provides a number of the pre-requisites for ComfyUI to be executed from a read-only location.
- Covers additional folders with #6576.
- No change if env var is not set.