### PR TITLE
Call unpatch_hooks at the start of ModelPatcher.partially_unload

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -747,6 +747,7 @@ class ModelPatcher:
 
     def partially_unload(self, device_to, memory_to_free=0):
         with self.use_ejected():
+            self.unpatch_hooks()
             memory_freed = 0
             patch_counter = 0
             unload_list = self._load_list()

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -747,7 +747,7 @@ class ModelPatcher:
 
     def partially_unload(self, device_to, memory_to_free=0):
         with self.use_ejected():
-            self.unpatch_hooks()
+            hooks_unpatched = False
             memory_freed = 0
             patch_counter = 0
             unload_list = self._load_list()
@@ -770,6 +770,10 @@ class ModelPatcher:
                             if not lowvram_possible:
                                 move_weight = False
                                 break
+
+                            if not hooks_unpatched:
+                                self.unpatch_hooks()
+                                hooks_unpatched = True
 
                             if bk.inplace_update:
                                 comfy.utils.copy_to_param(self.model, key, bk.weight)


### PR DESCRIPTION
Addresses bug found in: https://github.com/comfyanonymous/ComfyUI/issues/7195

There are likely other edge cases with hooks when weights cannot be loaded fully at a model's usage time, but this at least resolves the issues encountered when a model is unloaded partially at any point before it is used again and fully loaded.