### PR TITLE
Correct beta scheduler to match paper

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -445,7 +445,7 @@ def normal_scheduler(model_sampling, steps, sgm=False, floor=False):
 # Implemented based on: https://arxiv.org/abs/2407.12173
 def beta_scheduler(model_sampling, steps, alpha=0.6, beta=0.6):
     total_timesteps = (len(model_sampling.sigmas) - 1)
-    ts = 1 - numpy.linspace(0, 1, steps, endpoint=False)
+    ts = 1 - numpy.linspace(0, 1, steps)
     ts = numpy.rint(scipy.stats.beta.ppf(ts, alpha, beta) * total_timesteps)
 
     sigs = []


### PR DESCRIPTION
This PR fixes what I believe may be an oversight in adapting [the paper](https://arxiv.org/abs/2407.12173) related to the beta scheduler.

Section 4 of the paper describes:
> a set of uniformly sampled time steps ti, where i = 1, 2, ..., N , and ti ∈ [0, T − 1]

This would correspond to the line `total_timesteps = (len(model_sampling.sigmas) - 1)`.

The line that follows seems to conflict with the paper. The paper describes:
> The Beta distribution is selected for its flexibility in modeling various shapes **over a finite interval [0, 1]**

The brackets in `[0, 1]` would imply the linear space is inclusive, thus the code to generate this should simply be `numpy.linspace(0, 1, steps)`, keeping the endpoint intact (the default behavior of `numpy.linspace`).

I think the endpoint may have been mistakenly removed due to the `[0, T − 1]` mentioned earlier. Whatever the case may be for it, the current code seems incorrect. I'd be happy to be proven otherwise though.

---

Perhaps of note, the current code in ComfyUI also conflicts with the [diffusers implementation](https://github.com/huggingface/diffusers/blob/e23705e5577387872dd55ebf6db81bd59df928f1/src/diffusers/schedulers/scheduling_euler_discrete.py#L523), which does not remove the endpoint.