### PR TITLE
Added support for Moore Threads GPUs

### DIFF
--- a/comfy/clip_vision.py
+++ b/comfy/clip_vision.py
@@ -29,7 +29,7 @@ def clip_preprocess(image, size=224, mean=[0.48145466, 0.4578275, 0.40821073], s
         else:
             scale_size = (size, size)
 
-        image = torch.nn.functional.interpolate(image, size=scale_size, mode="bicubic", antialias=True)
+        image = torch.nn.functional.interpolate(image, size=scale_size, mode="bilinear")
         h = (image.shape[2] - size)//2
         w = (image.shape[3] - size)//2
         image = image[:,:,h:h+size,w:w+size]


### PR DESCRIPTION
## System Configuration:
Architecture: x86_64
Operating System: Linux
GPU: Moore Threads MTT S4000
VRAM: 48GB
python Version: 3.10.8
torch Version: 2.2.0a0+git8ac9b20
torchvision Version: 0.17.2+c1d70fe
torchaudio Version: 2.2.2+cefdb36
torch_musa Version: 1.3.0

## Project Objective:
I have added code to ComfyUI to enable support for the Moore Threads GPU, leveraging the MUSA backend through . I would like to contribute this enhancement to the main branch of ComfyUI under the repository.

## Launch Information:
```
/root/autodl-tmp/ComfyUI
[START] Security scan
[DONE] Security scan
## ComfyUI-Manager: installing dependencies done.
** ComfyUI startup time: 2025-05-09 01:47:55.170
** Platform: Linux
** Python version: 3.10.8 (main, Nov 24 2022, 14:13:03) [GCC 11.2.0]
** Python executable: /root/miniconda3/bin/python
** ComfyUI Path: /root/autodl-tmp/ComfyUI
** ComfyUI Base Folder Path: /root/autodl-tmp/ComfyUI
** User directory: /root/autodl-tmp/ComfyUI/user
** ComfyUI-Manager config path: /root/autodl-tmp/ComfyUI/user/default/ComfyUI-Manager/config.ini
** Log path: /root/autodl-tmp/ComfyUI/user/comfyui.log

Prestartup times for custom nodes:
   0.0 seconds: /root/autodl-tmp/ComfyUI/custom_nodes/rgthree-comfy
   2.6 seconds: /root/autodl-tmp/ComfyUI/custom_nodes/ComfyUI-Manager

Warning, you are using an old pytorch version and some ckpt/pt files might be loaded unsafely. Upgrading to 2.4 or above is recommended.
/root/miniconda3/lib/python3.10/site-packages/transformers/utils/generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
  _torch_pytree._register_pytree_node(
MUSA device detected: MTT S4000
Total VRAM 49062 MB, total RAM 1031698 MB
pytorch version: 2.2.0
Set vram state to: NORMAL_VRAM
Device: musa
/root/miniconda3/lib/python3.10/site-packages/torchvision/io/image.py:13: UserWarning: Failed to load image Python extension: ''If you don't plan on using image functionality from `torchvision.io`, you can ignore this warning. Otherwise, there might be something wrong with your environment. Did you have `libjpeg` or `libpng` installed before building `torchvision` from source?
  warn(
Using split optimization for attention
Python version: 3.10.8 (main, Nov 24 2022, 14:13:03) [GCC 11.2.0]
ComfyUI version: 0.3.32
ComfyUI frontend version: 1.18.9
[Prompt Server] web root: /root/miniconda3/lib/python3.10/site-packages/comfyui_frontend_package/static
[/root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux] | INFO -> Using ckpts path: /root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux/ckpts
[/root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux] | INFO -> Using symlinks: False
[/root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux] | INFO -> Using ort providers: ['CUDAExecutionProvider', 'DirectMLExecutionProvider', 'OpenVINOExecutionProvider', 'ROCMExecutionProvider', 'CPUExecutionProvider', 'CoreMLExecutionProvider']
/root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux/node_wrappers/dwpose.py:26: UserWarning: DWPose: Onnxruntime not found or doesn't come with acceleration providers, switch to OpenCV with CPU device. DWPose might run very slowly
  warnings.warn("DWPose: Onnxruntime not found or doesn't come with acceleration providers, switch to OpenCV with CPU device. DWPose might run very slowly")
### Loading: ComfyUI-Manager (V3.31.13)
[ComfyUI-Manager] network_mode: public
### ComfyUI Version: v0.3.32-8-gc7c025b8 | Released on '2025-05-08'

[rgthree-comfy] Loaded 42 extraordinary nodes. 🎉


Import times for custom nodes:
   0.0 seconds: /root/autodl-tmp/ComfyUI/custom_nodes/websocket_image_save.py
   0.0 seconds: /root/autodl-tmp/ComfyUI/custom_nodes/aigodlike-comfyui-translation
   0.0 seconds: /root/autodl-tmp/ComfyUI/custom_nodes/rgthree-comfy
   0.0 seconds: /root/autodl-tmp/ComfyUI/custom_nodes/ComfyUI_IPAdapter_plus
   0.1 seconds: /root/autodl-tmp/ComfyUI/custom_nodes/ComfyUI-Manager
   0.5 seconds: /root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux

Starting server

To see the GUI go to: http://127.0.0.1:6006/
[ComfyUI-Manager] default cache updated: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main/extension-node-map.json
[ComfyUI-Manager] default cache updated: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main/custom-node-list.json
[ComfyUI-Manager] default cache updated: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main/model-list.json
[ComfyUI-Manager] default cache updated: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main/alter-list.json
[ComfyUI-Manager] default cache updated: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main/github-stats.json
got prompt
model weight dtype torch.float16, manual cast: None
model_type EPS
Using split attention in VAE
Using split attention in VAE
VAE load device: musa:0, offload device: cpu, dtype: torch.bfloat16
CLIP/text encoder model load device: musa:0, offload device: cpu, current: cpu, dtype: torch.float16
Requested to load SD1ClipModel
loaded completely 47836.78046875 235.84423828125 True
INFO: Clip Vision model loaded from /root/autodl-tmp/ComfyUI/models/clip_vision/CLIP-ViT-H-14-laion2B-s32B-b79K.safetensors
INFO: IPAdapter model loaded from /root/autodl-tmp/ComfyUI/models/ipadapter/ip-adapter_sd15_light_v11.bin
INFO: the IPAdapter reference image is not a square, CLIPImageProcessor will resize and crop it at the center. If the main focus of the picture is not in the middle the result might not be what you are expecting.
Requested to load CLIPVisionModelProjection
loaded completely 47552.3732421875 1208.09814453125 True
Requested to load BaseModel
loaded completely 46277.04658203125 1639.406135559082 True
 30%|█████████████▏                              | 6/20 [00:01<00:02,  4.73it/s]FETCH ComfyRegistry Data: 5/84
100%|███████████████████████████████████████████| 20/20 [00:04<00:00,  4.84it/s]
Requested to load AutoencoderKL
loaded completely 44292.29931640625 159.55708122253418 True
Prompt executed in 7.16 seconds
FETCH ComfyRegistry Data: 10/84
FETCH ComfyRegistry Data: 15/84
FETCH ComfyRegistry Data: 20/84
got prompt
INFO: IPAdapter model loaded from /root/autodl-tmp/ComfyUI/models/ipadapter/ip-adapter_sd15.safetensors
INFO: the IPAdapter reference image is not a square, CLIPImageProcessor will resize and crop it at the center. If the main focus of the picture is not in the middle the result might not be what you are expecting.
Requested to load BaseModel
 15%|██████▌                                     | 3/20 [00:00<00:02,  5.82it/s]FETCH ComfyRegistry Data: 25/84
100%|███████████████████████████████████████████| 20/20 [00:03<00:00,  5.80it/s]
Prompt executed in 3.87 seconds
FETCH ComfyRegistry Data: 30/84
FETCH ComfyRegistry Data: 35/84
FETCH ComfyRegistry Data: 40/84
FETCH ComfyRegistry Data: 45/84
FETCH ComfyRegistry Data: 50/84
FETCH ComfyRegistry Data: 55/84
FETCH ComfyRegistry Data: 60/84
FETCH ComfyRegistry Data: 65/84
FETCH ComfyRegistry Data: 70/84
FETCH ComfyRegistry Data: 75/84
FETCH ComfyRegistry Data: 80/84
FETCH ComfyRegistry Data [DONE]
[ComfyUI-Manager] default cache updated: https://api.comfy.org/nodes
FETCH DATA from: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main/custom-node-list.json [DONE]
[ComfyUI-Manager] All startup tasks have been completed.
got prompt
100%|███████████████████████████████████████████| 20/20 [00:03<00:00,  5.81it/s]
Prompt executed in 3.62 seconds
got prompt
model weight dtype torch.float16, manual cast: None
model_type EPS
Using split attention in VAE
Using split attention in VAE
VAE load device: musa:0, offload device: cpu, dtype: torch.bfloat16
CLIP/text encoder model load device: musa:0, offload device: cpu, current: cpu, dtype: torch.float16
model_path is /root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux/ckpts/lllyasviel/Annotators/150_16_swin_l_oneformer_coco_100ep.pth
/root/miniconda3/lib/python3.10/site-packages/torch/functional.py:507: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /home/pytorch/aten/src/ATen/native/TensorShape.cpp:3549.)
  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]
[DetectionCheckpointer] Loading from /root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux/ckpts/lllyasviel/Annotators/150_16_swin_l_oneformer_coco_100ep.pth ...
model_path is /root/autodl-tmp/ComfyUI/custom_nodes/comfyui_controlnet_aux/ckpts/LayerNorm/DensePose-TorchScript-with-hint-image/densepose_r50_fpn_dl.torchscript
Requested to load SD1ClipModel
loaded completely 47579.58125 235.84423828125 True
Requested to load BaseModel
Requested to load ControlNet
loaded completely 47234.53916015625 1639.406135559082 True
loaded completely 45578.70859375 689.0852355957031 True
100%|███████████████████████████████████████████| 20/20 [00:05<00:00,  3.81it/s]
Requested to load AutoencoderKL
loaded completely 44167.8798828125 159.55708122253418 True
Prompt executed in 13.93 seconds
```
![PixPin_2025-05-09_01-59-15](https://github.com/user-attachments/assets/d69c9fff-7279-44c9-b46e-a793ae92365c)
![PixPin_2025-05-09_01-58-40](https://github.com/user-attachments/assets/d0f0aa58-1a7d-409b-a584-b1c997578fee)

