### PR TITLE
make conds use non-blocking transfers

### DIFF
--- a/comfy/conds.py
+++ b/comfy/conds.py
@@ -1,6 +1,7 @@
 import torch
 import math
 import comfy.utils
+from comfy.model_management import device_should_use_non_blocking
 
 
 class CONDRegular:
@@ -10,8 +11,14 @@ class CONDRegular:
     def _copy_with(self, cond):
         return self.__class__(cond)
 
+    def _pin_memory(self, cond):
+        if cond.device == torch.device('cpu'):
+            return cond.pin_memory()
+        else:
+            return cond
+
     def process_cond(self, batch_size, device, **kwargs):
-        return self._copy_with(comfy.utils.repeat_to_batch_size(self.cond, batch_size).to(device))
+        return self._copy_with(comfy.utils.repeat_to_batch_size(self._pin_memory(self.cond), batch_size).to(device, non_blocking=device_should_use_non_blocking(device))
 
     def can_concat(self, other):
         if self.cond.shape != other.cond.shape:

--- a/comfy/conds.py
+++ b/comfy/conds.py
@@ -19,9 +19,9 @@ class CONDRegular:
 
     def process_cond(self, batch_size, device, **kwargs):
         if device_should_use_non_blocking(device):
-            return self._copy_with(comfy.utils.repeat_to_batch_size(self._pin_memory(self.cond), batch_size).to(device, non_blocking=True)
+            return self._copy_with(comfy.utils.repeat_to_batch_size(self._pin_memory(self.cond), batch_size).to(device, non_blocking=True))
         else:
-            return self._copy_with(comfy.utils.repeat_to_batch_size(self.cond, batch_size).to(device)
+            return self._copy_with(comfy.utils.repeat_to_batch_size(self.cond, batch_size).to(device))
 
     def can_concat(self, other):
         if self.cond.shape != other.cond.shape:

--- a/comfy/conds.py
+++ b/comfy/conds.py
@@ -18,7 +18,10 @@ class CONDRegular:
             return cond
 
     def process_cond(self, batch_size, device, **kwargs):
-        return self._copy_with(comfy.utils.repeat_to_batch_size(self._pin_memory(self.cond), batch_size).to(device, non_blocking=device_should_use_non_blocking(device))
+        if device_should_use_non_blocking(device):
+            return self._copy_with(comfy.utils.repeat_to_batch_size(self._pin_memory(self.cond), batch_size).to(device, non_blocking=True)
+        else:
+            return self._copy_with(comfy.utils.repeat_to_batch_size(self.cond, batch_size).to(device)
 
     def can_concat(self, other):
         if self.cond.shape != other.cond.shape:


### PR DESCRIPTION
This change should make use of non-blocking transfers for conds, avoiding unnecessary syncs.  Should improve speed, as long as other things are not causing syncs between steps.  It is also set up to use existing functions from the model management class to avoid using non blocking on unsupported platforms.