### PR TITLE
Fix: Error creating video when sliced audio tensor chunks are non-c-contiguous

### DIFF
--- a/comfy_api/input_impl/video_types.py
+++ b/comfy_api/input_impl/video_types.py
@@ -211,7 +211,12 @@ class VideoFromComponents(VideoInput):
                     start = i * samples_per_frame
                     end = start + samples_per_frame
                     # TODO(Feature) - Add support for stereo audio
-                    chunk = self.__components.audio['waveform'][0, 0, start:end].unsqueeze(0).numpy()
+                    chunk = (
+                        self.__components.audio["waveform"][0, 0, start:end]
+                        .unsqueeze(0)
+                        .contiguous()
+                        .numpy()
+                    )
                     audio_frame = av.AudioFrame.from_ndarray(chunk, format='fltp', layout='mono')
                     audio_frame.sample_rate = audio_sample_rate
                     audio_frame.pts = i * samples_per_frame


### PR DESCRIPTION
It's possible to create `VIDEO` Comfy type by combining `AUDIO` and `IMAGE` Comfy types (e.g., using core `CreateVideo` node). When this process happens, the audio is encoded from (tensor) chunks. A bug can occur if the slicing creates non-c-contiguous chunks, as `av.AudioFrame.from_ndarray` expects contiguous array. Fix by making contiguous explicitly before converting to numpy array.

To reproduce issue:

1. Load and run [this workflow](https://github.com/user-attachments/files/20031107/test-audio-contiguous.json)
2. Assets used: [video](https://github.com/user-attachments/assets/33ce77de-ff73-4c99-a3c4-8bd9b7408889), [audio](https://github.com/user-attachments/assets/2c149368-d067-4742-96e3-4216659888b5) (`LoadAudio` node implicitly takes audio from video files)

After applying the fix, the workflow should work.