### PR TITLE
Add prepare_sampling wrapper to allow modifying noise_shape

### DIFF
--- a/comfy/patcher_extension.py
+++ b/comfy/patcher_extension.py
@@ -48,6 +48,7 @@ def get_all_callbacks(call_type: str, transformer_options: dict, is_model_option
 
 class WrappersMP:
     OUTER_SAMPLE = "outer_sample"
+    PREPARE_SAMPLING = "prepare_sampling"
     SAMPLER_SAMPLE = "sampler_sample"
     CALC_COND_BATCH = "calc_cond_batch"
     APPLY_MODEL = "apply_model"

--- a/comfy/sampler_helpers.py
+++ b/comfy/sampler_helpers.py
@@ -106,6 +106,13 @@ def cleanup_additional_models(models):
 
 
 def prepare_sampling(model: ModelPatcher, noise_shape, conds, model_options=None):
+    executor = comfy.patcher_extension.WrapperExecutor.new_executor(
+        _prepare_sampling,
+        comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.PREPARE_SAMPLING, model_options, is_model_options=True)
+    )
+    return executor.execute(model, noise_shape, conds, model_options=model_options)
+
+def _prepare_sampling(model: ModelPatcher, noise_shape, conds, model_options=None):
     real_model: BaseModel = None
     models, inference_memory = get_additional_models(conds, model.model_dtype())
     models += get_additional_models_from_model_options(model_options)


### PR DESCRIPTION
Most likely starting 4 months ago with the memory management changes, memory usage expectation for context window-related sampling (such as with AnimateDiff-Evolved) is vastly overestimated. There doesn't seem to be anything 'wrong' with that code - ComfyUI is simply trying to account for things in memory estimation it wasn't before.

In practice, this at best decreases performance by >25% due to models being forced to be loaded partially with high total latent counts, and at worst causes new edge cases that may cause crashes on select workflows.

This PR adds a wrapper around the prepare_sampling function to allow custom nodes to provide a better estimate for noise_shape without the need for any monkey patching.

Related PR that will be merged into AnimateDiff-Evolved once this is merged: https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved/pull/549