### PR TITLE
Replace aom-av1 with svt-av1 for saving webm videos, use preset 6 + yuv420p10le pixel format

### DIFF
--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -20,9 +20,10 @@ class SaveWEBM:
         return {"required":
                     {"images": ("IMAGE", ),
                      "filename_prefix": ("STRING", {"default": "ComfyUI"}),
-                     "codec": (["vp9", "av1"],),
+                     "codec": (["vp9", "av1", "svt-av1"],),
                      "fps": ("FLOAT", {"default": 24.0, "min": 0.01, "max": 1000.0, "step": 0.01}),
                      "crf": ("FLOAT", {"default": 32.0, "min": 0, "max": 63.0, "step": 1, "tooltip": "Higher crf means lower quality with a smaller file size, lower crf means higher quality higher filesize."}),
+                     "pixel_format": (["yuv420p", "yuv420p10le"],),
                      },
                 "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},
                 }
@@ -36,7 +37,7 @@ class SaveWEBM:
 
     EXPERIMENTAL = True
 
-    def save_images(self, images, codec, fps, filename_prefix, crf, prompt=None, extra_pnginfo=None):
+    def save_images(self, images, codec, fps, filename_prefix, crf, pixel_format="yuv420p", prompt=None, extra_pnginfo=None):
         filename_prefix += self.prefix_append
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
 
@@ -50,13 +51,15 @@ class SaveWEBM:
             for x in extra_pnginfo:
                 container.metadata[x] = json.dumps(extra_pnginfo[x])
 
-        codec_map = {"vp9": "libvpx-vp9", "av1": "libaom-av1"}
+        codec_map = {"vp9": "libvpx-vp9", "av1": "libaom-av1", "svt-av1": "libsvtav1"}
         stream = container.add_stream(codec_map[codec], rate=Fraction(round(fps * 1000), 1000))
         stream.width = images.shape[-2]
         stream.height = images.shape[-3]
-        stream.pix_fmt = "yuv420p"
+        stream.pix_fmt = pixel_format
         stream.bit_rate = 0
         stream.options = {'crf': str(crf)}
+        if codec == "svt-av1":
+            stream.options["preset"] = "6"
 
         for frame in images:
             frame = av.VideoFrame.from_ndarray(torch.clamp(frame[..., :3] * 255, min=0, max=255).to(device=torch.device("cpu"), dtype=torch.uint8).numpy(), format="rgb24")

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ psutil
 kornia>=0.7.1
 spandrel
 soundfile
-av
+av>=14.1.0


### PR DESCRIPTION
This PR ~adds support for saving .webm outputs using codec svt-av1 and adds an options for using yuv420p10le pixel format~ switches aom-av1 codec for svt-av1 + yuv420p10le pixel format.

svt-av1 is significantly faster at encoding compared to libaom-av1 and yuv420p10le provides higher quality av1 output without size increase.

Note: av added support for libsvtav1 in v14.1.0, the requirements.txt are upped to reflect this.

# Comparison
## before (5d0d4ee9)
Took **407s** to save an 81 frame wan webm using libaom-av1, crf 10.

1.8MB, VMAF 96.9885 vs an animated png output.

## pr code with svt-av1 & yuv420p10le selected
Took **1s** with libsvtav1 (preset 6, crf 10).

2.3MB, VMAF 97.23115 _(note pixel format provides better quality vs aom at yuv420)_

### preset time & quality
I've set preset 6 for svt-av1, would be straightforward to make this configurable (perhaps later).
* preset 1: 19.46s, VMAF 97.43995
* preset 3: 3.88s, VMAF 97.39643
* preset 6: 0.95s, VMAF 97.23115
* preset 8: 0.67s, VMAF 96.918396

### vs webp
Result is ~2.3MB vs ~6MB .webp using slowest/quality:90, webp also having visibly lower quality.

# Implementation notes
~I tried to make this non-breaking so any existing usage of av1 will continue to use aom-av1 + yuv420. However, I would  recommend always using svt-av1 and yuv420p10le for any CPU-encoding scenario (which seem best for short videos like this as they are better quality than gpu encoding). So perhaps the aom-av1 option should be phased out or somehow discouraged in future. Maybe renamed "aom-av1 (slow)" or something?~