### PR TITLE
feat(nodes.py): Add support for alpha channel output in LoadImage node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1648,14 +1648,17 @@ class LoadImage:
         input_dir = folder_paths.get_input_directory()
         files = [f for f in os.listdir(input_dir) if os.path.isfile(os.path.join(input_dir, f))]
         return {"required":
-                    {"image": (sorted(files), {"image_upload": True})},
+                    {
+                        "image": (sorted(files), {"image_upload": True}),
+                        "out_alpha": ("BOOLEAN", {"default": False}),
+                    }
                 }
 
     CATEGORY = "image"
 
     RETURN_TYPES = ("IMAGE", "MASK")
     FUNCTION = "load_image"
-    def load_image(self, image):
+    def load_image(self, image, out_alpha):
         image_path = folder_paths.get_annotated_filepath(image)
 
         img = node_helpers.pillow(Image.open, image_path)
@@ -1671,7 +1674,7 @@ class LoadImage:
 
             if i.mode == 'I':
                 i = i.point(lambda i: i * (1 / 255))
-            image = i.convert("RGB")
+            image = i.convert("RGBA" if out_alpha else "RGB")
 
             if len(output_images) == 0:
                 w = image.size[0]


### PR DESCRIPTION
#feature-request

feat(nodes.py): Add support for alpha channel output in LoadImage node

This commit enhances the LoadImage node by adding support for outputting the alpha channel of images. The change ensures that images with transparency can be correctly handled and used in subsequent nodes.

Changes made:
- Modified the `load_image` method to include an `out_alpha` parameter.
- Updated the method to check for the alpha channel in the loaded image and output it if requested.

This enhancement allows for more flexible image processing workflows, particularly in scenarios where transparency is crucial.