### PR TITLE
Reload model lists when reloading object_info

### DIFF
--- a/server.py
+++ b/server.py
@@ -584,6 +584,7 @@ class PromptServer():
 
         @routes.get("/object_info")
         async def get_object_info(request):
+            folder_paths.cache_helper.clear()
             with folder_paths.cache_helper:
                 out = {}
                 for x in nodes.NODE_CLASS_MAPPINGS:


### PR DESCRIPTION
Right now there's no way to clear the folder_paths.cache_helper's model list, when reloading object_info I think we should clear this cache so that newly downloaded models are reflected.

Apologies if I got this wrong.