### PR TITLE
Fixes

### DIFF
--- a/.ci/update_windows/update_comfyui.bat
+++ b/.ci/update_windows/update_comfyui.bat
@@ -1,8 +1,8 @@
 @echo off
-..\python_embeded\python.exe .\update.py ..\ComfyUI\
+..\python_embedded\python.exe .\update.py ..\ComfyUI\
 if exist update_new.py (
   move /y update_new.py update.py
   echo Running updater again since it got updated.
-  ..\python_embeded\python.exe .\update.py ..\ComfyUI\ --skip_self_update
+  ..\python_embedded\python.exe .\update.py ..\ComfyUI\ --skip_self_update
 )
 if "%~1"=="" pause

--- a/.ci/update_windows/update_comfyui_stable.bat
+++ b/.ci/update_windows/update_comfyui_stable.bat
@@ -1,8 +1,8 @@
 @echo off
-..\python_embeded\python.exe .\update.py ..\ComfyUI\ --stable
+..\python_embedded\python.exe .\update.py ..\ComfyUI\ --stable
 if exist update_new.py (
   move /y update_new.py update.py
   echo Running updater again since it got updated.
-  ..\python_embeded\python.exe .\update.py ..\ComfyUI\ --skip_self_update --stable
+  ..\python_embedded\python.exe .\update.py ..\ComfyUI\ --skip_self_update --stable
 )
 if "%~1"=="" pause

--- a/.ci/windows_base_files/run_cpu.bat
+++ b/.ci/windows_base_files/run_cpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --cpu --windows-standalone-build
+.\python_embedded\python.exe -s ComfyUI\main.py --cpu --windows-standalone-build
 pause

--- a/.ci/windows_base_files/run_nvidia_gpu.bat
+++ b/.ci/windows_base_files/run_nvidia_gpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build
+.\python_embedded\python.exe -s ComfyUI\main.py --windows-standalone-build
 pause

--- a/.ci/windows_nightly_base_files/run_nvidia_gpu_fast.bat
+++ b/.ci/windows_nightly_base_files/run_nvidia_gpu_fast.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --fast
+.\python_embedded\python.exe -s ComfyUI\main.py --windows-standalone-build --fast
 pause

--- a/.github/workflows/pullrequest-ci-run.yml
+++ b/.github/workflows/pullrequest-ci-run.yml
@@ -1,9 +1,10 @@
 # This is the GitHub Workflow that drives full-GPU-enabled tests of pull requests to ComfyUI, when the 'Run-CI-Test' label is added
 # Results are reported as checkmarks on the commits, as well as onto https://ci.comfy.org/
 name: Pull Request CI Workflow Runs
+
 on:
   pull_request_target:
-    types: [labeled]
+    types: labeled
 
 jobs:
   pr-test-stable:
@@ -12,19 +13,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos, linux, windows]
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
-        cuda_version: ["12.1"]
-        torch_version: ["stable"]
+        python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        cuda_version: ['12.1']
+        torch_version: ['stable']
         include:
           - os: macos
             runner_label: [self-hosted, macOS]
-            flags: "--use-pytorch-cross-attention"
+            flags: '--use-pytorch-cross-attention'
           - os: linux
             runner_label: [self-hosted, Linux]
-            flags: ""
+            flags: ''
           - os: windows
             runner_label: [self-hosted, Windows]
-            flags: ""
+            flags: ''
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows
@@ -35,7 +36,8 @@ jobs:
           torch_version: ${{ matrix.torch_version }}
           google_credentials: ${{ secrets.GCS_SERVICE_ACCOUNT_JSON }}
           comfyui_flags: ${{ matrix.flags }}
