### PR TITLE
Make CLIP nodes input 'type' more dynamic

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -704,6 +704,23 @@ class CLIPType(Enum):
     LUMINA2 = 12
     WAN = 13
 
+class SingleCLIP(Enum):
+    STABLE_DIFFUSION = "stable_diffusion"
+    STABLE_CASCADE = "stable_cascade"
+    SD3 = "sd3"
+    STABLE_AUDIO = "stable_audio"
+    MOCHI = "mochi"
+    LTXV = "ltxv"
+    PIXART = "pixart"
+    COSMOS = "cosmos"
+    LUMINA2 = "lumina2"
+    WAN = "wan"
+
+class DualCLIP(Enum):
+    SDXL = "sdxl"
+    SD3 = "sd3"
+    FLUX = "flux"
+    HUNYUAN_VIDEO = "hunyuan_video"
 
 def load_clip(ckpt_paths, embedding_directory=None, clip_type=CLIPType.STABLE_DIFFUSION, model_options={}):
     clip_data = []

--- a/nodes.py
+++ b/nodes.py
@@ -31,6 +31,7 @@ import comfy.clip_vision
 
 import comfy.model_management
 from comfy.cli_args import args
+from comfy.sd import SingleCLIP, DualCLIP
 
 import importlib
 
@@ -916,8 +917,9 @@ class UNETLoader:
 class CLIPLoader:
     @classmethod
     def INPUT_TYPES(s):
+        single_clip_types = [member.value for member in SingleCLIP]
         return {"required": { "clip_name": (folder_paths.get_filename_list("text_encoders"), ),
-                              "type": (["stable_diffusion", "stable_cascade", "sd3", "stable_audio", "mochi", "ltxv", "pixart", "cosmos", "lumina2", "wan"], ),
+                              "type": (single_clip_types, ),
                               },
                 "optional": {
                               "device": (["default", "cpu"], {"advanced": True}),
@@ -943,9 +945,10 @@ class CLIPLoader:
 class DualCLIPLoader:
     @classmethod
     def INPUT_TYPES(s):
+        dual_clip_types = [member.value for member in DualCLIP]
         return {"required": { "clip_name1": (folder_paths.get_filename_list("text_encoders"), ),
                               "clip_name2": (folder_paths.get_filename_list("text_encoders"), ),
-                              "type": (["sdxl", "sd3", "flux", "hunyuan_video"], ),
+                              "type": (dual_clip_types, ),
                               },
                 "optional": {
                               "device": (["default", "cpu"], {"advanced": True}),


### PR DESCRIPTION
This handles issues such as custom nodes wanting to create their own loader as is the case with city96/ComfyUI-GGUF.
Now the input can be set simplyt through the Enum.