### PR TITLE
Normalize extra_model_config.yaml paths to prevent duplicates.

### DIFF
--- a/tests-unit/utils/extra_config_test.py
+++ b/tests-unit/utils/extra_config_test.py
@@ -197,8 +197,8 @@ def test_load_extra_path_config_relative_base_path(
 
     load_extra_path_config(dummy_yaml_name)
 
-    expected_checkpoints = os.path.abspath(os.path.join(str(tmp_path), sub_folder, "checkpoints"))
-    expected_some_value = os.path.abspath(os.path.join(str(tmp_path), sub_folder, "some_value"))
+    expected_checkpoints = os.path.abspath(os.path.join(str(tmp_path), "my_rel_base", "checkpoints"))
+    expected_some_value = os.path.abspath(os.path.join(str(tmp_path), "my_rel_base", "some_value"))
 
     actual_paths = folder_paths.folder_names_and_paths["checkpoints"][0]
     assert len(actual_paths) == 1, "Should have one path added for 'checkpoints'."

--- a/tests-unit/utils/extra_config_test.py
+++ b/tests-unit/utils/extra_config_test.py
@@ -145,7 +145,7 @@ def test_load_extra_model_paths_expands_appdata(
     else:
         expected_base_path = '/Users/TestUser/AppData/Roaming/ComfyUI'
     expected_calls = [
-        ('checkpoints', os.path.join(expected_base_path, 'models/checkpoints'), False),
+        ('checkpoints', os.path.normpath(os.path.join(expected_base_path, 'models/checkpoints')), False),
     ]
 
     assert mock_add_model_folder_path.call_count == len(expected_calls)

--- a/utils/extra_config.py
+++ b/utils/extra_config.py
@@ -29,5 +29,6 @@ def load_extra_path_config(yaml_path):
                     full_path = os.path.join(base_path, full_path)
                 elif not os.path.isabs(full_path):
                     full_path = os.path.abspath(os.path.join(yaml_dir, y))
-                logging.info("Adding extra search path {} {}".format(x, full_path))
-                folder_paths.add_model_folder_path(x, full_path, is_default)
+                normalized_path = os.path.normpath(full_path)
+                logging.info("Adding extra search path {} {}".format(x, normalized_path))
+                folder_paths.add_model_folder_path(x, normalized_path, is_default)


### PR DESCRIPTION
Currently if you have this as your extra_model_paths.yaml, ComfyUI will try to add 
`/path/to/ComfyUI/custom_nodes/` to folder_paths, which is not differentiated from `/path/to/ComfyUI/custom_nodes` without the trailing `/`.

```
comfyui:
  custom_nodes: custom_nodes/
  base_path: /path/to/ComfyUI
```

This causes ComfyUI to import custom nodes twice.
```
Import times for custom nodes:
   0.0 seconds: /Users/../Desktop/custom_nodes/aigodlike-comfyui-translation
   0.0 seconds: /Users/../Desktop/custom_nodes/aigodlike-comfyui-translation
```

https://forum.comfy.org/t/when-installing-the-translation-plugin-through-manager-an-error-occurs-after-deleting-the-translation-plugin-it-can-be-opened/1549/6