-          use_prior_commit: 'true'
+          use_prior_commit: true
+
   comment:
     if: ${{ github.event.label.name == 'Run-CI-Test' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pullrequest-ci-run.yml
+++ b/.github/workflows/pullrequest-ci-run.yml
@@ -42,7 +42,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/pullrequest-ci-run.yml
+++ b/.github/workflows/pullrequest-ci-run.yml
@@ -2,8 +2,8 @@
 # Results are reported as checkmarks on the commits, as well as onto https://ci.comfy.org/
 name: Pull Request CI Workflow Runs
 on:
-    pull_request_target:
-        types: [labeled]
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   pr-test-stable:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,18 +6,14 @@ jobs:
   ruff:
     name: Run Ruff
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
-
+          python-version: '3.x'
       - name: Install Ruff
         run: pip install ruff
-
       - name: Run Ruff
         run: ruff check .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.x
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
 
-    - name: Install Ruff
-      run: pip install ruff
+      - name: Install Ruff
+        run: pip install ruff
 
-    - name: Run Ruff
-      run: ruff check .
+      - name: Run Ruff
+        run: ruff check .

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,4 +1,3 @@
-
 name: "Release Stable Version"
 
 on:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -84,7 +84,7 @@ jobs:
 
           cd ..
 
-          7z a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
+          7z a -mx=9 -md=32m ComfyUI_windows_portable.7z ComfyUI_windows_portable
           mv ComfyUI_windows_portable.7z ComfyUI/ComfyUI_windows_portable_nvidia.7z
 
           cd ComfyUI_windows_portable

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -58,9 +58,9 @@ jobs:
         run: |
           cd ..
           cp -r ComfyUI ComfyUI_copy
-          curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embeded.zip
-          unzip python_embeded.zip -d python_embeded
-          cd python_embeded
+          curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
+          unzip python_embedded.zip -d python_embedded
+          cd python_embedded
           echo ${{ env.MINOR_VERSION }}
           echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
@@ -73,7 +73,7 @@ jobs:
           cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/
 
           mkdir ComfyUI_windows_portable
-          mv python_embeded ComfyUI_windows_portable
+          mv python_embedded ComfyUI_windows_portable
           mv ComfyUI_copy ComfyUI_windows_portable/ComfyUI
 
           cd ComfyUI_windows_portable
@@ -89,7 +89,7 @@ jobs:
           mv ComfyUI_windows_portable.7z ComfyUI/ComfyUI_windows_portable_nvidia.7z
 
           cd ComfyUI_windows_portable
-          python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
+          python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
           ls
 

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,4 +1,4 @@
-name: "Release Stable Version"
+name: Release Stable Version
 
 on:
   workflow_dispatch:
@@ -11,25 +11,28 @@ on:
         description: 'CUDA version'
         required: true
         type: string
-        default: "126"
+        default: '126'
       python_minor:
         description: 'Python minor version'
         required: true
         type: string
-        default: "12"
+        default: '12'
       python_patch:
         description: 'Python patch version'
         required: true
         type: string
-        default: "8"
+        default: '8'
 
+defaults:
+  run:
+    shell: bash
 
 jobs:
   package_comfy_windows:
     permissions:
-      contents: "write"
-      packages: "write"
-      pull-requests: "read"
+      contents: write
+      packages: write
+      pull-requests: read
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,29 +47,26 @@ jobs:
             cu${{ inputs.cu }}_python_deps.tar
             update_comfyui_and_python_dependencies.bat
           key: ${{ runner.os }}-build-cu${{ inputs.cu }}-${{ inputs.python_minor }}
-      - shell: bash
-        run: |
+      - run: |
           mv cu${{ inputs.cu }}_python_deps.tar ../
           mv update_comfyui_and_python_dependencies.bat ../
           cd ..
           tar xf cu${{ inputs.cu }}_python_deps.tar
           pwd
           ls
-
-      - shell: bash
-        run: |
+      - run: |
           cd ..
           cp -r ComfyUI ComfyUI_copy
           curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
           unzip python_embedded.zip -d python_embedded
           cd python_embedded
-          echo ${{ env.MINOR_VERSION }}
+          echo ${{ inputs.python_minor }}
           echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
-          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          curl -fLO https://bootstrap.pypa.io/get-pip.py
           ./python.exe get-pip.py
           ./python.exe -s -m pip install ../cu${{ inputs.cu }}_python_deps/*
-            sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
-            cd ..
+          sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
+          cd ..
 
           git clone --depth 1 https://github.com/comfyanonymous/taesd
           cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/
@@ -84,14 +84,13 @@ jobs:
 
           cd ..
 
-          "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
+          7z a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
           mv ComfyUI_windows_portable.7z ComfyUI/ComfyUI_windows_portable_nvidia.7z
 
           cd ComfyUI_windows_portable
           python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
           ls
-
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,4 +1,5 @@
-name: 'Close stale issues'
+name: Close stale issues
+
 on:
   schedule:
     # Run daily at 430 am PT
@@ -12,7 +13,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: "This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if your issue still isn't solved, and it will be left open. Otherwise, the issue will be closed automatically."
+          stale-issue-message: 'This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if your issue still isn't solved, and it will be left open. Otherwise, the issue will be closed automatically.'
           days-before-stale: 30
           days-before-close: 7
           stale-issue-label: 'Stale'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,15 +1,13 @@
 name: Build package
-
 #
 # This workflow is a test of the python package build.
 # Install Python dependencies across different Python versions.
 #
-
 on:
   push:
     paths:
-      - "requirements.txt"
-      - ".github/workflows/test-build.yml"
+      - 'requirements.txt'
+      - '.github/workflows/test-build.yml'
 
 jobs:
   build:
@@ -18,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,6 +1,7 @@
 # This is the GitHub Workflow that drives automatic full-GPU-enabled tests of all new commits to the master branch of ComfyUI
 # Results are reported as checkmarks on the commits, as well as onto https://ci.comfy.org/
 name: Full Comfy CI Workflow Runs
+
 on:
   push:
     branches:
@@ -22,19 +23,19 @@ jobs:
       matrix:
         # os: [macos, linux, windows]
         os: [macos, linux]
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
-        cuda_version: ["12.1"]
-        torch_version: ["stable"]
+        python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        cuda_version: ['12.1']
+        torch_version: ['stable']
         include:
           - os: macos
             runner_label: [self-hosted, macOS]
-            flags: "--use-pytorch-cross-attention"
+            flags: '--use-pytorch-cross-attention'
           - os: linux
             runner_label: [self-hosted, Linux]
-            flags: ""
+            flags: ''
           # - os: windows
           #   runner_label: [self-hosted, Windows]
-          #   flags: ""
+          #   flags: ''
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows
@@ -51,13 +52,13 @@ jobs:
   #     fail-fast: true
   #     matrix:
   #       os: [windows]
-  #       python_version: ["3.9", "3.10", "3.11", "3.12"]
-  #       cuda_version: ["12.1"]
-  #       torch_version: ["nightly"]
+  #       python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+  #       cuda_version: ['12.1']
+  #       torch_version: ['nightly']
   #       include:
   #         - os: windows
   #           runner_label: [self-hosted, Windows]
-  #           flags: ""
+  #           flags: ''
   #   runs-on: ${{ matrix.runner_label }}
   #   steps:
   #     - name: Test Workflows
@@ -74,16 +75,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos, linux]
-        python_version: ["3.11"]
-        cuda_version: ["12.1"]
-        torch_version: ["nightly"]
+        python_version: ['3.11']
+        cuda_version: ['12.1']
+        torch_version: ['nightly']
         include:
           - os: macos
             runner_label: [self-hosted, macOS]
-            flags: "--use-pytorch-cross-attention"
+            flags: '--use-pytorch-cross-attention'
           - os: linux
             runner_label: [self-hosted, Linux]
-            flags: ""
+            flags: ''
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows

--- a/.github/workflows/test-launch.yml
+++ b/.github/workflows/test-launch.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           repository: "comfyanonymous/ComfyUI"
           path: "ComfyUI"
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install requirements

--- a/.github/workflows/test-launch.yml
+++ b/.github/workflows/test-launch.yml
@@ -10,36 +10,36 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout ComfyUI
-      uses: actions/checkout@v4
-      with:
-        repository: "comfyanonymous/ComfyUI"
-        path: "ComfyUI"
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-    - name: Install requirements
-      run: |
-        python -m pip install --upgrade pip
-        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-        pip install -r requirements.txt
-        pip install wait-for-it
-      working-directory: ComfyUI
-    - name: Start ComfyUI server
-      run: |
-        python main.py --cpu 2>&1 | tee console_output.log &
-        wait-for-it --service 127.0.0.1:8188 -t 30
-      working-directory: ComfyUI
-    - name: Check for unhandled exceptions in server log
-      run: |
-        if grep -qE "Exception|Error" console_output.log; then
-          echo "Unhandled exception/error found in server log."
-          exit 1
-        fi
-      working-directory: ComfyUI
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: console-output
-        path: ComfyUI/console_output.log
-        retention-days: 30
+      - name: Checkout ComfyUI
+        uses: actions/checkout@v4
+        with:
+          repository: "comfyanonymous/ComfyUI"
+          path: "ComfyUI"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt
+          pip install wait-for-it
+        working-directory: ComfyUI
+      - name: Start ComfyUI server
+        run: |
+          python main.py --cpu 2>&1 | tee console_output.log &
+          wait-for-it --service 127.0.0.1:8188 -t 30
+        working-directory: ComfyUI
+      - name: Check for unhandled exceptions in server log
+        run: |
+          if grep -qE "Exception|Error" console_output.log; then
+            echo "Unhandled exception/error found in server log."
+            exit 1
+          fi
+        working-directory: ComfyUI
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: console-output
+          path: ComfyUI/console_output.log
+          retention-days: 30

--- a/.github/workflows/test-launch.yml
+++ b/.github/workflows/test-launch.yml
@@ -2,9 +2,9 @@ name: Test server launches without errors
 
 on:
   push:
-    branches: [ main, master ]
+    branches: master
   pull_request:
-    branches: [ main, master ]
+    branches: master
 
 jobs:
   test:
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout ComfyUI
         uses: actions/checkout@v4
-        with:
-          repository: "comfyanonymous/ComfyUI"
-          path: "ComfyUI"
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
@@ -24,22 +21,19 @@ jobs:
           pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
           pip install wait-for-it
-        working-directory: ComfyUI
       - name: Start ComfyUI server
         run: |
           python main.py --cpu 2>&1 | tee console_output.log &
           wait-for-it --service 127.0.0.1:8188 -t 30
-        working-directory: ComfyUI
       - name: Check for unhandled exceptions in server log
         run: |
           if grep -qE "Exception|Error" console_output.log; then
             echo "Unhandled exception/error found in server log."
             exit 1
           fi
-        working-directory: ComfyUI
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: console-output
-          path: ComfyUI/console_output.log
+          path: console_output.log
           retention-days: 30

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: true
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python      
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.12'

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    - name: Install requirements
-      run: |
-        python -m pip install --upgrade pip
-        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-        pip install -r requirements.txt
-    - name: Run Unit Tests
-      run: |
-        pip install -r tests-unit/requirements.txt
-        python -m pytest tests-unit
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt
+      - name: Run Unit Tests
+        run: |
+          pip install -r tests-unit/requirements.txt
+          python -m pytest tests-unit

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install requirements

--- a/.github/workflows/update-frontend.yml
+++ b/.github/workflows/update-frontend.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout ComfyUI
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install requirements

--- a/.github/workflows/update-frontend.yml
+++ b/.github/workflows/update-frontend.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Frontend version to update to (e.g., 1.0.0)"
+        description: 'Frontend version to update to (e.g., 1.0.0)'
         required: true
         type: string
 
@@ -14,7 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-
     steps:
       - name: Checkout ComfyUI
         uses: actions/checkout@v4
@@ -47,8 +46,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.PR_BOT_PAT }}
-          commit-message: "Update frontend to v${{ github.event.inputs.version }}"
-          title: "Frontend Update: v${{ github.event.inputs.version }}"
+          commit-message: Update frontend to v${{ github.event.inputs.version }}
+          title: 'Frontend Update: v${{ github.event.inputs.version }}'
           body: |
             Automated PR to update frontend content to version ${{ github.event.inputs.version }}
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -3,15 +3,14 @@ name: Update Version File
 on:
   pull_request:
     paths:
-      - "pyproject.toml"
-    branches:
-      - master
+      - 'pyproject.toml'
+    branches: master
 
 jobs:
   update-version:
     runs-on: ubuntu-latest
     # Don't run on fork PRs
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       pull-requests: write
       contents: write
@@ -23,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows_release_dependencies.yml
+++ b/.github/workflows/windows_release_dependencies.yml
@@ -53,7 +53,7 @@ jobs:
             echo If you just want to update normally, close this and run update_comfyui.bat instead.
             echo -
             pause
-            ..\python_embeded\python.exe -s -m pip install --upgrade torch torchvision torchaudio ${{ inputs.xformers }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
+            ..\python_embedded\python.exe -s -m pip install --upgrade torch torchvision torchaudio ${{ inputs.xformers }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
             pause" > update_comfyui_and_python_dependencies.bat
 
             python -m pip wheel --no-cache-dir torch torchvision torchaudio ${{ inputs.xformers }} ${{ inputs.extra_dependencies }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r requirements.txt pygit2 -w ./temp_wheel_dir

--- a/.github/workflows/windows_release_dependencies.yml
+++ b/.github/workflows/windows_release_dependencies.yml
@@ -1,4 +1,4 @@
-name: "Windows Release dependencies"
+name: Windows Release dependencies
 
 on:
   workflow_dispatch:
@@ -7,32 +7,36 @@ on:
         description: 'xformers version'
         required: false
         type: string
-        default: ""
+        default: ''
       extra_dependencies:
         description: 'extra dependencies'
         required: false
         type: string
-        default: ""
+        default: ''
       cu:
         description: 'cuda version'
         required: true
         type: string
-        default: "126"
+        default: '126'
 
       python_minor:
         description: 'python minor version'
         required: true
         type: string
-        default: "12"
+        default: '12'
 
       python_patch:
         description: 'python patch version'
         required: true
         type: string
-        default: "8"
+        default: '8'
 #  push:
 #    branches:
 #      - master
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build_dependencies:
@@ -42,9 +46,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
-
-      - shell: bash
-        run: |
+      - run: |
           echo "@echo off
           call update_comfyui.bat nopause
           echo -
@@ -58,11 +60,10 @@ jobs:
 
           python -m pip wheel --no-cache-dir torch torchvision torchaudio ${{ inputs.xformers }} ${{ inputs.extra_dependencies }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r requirements.txt pygit2 -w ./temp_wheel_dir
           python -m pip install --no-cache-dir ./temp_wheel_dir/*
-          echo installed basic
+          echo "installed basic"
           ls -lah temp_wheel_dir
           mv temp_wheel_dir cu${{ inputs.cu }}_python_deps
           tar cf cu${{ inputs.cu }}_python_deps.tar cu${{ inputs.cu }}_python_deps
-
       - uses: actions/cache/save@v4
         with:
           path: |

--- a/.github/workflows/windows_release_dependencies.yml
+++ b/.github/workflows/windows_release_dependencies.yml
@@ -38,34 +38,34 @@ jobs:
   build_dependencies:
     runs-on: windows-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-python@v5
-          with:
-            python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
 
-        - shell: bash
-          run: |
-            echo "@echo off
-            call update_comfyui.bat nopause
-            echo -
-            echo This will try to update pytorch and all python dependencies.
-            echo -
-            echo If you just want to update normally, close this and run update_comfyui.bat instead.
-            echo -
-            pause
-            ..\python_embedded\python.exe -s -m pip install --upgrade torch torchvision torchaudio ${{ inputs.xformers }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
-            pause" > update_comfyui_and_python_dependencies.bat
+      - shell: bash
+        run: |
+          echo "@echo off
+          call update_comfyui.bat nopause
+          echo -
+          echo This will try to update pytorch and all python dependencies.
+          echo -
+          echo If you just want to update normally, close this and run update_comfyui.bat instead.
+          echo -
+          pause
+          ..\python_embedded\python.exe -s -m pip install --upgrade torch torchvision torchaudio ${{ inputs.xformers }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
+          pause" > update_comfyui_and_python_dependencies.bat
 
-            python -m pip wheel --no-cache-dir torch torchvision torchaudio ${{ inputs.xformers }} ${{ inputs.extra_dependencies }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r requirements.txt pygit2 -w ./temp_wheel_dir
-            python -m pip install --no-cache-dir ./temp_wheel_dir/*
-            echo installed basic
-            ls -lah temp_wheel_dir
-            mv temp_wheel_dir cu${{ inputs.cu }}_python_deps
-            tar cf cu${{ inputs.cu }}_python_deps.tar cu${{ inputs.cu }}_python_deps
+          python -m pip wheel --no-cache-dir torch torchvision torchaudio ${{ inputs.xformers }} ${{ inputs.extra_dependencies }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r requirements.txt pygit2 -w ./temp_wheel_dir
+          python -m pip install --no-cache-dir ./temp_wheel_dir/*
+          echo installed basic
+          ls -lah temp_wheel_dir
+          mv temp_wheel_dir cu${{ inputs.cu }}_python_deps
+          tar cf cu${{ inputs.cu }}_python_deps.tar cu${{ inputs.cu }}_python_deps
 
-        - uses: actions/cache/save@v4
-          with:
-            path: |
-              cu${{ inputs.cu }}_python_deps.tar
-              update_comfyui_and_python_dependencies.bat
-            key: ${{ runner.os }}-build-cu${{ inputs.cu }}-${{ inputs.python_minor }}
+      - uses: actions/cache/save@v4
+        with:
+          path: |
+            cu${{ inputs.cu }}_python_deps.tar
+            update_comfyui_and_python_dependencies.bat
+          key: ${{ runner.os }}-build-cu${{ inputs.cu }}-${{ inputs.python_minor }}

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -1,4 +1,4 @@
-name: "Windows Release Nightly pytorch"
+name: Windows Release Nightly pytorch
 
 on:
   workflow_dispatch:
@@ -7,29 +7,32 @@ on:
         description: 'cuda version'
         required: true
         type: string
-        default: "126"
+        default: '126'
 
       python_minor:
         description: 'python minor version'
         required: true
         type: string
-        default: "13"
+        default: '13'
 
       python_patch:
         description: 'python patch version'
         required: true
         type: string
-        default: "1"
+        default: '1'
 #  push:
-#    branches:
-#      - master
+#    branches: master
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build:
     permissions:
-      contents: "write"
-      packages: "write"
-      pull-requests: "read"
+      contents: write
+      packages: write
+      pull-requests: read
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,15 +42,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
-      - shell: bash
-        run: |
+      - run: |
           cd ..
           cp -r ComfyUI ComfyUI_copy
           curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
           unzip python_embedded.zip -d python_embedded
           cd python_embedded
           echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
-          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          curl -fLO https://bootstrap.pypa.io/get-pip.py
           ./python.exe get-pip.py
           python -m pip wheel torch torchvision torchaudio --pre --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2 -w ../temp_wheel_dir
           ls ../temp_wheel_dir
@@ -74,18 +76,17 @@ jobs:
           pause" > ./update/update_comfyui_and_python_dependencies.bat
           cd ..
 
-          "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI_windows_portable_nightly_pytorch
+          7z a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI_windows_portable_nightly_pytorch
           mv ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI/ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
 
           cd ComfyUI_windows_portable_nightly_pytorch
           python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
           ls
-
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
-          tag: "latest"
+          tag: latest
           overwrite: true

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -27,65 +27,65 @@ on:
 jobs:
   build:
     permissions:
-        contents: "write"
-        packages: "write"
-        pull-requests: "read"
+      contents: "write"
+      packages: "write"
+      pull-requests: "read"
     runs-on: windows-latest
     steps:
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
-            persist-credentials: false
-        - uses: actions/setup-python@v5
-          with:
-            python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
-        - shell: bash
-          run: |
-            cd ..
-            cp -r ComfyUI ComfyUI_copy
-            curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
-            unzip python_embedded.zip -d python_embedded
-            cd python_embedded
-            echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
-            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            ./python.exe get-pip.py
-            python -m pip wheel torch torchvision torchaudio --pre --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2 -w ../temp_wheel_dir
-            ls ../temp_wheel_dir
-            ./python.exe -s -m pip install --pre ../temp_wheel_dir/*
-            sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
-            cd ..
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
+      - shell: bash
+        run: |
+          cd ..
+          cp -r ComfyUI ComfyUI_copy
+          curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
+          unzip python_embedded.zip -d python_embedded
+          cd python_embedded
+          echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          ./python.exe get-pip.py
+          python -m pip wheel torch torchvision torchaudio --pre --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2 -w ../temp_wheel_dir
+          ls ../temp_wheel_dir
+          ./python.exe -s -m pip install --pre ../temp_wheel_dir/*
+          sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
+          cd ..
 
-            git clone --depth 1 https://github.com/comfyanonymous/taesd
-            cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/
+          git clone --depth 1 https://github.com/comfyanonymous/taesd
+          cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/
 
-            mkdir ComfyUI_windows_portable_nightly_pytorch
-            mv python_embedded ComfyUI_windows_portable_nightly_pytorch
-            mv ComfyUI_copy ComfyUI_windows_portable_nightly_pytorch/ComfyUI
+          mkdir ComfyUI_windows_portable_nightly_pytorch
+          mv python_embedded ComfyUI_windows_portable_nightly_pytorch
+          mv ComfyUI_copy ComfyUI_windows_portable_nightly_pytorch/ComfyUI
 
-            cd ComfyUI_windows_portable_nightly_pytorch
+          cd ComfyUI_windows_portable_nightly_pytorch
 
-            mkdir update
-            cp -r ComfyUI/.ci/update_windows/* ./update/
-            cp -r ComfyUI/.ci/windows_base_files/* ./
-            cp -r ComfyUI/.ci/windows_nightly_base_files/* ./
+          mkdir update
+          cp -r ComfyUI/.ci/update_windows/* ./update/
+          cp -r ComfyUI/.ci/windows_base_files/* ./
+          cp -r ComfyUI/.ci/windows_nightly_base_files/* ./
 
-            echo "call update_comfyui.bat nopause
-            ..\python_embedded\python.exe -s -m pip install --upgrade --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
-            pause" > ./update/update_comfyui_and_python_dependencies.bat
-            cd ..
+          echo "call update_comfyui.bat nopause
+          ..\python_embedded\python.exe -s -m pip install --upgrade --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
+          pause" > ./update/update_comfyui_and_python_dependencies.bat
+          cd ..
 
-            "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI_windows_portable_nightly_pytorch
-            mv ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI/ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
+          "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI_windows_portable_nightly_pytorch
+          mv ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI/ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
 
-            cd ComfyUI_windows_portable_nightly_pytorch
-            python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
+          cd ComfyUI_windows_portable_nightly_pytorch
+          python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
-            ls
+          ls
 
-        - name: Upload binaries to release
-          uses: svenstaro/upload-release-action@v2
-          with:
-                repo_token: ${{ secrets.GITHUB_TOKEN }}
-                file: ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
-                tag: "latest"
-                overwrite: true
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
+          tag: "latest"
+          overwrite: true

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -43,9 +43,9 @@ jobs:
           run: |
             cd ..
             cp -r ComfyUI ComfyUI_copy
-            curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embeded.zip
-            unzip python_embeded.zip -d python_embeded
-            cd python_embeded
+            curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
+            unzip python_embedded.zip -d python_embedded
+            cd python_embedded
             echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             ./python.exe get-pip.py
@@ -59,7 +59,7 @@ jobs:
             cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/
 
             mkdir ComfyUI_windows_portable_nightly_pytorch
-            mv python_embeded ComfyUI_windows_portable_nightly_pytorch
+            mv python_embedded ComfyUI_windows_portable_nightly_pytorch
             mv ComfyUI_copy ComfyUI_windows_portable_nightly_pytorch/ComfyUI
 
             cd ComfyUI_windows_portable_nightly_pytorch
@@ -70,7 +70,7 @@ jobs:
             cp -r ComfyUI/.ci/windows_nightly_base_files/* ./
 
             echo "call update_comfyui.bat nopause
-            ..\python_embeded\python.exe -s -m pip install --upgrade --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
+            ..\python_embedded\python.exe -s -m pip install --upgrade --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
             pause" > ./update/update_comfyui_and_python_dependencies.bat
             cd ..
 
@@ -78,7 +78,7 @@ jobs:
             mv ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI/ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
 
             cd ComfyUI_windows_portable_nightly_pytorch
-            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
+            python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
             ls
 

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -76,7 +76,7 @@ jobs:
           pause" > ./update/update_comfyui_and_python_dependencies.bat
           cd ..
 
-          7z a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI_windows_portable_nightly_pytorch
+          7z a -mx=9 -md=32m ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI_windows_portable_nightly_pytorch
           mv ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI/ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
 
           cd ComfyUI_windows_portable_nightly_pytorch

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -97,4 +97,3 @@ jobs:
                 file: new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
                 tag: "latest"
                 overwrite: true
-

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -56,9 +56,9 @@ jobs:
           run: |
             cd ..
             cp -r ComfyUI ComfyUI_copy
-            curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embeded.zip
-            unzip python_embeded.zip -d python_embeded
-            cd python_embeded
+            curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
+            unzip python_embedded.zip -d python_embedded
+            cd python_embedded
             echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             ./python.exe get-pip.py
@@ -70,7 +70,7 @@ jobs:
             cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/
 
             mkdir ComfyUI_windows_portable
-            mv python_embeded ComfyUI_windows_portable
+            mv python_embedded ComfyUI_windows_portable
             mv ComfyUI_copy ComfyUI_windows_portable/ComfyUI
 
             cd ComfyUI_windows_portable
@@ -86,7 +86,7 @@ jobs:
             mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
 
             cd ComfyUI_windows_portable
-            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
+            python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
             ls
 

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -83,7 +83,7 @@ jobs:
 
           cd ..
 
-          7z a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
+          7z a -mx=9 -md=32m ComfyUI_windows_portable.7z ComfyUI_windows_portable
           mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
 
           cd ComfyUI_windows_portable

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -1,4 +1,4 @@
-name: "Windows Release packaging"
+name: Windows Release packaging
 
 on:
   workflow_dispatch:
@@ -7,29 +7,32 @@ on:
         description: 'cuda version'
         required: true
         type: string
-        default: "126"
+        default: '126'
 
       python_minor:
         description: 'python minor version'
         required: true
         type: string
-        default: "12"
+        default: '12'
 
       python_patch:
         description: 'python patch version'
         required: true
         type: string
-        default: "8"
+        default: '8'
 #  push:
-#    branches:
-#      - master
+#    branches: master
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   package_comfyui:
     permissions:
-        contents: "write"
-        packages: "write"
-        pull-requests: "read"
+        contents: write
+        packages: write
+        pull-requests: read
     runs-on: windows-latest
     steps:
       - uses: actions/cache/restore@v4
@@ -39,8 +42,7 @@ jobs:
             cu${{ inputs.cu }}_python_deps.tar
             update_comfyui_and_python_dependencies.bat
           key: ${{ runner.os }}-build-cu${{ inputs.cu }}-${{ inputs.python_minor }}
-      - shell: bash
-        run: |
+      - run: |
           mv cu${{ inputs.cu }}_python_deps.tar ../
           mv update_comfyui_and_python_dependencies.bat ../
           cd ..
@@ -52,15 +54,14 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - shell: bash
-        run: |
+      - run: |
           cd ..
           cp -r ComfyUI ComfyUI_copy
           curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
           unzip python_embedded.zip -d python_embedded
           cd python_embedded
           echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
-          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          curl -fLO https://bootstrap.pypa.io/get-pip.py
           ./python.exe get-pip.py
           ./python.exe -s -m pip install ../cu${{ inputs.cu }}_python_deps/*
           sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
@@ -82,18 +83,17 @@ jobs:
 
           cd ..
 
-          "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
+          7z a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
           mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
 
           cd ComfyUI_windows_portable
           python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
           ls
-
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
-          tag: "latest"
+          tag: latest
           overwrite: true

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -32,68 +32,68 @@ jobs:
         pull-requests: "read"
     runs-on: windows-latest
     steps:
-        - uses: actions/cache/restore@v4
-          id: cache
-          with:
-            path: |
-              cu${{ inputs.cu }}_python_deps.tar
-              update_comfyui_and_python_dependencies.bat
-            key: ${{ runner.os }}-build-cu${{ inputs.cu }}-${{ inputs.python_minor }}
-        - shell: bash
-          run: |
-            mv cu${{ inputs.cu }}_python_deps.tar ../
-            mv update_comfyui_and_python_dependencies.bat ../
-            cd ..
-            tar xf cu${{ inputs.cu }}_python_deps.tar
-            pwd
-            ls
+      - uses: actions/cache/restore@v4
+        id: cache
+        with:
+          path: |
+            cu${{ inputs.cu }}_python_deps.tar
+            update_comfyui_and_python_dependencies.bat
+          key: ${{ runner.os }}-build-cu${{ inputs.cu }}-${{ inputs.python_minor }}
+      - shell: bash
+        run: |
+          mv cu${{ inputs.cu }}_python_deps.tar ../
+          mv update_comfyui_and_python_dependencies.bat ../
+          cd ..
+          tar xf cu${{ inputs.cu }}_python_deps.tar
+          pwd
+          ls
 
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
-            persist-credentials: false
-        - shell: bash
-          run: |
-            cd ..
-            cp -r ComfyUI ComfyUI_copy
-            curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
-            unzip python_embedded.zip -d python_embedded
-            cd python_embedded
-            echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
-            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            ./python.exe get-pip.py
-            ./python.exe -s -m pip install ../cu${{ inputs.cu }}_python_deps/*
-            sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
-            cd ..
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - shell: bash
+        run: |
+          cd ..
+          cp -r ComfyUI ComfyUI_copy
+          curl https://www.python.org/ftp/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }}/python-3.${{ inputs.python_minor }}.${{ inputs.python_patch }}-embed-amd64.zip -o python_embedded.zip
+          unzip python_embedded.zip -d python_embedded
+          cd python_embedded
+          echo 'import site' >> ./python3${{ inputs.python_minor }}._pth
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          ./python.exe get-pip.py
+          ./python.exe -s -m pip install ../cu${{ inputs.cu }}_python_deps/*
+          sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
+          cd ..
 
-            git clone --depth 1 https://github.com/comfyanonymous/taesd
-            cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/
+          git clone --depth 1 https://github.com/comfyanonymous/taesd
+          cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/
 
-            mkdir ComfyUI_windows_portable
-            mv python_embedded ComfyUI_windows_portable
-            mv ComfyUI_copy ComfyUI_windows_portable/ComfyUI
+          mkdir ComfyUI_windows_portable
+          mv python_embedded ComfyUI_windows_portable
+          mv ComfyUI_copy ComfyUI_windows_portable/ComfyUI
 
-            cd ComfyUI_windows_portable
+          cd ComfyUI_windows_portable
 
-            mkdir update
-            cp -r ComfyUI/.ci/update_windows/* ./update/
-            cp -r ComfyUI/.ci/windows_base_files/* ./
-            cp ../update_comfyui_and_python_dependencies.bat ./update/
+          mkdir update
+          cp -r ComfyUI/.ci/update_windows/* ./update/
+          cp -r ComfyUI/.ci/windows_base_files/* ./
+          cp ../update_comfyui_and_python_dependencies.bat ./update/
 
-            cd ..
+          cd ..
 
-            "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
-            mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
+          "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
+          mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
 
-            cd ComfyUI_windows_portable
-            python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
+          cd ComfyUI_windows_portable
+          python_embedded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
-            ls
+          ls
 
-        - name: Upload binaries to release
-          uses: svenstaro/upload-release-action@v2
-          with:
-                repo_token: ${{ secrets.GITHUB_TOKEN }}
-                file: new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
-                tag: "latest"
-                overwrite: true
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
+          tag: "latest"
+          overwrite: true

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This is the command to install the nightly with ROCm 6.3 which might have some p
 ### Intel GPUs (Windows and Linux)
 
 (Option 1) Intel Arc GPU users can install native PyTorch with torch.xpu support using pip (currently available in PyTorch nightly builds). More information can be found [here](https://pytorch.org/docs/main/notes/get_start_xpu.html)
-  
+
 1. To install PyTorch nightly, use the following command:
 
 ```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/xpu```
@@ -288,7 +288,7 @@ Generate a self-signed certificate (not appropriate for shared/production use) a
 
 Use `--tls-keyfile key.pem --tls-certfile cert.pem` to enable TLS/SSL, the app will now be accessible with `https://...` instead of `http://...`.
 
-> Note: Windows users can use [alexisrolland/docker-openssl](https://github.com/alexisrolland/docker-openssl) or one of the [3rd party binary distributions](https://wiki.openssl.org/index.php/Binaries) to run the command example above. 
+> Note: Windows users can use [alexisrolland/docker-openssl](https://github.com/alexisrolland/docker-openssl) or one of the [3rd party binary distributions](https://wiki.openssl.org/index.php/Binaries) to run the command example above.
 <br/><br/>If you use a container, note that the volume mount `-v` can be a relative path so `... -v ".\:/openssl-certs" ...` would create the key & cert files in the current directory of your command prompt or powershell terminal.
 
 ## Support and dev channel

--- a/app/logger.py
+++ b/app/logger.py
@@ -11,7 +11,7 @@ stderr_interceptor = None
 
 
 class LogInterceptor(io.TextIOWrapper):
-    def __init__(self, stream,  *args, **kwargs):
+    def __init__(self, stream, *args, **kwargs):
         buffer = stream.buffer
         encoding = stream.encoding
         super().__init__(buffer, *args, **kwargs, encoding=encoding, line_buffering=stream.line_buffering)

--- a/comfy/hooks.py
+++ b/comfy/hooks.py
@@ -587,7 +587,7 @@ def get_sorted_list_via_attr(objects: list, attr: str) -> list:
         sorted_list.extend(object_list)
     return sorted_list
 
-def create_transformer_options_from_hooks(model: ModelPatcher, hooks: HookGroup,  transformer_options: dict[str]=None):
+def create_transformer_options_from_hooks(model: ModelPatcher, hooks: HookGroup, transformer_options: dict[str]=None):
     # if no hooks or is not a ModelPatcher for sampling, return empty dict
     if hooks is None or model.is_clip:
         return {}

--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -601,10 +601,10 @@ class PixArtAlpha(supported_models_base.BASE):
     }
 
     sampling_settings = {
-        "beta_schedule" : "sqrt_linear",
-        "linear_start"  : 0.0001,
-        "linear_end"    : 0.02,
-        "timesteps"     : 1000,
+        "beta_schedule": "sqrt_linear",
+        "linear_start": 0.0001,
+        "linear_end": 0.02,
+        "timesteps": 1000,
     }
 
     unet_extra_config = {}
@@ -664,8 +664,8 @@ class HunyuanDiT1(HunyuanDiT):
     unet_extra_config = {}
 
     sampling_settings = {
-        "linear_start" : 0.00085,
-        "linear_end" : 0.03,
+        "linear_start": 0.00085,
+        "linear_end": 0.03,
     }
 
 class Flux(supported_models_base.BASE):

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -443,8 +443,8 @@ PIXART_MAP_BLOCK = {
     ("mlp.fc1.bias", "ff.net.0.proj.bias"),
     ("mlp.fc2.weight", "ff.net.2.weight"),
     ("mlp.fc2.bias", "ff.net.2.bias"),
-    ("cross_attn.proj.weight" ,"attn2.to_out.0.weight"),
-    ("cross_attn.proj.bias"   ,"attn2.to_out.0.bias"),
+    ("cross_attn.proj.weight", "attn2.to_out.0.weight"),
+    ("cross_attn.proj.bias", "attn2.to_out.0.bias"),
 }
 
 def pixart_to_diffusers(mmdit_config, output_prefix=""):

--- a/comfy_extras/nodes_morphology.py
+++ b/comfy_extras/nodes_morphology.py
@@ -8,7 +8,7 @@ class Morphology:
     @classmethod
     def INPUT_TYPES(s):
         return {"required": {"image": ("IMAGE",),
-                                "operation": (["erode",  "dilate", "open", "close", "gradient", "bottom_hat", "top_hat"],),
+                                "operation": (["erode", "dilate", "open", "close", "gradient", "bottom_hat", "top_hat"],),
                                 "kernel_size": ("INT", {"default": 3, "min": 3, "max": 999, "step": 1}),
                                 }}
 

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -84,7 +84,7 @@ class CacheHelper:
 cache_helper = CacheHelper()
 
 extension_mimetypes_cache = {
-    "webp" : "image",
+    "webp": "image",
 }
 
 def map_legacy(folder_name: str) -> str:

--- a/new_updater.py
+++ b/new_updater.py
@@ -19,14 +19,14 @@ def update_windows_updater():
     except:
         return
 
-    if not contents.startswith(b"..\\python_embeded\\python.exe .\\update.py"):
+    if not contents.startswith(b"..\\python_embedded\\python.exe .\\update.py"):
         return
 
     shutil.copy(updater_path, dest_updater_path)
     try:
         with open(dest_bat_deps_path, 'rb') as f:
             contents = f.read()
-            contents = contents.replace(b'..\\python_embeded\\python.exe .\\update.py ..\\ComfyUI\\', b'call update_comfyui.bat nopause')
+            contents = contents.replace(b'..\\python_embedded\\python.exe .\\update.py ..\\ComfyUI\\', b'call update_comfyui.bat nopause')
         with open(dest_bat_deps_path, 'wb') as f:
             f.write(contents)
     except:

--- a/nodes.py
+++ b/nodes.py
@@ -1955,7 +1955,7 @@ NODE_CLASS_MAPPINGS = {
     "ImageBatch": ImageBatch,
     "ImagePadForOutpaint": ImagePadForOutpaint,
     "EmptyImage": EmptyImage,
-    "ConditioningAverage": ConditioningAverage ,
+    "ConditioningAverage": ConditioningAverage,
     "ConditioningCombine": ConditioningCombine,
     "ConditioningConcat": ConditioningConcat,
     "ConditioningSetArea": ConditioningSetArea,
@@ -2042,7 +2042,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "LatentUpscaleBy": "Upscale Latent By",
     "LatentComposite": "Latent Composite",
     "LatentBlend": "Latent Blend",
-    "LatentFromBatch" : "Latent From Batch",
+    "LatentFromBatch": "Latent From Batch",
     "RepeatLatentBatch": "Repeat Latent Batch",
     # Image
     "SaveImage": "Save Image",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-markers = 
+markers =
   inference: mark as inference test (deselect with '-m "not inference"')
   execution: mark as execution test (deselect with '-m "not execution"')
 testpaths =

--- a/server.py
+++ b/server.py
@@ -531,7 +531,7 @@ class PromptServer():
                     "comfyui_version": __version__,
                     "python_version": sys.version,
                     "pytorch_version": comfy.model_management.torch_version,
-                    "embedded_python": os.path.split(os.path.split(sys.executable)[0])[1] == "python_embeded",
+                    "embedded_python": os.path.split(os.path.split(sys.executable)[0])[1] == "python_embedded",
                     "argv": sys.argv
                 },
                 "devices": [


### PR DESCRIPTION
* Fix `embeded` typo.
* Remove whitespace
* Make indentation more consistent
* Update actions (setup-python to v5, github-scripts to v7)
* Replace `"` with `'`
* Remove unnecessary quotes, add them where they belong
* Replace `shell: bash` with `defaults: run`
* Make spacing around colons and commas more consistent
* Remove useless 7z arguments, use max compression level (8 might be invalid: https://7zip.bugaco.com/7zip/MANUAL/cmdline/switches/method.htm)
  * 7z is on path, you don't need to specify the full path to it