### PR TITLE
Allow changing folder_paths.base_path via command line argument.

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -43,10 +43,11 @@ parser.add_argument("--tls-certfile", type=str, help="Path to TLS (SSL) certific
 parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
 parser.add_argument("--max-upload-size", type=float, default=100, help="Set the maximum upload size in MB.")
 
+parser.add_argument("--base-directory", type=str, default=None, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")
 parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
-parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory.")
-parser.add_argument("--temp-directory", type=str, default=None, help="Set the ComfyUI temp directory (default is in the ComfyUI directory).")
-parser.add_argument("--input-directory", type=str, default=None, help="Set the ComfyUI input directory.")
+parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory. Overrides --base-directory.")
+parser.add_argument("--temp-directory", type=str, default=None, help="Set the ComfyUI temp directory (default is in the ComfyUI directory). Overrides --base-directory.")
+parser.add_argument("--input-directory", type=str, default=None, help="Set the ComfyUI input directory. Overrides --base-directory.")
 parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")
 parser.add_argument("--disable-auto-launch", action="store_true", help="Disable auto launching the browser.")
 parser.add_argument("--cuda-device", type=int, default=None, metavar="DEVICE_ID", help="Set the id of the cuda device this instance will use.")
@@ -176,7 +177,7 @@ parser.add_argument(
     help="The local filesystem path to the directory where the frontend is located. Overrides --front-end-version.",
 )
 
-parser.add_argument("--user-directory", type=is_valid_directory, default=None, help="Set the ComfyUI user directory with an absolute path.")
+parser.add_argument("--user-directory", type=is_valid_directory, default=None, help="Set the ComfyUI user directory with an absolute path. Overrides --base-directory.")
 
 if comfy.options.args_parsing:
     args = parser.parse_args()

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -31,13 +31,13 @@ folder_names_and_paths["gligen"] = ([os.path.join(models_dir, "gligen")], suppor
 
 folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_models")], supported_pt_extensions)
 
-folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
-
 folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
 
 folder_names_and_paths["photomaker"] = ([os.path.join(models_dir, "photomaker")], supported_pt_extensions)
 
 folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
+
+folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
 
 output_directory = os.path.join(base_path, "output")
 temp_directory = os.path.join(base_path, "temp")

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -10,6 +10,7 @@ from collections.abc import Collection
 supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.bin', '.pth', '.safetensors', '.pkl', '.sft'}
 
 folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
+filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
 
 base_path = os.path.dirname(os.path.realpath(__file__))
 models_dir = os.path.join(base_path, "models")
@@ -43,8 +44,6 @@ output_directory = os.path.join(base_path, "output")
 temp_directory = os.path.join(base_path, "temp")
 input_directory = os.path.join(base_path, "input")
 user_directory = os.path.join(base_path, "user")
-
-filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
 
 class CacheHelper:
     """

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -10,83 +10,41 @@ from collections.abc import Collection
 supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.bin', '.pth', '.safetensors', '.pkl', '.sft'}
 
 folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
+
+base_path = os.path.dirname(os.path.realpath(__file__))
+models_dir = os.path.join(base_path, "models")
+folder_names_and_paths["checkpoints"] = ([os.path.join(models_dir, "checkpoints")], supported_pt_extensions)
+folder_names_and_paths["configs"] = ([os.path.join(models_dir, "configs")], [".yaml"])
+
+folder_names_and_paths["loras"] = ([os.path.join(models_dir, "loras")], supported_pt_extensions)
+folder_names_and_paths["vae"] = ([os.path.join(models_dir, "vae")], supported_pt_extensions)
+folder_names_and_paths["text_encoders"] = ([os.path.join(models_dir, "text_encoders"), os.path.join(models_dir, "clip")], supported_pt_extensions)
+folder_names_and_paths["diffusion_models"] = ([os.path.join(models_dir, "unet"), os.path.join(models_dir, "diffusion_models")], supported_pt_extensions)
+folder_names_and_paths["clip_vision"] = ([os.path.join(models_dir, "clip_vision")], supported_pt_extensions)
+folder_names_and_paths["style_models"] = ([os.path.join(models_dir, "style_models")], supported_pt_extensions)
+folder_names_and_paths["embeddings"] = ([os.path.join(models_dir, "embeddings")], supported_pt_extensions)
+folder_names_and_paths["diffusers"] = ([os.path.join(models_dir, "diffusers")], ["folder"])
+folder_names_and_paths["vae_approx"] = ([os.path.join(models_dir, "vae_approx")], supported_pt_extensions)
+
+folder_names_and_paths["controlnet"] = ([os.path.join(models_dir, "controlnet"), os.path.join(models_dir, "t2i_adapter")], supported_pt_extensions)
+folder_names_and_paths["gligen"] = ([os.path.join(models_dir, "gligen")], supported_pt_extensions)
+
+folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_models")], supported_pt_extensions)
+
+folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
+
+folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
+
+folder_names_and_paths["photomaker"] = ([os.path.join(models_dir, "photomaker")], supported_pt_extensions)
+
+folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
+
+output_directory = os.path.join(base_path, "output")
+temp_directory = os.path.join(base_path, "temp")
+input_directory = os.path.join(base_path, "input")
+user_directory = os.path.join(base_path, "user")
+
 filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
-
-
-def reset_all_paths(new_base_path: str) -> None:
-    """
-    Internal use only. Designed for use immediately after startup.
-
-    Removes all existing known paths, clears the filename cache, and creates the defaults under a new base path.
-
-    Paths:
-    - All default model paths
-    - input
-    - output
-    - temp
-    - user
-    - custom_nodes
-
-    Also creates the input directory if missing.
-
-    Args:
-        new_base_path: The base path to prepend to all default relative paths.
-    """
-
-    global base_path
-    global models_dir
-    global output_directory
-    global temp_directory
-    global input_directory
-    global user_directory
-
-    filename_list_cache.clear()
-    folder_names_and_paths.clear()
-
-    base_path = new_base_path
-    models_dir = os.path.join(base_path, "models")
-    folder_names_and_paths["checkpoints"] = ([os.path.join(models_dir, "checkpoints")], supported_pt_extensions)
-    folder_names_and_paths["configs"] = ([os.path.join(models_dir, "configs")], [".yaml"])
-
-    folder_names_and_paths["loras"] = ([os.path.join(models_dir, "loras")], supported_pt_extensions)
-    folder_names_and_paths["vae"] = ([os.path.join(models_dir, "vae")], supported_pt_extensions)
-    folder_names_and_paths["text_encoders"] = ([os.path.join(models_dir, "text_encoders"), os.path.join(models_dir, "clip")], supported_pt_extensions)
-    folder_names_and_paths["diffusion_models"] = ([os.path.join(models_dir, "unet"), os.path.join(models_dir, "diffusion_models")], supported_pt_extensions)
-    folder_names_and_paths["clip_vision"] = ([os.path.join(models_dir, "clip_vision")], supported_pt_extensions)
-    folder_names_and_paths["style_models"] = ([os.path.join(models_dir, "style_models")], supported_pt_extensions)
-    folder_names_and_paths["embeddings"] = ([os.path.join(models_dir, "embeddings")], supported_pt_extensions)
-    folder_names_and_paths["diffusers"] = ([os.path.join(models_dir, "diffusers")], ["folder"])
-    folder_names_and_paths["vae_approx"] = ([os.path.join(models_dir, "vae_approx")], supported_pt_extensions)
-
-    folder_names_and_paths["controlnet"] = ([os.path.join(models_dir, "controlnet"), os.path.join(models_dir, "t2i_adapter")], supported_pt_extensions)
-    folder_names_and_paths["gligen"] = ([os.path.join(models_dir, "gligen")], supported_pt_extensions)
-
-    folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_models")], supported_pt_extensions)
-
-    folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
-
-    folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
-
-    folder_names_and_paths["photomaker"] = ([os.path.join(models_dir, "photomaker")], supported_pt_extensions)
-
-    folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
-
-    output_directory = os.path.join(base_path, "output")
-    temp_directory = os.path.join(base_path, "temp")
-    input_directory = os.path.join(base_path, "input")
-    user_directory = os.path.join(base_path, "user")
-
-    # Create input dir if it does not already exist.
-    if not os.path.exists(input_directory):
-        try:
-            os.makedirs(input_directory)
-        except:
-            logging.error("Failed to create input directory")
-
-
-# Default configuration: add all paths relative to this file.
-reset_all_paths(os.path.dirname(os.path.realpath(__file__)))
-
 
 class CacheHelper:
     """
@@ -126,6 +84,12 @@ def map_legacy(folder_name: str) -> str:
     legacy = {"unet": "diffusion_models",
               "clip": "text_encoders"}
     return legacy.get(folder_name, folder_name)
+
+if not os.path.exists(input_directory):
+    try:
+        os.makedirs(input_directory)
+    except:
+        logging.error("Failed to create input directory")
 
 def set_output_directory(output_dir: str) -> None:
     global output_directory

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -14,6 +14,43 @@ supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.bin', '.pth', '.safetenso
 folder_names_and_paths: dict[str, tuple[list[str], set[str] | list[str]]] = {}
 filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
 
+
+class DefaultModelSubdirOptions(TypedDict, total=False):
+    extensions: set[str] | list[str]
+    alternate_names: list[str]
+
+
+# Default models subdirs
+default_paths: dict[str, DefaultModelSubdirOptions] = {
+    "checkpoints": {},
+    "configs": {
+        "extensions": [".yaml"],
+    },
+    "loras": {},
+    "vae": {},
+    "text_encoders": {
+        "alternate_names": ["clip"],
+    },
+    "clip_vision": {},
+    "style_models": {},
+    "embeddings": {},
+    "diffusers": {
+        "extensions": ["folder"],
+    },
+    "vae_approx": {},
+    "controlnet": {
+        "alternate_names": ["t2i_adapter"],
+    },
+    "gligen": {},
+    "upscale_models": {},
+    "hypernetworks": {},
+    "photomaker": {},
+    "classifiers": {
+        "extensions": {""},
+    },
+}
+
+
 class CacheHelper:
     """
     Helper class for managing file list cache data.
@@ -353,42 +390,6 @@ def get_save_image_path(filename_prefix: str, output_dir: str, image_width=0, im
         os.makedirs(full_output_folder, exist_ok=True)
         counter = 1
     return full_output_folder, filename, counter, subfolder, filename_prefix
-
-
-class DefaultModelSubdirOptions(TypedDict, total=False):
-    extensions: set[str] | list[str]
-    alternate_names: list[str]
-
-
-# Default models subdirs
-default_paths: dict[str, DefaultModelSubdirOptions] = {
-    "checkpoints": {},
-    "configs": {
-        "extensions": [".yaml"],
-    },
-    "loras": {},
-    "vae": {},
-    "text_encoders": {
-        "alternate_names": ["clip"],
-    },
-    "clip_vision": {},
-    "style_models": {},
-    "embeddings": {},
-    "diffusers": {
-        "extensions": ["folder"],
-    },
-    "vae_approx": {},
-    "controlnet": {
-        "alternate_names": ["t2i_adapter"],
-    },
-    "gligen": {},
-    "upscale_models": {},
-    "hypernetworks": {},
-    "photomaker": {},
-    "classifiers": {
-        "extensions": {""},
-    },
-}
 
 
 def reset_all_paths(new_base_path: str) -> None:

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -9,7 +9,7 @@ from collections.abc import Collection
 
 supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.bin', '.pth', '.safetensors', '.pkl', '.sft'}
 
-folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
+folder_names_and_paths: dict[str, tuple[list[str], set[str] | list[str]]] = {}
 
 base_path = os.path.dirname(os.path.realpath(__file__))
 models_dir = os.path.join(base_path, "models")

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -196,9 +196,17 @@ def exists_annotated_filepath(name) -> bool:
     return os.path.exists(filepath)
 
 
-def add_model_folder_path(folder_name: str, full_folder_path: str, is_default: bool = False) -> None:
+def add_model_folder_path(
+    folder_name: str,
+    full_folder_path: str,
+    is_default: bool = False,
+    is_legacy: bool = False,
+    valid_extensions: set[str] | list[str] = set(),
+) -> None:
     global folder_names_and_paths
-    folder_name = map_legacy(folder_name)
+    if not is_legacy:
+        folder_name = map_legacy(folder_name)
+
     if folder_name in folder_names_and_paths:
         paths, _exts = folder_names_and_paths[folder_name]
         if full_folder_path in paths:
@@ -212,7 +220,7 @@ def add_model_folder_path(folder_name: str, full_folder_path: str, is_default: b
             else:
                 paths.append(full_folder_path)
     else:
-        folder_names_and_paths[folder_name] = ([full_folder_path], set())
+        folder_names_and_paths[folder_name] = ([full_folder_path], valid_extensions)
 
 def get_folder_paths(folder_name: str) -> list[str]:
     folder_name = map_legacy(folder_name)

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -12,38 +12,81 @@ supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.bin', '.pth', '.safetenso
 folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
 filename_list_cache: dict[str, tuple[list[str], dict[str, float], float]] = {}
 
-base_path = os.path.dirname(os.path.realpath(__file__))
-models_dir = os.path.join(base_path, "models")
-folder_names_and_paths["checkpoints"] = ([os.path.join(models_dir, "checkpoints")], supported_pt_extensions)
-folder_names_and_paths["configs"] = ([os.path.join(models_dir, "configs")], [".yaml"])
 
-folder_names_and_paths["loras"] = ([os.path.join(models_dir, "loras")], supported_pt_extensions)
-folder_names_and_paths["vae"] = ([os.path.join(models_dir, "vae")], supported_pt_extensions)
-folder_names_and_paths["text_encoders"] = ([os.path.join(models_dir, "text_encoders"), os.path.join(models_dir, "clip")], supported_pt_extensions)
-folder_names_and_paths["diffusion_models"] = ([os.path.join(models_dir, "unet"), os.path.join(models_dir, "diffusion_models")], supported_pt_extensions)
-folder_names_and_paths["clip_vision"] = ([os.path.join(models_dir, "clip_vision")], supported_pt_extensions)
-folder_names_and_paths["style_models"] = ([os.path.join(models_dir, "style_models")], supported_pt_extensions)
-folder_names_and_paths["embeddings"] = ([os.path.join(models_dir, "embeddings")], supported_pt_extensions)
-folder_names_and_paths["diffusers"] = ([os.path.join(models_dir, "diffusers")], ["folder"])
-folder_names_and_paths["vae_approx"] = ([os.path.join(models_dir, "vae_approx")], supported_pt_extensions)
+def reset_all_paths(new_base_path: str) -> None:
+    """
+    Internal use only. Designed for use immediately after startup.
 
-folder_names_and_paths["controlnet"] = ([os.path.join(models_dir, "controlnet"), os.path.join(models_dir, "t2i_adapter")], supported_pt_extensions)
-folder_names_and_paths["gligen"] = ([os.path.join(models_dir, "gligen")], supported_pt_extensions)
+    Removes all existing known paths, clears the filename cache, and creates the defaults under a new base path.
 
-folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_models")], supported_pt_extensions)
+    Paths:
+    - All default model paths
+    - input
+    - output
+    - temp
+    - user
+    - custom_nodes
 
-folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
+    Also creates the input directory if missing.
 
-folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
+    Args:
+        new_base_path: The base path to prepend to all default relative paths.
+    """
 
-folder_names_and_paths["photomaker"] = ([os.path.join(models_dir, "photomaker")], supported_pt_extensions)
+    global base_path
+    global models_dir
+    global output_directory
+    global temp_directory
+    global input_directory
+    global user_directory
 
-folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
+    filename_list_cache.clear()
+    folder_names_and_paths.clear()
 
-output_directory = os.path.join(base_path, "output")
-temp_directory = os.path.join(base_path, "temp")
-input_directory = os.path.join(base_path, "input")
-user_directory = os.path.join(base_path, "user")
+    base_path = new_base_path
+    models_dir = os.path.join(base_path, "models")
+    folder_names_and_paths["checkpoints"] = ([os.path.join(models_dir, "checkpoints")], supported_pt_extensions)
+    folder_names_and_paths["configs"] = ([os.path.join(models_dir, "configs")], [".yaml"])
+
+    folder_names_and_paths["loras"] = ([os.path.join(models_dir, "loras")], supported_pt_extensions)
+    folder_names_and_paths["vae"] = ([os.path.join(models_dir, "vae")], supported_pt_extensions)
+    folder_names_and_paths["text_encoders"] = ([os.path.join(models_dir, "text_encoders"), os.path.join(models_dir, "clip")], supported_pt_extensions)
+    folder_names_and_paths["diffusion_models"] = ([os.path.join(models_dir, "unet"), os.path.join(models_dir, "diffusion_models")], supported_pt_extensions)
+    folder_names_and_paths["clip_vision"] = ([os.path.join(models_dir, "clip_vision")], supported_pt_extensions)
+    folder_names_and_paths["style_models"] = ([os.path.join(models_dir, "style_models")], supported_pt_extensions)
+    folder_names_and_paths["embeddings"] = ([os.path.join(models_dir, "embeddings")], supported_pt_extensions)
+    folder_names_and_paths["diffusers"] = ([os.path.join(models_dir, "diffusers")], ["folder"])
+    folder_names_and_paths["vae_approx"] = ([os.path.join(models_dir, "vae_approx")], supported_pt_extensions)
+
+    folder_names_and_paths["controlnet"] = ([os.path.join(models_dir, "controlnet"), os.path.join(models_dir, "t2i_adapter")], supported_pt_extensions)
+    folder_names_and_paths["gligen"] = ([os.path.join(models_dir, "gligen")], supported_pt_extensions)
+
+    folder_names_and_paths["upscale_models"] = ([os.path.join(models_dir, "upscale_models")], supported_pt_extensions)
+
+    folder_names_and_paths["custom_nodes"] = ([os.path.join(base_path, "custom_nodes")], set())
+
+    folder_names_and_paths["hypernetworks"] = ([os.path.join(models_dir, "hypernetworks")], supported_pt_extensions)
+
+    folder_names_and_paths["photomaker"] = ([os.path.join(models_dir, "photomaker")], supported_pt_extensions)
+
+    folder_names_and_paths["classifiers"] = ([os.path.join(models_dir, "classifiers")], {""})
+
+    output_directory = os.path.join(base_path, "output")
+    temp_directory = os.path.join(base_path, "temp")
+    input_directory = os.path.join(base_path, "input")
+    user_directory = os.path.join(base_path, "user")
+
+    # Create input dir if it does not already exist.
+    if not os.path.exists(input_directory):
+        try:
+            os.makedirs(input_directory)
+        except:
+            logging.error("Failed to create input directory")
+
+
+# Default configuration: add all paths relative to this file.
+reset_all_paths(os.path.dirname(os.path.realpath(__file__)))
+
 
 class CacheHelper:
     """
@@ -83,12 +126,6 @@ def map_legacy(folder_name: str) -> str:
     legacy = {"unet": "diffusion_models",
               "clip": "text_encoders"}
     return legacy.get(folder_name, folder_name)
-
-if not os.path.exists(input_directory):
-    try:
-        os.makedirs(input_directory)
-    except:
-        logging.error("Failed to create input directory")
 
 def set_output_directory(output_dir: str) -> None:
     global output_directory

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -7,11 +7,19 @@ import logging
 from typing import Literal
 from collections.abc import Collection
 
+from comfy.cli_args import args
+
 supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.bin', '.pth', '.safetensors', '.pkl', '.sft'}
 
 folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
 
-base_path = os.path.dirname(os.path.realpath(__file__))
+# --base-directory - Resets all default paths configured in folder_paths with a new base path
+if args.base_directory:
+    base_path = os.path.abspath(args.base_directory)
+    logging.info(f"Setting base directory to: {base_path}")
+else:
+    base_path = os.path.dirname(os.path.realpath(__file__))
+
 models_dir = os.path.join(base_path, "models")
 folder_names_and_paths["checkpoints"] = ([os.path.join(models_dir, "checkpoints")], supported_pt_extensions)
 folder_names_and_paths["configs"] = ([os.path.join(models_dir, "configs")], [".yaml"])

--- a/main.py
+++ b/main.py
@@ -20,12 +20,6 @@ if __name__ == "__main__":
 setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
 
 def apply_custom_paths():
-    # --base-directory - Resets all default paths configured in folder_paths with a new base path
-    if args.base_directory:
-        new_base_path = os.path.abspath(args.base_directory)
-        logging.info(f"Setting base directory to: {new_base_path}")
-        folder_paths.reset_all_paths(new_base_path)
-
     # extra model paths
     extra_model_paths_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extra_model_paths.yaml")
     if os.path.isfile(extra_model_paths_config_path):

--- a/main.py
+++ b/main.py
@@ -20,6 +20,12 @@ if __name__ == "__main__":
 setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
 
 def apply_custom_paths():
+    # --base-directory - Resets all default paths configured in folder_paths with a new base path
+    if args.base_directory:
+        new_base_path = os.path.abspath(args.base_directory)
+        logging.info(f"Setting base directory to: {new_base_path}")
+        folder_paths.reset_all_paths(new_base_path)
+
     # extra model paths
     extra_model_paths_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extra_model_paths.yaml")
     if os.path.isfile(extra_model_paths_config_path):

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -32,7 +32,11 @@ def set_base_dir():
         with patch.object(sys, 'argv', ["main.py", "--base-directory", base_dir]):
             reload(comfy.cli_args)
             reload(folder_paths)
-    return _set_base_dir
+    yield _set_base_dir
+    # Reload the modules after each test to ensure isolation
+    with patch.object(sys, 'argv', ["main.py"]):
+        reload(comfy.cli_args)
+        reload(folder_paths)
 
 
 def test_get_directory_by_type(clear_folder_paths):

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -108,45 +108,34 @@ def test_base_path_changes(clear_folder_paths):
 
     assert os.path.join(test_dir, "custom_nodes") in folder_paths.get_folder_paths("custom_nodes")
 
-    for name in ["checkpoints", "loras", "vae", "configs", "embeddings", "controlnet", "classifiers", "configs"]:
-        assert folder_paths.get_folder_paths(name)[0] == os.path.join(test_dir, name)
+    for name in ["checkpoints", "loras", "vae", "configs", "embeddings", "controlnet", "classifiers"]:
+        assert folder_paths.get_folder_paths(name)[0] == os.path.join(test_dir, "models", name)
 
 
-def test_add_default_paths_preseves_dirs(clear_folder_paths):
-    test_dir = os.path.abspath(os.path.join(os.path.curdir, "..", ".."))
-    base_path = folder_paths.base_path
-    models_dir = folder_paths.models_dir
-    input_directory = folder_paths.input_directory
+def test_base_path_change_clears_old(clear_folder_paths):
+    test_dir = "/test/path"
+    folder_paths.reset_all_paths(test_dir)
 
-    folder_paths.add_default_model_paths(test_dir)
-    assert folder_paths.base_path == base_path
-    assert folder_paths.models_dir == models_dir
-    assert folder_paths.input_directory == input_directory
+    assert len(folder_paths.get_folder_paths("custom_nodes")) == 1
 
+    single_model_paths = [
+        "checkpoints",
+        "loras",
+        "vae",
+        "configs",
+        "clip_vision",
+        "style_models",
+        "diffusers",
+        "vae_approx",
+        "gligen",
+        "upscale_models",
+        "embeddings",
+        "hypernetworks",
+        "photomaker",
+        "classifiers",
+    ]
+    for name in single_model_paths:
+        assert len(folder_paths.get_folder_paths(name)) == 1
 
-def test_add_default_paths_preseves_paths(clear_folder_paths):
-    test_dir = os.path.abspath(os.path.join(os.path.curdir, "invalid"))
-    checkpoints = folder_paths.get_folder_paths("checkpoints")[0]
-    text_encoders = folder_paths.get_folder_paths("text_encoders")[0]
-    clip = folder_paths.get_folder_paths("clip")[1]
-
-    folder_paths.add_default_model_paths(test_dir)
-    assert not os.path.join(test_dir, "custom_nodes") in folder_paths.get_folder_paths("custom_nodes")
-    assert folder_paths.get_folder_paths("checkpoints")[0] == checkpoints
-    assert folder_paths.get_folder_paths("text_encoders")[0] == text_encoders
-    assert folder_paths.get_folder_paths("clip")[1] == clip
-
-
-def test_add_default_model_paths(clear_folder_paths):
-    test_dir = os.path.abspath(os.path.join(os.path.curdir, "bad_path"))
-    folder_paths.add_default_model_paths(test_dir)
-
-    for name in ["checkpoints", "loras", "vae", "configs", "embeddings", "controlnet", "classifiers", "configs"]:
-        paths = folder_paths.get_folder_paths(name)
-        # Handle multiple default paths
-        assert len(paths) % 2 == 0
-        index = int(len(paths) / 2)
-        assert folder_paths.get_folder_paths(name)[index] == os.path.join(test_dir, name)
-
-    assert folder_paths.get_folder_paths("clip")[2] == os.path.join(test_dir, "text_encoders")
-    assert folder_paths.get_folder_paths("clip")[3] == os.path.join(test_dir, "clip")
+    for name in ["controlnet", "diffusion_models", "text_encoders"]:
+        assert len(folder_paths.get_folder_paths(name)) == 2

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -4,24 +4,22 @@ import pytest
 import os
 import tempfile
 from unittest.mock import patch
+from importlib import reload
 
 import folder_paths
 
 @pytest.fixture()
 def clear_folder_paths():
-    # Clear the global dictionary before each test to ensure isolation
-    original = folder_paths.folder_names_and_paths.copy()
-    folder_paths.folder_names_and_paths.clear()
+    # Reload the module after each test to ensure isolation
     yield
-    folder_paths.folder_names_and_paths = original
+    reload(folder_paths)
 
 @pytest.fixture
 def temp_dir():
     with tempfile.TemporaryDirectory() as tmpdirname:
         yield tmpdirname
 
-
-def test_get_directory_by_type():
+def test_get_directory_by_type(clear_folder_paths):
     test_dir = "/test/dir"
     folder_paths.set_output_directory(test_dir)
     assert folder_paths.get_directory_by_type("output") == test_dir
@@ -98,7 +96,7 @@ def test_get_save_image_path(temp_dir):
         assert filename_prefix == "test"
 
 
-def test_base_path_changes():
+def test_base_path_changes(clear_folder_paths):
     test_dir = "/test/dir"
     folder_paths.reset_all_paths(test_dir)
     assert folder_paths.base_path == test_dir
@@ -114,7 +112,7 @@ def test_base_path_changes():
         assert folder_paths.get_folder_paths(name)[0] == os.path.join(test_dir, name)
 
 
-def test_add_default_paths_preseves_dirs():
+def test_add_default_paths_preseves_dirs(clear_folder_paths):
     test_dir = os.path.abspath(os.path.join(os.path.curdir, "..", ".."))
     base_path = folder_paths.base_path
     models_dir = folder_paths.models_dir
@@ -126,8 +124,7 @@ def test_add_default_paths_preseves_dirs():
     assert folder_paths.input_directory == input_directory
 
 
-def test_add_default_paths_preseves_paths():
-    folder_paths.reset_all_paths("/test/dir")
+def test_add_default_paths_preseves_paths(clear_folder_paths):
     test_dir = os.path.abspath(os.path.join(os.path.curdir, "invalid"))
     checkpoints = folder_paths.get_folder_paths("checkpoints")[0]
     text_encoders = folder_paths.get_folder_paths("text_encoders")[0]
@@ -140,8 +137,7 @@ def test_add_default_paths_preseves_paths():
     assert folder_paths.get_folder_paths("clip")[1] == clip
 
 
-def test_add_default_model_paths():
-    folder_paths.reset_all_paths("/test/dir")
+def test_add_default_model_paths(clear_folder_paths):
     test_dir = os.path.abspath(os.path.join(os.path.curdir, "bad_path"))
     folder_paths.add_default_model_paths(test_dir)
 

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -28,7 +28,6 @@ def temp_dir():
 @pytest.fixture
 def set_base_dir():
     def _set_base_dir(base_dir):
-        base_dir = os.path.abspath(base_dir)
         # Mock CLI args
         with patch.object(sys, 'argv', ["main.py", "--base-directory", base_dir]):
             reload(comfy.cli_args)
@@ -114,7 +113,7 @@ def test_get_save_image_path(temp_dir):
 
 
 def test_base_path_changes(set_base_dir):
-    test_dir = "/test/dir"
+    test_dir = os.path.abspath("/test/dir")
     set_base_dir(test_dir)
 
     assert folder_paths.base_path == test_dir
@@ -131,7 +130,7 @@ def test_base_path_changes(set_base_dir):
 
 
 def test_base_path_change_clears_old(set_base_dir):
-    test_dir = "/test/dir"
+    test_dir = os.path.abspath("/test/dir")
     set_base_dir(test_dir)
 
     assert len(folder_paths.get_folder_paths("custom_nodes")) == 1


### PR DESCRIPTION
#### Current

- The `base_path` and `models_dir` properties of `folder_paths` are set during file import.
- Many extensions are using these directly.
- The ComfyUI directory cannot be read-only.

#### Proposed (Updated w/requested refactor)

- Add --base-directory command line argument.
- Almost* no change to existing behaviour
  - * cli_args is now imported prior to folder_paths - nil impact expected.