### PR TITLE
Bundle `include` and `libs` folders in the portable release

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,4 +1,3 @@
-
 name: "Release Stable Version"
 
 on:
@@ -68,6 +67,11 @@ jobs:
           ./python.exe -s -m pip install ../cu${{ inputs.cu }}_python_deps/*
             sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
             cd ..
+
+          curl --location https://www.nuget.org/api/v2/package/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }} -o python_nuget.zip
+          unzip python_nuget.zip -d python_nuget
+          cp -r python_nuget/tools/include python_embeded/
+          cp -r python_nuget/tools/libs python_embeded/
 
           git clone --depth 1 https://github.com/comfyanonymous/taesd
           cp taesd/*.pth ./ComfyUI_copy/models/vae_approx/

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -69,7 +69,7 @@ jobs:
             cd ..
 
           curl --location https://www.nuget.org/api/v2/package/python/3.${{ inputs.python_minor }}.${{ inputs.python_patch }} -o python_nuget.zip
-          unzip python_nuget.zip -d python_nuget
+          unzip -q python_nuget.zip -d python_nuget
           cp -r python_nuget/tools/include python_embeded/
           cp -r python_nuget/tools/libs python_embeded/
 


### PR DESCRIPTION
This is required by JIT compilation such as Triton, see https://github.com/woct0rdho/triton-windows#8-special-notes-for-comfyui-with-embeded-python

Because of the increasing popularity of Triton, I think it's needed to bundle the two folders in the ComfyUI portable release to make it easier for users to install Triton. This should be done at the level of Python distribution, rather than a pip package.

On Windows, the two folders are not bundled in the Python embed distribution, and the standard way to obtain them is nuget, see https://bugs.python.org/issue38224 and https://docs.python.org/3/using/windows.html

I've tested that the workflow runs successfully at https://github.com/woct0rdho/ComfyUI/releases/tag/test-nuget , and in this portable release Triton works without manually copying the two folders.

Note that the nuget API may produce HTTP 302 redirect to some CDN, so we need `curl --location`