### PR TITLE
throw away alpha channel in clip vision preprocessor

### DIFF
--- a/comfy/clip_vision.py
+++ b/comfy/clip_vision.py
@@ -18,6 +18,7 @@ class Output:
         setattr(self, key, item)
 
 def clip_preprocess(image, size=224, mean=[0.48145466, 0.4578275, 0.40821073], std=[0.26862954, 0.26130258, 0.27577711], crop=True):
+    image = image[:, :, :, :3] if image.shape[3] > 3 else image
     mean = torch.tensor(mean, device=image.device, dtype=image.dtype)
     std = torch.tensor(std, device=image.device, dtype=image.dtype)
     image = image.movedim(-1, 1)


### PR DESCRIPTION
saves users having to explicitly discard the channel