### PR TITLE
Fix the Issue with Inference on Ascend NPU

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1082,6 +1082,9 @@ def should_use_bf16(device=None, model_params=0, prioritize_performance=True, ma
 
     if is_intel_xpu():
         return True
+    
+    if is_ascend_npu():
+        return True
 
     props = torch.cuda.get_device_properties(device)
     if props.major >= 8:


### PR DESCRIPTION
This PR fixes an issue with inference on Ascend NPU caused by incomplete adaptation and has been validated on Atlas 800I A2. We need to install the [Ascend Toolkit](https://ascend.github.io/docs/sources/ascend/quick_install.html) first. Then run:

```
# setvers
source /usr/local/Ascend/ascend-toolkit/set_env.sh
# intsall dependencies
pip install -r requirements.txt
# run
python main.py
```

