### PR TITLE
Lcm scalewise

### DIFF
--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -929,30 +929,6 @@ def sample_lcm(model, x, sigmas, extra_args=None, callback=None, disable=None, n
     return x
 
 
-# x0 = 
-
-@torch.no_grad()
-def sample_lcm_scalewise(model, x, sigmas, extra_args=None, callback=None, disable=None, noise_sampler=None):
-    extra_args = {} if extra_args is None else extra_args
-    seed = extra_args.get("seed", None)
-    scales = extra_args.get("scales", None)
-    if scales:
-        assert len(scales) == len(sigmas) - 1, "Number of scales must be equal to number of sampling steps minus one."
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
-    s_in = x.new_ones([x.shape[0]])
-    for i in trange(len(sigmas) - 1, disable=disable):
-        denoised = model(x, sigmas[i] * s_in, **extra_args)
-        if callback is not None:
-            callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised})
-
-        x = denoised
-        if sigmas[i + 1] > 0:
-            if scales:
-                # Interpolate to next scale
-                x = nn.functional.interpolate(x, size=scales[i + 1], mode='bicubic')
-            x = model.inner_model.inner_model.model_sampling.noise_scaling(sigmas[i + 1], noise_sampler(sigmas[i], sigmas[i + 1]), x)
-    return x
-
 
 @torch.no_grad()
 def sample_heunpp2(model, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):

