### PR TITLE
Add disable_mmap arg in method load_torch_file

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -135,6 +135,7 @@ class PerformanceFeature(enum.Enum):
     Fp8MatrixMultiplication = "fp8_matrix_mult"
 
 parser.add_argument("--fast", nargs="*", type=PerformanceFeature, help="Enable some untested and potentially quality deteriorating optimizations. --fast with no arguments enables everything. You can pass a list specific optimizations if you only want to enable specific ones. Current valid optimizations: fp16_accumulation fp8_matrix_mult")
+parser.add_argument("--disable-mmap", action="store_true", help="When load .safetensors or .sft model sometimes.")
 
 parser.add_argument("--dont-print-server", action="store_true", help="Don't print server output.")
 parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test for CI.")


### PR DESCRIPTION
Under certain circumstances, switching between .safetensors or .sft models may be slow. You can choose to disable the mmap mode to load the models. There are two methods:

1. Globally disable mmap​ by adding --disable-mmap to the startup parameters.
2. Disable mmap for specific scenarios​ by setting disable_mmap=False when calling load_torch_file in those scenarios.