### PR TITLE
Handle PNG-8 indexed transparency in LoadImage node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1692,6 +1692,9 @@ class LoadImage:
             if 'A' in i.getbands():
                 mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
                 mask = 1. - torch.from_numpy(mask)
+            elif i.mode == 'P' and 'transparency' in i.info:
+                mask = np.array(i.convert('RGBA').getchannel('A')).astype(np.float32) / 255.0
+                mask = 1. - torch.from_numpy(mask)
             else:
                 mask = torch.zeros((64,64), dtype=torch.float32, device="cpu")
             output_images.append(image)


### PR DESCRIPTION
Check if image is [P mode](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes) and if it has a transparency index defined. If so, convert to RGBA to extra alpha channel that results from applying transparency index.

PNG-8 images with indexed transparency are apparently made in Ifran and Fireworks, or when optimizing pngs with tools like pngquant, or when dealing with things like game assets (example from user issue).

Before and after using [this example image](https://github.com/user-attachments/assets/7bba5522-c31b-44da-8526-0eb19d34d7b1) made with pngquant:

![Selection_1174](https://github.com/user-attachments/assets/50bc44a6-7bd4-40a0-bdbe-b61ed690bc7e)

![Selection_1176](https://github.com/user-attachments/assets/5b0fa7d0-e399-48c6-b70b-028f8f9bf71b)
