### PR TITLE
Improve: Provide a better guide message for the missing frontend message.

### DIFF
--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -22,7 +22,8 @@ try:
     import comfyui_frontend_package
 except ImportError:
     # TODO: Remove the check after roll out of 0.3.16
-    logging.error(f"\n\n********** ERROR ***********\n\ncomfyui-frontend-package is not installed. Please install the updated requirements.txt file by running:\n{sys.executable} -m pip install -r requirements.txt\n\nThis error is happening because the ComfyUI frontend is no longer shipped as part of the main repo but as a pip package instead.\n********** ERROR **********\n")
+    req_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'requirements.txt'))
+    logging.error(f"\n\n********** ERROR ***********\n\ncomfyui-frontend-package is not installed. Please install the updated requirements.txt file by running:\n{sys.executable} -m pip install -r {req_path}\n\nThis error is happening because the ComfyUI frontend is no longer shipped as part of the main repo but as a pip package instead.\n********** ERROR **********\n")
     exit(-1)
 
 


### PR DESCRIPTION
suggest absolute full path to the `requirements.txt` instead of just `requirements.txt`

For users of the portable version, there are occasional instances where commands are misinterpreted.