### PR TITLE
Correct DoRA implementation

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -413,11 +413,10 @@ def weight_decompose(dora_scale, weight, lora_diff, alpha, strength, intermediat
     lora_diff *= alpha
     weight_calc = weight + function(lora_diff).type(weight.dtype)
     weight_norm = (
-        weight_calc.transpose(0, 1)
-        .reshape(weight_calc.shape[1], -1)
+        weight_calc
+        .reshape(weight_calc.shape[0], -1)
         .norm(dim=1, keepdim=True)
-        .reshape(weight_calc.shape[1], *[1] * (weight_calc.dim() - 1))
-        .transpose(0, 1)
+        .reshape(weight_calc.shape[0], *[1] * (weight_calc.dim() - 1))
     )
 
     weight_calc *= (dora_scale / weight_norm).type(weight.dtype)


### PR DESCRIPTION
This PR corrects the current DoRA implementation which has been broken now for several months. This was fixed upstream in the [LyCORIS library](https://github.com/KohakuBlueleaf/LyCORIS) used for training, but has yet to have been corrected here. I personally don't see the reason to support backwards compatibility since this was never working correctly to begin with. (If it were desired, it would be a matter of checking if `wd_on_output` is not present or set to `False` in the safetensors metadata)

Ref:
https://github.com/KohakuBlueleaf/LyCORIS/issues/216
https://github.com/KohakuBlueleaf/LyCORIS/commit/61b7ed5e41de16379d35a3ed886692a896b85b1f
https://github.com/KohakuBlueleaf/LyCORIS?tab=readme-ov-file#20241209-update-to-311
https://github.com/KohakuBlueleaf/LyCORIS/pull/245

---

Unrelated to this PR, but https://github.com/KohakuBlueleaf/LyCORIS/issues/244 also negatively affected any DoRA trained with this library, and was only resolved within the last 24 hours as of this PR, so effectively any DoRA trained via LyCORIS up until this point (which is most, if not all publicly available) is not representative of the full benefits DoRA provides.