### PR TITLE
Beta: Change how numpy and scipy are loaded in samplers.py, split off into two for the original implementation + correct implementation

### DIFF
--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -141,6 +141,7 @@ class BetaSamplingScheduler:
                      "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                      "alpha": ("FLOAT", {"default": 0.6, "min": 0.0, "max": 50.0, "step":0.01, "round": False}),
                      "beta": ("FLOAT", {"default": 0.6, "min": 0.0, "max": 50.0, "step":0.01, "round": False}),
+                     "verus": ("BOOLEAN", {"default": False})
                       }
                }
     RETURN_TYPES = ("SIGMAS",)
@@ -148,8 +149,8 @@ class BetaSamplingScheduler:
 
     FUNCTION = "get_sigmas"
 
-    def get_sigmas(self, model, steps, alpha, beta):
-        sigmas = comfy.samplers.beta_scheduler(model.get_model_object("model_sampling"), steps, alpha=alpha, beta=beta)
+    def get_sigmas(self, model, steps, alpha, beta, verus):
+        sigmas = comfy.samplers.beta_scheduler(model.get_model_object("model_sampling"), steps, alpha=alpha, beta=beta, endpoint=verus)
         return (sigmas, )
 
 class VPScheduler:


### PR DESCRIPTION
The first change this brings is to firstly change how NumPy and SciPy are loaded in samplers.py. Originally, they were called at the top of the file, in their entirety, even though they are only ever used for the beta scheduler. This changes that, they are now only imported for the beta scheduler, and in SciPy's case, we only get the beta distribution function that we need for the scheduler to work, nothing else. This should reduce startup time by a marginal amount.

Secondly, as was brought up in #7914, the current implementation of the beta scheduler is not the correct implementation. However, because of how long it's been since it was added to Comfy, we shouldn't break any outputs because of it. My solution is simple: let us just split it off into two schedulers, beta and beta verus. Beta preserves the current:
`ts = 1 - np.linspace(0, 1, steps, endpoint=False)`
Whereas Beta Verus, the correct implementation, would set it as such:
`ts = 1 - np.linspace(0, 1, steps, endpoint=True)`

Which means that we can easily toggle between the correct implementation, endpoint=True, or the current implementation, endpoint=False. In practice, there is difference in details when we toggle it either on or off, but not a particularly huge shift.

In short, this would allow us to have the best of both worlds: a correct implementation of beta, with the ability to still generate deterministic results from before.