### PR TITLE
General way of receiving image for multiple json

### DIFF
--- a/script_examples/websockets_api_example_ws_images.py
+++ b/script_examples/websockets_api_example_ws_images.py
@@ -42,7 +42,7 @@ def get_images(ws, prompt):
                     else:
                         current_node = data['node']
         else:
-            if current_node == 'save_image_websocket_node':
+            if prompt[current_node]['class_type'] == 'SaveImageWebsocket':
                 images_output = output_images.get(current_node, [])
                 images_output.append(out[8:])
                 output_images[current_node] = images_output


### PR DESCRIPTION
I notice that now comfy is not trasmitting any type or anything called 'save_image_websocket_node' but a number. So the correct case is to current_node ='1', say 1 is the node number.
But I think my way is a more general ready-to-use case.