### PR TITLE
fix a bug:AttributeError: 'Linear' object has no attribute 'weight_fu…

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -97,7 +97,7 @@ def wipe_lowvram_weight(m):
         m.comfy_cast_weights = m.prev_comfy_cast_weights
         del m.prev_comfy_cast_weights
 
-    if hasattr(m, "weight_function"):
+    if not hasattr(m, "weight_function"):
         m.weight_function = []
 
     if hasattr(m, "bias_function"):


### PR DESCRIPTION
fix a bug:AttributeError: 'Linear' object has no attribute 'weight_function'
Flux model generation will cause this issue.