### PR TITLE
Fix LoadImageOutput node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1785,14 +1785,7 @@ class LoadImageOutput(LoadImage):
 
     DESCRIPTION = "Load an image from the output folder. When the refresh button is clicked, the node will update the image list and automatically select the first image, allowing for easy iteration."
     EXPERIMENTAL = True
-    FUNCTION = "load_image_output"
-
-    def load_image_output(self, image):
-        return self.load_image(f"{image} [output]")
-
-    @classmethod
-    def VALIDATE_INPUTS(s, image):
-        return True
+    FUNCTION = "load_image"
 
 
 class ImageScale:


### PR DESCRIPTION
The frontend now annotates uploaded image filepaths if the `image_folder` option is set (https://github.com/Comfy-Org/ComfyUI_frontend/pull/2597). Annotating in this python class is now redundant and results in paths like `path/to/image.png [output] [output]`. Fixes https://github.com/comfyanonymous/ComfyUI/issues/7142.