### PR TITLE
Remove Python 3.9 from test-build.yml

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This pull request updates the Python version matrix in the GitHub Actions workflow configuration file to remove support for Python 3.9.

Workflow configuration update:

* [`.github/workflows/test-build.yml`](diffhunk://#diff-a583f7935a5f3192471a2999cbf059eadc857228b5be2c7247f481b799949f8dL21-R21): Removed Python 3.9 from the `python-version` matrix in the `jobs:` section, leaving support for Python 3.10 through 3.13.