### PR TITLE
Prevent custom nodes from accidentally overwriting global modules.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2129,23 +2129,25 @@ def get_module_name(module_path: str) -> str:
 
 
 def load_custom_node(module_path: str, ignore=set(), module_parent="custom_nodes") -> bool:
+    module_name = get_module_name(module_path)
     if os.path.isfile(module_path):
         sp = os.path.splitext(module_path)
         module_name = sp[0]
+        sys_module_name = module_name
     elif os.path.isdir(module_path):
-        module_name = module_path
+        sys_module_name = module_path
 
     try:
         logging.debug("Trying to load custom node {}".format(module_path))
         if os.path.isfile(module_path):
-            module_spec = importlib.util.spec_from_file_location(module_name, module_path)
+            module_spec = importlib.util.spec_from_file_location(sys_module_name, module_path)
             module_dir = os.path.split(module_path)[0]
         else:
-            module_spec = importlib.util.spec_from_file_location(module_name, os.path.join(module_path, "__init__.py"))
+            module_spec = importlib.util.spec_from_file_location(sys_module_name, os.path.join(module_path, "__init__.py"))
             module_dir = module_path
 
         module = importlib.util.module_from_spec(module_spec)
-        sys.modules[module_name] = module
+        sys.modules[sys_module_name] = module
         module_spec.loader.exec_module(module)
 
         LOADED_MODULE_DIRS[module_name] = os.path.abspath(module_dir)

--- a/nodes.py
+++ b/nodes.py
@@ -2129,10 +2129,12 @@ def get_module_name(module_path: str) -> str:
 
 
 def load_custom_node(module_path: str, ignore=set(), module_parent="custom_nodes") -> bool:
-    module_name = os.path.basename(module_path)
     if os.path.isfile(module_path):
         sp = os.path.splitext(module_path)
         module_name = sp[0]
+    elif os.path.isdir(module_path):
+        module_name = module_path
+
     try:
         logging.debug("Trying to load custom node {}".format(module_path))
         if os.path.isfile(module_path):


### PR DESCRIPTION
This apparently breaks some custom nodes so I have moved this change to this pull request. 

Nodes that need to be fixed:

@ltdrdata ComfyUI manager
@rgthree rgthree-comfy

And probably some others.

If your custom node is a normal one that doesn't do anything weird with the sys.modules you should be good.

This is an important fix to prevent custom nodes from conflicting with python packages so it will be merged eventually.
