### PR TITLE
Allow searching for .pt2 archives

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -9,7 +9,7 @@ from collections.abc import Collection
 
 from comfy.cli_args import args
 
-supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.bin', '.pth', '.safetensors', '.pkl', '.sft'}
+supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft'}
 
 folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
 


### PR DESCRIPTION
Pytorch 2.6 introduces [a new format for AOTInductor modules](https://pytorch.org/blog/pytorch2-6/#beta-new-packaging-apis-for-aotinductor), which uses the extension `.pt2`. 

I've had good results compiling comfyui models to AOTInductor modules and then loading them back in ComfyUI: you get the same performance improvements as `torch.compile`, but without the overhead of compiling at runtime.  At the moment there's no standardization for the metadata contained in an AOTInductor archive, and all the config/tensor name information is stripped, so to actually detect what kind of model is being loaded is a question for the future.  For now, we can make it easier to load AOTI archives in custom nodes by adding the format as a known pytorch extension.