### PR TITLE
Support loading and using SkyReels-V1-Hunyuan-I2V

### DIFF
--- a/comfy/ldm/hunyuan_video/model.py
+++ b/comfy/ldm/hunyuan_video/model.py
@@ -310,7 +310,7 @@ class HunyuanVideo(nn.Module):
             shape[i] = shape[i] // self.patch_size[i]
         img = img.reshape([img.shape[0]] + shape + [self.out_channels] + self.patch_size)
         img = img.permute(0, 4, 1, 5, 2, 6, 3, 7)
-        img = img.reshape(initial_shape)
+        img = img.reshape(initial_shape[0], self.out_channels, initial_shape[2], initial_shape[3], initial_shape[4])
         return img
 
     def forward(self, x, timestep, context, y, guidance=None, attention_mask=None, control=None, transformer_options={}, **kwargs):

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -879,7 +879,7 @@ class HunyuanVideo(BaseModel):
         else:
             padding_shape = (noise.shape[0], 16, noise.shape[2] - 1, noise.shape[3], noise.shape[4])
             latent_padding = torch.zeros(padding_shape, device=noise.device, dtype=noise.dtype)
-            image_latents = torch.cat([image.to(noise), latent_padding], dim=2)
+            image_latents = torch.cat([image.to(noise), latent_padding], dim=2) * 0.476986
 
         process_image_in = lambda image: image
         out['c_concat'] = comfy.conds.CONDNoiseShape(process_image_in(image_latents))

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -874,15 +874,11 @@ class HunyuanVideo(BaseModel):
         image = kwargs.get("concat_latent_image", None)
         noise = kwargs.get("noise", None)
 
-        if image is None:
-            image_latents = torch.zeros_like(noise)
-        else:
+        if image is not None:
             padding_shape = (noise.shape[0], 16, noise.shape[2] - 1, noise.shape[3], noise.shape[4])
             latent_padding = torch.zeros(padding_shape, device=noise.device, dtype=noise.dtype)
             image_latents = torch.cat([image.to(noise), latent_padding], dim=2) * 0.476986
-
-        process_image_in = lambda image: image
-        out['c_concat'] = comfy.conds.CONDNoiseShape(process_image_in(image_latents))
+            out['c_concat'] = comfy.conds.CONDNoiseShape(image_latents)
 
         guidance = kwargs.get("guidance", 6.0)
         if guidance is not None:

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -871,6 +871,19 @@ class HunyuanVideo(BaseModel):
         if cross_attn is not None:
             out['c_crossattn'] = comfy.conds.CONDRegular(cross_attn)
 
+        image = kwargs.get("concat_latent_image", None)
+        noise = kwargs.get("noise", None)
+
+        if image is None:
+            image_latents = torch.zeros_like(noise)
+        else:
+            padding_shape = (noise.shape[0], 16, noise.shape[2] - 1, noise.shape[3], noise.shape[4])
+            latent_padding = torch.zeros(padding_shape, device=noise.device, dtype=noise.dtype)
+            image_latents = torch.cat([image.to(noise), latent_padding], dim=2)
+
+        process_image_in = lambda image: image
+        out['c_concat'] = comfy.conds.CONDNoiseShape(process_image_in(image_latents))
+
         guidance = kwargs.get("guidance", 6.0)
         if guidance is not None:
             out['guidance'] = comfy.conds.CONDRegular(torch.FloatTensor([guidance]))

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -877,8 +877,8 @@ class HunyuanVideo(BaseModel):
         if image is not None:
             padding_shape = (noise.shape[0], 16, noise.shape[2] - 1, noise.shape[3], noise.shape[4])
             latent_padding = torch.zeros(padding_shape, device=noise.device, dtype=noise.dtype)
-            image_latents = torch.cat([image.to(noise), latent_padding], dim=2) * 0.476986
-            out['c_concat'] = comfy.conds.CONDNoiseShape(image_latents)
+            image_latents = torch.cat([image.to(noise), latent_padding], dim=2)
+            out['c_concat'] = comfy.conds.CONDNoiseShape(self.process_latent_in(image_latents))
 
         guidance = kwargs.get("guidance", 6.0)
         if guidance is not None:

--- a/comfy/model_detection.py
+++ b/comfy/model_detection.py
@@ -136,7 +136,7 @@ def detect_unet_config(state_dict, key_prefix):
     if '{}txt_in.individual_token_refiner.blocks.0.norm1.weight'.format(key_prefix) in state_dict_keys: #Hunyuan Video
         dit_config = {}
         dit_config["image_model"] = "hunyuan_video"
-        dit_config["in_channels"] = 16
+        dit_config["in_channels"] = state_dict["img_in.proj.weight"].shape[1] #SkyReels img2video 32 has input channels
         dit_config["patch_size"] = [1, 2, 2]
         dit_config["out_channels"] = 16
         dit_config["vec_in_dim"] = 768

--- a/comfy/model_detection.py
+++ b/comfy/model_detection.py
@@ -136,7 +136,7 @@ def detect_unet_config(state_dict, key_prefix):
     if '{}txt_in.individual_token_refiner.blocks.0.norm1.weight'.format(key_prefix) in state_dict_keys: #Hunyuan Video
         dit_config = {}
         dit_config["image_model"] = "hunyuan_video"
-        dit_config["in_channels"] = state_dict["img_in.proj.weight"].shape[1] #SkyReels img2video 32 has input channels
+        dit_config["in_channels"] = state_dict["img_in.proj.weight"].shape[1] #SkyReels img2video has 32 input channels
         dit_config["patch_size"] = [1, 2, 2]
         dit_config["out_channels"] = 16
         dit_config["vec_in_dim"] = 768


### PR DESCRIPTION
https://huggingface.co/Skywork/SkyReels-V1-Hunyuan-I2V

Converted back to the original format from diffusers format, which didn't load natively:

https://huggingface.co/Kijai/SkyReels-V1-Hunyuan_comfy/blob/main/skyreels_hunyuan_i2v_bf16.safetensors

This finetune of HunyuanVideo has double the input channels for image2video, I did the minimum changes to allow loading and using it with the ip2p conditioning node, unsure if there should be additional node or not.


https://github.com/user-attachments/assets/d496fe39-43a3-41ee-8177-903694632abb

