### PR TITLE
Selective Loading of Custom Nodes Using INCLUDED_CUSTOM_NODES Environment Variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,6 +69,13 @@ def execute_prestartup_script():
     if args.disable_all_custom_nodes:
         return
 
+    # Get the environment variable and convert it to a list (if not empty)
+    included_custom_nodes = os.environ.get("INCLUDED_CUSTOM_NODES", "").strip()
+    included_custom_nodes = (
+        [name.strip() for name in included_custom_nodes.split(",")]
+        if included_custom_nodes else None
+    )
+
     node_paths = folder_paths.get_folder_paths("custom_nodes")
     for custom_node_path in node_paths:
         possible_modules = os.listdir(custom_node_path)
@@ -77,6 +84,11 @@ def execute_prestartup_script():
         for possible_module in possible_modules:
             module_path = os.path.join(custom_node_path, possible_module)
             if os.path.isfile(module_path) or module_path.endswith(".disabled") or module_path == "__pycache__":
+                continue
+
+            # Skip modules that are not in INCLUDED_CUSTOM_NODES
+            if included_custom_nodes and possible_module not in included_custom_nodes:
+                logging.debug(f"Skipping {possible_module} (not in INCLUDED_CUSTOM_NODES)")
                 continue
 
             script_path = os.path.join(module_path, "prestartup_script.py")

--- a/nodes.py
+++ b/nodes.py
@@ -2144,6 +2144,13 @@ def init_external_custom_nodes():
     Returns:
         None
     """
+    # Get the environment variable and convert it to a list (if not empty)
+    included_custom_nodes = os.environ.get("INCLUDED_CUSTOM_NODES", "").strip()
+    included_custom_nodes = (
+        [name.strip() for name in included_custom_nodes.split(",")]
+        if included_custom_nodes else None
+    )
+
     base_node_names = set(NODE_CLASS_MAPPINGS.keys())
     node_paths = folder_paths.get_folder_paths("custom_nodes")
     node_import_times = []
@@ -2153,6 +2160,11 @@ def init_external_custom_nodes():
             possible_modules.remove("__pycache__")
 
         for possible_module in possible_modules:
+            # Skip modules that are not in INCLUDED_CUSTOM_NODES
+            if included_custom_nodes and possible_module not in included_custom_nodes:
+                logging.debug(f"Skipping {possible_module} (not in INCLUDED_CUSTOM_NODES)")
+                continue
+
             module_path = os.path.join(custom_node_path, possible_module)
             if os.path.isfile(module_path) and os.path.splitext(module_path)[1] != ".py": continue
             if module_path.endswith(".disabled"): continue


### PR DESCRIPTION
In production environments, multiple instances of ComfyUI may share a single volume. In such cases, some instances might only need specific custom nodes to function, while others might require a different set of nodes.

Currently, all custom nodes are loaded indiscriminately, which can lead to increased startup times and unnecessary resource usage.

Feature Overview
This PR introduces the INCLUDED_CUSTOM_NODES environment variable, allowing users to specify which custom nodes should be loaded at startup. This significantly reduces loading times and improves performance in environments where only a subset of nodes is required.

Usage Example
export INCLUDED_CUSTOM_NODES="node1, node2, node3"

Benefits
✅ Faster startup times by skipping unnecessary nodes
✅ Optimized resource usage for multi-instance environments
✅ More control over which custom nodes are loaded per instance

Looking forward to your feedback!
Thanks and best regards. 😊🚀