### PR TITLE
fixed: crash caused by outdated incompatible `aiohttp` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ transformers>=4.28.1
 tokenizers>=0.13.3
 sentencepiece
 safetensors>=0.4.2
-aiohttp
+aiohttp>=3.11.8
+yarl>=1.18.0
 pyyaml
 Pillow
 scipy


### PR DESCRIPTION
This PR fixes these issues.

https://github.com/comfyanonymous/ComfyUI/issues/6038#issuecomment-2661776795 https://github.com/comfyanonymous/ComfyUI/issues/5814#issue-2700816845