### PR TITLE
Update `filter_files_content_types` to support filtering 3d models

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -85,6 +85,7 @@ cache_helper = CacheHelper()
 
 extension_mimetypes_cache = {
     "webp" : "image",
+    "fbx" : "model",
 }
 
 def map_legacy(folder_name: str) -> str:
@@ -140,11 +141,14 @@ def get_directory_by_type(type_name: str) -> str | None:
         return get_input_directory()
     return None
 
-def filter_files_content_types(files: list[str], content_types: Literal["image", "video", "audio"]) -> list[str]:
+def filter_files_content_types(files: list[str], content_types: Literal["image", "video", "audio", "model"]) -> list[str]:
     """
     Example:
         files = os.listdir(folder_paths.get_input_directory())
-        filter_files_content_types(files, ["image", "audio", "video"])
+        videos = filter_files_content_types(files, ["video"])
+        
+    Note:
+        - 'model' in MIME context refers to 3D models, not files containing trained weights and parameters
     """
     global extension_mimetypes_cache
     result = []

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -146,7 +146,7 @@ def filter_files_content_types(files: list[str], content_types: Literal["image",
     Example:
         files = os.listdir(folder_paths.get_input_directory())
         videos = filter_files_content_types(files, ["video"])
-        
+
     Note:
         - 'model' in MIME context refers to 3D models, not files containing trained weights and parameters
     """

--- a/tests-unit/folder_paths_test/filter_by_content_types_test.py
+++ b/tests-unit/folder_paths_test/filter_by_content_types_test.py
@@ -11,7 +11,7 @@ def file_extensions():
         'image': ['gif', 'heif', 'ico', 'jpeg', 'jpg', 'png', 'pnm', 'ppm', 'svg', 'tiff', 'webp', 'xbm', 'xpm'],
         'audio': ['aif', 'aifc', 'aiff', 'au', 'flac', 'm4a', 'mp2', 'mp3', 'ogg', 'snd', 'wav'],
         'video': ['avi', 'm2v', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ogv', 'qt', 'webm', 'wmv'],
-        'model': ['gltf', 'glb', 'obj', 'mtl', 'fbx', 'stl']
+        'model': ['gltf', 'glb', 'obj', 'fbx', 'stl']
     }
 
 

--- a/tests-unit/folder_paths_test/filter_by_content_types_test.py
+++ b/tests-unit/folder_paths_test/filter_by_content_types_test.py
@@ -8,7 +8,8 @@ def file_extensions():
     return {
         'image': ['gif', 'heif', 'ico', 'jpeg', 'jpg', 'png', 'pnm', 'ppm', 'svg', 'tiff', 'webp', 'xbm', 'xpm'],
         'audio': ['aif', 'aifc', 'aiff', 'au', 'flac', 'm4a', 'mp2', 'mp3', 'ogg', 'snd', 'wav'],
-        'video': ['avi', 'm2v', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ogv', 'qt', 'webm', 'wmv']
+        'video': ['avi', 'm2v', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ogv', 'qt', 'webm', 'wmv'],
+        'model': ['gltf', 'glb', 'obj', 'mtl', 'fbx', 'stl']
     }
 
 


### PR DESCRIPTION
Updates type, docstring, and unit tests for `filter_files_content_types` function of `folder_paths` module to support filtering 3d model files, as ComfyUI now supports 3D.

`fbx` is added to the mimetype cache manually, as .fbx (Filmbox) files aren't included in the standard MIME type databases on many systems, including Ubuntu. (FBX is a proprietary 3D model format developed by Autodesk.)