### PR TITLE
Add unwrap widget value support

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -634,6 +634,13 @@ def validate_inputs(prompt, item, validated):
                 continue
         else:
             try:
+                # Unwraps values wrapped in __value__ key. This is used to pass
+                # list widget value to execution, as by default list value is
+                # reserved to represent the connection between nodes.
+                if isinstance(val, dict) and "__value__" in val:
+                    val = val["__value__"]
+                    inputs[x] = val
+
                 if type_input == "INT":
                     val = int(val)
                     inputs[x] = val
@@ -645,12 +652,6 @@ def validate_inputs(prompt, item, validated):
                     inputs[x] = val
                 if type_input == "BOOLEAN":
                     val = bool(val)
-                    inputs[x] = val
-                # Unwraps values wrapped in __value__ key. This is used to pass
-                # list widget value to execution, as by default list value is
-                # reserved to represent the connection between nodes.
-                if isinstance(val, dict) and "__value__" in val:
-                    val = val["__value__"]
                     inputs[x] = val
             except Exception as ex:
                 error = {

--- a/execution.py
+++ b/execution.py
@@ -646,6 +646,12 @@ def validate_inputs(prompt, item, validated):
                 if type_input == "BOOLEAN":
                     val = bool(val)
                     inputs[x] = val
+                # Unwraps values wrapped in __value__ key. This is used to pass
+                # list widget value to execution, as by default list value is
+                # reserved to represent the connection between nodes.
+                if isinstance(val, dict) and "__value__" in val:
+                    val = val["__value__"]
+                    inputs[x] = val
             except Exception as ex:
                 error = {
                     "type": "invalid_input_type",


### PR DESCRIPTION
Currently if the frontend sets a list as widget value, it will be interpreted as a link between 2 nodes. This PR adds an unwrap mechanism to fix this issue. The frontend will wrap the widget value in a dict with reserved key `__value__`, e.g. `{"__value__": [1, 2, 3]}`, and the execution engine unwraps it to restore the internal content.