### PR TITLE
Change log level for `example_workflows` folder name check

### DIFF
--- a/app/custom_node_manager.py
+++ b/app/custom_node_manager.py
@@ -127,8 +127,8 @@ class CustomNodeManager:
 
                 if os.path.exists(workflows_dir):
                     if folder_name != "example_workflows":
-                        logging.warning(
-                            "WARNING: Found example workflow folder '%s' for custom node '%s', consider renaming it to 'example_workflows'",
+                        logging.debug(
+                            "Found example workflow folder '%s' for custom node '%s', consider renaming it to 'example_workflows'",
                             folder_name, module_name)
 
                     webapp.add_routes(


### PR DESCRIPTION
Title. Instructing a normal end user to do this is wrong. This log message is only applicable to devs and makes the console log far too noisy if many custom nodes are installed (a likely case for the end user).