### PR TITLE
Replace CLIPType if with getattr

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -958,7 +958,6 @@ class DualCLIPLoader:
     DESCRIPTION = "[Recipes]\n\nsdxl: clip-l, clip-g\nsd3: clip-l, clip-g / clip-l, t5 / clip-g, t5\nflux: clip-l, t5"
 
     def load_clip(self, clip_name1, clip_name2, type, device="default"):
-        breakpoint()
         clip_type = getattr(comfy.sd.CLIPType, type.upper(), comfy.sd.CLIPType.STABLE_DIFFUSION)
 
         clip_path1 = folder_paths.get_full_path_or_raise("text_encoders", clip_name1)

--- a/nodes.py
+++ b/nodes.py
@@ -930,26 +930,7 @@ class CLIPLoader:
     DESCRIPTION = "[Recipes]\n\nstable_diffusion: clip-l\nstable_cascade: clip-g\nsd3: t5 xxl/ clip-g / clip-l\nstable_audio: t5 base\nmochi: t5 xxl\ncosmos: old t5 xxl\nlumina2: gemma 2 2B\nwan: umt5 xxl"
 
     def load_clip(self, clip_name, type="stable_diffusion", device="default"):
-        if type == "stable_cascade":
-            clip_type = comfy.sd.CLIPType.STABLE_CASCADE
-        elif type == "sd3":
-            clip_type = comfy.sd.CLIPType.SD3
-        elif type == "stable_audio":
-            clip_type = comfy.sd.CLIPType.STABLE_AUDIO
-        elif type == "mochi":
-            clip_type = comfy.sd.CLIPType.MOCHI
-        elif type == "ltxv":
-            clip_type = comfy.sd.CLIPType.LTXV
-        elif type == "pixart":
-            clip_type = comfy.sd.CLIPType.PIXART
-        elif type == "cosmos":
-            clip_type = comfy.sd.CLIPType.COSMOS
-        elif type == "lumina2":
-            clip_type = comfy.sd.CLIPType.LUMINA2
-        elif type == "wan":
-            clip_type = comfy.sd.CLIPType.WAN
-        else:
-            clip_type = comfy.sd.CLIPType.STABLE_DIFFUSION
+        clip_type = getattr(comfy.sd.CLIPType, type.upper(), comfy.sd.CLIPType.STABLE_DIFFUSION)
 
         model_options = {}
         if device == "cpu":
@@ -977,16 +958,11 @@ class DualCLIPLoader:
     DESCRIPTION = "[Recipes]\n\nsdxl: clip-l, clip-g\nsd3: clip-l, clip-g / clip-l, t5 / clip-g, t5\nflux: clip-l, t5"
 
     def load_clip(self, clip_name1, clip_name2, type, device="default"):
+        breakpoint()
+        clip_type = getattr(comfy.sd.CLIPType, type.upper(), comfy.sd.CLIPType.STABLE_DIFFUSION)
+
         clip_path1 = folder_paths.get_full_path_or_raise("text_encoders", clip_name1)
         clip_path2 = folder_paths.get_full_path_or_raise("text_encoders", clip_name2)
-        if type == "sdxl":
-            clip_type = comfy.sd.CLIPType.STABLE_DIFFUSION
-        elif type == "sd3":
-            clip_type = comfy.sd.CLIPType.SD3
-        elif type == "flux":
-            clip_type = comfy.sd.CLIPType.FLUX
-        elif type == "hunyuan_video":
-            clip_type = comfy.sd.CLIPType.HUNYUAN_VIDEO
 
         model_options = {}
         if device == "cpu":


### PR DESCRIPTION
This is mostly a small change that replaces the long if statement with a getattr where the common name (e.g. "wan") gets mapped to the enum (`CLIPType.WAN`) in the clip loader nodes.

The main benefit of this is assuring that the common name actually matches the enum, so that downstream nodes don't need to keep their own mapping for custom clip loader nodes. (ref: https://github.com/city96/ComfyUI-GGUF/issues/246#issuecomment-2797782580)

Test for the current values in the single / dual clip loader node. Only odd one out is SDXL which doesn't have an enum and instead uses "stabe_diffusion". The logic in the single clip loader node already defaults to `CLIPType.STABLE_DIFFUSION`, so I just extended this to the dual clip loader as well.

```py
test = lambda type: getattr(comfy.sd.CLIPType, type.upper(), comfy.sd.CLIPType.STABLE_DIFFUSION)

[test(x) for x in ["stable_diffusion", "stable_cascade", "sd3", "stable_audio", "mochi", "ltxv", "pixart", "cosmos", "lumina2", "wan"]]
# returns: [<CLIPType.STABLE_DIFFUSION: 1>, <CLIPType.STABLE_CASCADE: 2>, <CLIPType.SD3: 3>, <CLIPType.STABLE_AUDIO: 4>, <CLIPType.MOCHI: 7>, <CLIPType.LTXV: 8>, <CLIPType.PIXART: 10>, <CLIPType.COSMOS: 11>, <CLIPType.LUMINA2: 12>, <CLIPType.WAN: 13>]

[test(x) for x in ["sdxl", "sd3", "flux", "hunyuan_video"]]
# returns: [<CLIPType.STABLE_DIFFUSION: 1>, <CLIPType.SD3: 3>, <CLIPType.FLUX: 6>, <CLIPType.HUNYUAN_VIDEO: 9>]
```
