### PR TITLE
improved: better frontend package installation guide

### DIFF
--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 import os
 import re
+import sys
 import tempfile
 import zipfile
 import importlib
@@ -21,8 +22,8 @@ try:
     import comfyui_frontend_package
 except ImportError as e:
     # TODO: Remove the check after roll out of 0.3.16
-    logging.error("\n\n********** ERROR ***********\n\ncomfyui-frontend-package is not installed. Please install the updated requirements.txt file by running:\npip install -r requirements.txt\n\nThis error is happening because the ComfyUI frontend is no longer shipped as part of the main repo but as a pip package instead.\n********** ERROR **********\n")
-    raise e
+    logging.error(f"\n\n********** ERROR ***********\n\ncomfyui-frontend-package is not installed. Please install the updated requirements.txt file by running:\n{sys.executable} -m pip install -r requirements.txt\n\nThis error is happening because the ComfyUI frontend is no longer shipped as part of the main repo but as a pip package instead.\n********** ERROR **********\n")
+    exit(-1)
 
 
 REQUEST_TIMEOUT = 10  # seconds

--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -20,7 +20,7 @@ from comfy.cli_args import DEFAULT_VERSION_STRING
 
 try:
     import comfyui_frontend_package
-except ImportError as e:
+except ImportError:
     # TODO: Remove the check after roll out of 0.3.16
     logging.error(f"\n\n********** ERROR ***********\n\ncomfyui-frontend-package is not installed. Please install the updated requirements.txt file by running:\n{sys.executable} -m pip install -r requirements.txt\n\nThis error is happening because the ComfyUI frontend is no longer shipped as part of the main repo but as a pip package instead.\n********** ERROR **********\n")
     exit(-1)


### PR DESCRIPTION
improved: better installation guide
- change `pip` to `{sys.executable} -m pip` 

modified: To prevent the guide message from being obscured by a complex error message, apply `exit` instead of `raise`.