--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -929,6 +929,30 @@ def sample_lcm(model, x, sigmas, extra_args=None, callback=None, disable=None, n
     return x
 
 
+# x0 = 
+
+@torch.no_grad()
+def sample_lcm_scalewise(model, x, sigmas, extra_args=None, callback=None, disable=None, noise_sampler=None):
+    extra_args = {} if extra_args is None else extra_args
+    seed = extra_args.get("seed", None)
+    scales = extra_args.get("scales", None)
+    if scales:
+        assert len(scales) == len(sigmas) - 1, "Number of scales must be equal to number of sampling steps minus one."
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    s_in = x.new_ones([x.shape[0]])
+    for i in trange(len(sigmas) - 1, disable=disable):
+        denoised = model(x, sigmas[i] * s_in, **extra_args)
+        if callback is not None:
+            callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised})
+
+        x = denoised
+        if sigmas[i + 1] > 0:
+            if scales:
+                # Interpolate to next scale
+                x = nn.functional.interpolate(x, size=scales[i + 1], mode='bicubic')
+            x = model.inner_model.inner_model.model_sampling.noise_scaling(sigmas[i + 1], noise_sampler(sigmas[i], sigmas[i + 1]), x)
+    return x
+
 
 @torch.no_grad()
 def sample_heunpp2(model, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -708,7 +708,7 @@ class Sampler:
 
 KSAMPLER_NAMES = ["euler", "euler_cfg_pp", "euler_ancestral", "euler_ancestral_cfg_pp", "heun", "heunpp2","dpm_2", "dpm_2_ancestral",
                   "lms", "dpm_fast", "dpm_adaptive", "dpmpp_2s_ancestral", "dpmpp_2s_ancestral_cfg_pp", "dpmpp_sde", "dpmpp_sde_gpu",
-                  "dpmpp_2m", "dpmpp_2m_cfg_pp", "dpmpp_2m_sde", "dpmpp_2m_sde_gpu", "dpmpp_3m_sde", "dpmpp_3m_sde_gpu", "ddpm", "lcm",
+                  "dpmpp_2m", "dpmpp_2m_cfg_pp", "dpmpp_2m_sde", "dpmpp_2m_sde_gpu", "dpmpp_3m_sde", "dpmpp_3m_sde_gpu", "ddpm", "lcm", "lcm_scalewise",
                   "ipndm", "ipndm_v", "deis", "res_multistep", "res_multistep_cfg_pp", "res_multistep_ancestral", "res_multistep_ancestral_cfg_pp",
                   "gradient_estimation", "er_sde"]
 

--- a/comfy_extras/nodes_advanced_samplers.py
+++ b/comfy_extras/nodes_advanced_samplers.py
@@ -1,5 +1,6 @@
 import comfy.samplers
 import comfy.utils
+from comfy.k_diffusion.sampling import default_noise_sampler
 import torch
 import numpy as np
 from tqdm.auto import trange
@@ -54,6 +55,64 @@ class SamplerLCMUpscale:
             scale_steps = None
         sampler = comfy.samplers.KSAMPLER(sample_lcm_upscale, extra_options={"total_upscale": scale_ratio, "upscale_steps": scale_steps, "upscale_method": upscale_method})
         return (sampler, )
+    
+
+@torch.no_grad()
+def sample_lcm_scalewise(model, x, sigmas, extra_args=None, callback=None, disable=None, total_upscale=2.0, upscale_method="bislerp", upscale_steps=None):
+    extra_args = {} if extra_args is None else extra_args
+    seed = extra_args.get("seed", None)
+
+    if upscale_steps is None:
+        upscale_steps = max(len(sigmas) // 2 + 1, 2)
+    else:
+        upscale_steps += 1
+        upscale_steps = min(upscale_steps, len(sigmas) + 1)
+
+    upscales = np.linspace(1.0, total_upscale, upscale_steps)[1:]
+
+    orig_shape = x.size()
+    s_in = x.new_ones([x.shape[0]])
+    for i in trange(len(sigmas) - 1, disable=disable):
+        denoised = model(x, sigmas[i] * s_in, **extra_args)
+        if callback is not None:
+            callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised})
+
+        x = denoised
+        if i < len(upscales):
+            x = comfy.utils.common_upscale(x, round(orig_shape[-1] * upscales[i]), round(orig_shape[-2] * upscales[i]), upscale_method, "disabled")
+
+        if sigmas[i + 1] > 0:
+            # Since the size of noise if changing, noise_sampler has to be redefined each time
+            noise_sampler = default_noise_sampler(x, seed=seed)
+            # Noise using the model's scheduler
+            x = model.inner_model.inner_model.model_sampling.noise_scaling(sigmas[i + 1], noise_sampler(sigmas[i], sigmas[i + 1]), x)
+    return x
+
+
+class SamplerLCMScalewise:
+    upscale_methods = ["bicubic", "bilinear", "nearest-exact"]
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required":
+            {
+                "scale_ratio": ("FLOAT", {"default": 1.0, "min": 1.0, "max": 4.0, "step": 0.25}),
+                "scale_steps": ("INT", {"default": -1, "min": -1, "max": 1000, "step": 1}),
+                "upscale_method": (s.upscale_methods,),
+            }
+        }
+    RETURN_TYPES = ("SAMPLER",)
+    CATEGORY = "sampling/custom_sampling/samplers"
+
+    FUNCTION = "get_sampler"
+
+    def get_sampler(self, scale_ratio, scale_steps, upscale_method):
+        if scale_steps < 0:
+            scale_steps = None
+        sampler = comfy.samplers.KSAMPLER(sample_lcm_scalewise, extra_options={"total_upscale": scale_ratio, "upscale_steps": scale_steps, "upscale_method": upscale_method})
+        return (sampler, )
+
 
 from comfy.k_diffusion.sampling import to_d
 import comfy.model_patcher
@@ -103,6 +162,7 @@ class SamplerEulerCFGpp:
 
 NODE_CLASS_MAPPINGS = {
     "SamplerLCMUpscale": SamplerLCMUpscale,
+    "SamplerLCMScalewise": SamplerLCMScalewise,
     "SamplerEulerCFGpp": SamplerEulerCFGpp,
 }
 


### PR DESCRIPTION
## Description

This PR adds `SamplerLCMScalewise` Node implementing the sampling procedure from [Scale-wise Distillation of Diffusion Models](https://arxiv.org/abs/2503.16397) paper.

The options to be set are:
* The target upscale factor - `scale_ratio`
* Number of upscale steps

## Why not using ` SamplerLCMUpscale`

This sampler has very similar functionality. However, it is fixed to Variance Exploding (VE) diffusion process, whereas Flow Matching and alternative noising processes are common. 