### PR TITLE
Fix incorrect Content-Type for WebP images

### DIFF
--- a/server.py
+++ b/server.py
@@ -150,7 +150,8 @@ class PromptServer():
         PromptServer.instance = self
 
         mimetypes.init()
-        mimetypes.types_map['.js'] = 'application/javascript; charset=utf-8'
+        mimetypes.add_type('application/javascript; charset=utf-8', '.js')
+        mimetypes.add_type('image/webp', '.webp')
 
         self.user_manager = UserManager()
         self.model_file_manager = ModelFileManager()


### PR DESCRIPTION
When opening a .webp image in a new tab, Chrome was downloading the file instead of displaying it. This happened because the MIME type for .webp was not registered, causing the server to return Content-Type: application/octet-stream instead of image/webp.

![image](https://github.com/user-attachments/assets/ab3a88a2-c154-4e0e-a392-115de055fdb2)

**Fix:**
- Added MIME type registration for .webp images.
- Also, I corrected the .js MIME type using mimetypes.add_type().

workflow with webp image:
[webp_preview.json](https://github.com/user-attachments/files/18722172/webp_preview.json)
