### PR TITLE
Remove Python 3.9 from test-ci.yml

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # os: [macos, linux, windows]
         os: [macos, linux]
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.10", "3.11", "3.12"]
         cuda_version: ["12.1"]
         torch_version: ["stable"]
         include:


### PR DESCRIPTION
This pull request updates the CI workflow configuration to streamline the testing matrix by removing support for Python 3.9.

Changes to the CI workflow:

* [`.github/workflows/test-ci.yml`](diffhunk://#diff-6fc0cfc32988f2cc6b9a0f5b8160950c4ca1c13d1159f326bf8a8841676fdca0L25-R25): Removed Python 3.9 from the `python_version` matrix in the CI configuration, leaving Python 3.10, 3.11, and 3.12 as the supported versions.