### PR TITLE
Fix failing ffmpeg extension import Windows.

### DIFF
--- a/main.py
+++ b/main.py
@@ -260,6 +260,14 @@ def start_comfyui(asyncio_loop=None):
     prompt_server = server.PromptServer(asyncio_loop)
     q = execution.PromptQueue(prompt_server)
 
+    if os.name =="nt":
+        for path in os.environ.get("PATH", "").split(";"):
+            if os.path.exists(path):
+                try:
+                    os.add_dll_directory(path)
+                except Exception:
+                    pass
+
     nodes.init_extra_nodes(init_custom_nodes=not args.disable_all_custom_nodes)
 
     cuda_malloc_warning()


### PR DESCRIPTION
Due to how comfy_extra nodes are imported as modules, importing of torchaudio_ffmpeg pyd libraries fails since there are no available dll libraries. That resulted in the error:
```
Loading FFmpeg6
Failed to load FFmpeg6 extension.
Traceback (most recent call last):
  File "C:\Users\ishim\Tools\ComfyUI\venv\Lib\site-packages\torio\_extension\utils.py", line 116, in _find_ffmpeg_extension
    ext = _find_versionsed_ffmpeg_extension(ffmpeg_ver)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ishim\Tools\ComfyUI\venv\Lib\site-packages\torio\_extension\utils.py", line 108, in _find_versionsed_ffmpeg_extension
    _load_lib(lib)
  File "C:\Users\ishim\Tools\ComfyUI\venv\Lib\site-packages\torio\_extension\utils.py", line 94, in _load_lib
    torch.ops.load_library(path)
  File "C:\Users\ishim\Tools\ComfyUI\venv\Lib\site-packages\torch\_ops.py", line 1357, in load_library
    ctypes.CDLL(path)
  File "C:\Program Files\Python312\Lib\ctypes\__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: Could not find module 'C:\Users\ishim\Tools\ComfyUI\venv\Lib\site-packages\torio\lib\libtorio_ffmpeg6.pyd' (or one of its dependencies). Try using the full path with constructor syntax.
```
Which it repeats for version 5 and 4 as well.
This PR fixes this by adding paths in the "PATH" environment variable as dll library directories using os.add_dll_directory() which was introduced with Python version 3.8. 

There might be need for some additions for conda environments but as I myself do not use this and it is not among the official methods of running ComfyUI apart from with Intel GPU, I leave the task of adding that to someone with the experience in that area.