### PR TITLE
VAE handle HIP OOM exceptions

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -235,6 +235,14 @@ try:
 except:
     OOM_EXCEPTION = Exception
 
+
+def is_oom_exception(ex):
+    if isinstance(ex, OOM_EXCEPTION):
+        return True
+    # handle also other kinds of oom, e.g. "HIP error: out of memory"
+    msg = str(ex)
+    return "out of memory" in msg
+
 XFORMERS_VERSION = ""
 XFORMERS_ENABLED_VAE = True
 if args.disable_xformers:

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -529,7 +529,9 @@ class VAE:
                 if pixel_samples is None:
                     pixel_samples = torch.empty((samples_in.shape[0],) + tuple(out.shape[1:]), device=self.output_device)
                 pixel_samples[x:x+batch_number] = out
-        except model_management.OOM_EXCEPTION:
+        except Exception as ex:
+            if not model_management.is_oom_exception(ex):
+                raise
             logging.warning("Warning: Ran out of memory when regular VAE decoding, retrying with tiled VAE decoding.")
             dims = samples_in.ndim - 2
             if dims == 1:

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -592,8 +592,9 @@ class VAE:
                 if samples is None:
                     samples = torch.empty((pixel_samples.shape[0],) + tuple(out.shape[1:]), device=self.output_device)
                 samples[x:x + batch_number] = out
-
-        except model_management.OOM_EXCEPTION:
+        except Exception as ex:
+            if not model_management.is_oom_exception(ex):
+                raise
             logging.warning("Warning: Ran out of memory when regular VAE encoding, retrying with tiled VAE encoding.")
             if self.latent_dim == 3:
                 tile = 256


### PR DESCRIPTION
Enhance VAE encode/decode exception handling to treat RuntimeException "HIP error: out of memory" the same as `OOM_EXCEPTION`.

Resolves #7761

My python isn't so polished so feel free to rewrite this or implement this any other way.