### PR TITLE
Make torchaudio not a hard requirement.

### DIFF
--- a/comfy/ldm/ace/vae/music_dcae_pipeline.py
+++ b/comfy/ldm/ace/vae/music_dcae_pipeline.py
@@ -1,7 +1,12 @@
 # Original from: https://github.com/ace-step/ACE-Step/blob/main/music_dcae/music_dcae_pipeline.py
 import torch
 from .autoencoder_dc import AutoencoderDC
-import torchaudio
+import logging
+try:
+    import torchaudio
+except:
+    logging.warning("torchaudio missing, ACE model will be broken")
+
 import torchvision.transforms as transforms
 from .music_vocoder import ADaMoSHiFiGANV1
 

--- a/comfy/ldm/ace/vae/music_log_mel.py
+++ b/comfy/ldm/ace/vae/music_log_mel.py
@@ -2,7 +2,12 @@
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torchaudio.transforms import MelScale
+import logging
+try:
+    from torchaudio.transforms import MelScale
+except:
+    logging.warning("torchaudio missing, ACE model will be broken")
+
 import comfy.model_management
 
 class LinearSpectrogram(nn.Module):


### PR DESCRIPTION
Some platforms cant install it apparently so if it's not there it should only break models that actually use it.