### PR TITLE
Lint node method's `self` argument

### DIFF
--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -140,6 +140,7 @@ class Quantize:
 
     CATEGORY = "image/postprocessing"
 
+    @staticmethod
     def bayer(im, pal_im, order):
         def normalized_bayer_matrix(n):
             if n == 0:

--- a/comfy_extras/nodes_webcam.py
+++ b/comfy_extras/nodes_webcam.py
@@ -20,7 +20,7 @@ class WebcamCapture(nodes.LoadImage):
 
     CATEGORY = "image"
 
-    def load_capture(s, image, **kwargs):
+    def load_capture(self, image, **kwargs):
         return super().load_image(folder_paths.get_annotated_filepath(image))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.comfy.org/"
 
 [tool.ruff]
 lint.select = [
+  "N805", # invalid-first-argument-name-for-method
   "S307", # suspicious-eval-usage
   "S102", # exec
   "T",    # print-usage


### PR DESCRIPTION
This PR adds a basic linter rule which helps keep node function definitions consistent.
Ref: https://docs.astral.sh/ruff/rules/invalid-first-argument-name-for-method/