### PR TITLE
[HiDream] Hard-cap T5 embeddings to 128 length to improve quality

### DIFF
--- a/comfy/text_encoders/hidream.py
+++ b/comfy/text_encoders/hidream.py
@@ -108,6 +108,8 @@ class HiDreamTEModel(torch.nn.Module):
         if self.t5xxl is not None:
             t5_output = self.t5xxl.encode_token_weights(token_weight_pairs_t5)
             t5_out, t5_pooled = t5_output[:2]
+            # Quality rapidly degrades if T5 embeddings are >128 length. Llama3 is not as bad, so we allow that one to be longer.
+            t5_out = t5_out[:, :128, :]
 
         if self.llama is not None:
             ll_output = self.llama.encode_token_weights(token_weight_pairs_llama)


### PR DESCRIPTION
HiDream was trained with 128 sequence length for T5 and Llama embeddings. When the prompt exceeds 128 tokens, quality rapidly degrades. The image first becomes washed out and blurry, and then keeps getting worse as sequence length increases.

Turns out, this seems to be mostly due to T5 embeddings. If you cap T5 at 128 sequence length, but let Llama be unbounded, quality is much better. I am also able to measure the same thing quantitatively in diffusion-pipe by looking at stabilized validation loss. The Llama embeddings are doing almost all the work in this model, so this seems like a good change to make universally. Of course, test this yourself and make sure you agree it causes an increase in quality across the board. I've only done a few comparisons.

Here's an example. Same seed for both images.
Original:
![hidream_default](https://github.com/user-attachments/assets/aa4015df-3d2c-49c6-ac7e-8bbae4c1d2f6)

This change:
![hidream_change](https://github.com/user-attachments/assets/6f26b668-3dd8-4845-bfee-ee9262e37788)

Prompt:
A high quality photo captures a man posing with his dog in a public park. The man is kneeling on the grass, wearing a pair of casual blue jeans and a long-sleeve flannel shirt. He has medium length brown hair, a well-kempt beard, and is sporting a wristwatch on his left wrist. He's looking at the viewer with a smile on his face. His dog, a golden retriever with lush, flowing fur, is sitting next to him, its mouth open in a happy expression. A large tree is visible in the background on the left side of the image. Off in the distance, a gravel pathway can be seen, along with a playground with children playing on it. The image depicts a casual moment of a young man having a photoshoot with his dog on a warm, vibrant spring day.