### PR TITLE
Add support for including empty directories in `listuserdata` endpoint

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -187,7 +187,12 @@ class UserManager():
 
                 rel_path = os.path.relpath(full_path, path).replace(os.sep, '/')
                 if split_path:
-                    return [rel_path] + rel_path.split('/')
+                    if os.path.isdir(full_path):
+                        dirname, basename = rel_path, ""
+                    else:
+                        head, tail = rel_path.rsplit('/', 1) if '/' in rel_path else ("", rel_path)
+                        dirname, basename = head, tail
+                    return [rel_path, dirname, basename]
 
                 return rel_path
 


### PR DESCRIPTION
This PR adds `emptyDirs` as an argument to the `listuserdata` endpoint. Setting `emptyDirs=true` would also return empty directories, as well as files.

This is set to `false` by default to prevent breaking any existing references.

This is planned to be used in improved workflow management in the frontend. There was an issue where new folders created through the workflows sidebar wouldn't appear because they contained no files/workflows.