### PR TITLE
Fix spawned process imports by using absolute import paths

### DIFF
--- a/app/custom_node_manager.py
+++ b/app/custom_node_manager.py
@@ -8,7 +8,7 @@ import json
 import logging
 from functools import lru_cache
 
-from ComfyUI.utils.json_util import merge_json_recursive
+from utils.json_util import merge_json_recursive
 
 
 # Extra locale files to load into main.json

--- a/app/custom_node_manager.py
+++ b/app/custom_node_manager.py
@@ -8,7 +8,7 @@ import json
 import logging
 from functools import lru_cache
 
-from utils.json_util import merge_json_recursive
+from ComfyUI.utils.json_util import merge_json_recursive
 
 
 # Extra locale files to load into main.json

--- a/main.py
+++ b/main.py
@@ -11,8 +11,8 @@ import itertools
 import logging
 import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import ComfyUI.utils.extra_config
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+import utils.extra_config
 
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI which should already have no communication with the internet, they are for custom nodes.
@@ -26,11 +26,11 @@ def apply_custom_paths():
     # extra model paths
     extra_model_paths_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extra_model_paths.yaml")
     if os.path.isfile(extra_model_paths_config_path):
-        ComfyUI.utils.extra_config.load_extra_path_config(extra_model_paths_config_path)
+        utils.extra_config.load_extra_path_config(extra_model_paths_config_path)
 
     if args.extra_model_paths_config:
         for config_path in itertools.chain(*args.extra_model_paths_config):
-            ComfyUI.utils.extra_config.load_extra_path_config(config_path)
+            utils.extra_config.load_extra_path_config(config_path)
 
     # --output-directory, --input-directory, --user-directory
     if args.output_directory:

--- a/main.py
+++ b/main.py
@@ -8,9 +8,11 @@ import time
 from comfy.cli_args import args
 from app.logger import setup_logger
 import itertools
-import utils.extra_config
 import logging
 import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import ComfyUI.utils.extra_config
 
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI which should already have no communication with the internet, they are for custom nodes.
@@ -24,11 +26,11 @@ def apply_custom_paths():
     # extra model paths
     extra_model_paths_config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extra_model_paths.yaml")
     if os.path.isfile(extra_model_paths_config_path):
-        utils.extra_config.load_extra_path_config(extra_model_paths_config_path)
+        ComfyUI.utils.extra_config.load_extra_path_config(extra_model_paths_config_path)
 
     if args.extra_model_paths_config:
         for config_path in itertools.chain(*args.extra_model_paths_config):
-            utils.extra_config.load_extra_path_config(config_path)
+            ComfyUI.utils.extra_config.load_extra_path_config(config_path)
 
     # --output-directory, --input-directory, --user-directory
     if args.output_directory:


### PR DESCRIPTION
While developing a custom node involving multiprocessing, I ran into an issue where `import utils.extra_config` in main.py would fail with `ModuleNotFoundError: No module named 'utils.extra_config'; 'utils' is not a package`.

I believe this is happening because multiprocessing spawns new Python processes that re-execute the main module (main.py) and its imports in isolation. These child processes don't inherit the paths of the current working directory. As a result, relative imports like import utils.extra_config fail when the spawned process doesn't have the appropriate path context.

To resolve this, I added:
`sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))` to the top of main.py

This ensures that ComfyUI is always on the import path, regardless of how or where main.py is executed. 

I also updated the import to `import ComfyUI.utils.extra_config`, as adding the parent directory of ComfyUI to sys.path requires that imports be specified with the full package path from that point forward.
