### PR TITLE
HiDream: Unlock max length for some text encoders (t5 and llama)

### DIFF
--- a/comfy/text_encoders/hidream.py
+++ b/comfy/text_encoders/hidream.py
@@ -9,6 +9,7 @@ import logging
 
 class HiDreamTokenizer:
     def __init__(self, embedding_directory=None, tokenizer_data={}):
+        # TODO: Load tokenizers dynamically only when needed, based on the active model.
         self.clip_l = sd1_clip.SDTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
         self.clip_g = sdxl_clip.SDXLClipGTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
         self.t5xxl = sd3_clip.T5XXLTokenizer(embedding_directory=embedding_directory, min_length=128, max_length=128, tokenizer_data=tokenizer_data)


### PR DESCRIPTION
Improvement of the last PR: #7676 

Currently, T5 and Llama text encoders have restrictive max length limits (77 tokens), which can hinder performance for long-context tasks. This PR removes those constraints, allowing full utilization of the models' capabilities.

**Key changes:**
- Unlocks T5xxl limit to 128 tokens
- Extends Llama limit to 4096 tokens

**Note:**  
The DiT model cannot generate high-quality images despite having long contexts. This may be because DiT wasn't trained for long tokens.
![f05085964cd4df218c9c14f5b6bf1593](https://github.com/user-attachments/assets/38c35d0d-76de-4b26-9b0a-2de5fc3ff6a6)
