### PR TITLE
Open yaml files with utf-8 encoding for extra_model_paths.yaml

### DIFF
--- a/utils/extra_config.py
+++ b/utils/extra_config.py
@@ -4,7 +4,7 @@ import folder_paths
 import logging
 
 def load_extra_path_config(yaml_path):
-    with open(yaml_path, 'r') as stream:
+    with open(yaml_path, 'r', encoding='utf-8') as stream:
         config = yaml.safe_load(stream)
     yaml_dir = os.path.dirname(os.path.abspath(yaml_path))
     for c in config:


### PR DESCRIPTION
Opens extra_model_paths.yaml with utf-8 encoding by default to handle special characters like Chinese or emojis.

When extra_model_paths.yaml has special characters (like Chinese characters), we get this error (on Windows)

```
  File "C:\Users\robin\AppData\Local\Programs\@comfyorgcomfyui-electron\resources\ComfyUI\utils\extra_config.py", line 8, in load_extra_path_config
    config = yaml.safe_load(stream)
....
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2544.0_x64__qbz5n2kfra8p0\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 113: character maps to <undefined>
```

This is because Windows commonly uses ANSI encoding by default. 

```
import locale
print(locale.getpreferredencoding()) 
cp1252
```