### PR TITLE
Add Load Image Output node

### DIFF
--- a/api_server/routes/internal/internal_routes.py
+++ b/api_server/routes/internal/internal_routes.py
@@ -1,8 +1,9 @@
 from aiohttp import web
 from typing import Optional
-from folder_paths import folder_names_and_paths
+from folder_paths import folder_names_and_paths, get_directory_by_type
 from api_server.services.terminal_service import TerminalService
 import app.logger
+import os
 
 class InternalRoutes:
     '''
@@ -49,6 +50,20 @@ class InternalRoutes:
             for key in folder_names_and_paths:
                 response[key] = folder_names_and_paths[key][0]
             return web.json_response(response)
+
+        @self.routes.get('/files/{directory_type}')
+        async def get_files(request: web.Request) -> web.Response:
+            directory_type = request.match_info['directory_type']
+            if directory_type not in ("output", "input", "temp"):
+                return web.json_response({"error": "Invalid directory type"}, status=400)
+
+            directory = get_directory_by_type(directory_type)
+            sorted_files = sorted(
+                (entry for entry in os.scandir(directory) if entry.is_file()),
+                key=lambda entry: -entry.stat().st_mtime
+            )
+            return web.json_response([entry.name for entry in sorted_files], status=200)
+
 
     def get_app(self):
         if self._app is None:

--- a/comfy/comfy_types/node_typing.py
+++ b/comfy/comfy_types/node_typing.py
@@ -66,6 +66,19 @@ class IO(StrEnum):
         b = frozenset(value.split(","))
         return not (b.issubset(a) or a.issubset(b))
 
+class RemoteInputOptions(TypedDict):
+    route: str
+    """The route to the remote source."""
+    refresh_button: bool
+    """Specifies whether to show a refresh button in the UI below the widget."""
+    control_after_refresh: Literal["first", "last"]
+    """Specifies the control after the refresh button is clicked. If "first", the first item will be automatically selected, and so on."""
+    timeout: int
+    """The maximum amount of time to wait for a response from the remote source in milliseconds."""
+    max_retries: int
+    """The maximum number of retries before aborting the request."""
+    refresh: int
+    """The TTL of the remote input's value in milliseconds. Specifies the interval at which the remote input's value is refreshed."""
 
 class InputTypeOptions(TypedDict):
     """Provides type hinting for the return type of the INPUT_TYPES node function.
@@ -113,6 +126,19 @@ class InputTypeOptions(TypedDict):
     # defaultVal: str
     dynamicPrompts: bool
     """Causes the front-end to evaluate dynamic prompts (``STRING``)"""
+    # class InputTypeCombo(InputTypeOptions):
+    image_upload: bool
+    """Specifies whether the input should have an image upload button and image preview attached to it. Requires that the input's name is `image`."""
+    image_folder: str
+    """Specifies which folder to get preview images from if the input has the ``image_upload`` flag.
+    
+    Valid values are:
+    - "input"
+    - "output"
+    - "temp"
+    """
+    remote: RemoteInputOptions
+    """Specifies the configuration for a remote input."""
 
 
 class HiddenInputTypeDict(TypedDict):

--- a/comfy/comfy_types/node_typing.py
+++ b/comfy/comfy_types/node_typing.py
@@ -129,13 +129,8 @@ class InputTypeOptions(TypedDict):
     # class InputTypeCombo(InputTypeOptions):
     image_upload: bool
     """Specifies whether the input should have an image upload button and image preview attached to it. Requires that the input's name is `image`."""
-    image_folder: str
+    image_folder: Literal["input", "output", "temp"]
     """Specifies which folder to get preview images from if the input has the ``image_upload`` flag.
-    
-    Valid values are:
-    - "input"
-    - "output"
-    - "temp"
     """
     remote: RemoteInputOptions
     """Specifies the configuration for a remote input."""

--- a/nodes.py
+++ b/nodes.py
@@ -1769,7 +1769,7 @@ class LoadImageOutput(LoadImage):
     def INPUT_TYPES(s):
         return {
             "required": {
-                "image": ([], {
+                "image": ("COMBO", {
                     "image_upload": True,
                     "image_folder": "output",
                     "remote": {
@@ -1782,6 +1782,7 @@ class LoadImageOutput(LoadImage):
         }
 
     DESCRIPTION = "Load an image from the output folder. When the refresh button is clicked, the node will update the image list and automatically select the first image, allowing for easy iteration."
+    EXPERIMENTAL = True
     FUNCTION = "load_image_output"
 
     def load_image_output(self, image):

--- a/nodes.py
+++ b/nodes.py
@@ -1763,6 +1763,35 @@ class LoadImageMask:
 
         return True
 
+
+class LoadImageOutput(LoadImage):
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "image": ([], {
+                    "image_upload": True,
+                    "image_folder": "output",
+                    "remote": {
+                        "route": "/internal/files/output",
+                        "refresh_button": True,
+                        "control_after_refresh": "first",
+                    },
+                }),
+            }
+        }
+
+    DESCRIPTION = "Load an image from the output folder. When the refresh button is clicked, the node will update the image list and automatically select the first image, allowing for easy iteration."
+    FUNCTION = "load_image_output"
+
+    def load_image_output(self, image):
+        return self.load_image(f"{image} [output]")
+
+    @classmethod
+    def VALIDATE_INPUTS(s, image):
+        return True
+
+
 class ImageScale:
     upscale_methods = ["nearest-exact", "bilinear", "area", "bicubic", "lanczos"]
     crop_methods = ["disabled", "center"]
@@ -1949,6 +1978,7 @@ NODE_CLASS_MAPPINGS = {
     "PreviewImage": PreviewImage,
     "LoadImage": LoadImage,
     "LoadImageMask": LoadImageMask,
+    "LoadImageOutput": LoadImageOutput,
     "ImageScale": ImageScale,
     "ImageScaleBy": ImageScaleBy,
     "ImageInvert": ImageInvert,
@@ -2049,6 +2079,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "PreviewImage": "Preview Image",
     "LoadImage": "Load Image",
     "LoadImageMask": "Load Image (as Mask)",
+    "LoadImageOutput": "Load Image (from Outputs)",
     "ImageScale": "Upscale Image",
     "ImageScaleBy": "Upscale Image By",
     "ImageUpscaleWithModel": "Upscale Image (using Model)",


### PR DESCRIPTION
Adds Load Image node with remote widget. When refreshed, it re-fetches the values from the given route (in this case, files from output folder). This node can test the features detailed in https://github.com/Comfy-Org/rfcs/pull/1 (lazy loading widget with remote source, changes to COMBO input spec). 

https://github.com/user-attachments/assets/e2e0f746-61c5-459c-9e26-260f7e85cff5

Frontend:

  - https://github.com/Comfy-Org/ComfyUI_frontend/pull/2422 v1.9.7
  - https://github.com/Comfy-Org/ComfyUI_frontend/pull/2494 v1.9.13
  - https://github.com/Comfy-Org/ComfyUI_frontend/pull/2509 v1.9.13

[Test nodes](https://github.com/Comfy-Org/ComfyUI_devtools/blob/main/dev_nodes.py), [Unit tests](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/tests-ui/tests/composables/widgets/useRemoteWidget.test.ts), [E2E tests](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/browser_tests/remoteWidgets.spec.ts)
