### PR TITLE
Add activations_shape info in UNet models

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -847,7 +847,7 @@ class SpatialTransformer(nn.Module):
         if not isinstance(context, list):
             context = [context] * len(self.transformer_blocks)
         b, c, h, w = x.shape
-        transformer_options["activations_shape"] = x.shape
+        transformer_options["activations_shape"] = list(x.shape)
         x_in = x
         x = self.norm(x)
         if not self.use_linear:
@@ -963,7 +963,7 @@ class SpatialVideoTransformer(SpatialTransformer):
         transformer_options={}
     ) -> torch.Tensor:
         _, _, h, w = x.shape
-        transformer_options["activations_shape"] = x.shape
+        transformer_options["activations_shape"] = list(x.shape)
         x_in = x
         spatial_context = None
         if exists(context):

--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -847,6 +847,7 @@ class SpatialTransformer(nn.Module):
         if not isinstance(context, list):
             context = [context] * len(self.transformer_blocks)
         b, c, h, w = x.shape
+        transformer_options["activations_shape"] = x.shape
         x_in = x
         x = self.norm(x)
         if not self.use_linear:
@@ -962,6 +963,7 @@ class SpatialVideoTransformer(SpatialTransformer):
         transformer_options={}
     ) -> torch.Tensor:
         _, _, h, w = x.shape
+        transformer_options["activations_shape"] = x.shape
         x_in = x
         spatial_context = None
         if exists(context):


### PR DESCRIPTION
Currently, the TransformerBlocks inside the UNet only receive the flattened activations. This makes it impossible for them to know what the actual spatial dimensions of the activations that were passed to them were (because of downsampling, padding, etc. the aspect ratio of the activations is different in different layers, so it can't even be reliably inferred from the original latent shape).

For example, in [Cubiq's IPAdapter implementation](https://github.com/cubiq/ComfyUI_IPAdapter_plus/blob/main/CrossAttentionPatch.py#L209), an initial guess is made to the mask size/shape, but in some cases we have to give up and pad the mask with zeros, likely creating incorrect results.

Similarly, in the [official comfy code for SAG](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy_extras/nodes_sag.py#L64) we actually attempt to factorize the attention map shape, and take whichever "possible shape" is closest to the shape of the original latent.

Clearly, the need to implement a heuristic algorithm that guesses what shape the original activations were makes it needlessly complex to create an attention patch. This PR adds a new key to transfomer_options, which is only set inside of SpatialTransformers and SpatialVideoTransformers, that contains the non-flattened, spatial shape of the activations inside that block. This makes it easy for attention patches to resize their masks correctly, compute attention maps, etc.