### PR TITLE
Dont cache workflow templates index.json file

### DIFF
--- a/server.py
+++ b/server.py
@@ -48,7 +48,7 @@ async def send_socket_catch_exception(function, message):
 @web.middleware
 async def cache_control(request: web.Request, handler):
     response: web.Response = await handler(request)
-    if request.path.endswith('.js') or request.path.endswith('.css'):
+    if request.path.endswith('.js') or request.path.endswith('.css') or request.path.endswith('index.json'):
         response.headers.setdefault('Cache-Control', 'no-cache')
     return response
 


### PR DESCRIPTION
New templates were added along with Hunyuan 3D-2 implementation release. However, some users reported that even after updating ComfyUI & frontend package, they did not see the new templates until a short while had passed ([example](https://discord.com/channels/1218270712402415686/1249784096712949772/1357008514144538904)), despite the blog post saying they should be there.

This PR ensures index file is never cached to prevent the issue from occurring during future model implementation releases.