### PR TITLE
Add REQUIRED_FRONTEND_VERSION prop on node def

### DIFF
--- a/comfy/comfy_types/node_typing.py
+++ b/comfy/comfy_types/node_typing.py
@@ -220,7 +220,7 @@ class ComfyNodeABC(ABC):
     """Flags a node as experimental, informing users that it may change or not work as expected."""
     DEPRECATED: bool
     """Flags a node as deprecated, indicating to users that they should find alternatives to this node."""
-    REQUIRED_FRONTEND_VERSION: str
+    REQUIRED_FRONTEND_VERSION: str | None
     """The minimum version of the ComfyUI frontend required to load this node.
 
     Usage::

--- a/comfy/comfy_types/node_typing.py
+++ b/comfy/comfy_types/node_typing.py
@@ -220,6 +220,13 @@ class ComfyNodeABC(ABC):
     """Flags a node as experimental, informing users that it may change or not work as expected."""
     DEPRECATED: bool
     """Flags a node as deprecated, indicating to users that they should find alternatives to this node."""
+    REQUIRED_FRONTEND_VERSION: str
+    """The minimum version of the ComfyUI frontend required to load this node.
+
+    Usage::
+
+        REQUIRED_FRONTEND_VERSION = "1.9.7"
+    """
 
     @classmethod
     @abstractmethod

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import sys
 import asyncio


### PR DESCRIPTION
Add REQUIRED_FRONTEND_VERSION prop on node def to allow node specify the minimum version frontend it needs. This would be helpful for node changes to get merged for testing for nightly frontend users.