### PR TITLE
upstream Preview Any from rgthree-comfy

### DIFF
--- a/comfy_extras/nodes_preview_any.py
+++ b/comfy_extras/nodes_preview_any.py
@@ -1,0 +1,46 @@
+import json
+
+# Preview Any - original implement from
+# https://github.com/rgthree/rgthree-comfy/blob/main/py/display_any.py
+# upstream requested in https://github.com/Kosinkadink/rfcs/blob/main/rfcs/0000-corenodes.md#preview-nodes
+class PreviewAny():
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"source": ("*", {})},
+        }
+
+    RETURN_TYPES = ()
+    FUNCTION = "main"
+    OUTPUT_NODE = True
+
+    CATEGORY = "utils"
+
+    @classmethod
+    def VALIDATE_INPUTS(s, input_types):
+        return True
+
+    def main(self, source=None):
+        value = 'None'
+        if isinstance(source, str):
+            value = source
+        elif isinstance(source, (int, float, bool)):
+            value = str(source)
+        elif source is not None:
+            try:
+                value = json.dumps(source)
+            except Exception:
+                try:
+                    value = str(source)
+                except Exception:
+                    value = 'source exists, but could not be serialized.'
+
+        return {"ui": {"text": (value,)}}
+
+NODE_CLASS_MAPPINGS = {
+    "PreviewAny": PreviewAny,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "PreviewAny": "Preview Any",
+}

--- a/nodes.py
+++ b/nodes.py
@@ -2258,6 +2258,7 @@ def init_builtin_extra_nodes():
         "nodes_optimalsteps.py",
         "nodes_hidream.py",
         "nodes_fresca.py",
+        "nodes_preview_any.py",
     ]
 
     api_nodes_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy_api_nodes")


### PR DESCRIPTION
BE change for https://github.com/Comfy-Org/ComfyUI_frontend/pull/3640

Upstream PreviewAny from rgthree-comfy
original implement from https://github.com/rgthree/rgthree-comfy/blob/main/py/display_any.py under MIT
upstream requested in https://github.com/Kosinkadink/rfcs/blob/main/rfcs/0000-corenodes.md#preview-nodes

some differences from original implement:

1. change name from Display Any (rgthree) to Preview View
2. put it under utils category
3. replace some deprecated api in FE

tested with the following types:
1. STRING
2. INT
3. BOOLEAN
4. IMAGE
5. MASK
6. LATENT
7. Json

screenshot
![image](https://github.com/user-attachments/assets/dbdfc298-acbd-4f56-9b80-fc9de7805b9f)

