### PR TITLE
allow custom command-line args

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -182,9 +182,9 @@ parser.add_argument("--user-directory", type=is_valid_directory, default=None, h
 parser.add_argument("--enable-compress-response-body", action="store_true", help="Enable compressing response body.")
 
 if comfy.options.args_parsing:
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
 else:
-    args = parser.parse_args([])
+    args, unknown_args = parser.parse_known_args([])
 
 if args.windows_standalone_build:
     args.auto_launch = True

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import os
 import importlib.util
 import folder_paths
 import time
-from comfy.cli_args import args
+from comfy.cli_args import args, unknown_args
 from app.logger import setup_logger
 import itertools
 import utils.extra_config
@@ -18,6 +18,8 @@ if __name__ == "__main__":
 
 
 setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
+if unknown_args:
+    logging.info("Found arguments not defined in the ComfyUI core: %s", unknown_args)
 
 def apply_custom_paths():
     # extra model paths


### PR DESCRIPTION
1. This allows custom nodes to specify some custom command line arguments in the readme.
2. Allows third-party integrators (who will probably have their own cmd arguments) to more easily integrate ComfyUI.

_I forced the corrected version, because in order to print something in the log, we first need to initialize the logger (and it is in main.py) and using the logger in the "cli_args.py" file was not correct._