### PR TITLE
Only show image files in LoadImage file select combo

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1654,6 +1654,7 @@ class LoadImage:
     def INPUT_TYPES(s):
         input_dir = folder_paths.get_input_directory()
         files = [f for f in os.listdir(input_dir) if os.path.isfile(os.path.join(input_dir, f))]
+        files = folder_paths.filter_files_content_types(files, ["image"])
         return {"required":
                     {"image": (sorted(files), {"image_upload": True})},
                 }


### PR DESCRIPTION
Filter out non-images from the file selection list in LoadImage node, as there is starting to be more video and 3d model files in the input folder which can cause issues if accidentally selected (e.g., when using the arrow buttons on the combo widget).

LoadAudio node uses same filtering function for past 7 months (since https://github.com/comfyanonymous/ComfyUI/pull/4054) without reported bugs:

https://github.com/comfyanonymous/ComfyUI/blob/22ad513c72b891322f7baf6b459aa41858087b3b/comfy_extras/nodes_audio.py#L218

