### PR TITLE
Add support for Comfy API keys

### DIFF
--- a/comfy_api_nodes/apinode_utils.py
+++ b/comfy_api_nodes/apinode_utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import logging
 from typing import Optional
@@ -314,7 +315,7 @@ def upload_file_to_comfyapi(
     file_bytes_io: BytesIO,
     filename: str,
     upload_mime_type: str,
-    auth_token: Optional[str] = None,
+    auth_kwargs: Optional[dict[str,str]] = None,
 ) -> str:
     """
     Uploads a single file to ComfyUI API and returns its download URL.
@@ -323,7 +324,7 @@ def upload_file_to_comfyapi(
         file_bytes_io: BytesIO object containing the file data.
         filename: The filename of the file.
         upload_mime_type: MIME type of the file.
-        auth_token: Optional authentication token.
+        auth_kwargs: Optional authentication token(s).
 
     Returns:
         The download URL for the uploaded file.
@@ -337,7 +338,7 @@ def upload_file_to_comfyapi(
             response_model=UploadResponse,
         ),
         request=request_object,
-        auth_token=auth_token,
+        auth_kwargs=auth_kwargs,
     )
 
     response: UploadResponse = operation.execute()
@@ -351,7 +352,7 @@ def upload_file_to_comfyapi(
 
 def upload_video_to_comfyapi(
     video: VideoInput,
-    auth_token: Optional[str] = None,
+    auth_kwargs: Optional[dict[str,str]] = None,
     container: VideoContainer = VideoContainer.MP4,
     codec: VideoCodec = VideoCodec.H264,
     max_duration: Optional[int] = None,
@@ -362,7 +363,7 @@ def upload_video_to_comfyapi(
 
     Args:
         video: VideoInput object (Comfy VIDEO type).
-        auth_token: Optional authentication token.
+        auth_kwargs: Optional authentication token(s).
         container: The video container format to use (default: MP4).
         codec: The video codec to use (default: H264).
         max_duration: Optional maximum duration of the video in seconds. If the video is longer than this, an error will be raised.
@@ -390,7 +391,7 @@ def upload_video_to_comfyapi(
     video_bytes_io.seek(0)
 
     return upload_file_to_comfyapi(
-        video_bytes_io, filename, upload_mime_type, auth_token
+        video_bytes_io, filename, upload_mime_type, auth_kwargs
     )
 
 
@@ -453,7 +454,7 @@ def audio_ndarray_to_bytesio(
 
 def upload_audio_to_comfyapi(
     audio: AudioInput,
-    auth_token: Optional[str] = None,
+    auth_kwargs: Optional[dict[str,str]] = None,
     container_format: str = "mp4",
     codec_name: str = "aac",
     mime_type: str = "audio/mp4",
@@ -465,7 +466,7 @@ def upload_audio_to_comfyapi(
 
     Args:
         audio: a Comfy `AUDIO` type (contains waveform tensor and sample_rate)
-        auth_token: Optional authentication token.
+        auth_kwargs: Optional authentication token(s).
 
     Returns:
         The download URL for the uploaded audio file.
@@ -477,11 +478,11 @@ def upload_audio_to_comfyapi(
         audio_data_np, sample_rate, container_format, codec_name
     )
 
-    return upload_file_to_comfyapi(audio_bytes_io, filename, mime_type, auth_token)
+    return upload_file_to_comfyapi(audio_bytes_io, filename, mime_type, auth_kwargs)
 
 
 def upload_images_to_comfyapi(
-    image: torch.Tensor, max_images=8, auth_token=None, mime_type: Optional[str] = None
+    image: torch.Tensor, max_images=8, auth_kwargs: Optional[dict[str,str]] = None, mime_type: Optional[str] = None
 ) -> list[str]:
     """
     Uploads images to ComfyUI API and returns download URLs.
@@ -490,7 +491,7 @@ def upload_images_to_comfyapi(
     Args:
         image: Input torch.Tensor image.
         max_images: Maximum number of images to upload.
-        auth_token: Optional authentication token.
+        auth_kwargs: Optional authentication token(s).
         mime_type: Optional MIME type for the image.
     """
     # if batch, try to upload each file if max_images is greater than 0
@@ -521,7 +522,7 @@ def upload_images_to_comfyapi(
                 response_model=UploadResponse,
             ),
             request=request_object,
-            auth_token=auth_token,
+            auth_kwargs=auth_kwargs,
         )
         response = operation.execute()
 

--- a/comfy_api_nodes/nodes_bfl.py
+++ b/comfy_api_nodes/nodes_bfl.py
@@ -179,6 +179,7 @@ class FluxProUltraImageNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -211,7 +212,6 @@ class FluxProUltraImageNode(ComfyNodeABC):
         seed=0,
         image_prompt=None,
         image_prompt_strength=0.1,
-        auth_token=None,
         **kwargs,
     ):
         if image_prompt is None:
@@ -244,7 +244,7 @@ class FluxProUltraImageNode(ComfyNodeABC):
                     None if image_prompt is None else round(image_prompt_strength, 2)
                 ),
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         output_image = handle_bfl_synchronous_operation(operation)
         return (output_image,)
@@ -319,6 +319,7 @@ class FluxProImageNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -337,7 +338,6 @@ class FluxProImageNode(ComfyNodeABC):
         seed=0,
         image_prompt=None,
         # image_prompt_strength=0.1,
-        auth_token=None,
         **kwargs,
     ):
         image_prompt = (
@@ -361,7 +361,7 @@ class FluxProImageNode(ComfyNodeABC):
                 seed=seed,
                 image_prompt=image_prompt,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         output_image = handle_bfl_synchronous_operation(operation)
         return (output_image,)
@@ -461,6 +461,7 @@ class FluxProExpandNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -482,7 +483,6 @@ class FluxProExpandNode(ComfyNodeABC):
         steps: int,
         guidance: float,
         seed=0,
-        auth_token=None,
         **kwargs,
     ):
         image = convert_image_to_base64(image)
@@ -506,7 +506,7 @@ class FluxProExpandNode(ComfyNodeABC):
                 seed=seed,
                 image=image,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         output_image = handle_bfl_synchronous_operation(operation)
         return (output_image,)
@@ -572,6 +572,7 @@ class FluxProFillNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -590,7 +591,6 @@ class FluxProFillNode(ComfyNodeABC):
         steps: int,
         guidance: float,
         seed=0,
-        auth_token=None,
         **kwargs,
     ):
         # prepare mask
@@ -615,7 +615,7 @@ class FluxProFillNode(ComfyNodeABC):
                 image=image,
                 mask=mask,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         output_image = handle_bfl_synchronous_operation(operation)
         return (output_image,)
@@ -706,6 +706,7 @@ class FluxProCannyNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -726,7 +727,6 @@ class FluxProCannyNode(ComfyNodeABC):
         steps: int,
         guidance: float,
         seed=0,
-        auth_token=None,
         **kwargs,
     ):
         control_image = convert_image_to_base64(control_image[:,:,:,:3])
@@ -763,7 +763,7 @@ class FluxProCannyNode(ComfyNodeABC):
                 canny_high_threshold=canny_high_threshold,
                 preprocessed_image=preprocessed_image,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         output_image = handle_bfl_synchronous_operation(operation)
         return (output_image,)
@@ -834,6 +834,7 @@ class FluxProDepthNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -852,7 +853,6 @@ class FluxProDepthNode(ComfyNodeABC):
         steps: int,
         guidance: float,
         seed=0,
-        auth_token=None,
         **kwargs,
     ):
         control_image = convert_image_to_base64(control_image[:,:,:,:3])
@@ -878,7 +878,7 @@ class FluxProDepthNode(ComfyNodeABC):
                 control_image=control_image,
                 preprocessed_image=preprocessed_image,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         output_image = handle_bfl_synchronous_operation(operation)
         return (output_image,)

--- a/comfy_api_nodes/nodes_ideogram.py
+++ b/comfy_api_nodes/nodes_ideogram.py
@@ -303,7 +303,10 @@ class IdeogramV1(ComfyNodeABC):
                     {"default": 1, "min": 1, "max": 8, "step": 1, "display": "number"},
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = (IO.IMAGE,)
@@ -321,7 +324,7 @@ class IdeogramV1(ComfyNodeABC):
         seed=0,
         negative_prompt="",
         num_images=1,
-        auth_token=None,
+        **kwargs,
     ):
         # Determine the model based on turbo setting
         aspect_ratio = V1_V2_RATIO_MAP.get(aspect_ratio, None)
@@ -347,7 +350,7 @@ class IdeogramV1(ComfyNodeABC):
                     negative_prompt=negative_prompt if negative_prompt else None,
                 )
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         response = operation.execute()
@@ -458,7 +461,10 @@ class IdeogramV2(ComfyNodeABC):
                 #    },
                 #),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = (IO.IMAGE,)
@@ -479,7 +485,7 @@ class IdeogramV2(ComfyNodeABC):
         negative_prompt="",
         num_images=1,
         color_palette="",
-        auth_token=None,
+        **kwargs,
     ):
         aspect_ratio = V1_V2_RATIO_MAP.get(aspect_ratio, None)
         resolution = V1_V1_RES_MAP.get(resolution, None)
@@ -519,7 +525,7 @@ class IdeogramV2(ComfyNodeABC):
                     color_palette=color_palette if color_palette else None,
                 )
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         response = operation.execute()
@@ -621,7 +627,10 @@ class IdeogramV3(ComfyNodeABC):
                     },
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = (IO.IMAGE,)
@@ -641,7 +650,7 @@ class IdeogramV3(ComfyNodeABC):
         seed=0,
         num_images=1,
         rendering_speed="BALANCED",
-        auth_token=None,
+        **kwargs,
     ):
         # Check if both image and mask are provided for editing mode
         if image is not None and mask is not None:
@@ -705,7 +714,7 @@ class IdeogramV3(ComfyNodeABC):
                     "mask": mask_binary,
                 },
                 content_type="multipart/form-data",
-                auth_token=auth_token,
+                auth_kwargs=kwargs,
             )
 
         elif image is not None or mask is not None:
@@ -746,7 +755,7 @@ class IdeogramV3(ComfyNodeABC):
                     response_model=IdeogramGenerateResponse,
                 ),
                 request=gen_request,
-                auth_token=auth_token,
+                auth_kwargs=kwargs,
             )
 
         # Execute the operation and process response

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -95,7 +95,7 @@ class KlingApiError(Exception):
     pass
 
 
-def poll_until_finished(auth_token: str, api_endpoint: ApiEndpoint[Any, R]) -> R:
+def poll_until_finished(auth_kwargs: dict[str,str], api_endpoint: ApiEndpoint[Any, R]) -> R:
     """Polls the Kling API endpoint until the task reaches a terminal state, then returns the response."""
     return PollingOperation(
         poll_endpoint=api_endpoint,
@@ -108,7 +108,7 @@ def poll_until_finished(auth_token: str, api_endpoint: ApiEndpoint[Any, R]) -> R
             if response.data and response.data.task_status
             else None
         ),
-        auth_token=auth_token,
+        auth_kwargs=auth_kwargs,
     ).execute()
 
 
@@ -391,16 +391,19 @@ class KlingTextToVideoNode(KlingNodeBase):
                     },
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = ("VIDEO", "STRING", "STRING")
     RETURN_NAMES = ("VIDEO", "video_id", "duration")
     DESCRIPTION = "Kling Text to Video Node"
 
-    def get_response(self, task_id: str, auth_token: str) -> KlingText2VideoResponse:
+    def get_response(self, task_id: str, auth_kwargs: dict[str,str]) -> KlingText2VideoResponse:
         return poll_until_finished(
-            auth_token,
+            auth_kwargs,
             ApiEndpoint(
                 path=f"{PATH_TEXT_TO_VIDEO}/{task_id}",
                 method=HttpMethod.GET,
@@ -419,7 +422,7 @@ class KlingTextToVideoNode(KlingNodeBase):
         camera_control: Optional[KlingCameraControl] = None,
         model_name: Optional[str] = None,
         duration: Optional[str] = None,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ) -> tuple[VideoFromFile, str, str]:
         validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_T2V)
         if model_name is None:
@@ -441,14 +444,14 @@ class KlingTextToVideoNode(KlingNodeBase):
                 aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
                 camera_control=camera_control,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         task_creation_response = initial_operation.execute()
         validate_task_creation_response(task_creation_response)
 
         task_id = task_creation_response.data.task_id
-        final_response = self.get_response(task_id, auth_token)
+        final_response = self.get_response(task_id, auth_kwargs=kwargs)
         validate_video_result_response(final_response)
 
         video = get_video_from_response(final_response)
@@ -495,7 +498,10 @@ class KlingCameraControlT2VNode(KlingTextToVideoNode):
                     },
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Transform text into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original text."
@@ -507,7 +513,7 @@ class KlingCameraControlT2VNode(KlingTextToVideoNode):
         cfg_scale: float,
         aspect_ratio: str,
         camera_control: Optional[KlingCameraControl] = None,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         return super().api_call(
             model_name=KlingVideoGenModelName.kling_v1,
@@ -518,7 +524,7 @@ class KlingCameraControlT2VNode(KlingTextToVideoNode):
             prompt=prompt,
             negative_prompt=negative_prompt,
             camera_control=camera_control,
-            auth_token=auth_token,
+            **kwargs,
         )
 
 
@@ -574,16 +580,19 @@ class KlingImage2VideoNode(KlingNodeBase):
                     enum_type=KlingVideoGenDuration,
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = ("VIDEO", "STRING", "STRING")
     RETURN_NAMES = ("VIDEO", "video_id", "duration")
     DESCRIPTION = "Kling Image to Video Node"
 
-    def get_response(self, task_id: str, auth_token: str) -> KlingImage2VideoResponse:
+    def get_response(self, task_id: str, auth_kwargs: dict[str,str]) -> KlingImage2VideoResponse:
         return poll_until_finished(
-            auth_token,
+            auth_kwargs,
             ApiEndpoint(
                 path=f"{PATH_IMAGE_TO_VIDEO}/{task_id}",
                 method=HttpMethod.GET,
@@ -604,7 +613,7 @@ class KlingImage2VideoNode(KlingNodeBase):
         duration: str,
         camera_control: Optional[KlingCameraControl] = None,
         end_frame: Optional[torch.Tensor] = None,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ) -> tuple[VideoFromFile]:
         validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_I2V)
 
@@ -635,14 +644,14 @@ class KlingImage2VideoNode(KlingNodeBase):
                 duration=KlingVideoGenDuration(duration),
                 camera_control=camera_control,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         task_creation_response = initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = self.get_response(task_id, auth_token)
+        final_response = self.get_response(task_id, auth_kwargs=kwargs)
         validate_video_result_response(final_response)
 
         video = get_video_from_response(final_response)
@@ -692,7 +701,10 @@ class KlingCameraControlI2VNode(KlingImage2VideoNode):
                     },
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Transform still images into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original image."
@@ -705,7 +717,7 @@ class KlingCameraControlI2VNode(KlingImage2VideoNode):
         cfg_scale: float,
         aspect_ratio: str,
         camera_control: KlingCameraControl,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         return super().api_call(
             model_name=KlingVideoGenModelName.kling_v1_5,
@@ -717,7 +729,7 @@ class KlingCameraControlI2VNode(KlingImage2VideoNode):
             prompt=prompt,
             negative_prompt=negative_prompt,
             camera_control=camera_control,
-            auth_token=auth_token,
+            **kwargs,
         )
 
 
@@ -785,7 +797,10 @@ class KlingStartEndFrameNode(KlingImage2VideoNode):
                     },
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Generate a video sequence that transitions between your provided start and end images. The node creates all frames in between, producing a smooth transformation from the first frame to the last."
@@ -799,7 +814,7 @@ class KlingStartEndFrameNode(KlingImage2VideoNode):
         cfg_scale: float,
         aspect_ratio: str,
         mode: str,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         mode, duration, model_name = KlingStartEndFrameNode.get_mode_string_mapping()[
             mode
@@ -814,7 +829,7 @@ class KlingStartEndFrameNode(KlingImage2VideoNode):
             aspect_ratio=aspect_ratio,
             duration=duration,
             end_frame=end_frame,
-            auth_token=auth_token,
+            **kwargs,
         )
 
 
@@ -844,16 +859,19 @@ class KlingVideoExtendNode(KlingNodeBase):
                     IO.STRING, KlingVideoExtendRequest, "video_id", forceInput=True
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = ("VIDEO", "STRING", "STRING")
     RETURN_NAMES = ("VIDEO", "video_id", "duration")
     DESCRIPTION = "Kling Video Extend Node. Extend videos made by other Kling nodes. The video_id is created by using other Kling Nodes."
 
-    def get_response(self, task_id: str, auth_token: str) -> KlingVideoExtendResponse:
+    def get_response(self, task_id: str, auth_kwargs: dict[str,str]) -> KlingVideoExtendResponse:
         return poll_until_finished(
-            auth_token,
+            auth_kwargs,
             ApiEndpoint(
                 path=f"{PATH_VIDEO_EXTEND}/{task_id}",
                 method=HttpMethod.GET,
@@ -868,7 +886,7 @@ class KlingVideoExtendNode(KlingNodeBase):
         negative_prompt: str,
         cfg_scale: float,
         video_id: str,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ) -> tuple[VideoFromFile, str, str]:
         validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_T2V)
         initial_operation = SynchronousOperation(
@@ -884,14 +902,14 @@ class KlingVideoExtendNode(KlingNodeBase):
                 cfg_scale=cfg_scale,
                 video_id=video_id,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         task_creation_response = initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = self.get_response(task_id, auth_token)
+        final_response = self.get_response(task_id, auth_kwargs=kwargs)
         validate_video_result_response(final_response)
 
         video = get_video_from_response(final_response)
@@ -904,9 +922,9 @@ class KlingVideoEffectsBase(KlingNodeBase):
     RETURN_TYPES = ("VIDEO", "STRING", "STRING")
     RETURN_NAMES = ("VIDEO", "video_id", "duration")
 
-    def get_response(self, task_id: str, auth_token: str) -> KlingVideoEffectsResponse:
+    def get_response(self, task_id: str, auth_kwargs: dict[str,str]) -> KlingVideoEffectsResponse:
         return poll_until_finished(
-            auth_token,
+            auth_kwargs,
             ApiEndpoint(
                 path=f"{PATH_VIDEO_EFFECTS}/{task_id}",
                 method=HttpMethod.GET,
@@ -924,7 +942,7 @@ class KlingVideoEffectsBase(KlingNodeBase):
         image_1: torch.Tensor,
         image_2: Optional[torch.Tensor] = None,
         mode: Optional[KlingVideoGenMode] = None,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         if dual_character:
             request_input_field = KlingDualCharacterEffectInput(
@@ -954,14 +972,14 @@ class KlingVideoEffectsBase(KlingNodeBase):
                 effect_scene=effect_scene,
                 input=request_input_field,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         task_creation_response = initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = self.get_response(task_id, auth_token)
+        final_response = self.get_response(task_id, auth_kwargs=kwargs)
         validate_video_result_response(final_response)
 
         video = get_video_from_response(final_response)
@@ -1002,7 +1020,10 @@ class KlingDualCharacterVideoEffectNode(KlingVideoEffectsBase):
                     enum_type=KlingVideoGenDuration,
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Achieve different special effects when generating a video based on the effect_scene. First image will be positioned on left side, second on right side of the composite."
@@ -1017,7 +1038,7 @@ class KlingDualCharacterVideoEffectNode(KlingVideoEffectsBase):
         model_name: KlingCharacterEffectModelName,
         mode: KlingVideoGenMode,
         duration: KlingVideoGenDuration,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         video, _, duration = super().api_call(
             dual_character=True,
@@ -1027,7 +1048,7 @@ class KlingDualCharacterVideoEffectNode(KlingVideoEffectsBase):
             duration=duration,
             image_1=image_left,
             image_2=image_right,
-            auth_token=auth_token,
+            **kwargs,
         )
         return video, duration
 
@@ -1063,7 +1084,10 @@ class KlingSingleImageVideoEffectNode(KlingVideoEffectsBase):
                     enum_type=KlingVideoGenDuration,
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Achieve different special effects when generating a video based on the effect_scene."
@@ -1074,7 +1098,7 @@ class KlingSingleImageVideoEffectNode(KlingVideoEffectsBase):
         effect_scene: KlingSingleImageEffectsScene,
         model_name: KlingSingleImageEffectModelName,
         duration: KlingVideoGenDuration,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         return super().api_call(
             dual_character=False,
@@ -1082,7 +1106,7 @@ class KlingSingleImageVideoEffectNode(KlingVideoEffectsBase):
             model_name=model_name,
             duration=duration,
             image_1=image,
-            auth_token=auth_token,
+            **kwargs,
         )
 
 
@@ -1100,10 +1124,10 @@ class KlingLipSyncBase(KlingNodeBase):
                 f"Text is too long. Maximum length is {MAX_PROMPT_LENGTH_LIP_SYNC} characters."
             )
 
-    def get_response(self, task_id: str, auth_token: str) -> KlingLipSyncResponse:
+    def get_response(self, task_id: str, auth_kwargs: dict[str,str]) -> KlingLipSyncResponse:
         """Polls the Kling API endpoint until the task reaches a terminal state."""
         return poll_until_finished(
-            auth_token,
+            auth_kwargs,
             ApiEndpoint(
                 path=f"{PATH_LIP_SYNC}/{task_id}",
                 method=HttpMethod.GET,
@@ -1121,18 +1145,18 @@ class KlingLipSyncBase(KlingNodeBase):
         text: Optional[str] = None,
         voice_speed: Optional[float] = None,
         voice_id: Optional[str] = None,
-        auth_token: Optional[str] = None,
+        **kwargs
     ) -> tuple[VideoFromFile, str, str]:
         if text:
             self.validate_text(text)
 
         # Upload video to Comfy API and get download URL
-        video_url = upload_video_to_comfyapi(video, auth_token)
+        video_url = upload_video_to_comfyapi(video, auth_kwargs=kwargs)
         logging.info("Uploaded video to Comfy API. URL: %s", video_url)
 
         # Upload the audio file to Comfy API and get download URL
         if audio:
-            audio_url = upload_audio_to_comfyapi(audio, auth_token)
+            audio_url = upload_audio_to_comfyapi(audio, auth_kwargs=kwargs)
             logging.info("Uploaded audio to Comfy API. URL: %s", audio_url)
         else:
             audio_url = None
@@ -1156,14 +1180,14 @@ class KlingLipSyncBase(KlingNodeBase):
                     voice_id=voice_id,
                 ),
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         task_creation_response = initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = self.get_response(task_id, auth_token)
+        final_response = self.get_response(task_id, auth_kwargs=kwargs)
         validate_video_result_response(final_response)
 
         video = get_video_from_response(final_response)
@@ -1186,7 +1210,10 @@ class KlingLipSyncAudioToVideoNode(KlingLipSyncBase):
                     enum_type=KlingLipSyncVoiceLanguage,
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Kling Lip Sync Audio to Video Node. Syncs mouth movements in a video file to the audio content of an audio file."
@@ -1196,14 +1223,14 @@ class KlingLipSyncAudioToVideoNode(KlingLipSyncBase):
         video: VideoInput,
         audio: AudioInput,
         voice_language: str,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         return super().api_call(
             video=video,
             audio=audio,
             voice_language=voice_language,
             mode="audio2video",
-            auth_token=auth_token,
+            **kwargs,
         )
 
 
@@ -1292,7 +1319,10 @@ class KlingLipSyncTextToVideoNode(KlingLipSyncBase):
                     IO.FLOAT, KlingLipSyncInputObject, "voice_speed", slider=True
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Kling Lip Sync Text to Video Node. Syncs mouth movements in a video file to a text prompt."
@@ -1303,7 +1333,7 @@ class KlingLipSyncTextToVideoNode(KlingLipSyncBase):
         text: str,
         voice: str,
         voice_speed: float,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         voice_id, voice_language = KlingLipSyncTextToVideoNode.get_voice_config()[voice]
         return super().api_call(
@@ -1313,7 +1343,7 @@ class KlingLipSyncTextToVideoNode(KlingLipSyncBase):
             voice_id=voice_id,
             voice_speed=voice_speed,
             mode="text2video",
-            auth_token=auth_token,
+            **kwargs,
         )
 
 
@@ -1350,16 +1380,19 @@ class KlingVirtualTryOnNode(KlingImageGenerationBase):
                     enum_type=KlingVirtualTryOnModelName,
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Kling Virtual Try On Node. Input a human image and a cloth image to try on the cloth on the human."
 
     def get_response(
-        self, task_id: str, auth_token: Optional[str] = None
+        self, task_id: str, auth_kwargs: dict[str,str] = None
     ) -> KlingVirtualTryOnResponse:
         return poll_until_finished(
-            auth_token,
+            auth_kwargs,
             ApiEndpoint(
                 path=f"{PATH_VIRTUAL_TRY_ON}/{task_id}",
                 method=HttpMethod.GET,
@@ -1373,7 +1406,7 @@ class KlingVirtualTryOnNode(KlingImageGenerationBase):
         human_image: torch.Tensor,
         cloth_image: torch.Tensor,
         model_name: KlingVirtualTryOnModelName,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         initial_operation = SynchronousOperation(
             endpoint=ApiEndpoint(
@@ -1387,14 +1420,14 @@ class KlingVirtualTryOnNode(KlingImageGenerationBase):
                 cloth_image=tensor_to_base64_string(cloth_image),
                 model_name=model_name,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         task_creation_response = initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = self.get_response(task_id, auth_token)
+        final_response = self.get_response(task_id, auth_kwargs=kwargs)
         validate_image_result_response(final_response)
 
         images = get_images_from_response(final_response)
@@ -1462,16 +1495,19 @@ class KlingImageGenerationNode(KlingImageGenerationBase):
             "optional": {
                 "image": (IO.IMAGE, {}),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     DESCRIPTION = "Kling Image Generation Node. Generate an image from a text prompt with an optional reference image."
 
     def get_response(
-        self, task_id: str, auth_token: Optional[str] = None
+        self, task_id: str, auth_kwargs: Optional[dict[str,str]] = None
     ) -> KlingImageGenerationsResponse:
         return poll_until_finished(
-            auth_token,
+            auth_kwargs,
             ApiEndpoint(
                 path=f"{PATH_IMAGE_GENERATIONS}/{task_id}",
                 method=HttpMethod.GET,
@@ -1491,7 +1527,7 @@ class KlingImageGenerationNode(KlingImageGenerationBase):
         n: int,
         aspect_ratio: KlingImageGenAspectRatio,
         image: Optional[torch.Tensor] = None,
-        auth_token: Optional[str] = None,
+        **kwargs,
     ):
         self.validate_prompt(prompt, negative_prompt)
 
@@ -1516,14 +1552,14 @@ class KlingImageGenerationNode(KlingImageGenerationBase):
                 n=n,
                 aspect_ratio=aspect_ratio,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         task_creation_response = initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = self.get_response(task_id, auth_token)
+        final_response = self.get_response(task_id, auth_kwargs=kwargs)
         validate_image_result_response(final_response)
 
         images = get_images_from_response(final_response)

--- a/comfy_api_nodes/nodes_luma.py
+++ b/comfy_api_nodes/nodes_luma.py
@@ -1,4 +1,6 @@
+from __future__ import annotations
 from inspect import cleandoc
+from typing import Optional
 from comfy.comfy_types.node_typing import IO, ComfyNodeABC
 from comfy_api.input_impl.video_types import VideoFromFile
 from comfy_api_nodes.apis.luma_api import (
@@ -201,6 +203,7 @@ class LumaImageGenerationNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -214,7 +217,6 @@ class LumaImageGenerationNode(ComfyNodeABC):
         image_luma_ref: LumaReferenceChain = None,
         style_image: torch.Tensor = None,
         character_image: torch.Tensor = None,
-        auth_token=None,
         **kwargs,
     ):
         validate_string(prompt, strip_whitespace=True, min_length=3)
@@ -222,19 +224,19 @@ class LumaImageGenerationNode(ComfyNodeABC):
         api_image_ref = None
         if image_luma_ref is not None:
             api_image_ref = self._convert_luma_refs(
-                image_luma_ref, max_refs=4, auth_token=auth_token
+                image_luma_ref, max_refs=4, auth_kwargs=kwargs,
             )
         # handle style_luma_ref
         api_style_ref = None
         if style_image is not None:
             api_style_ref = self._convert_style_image(
-                style_image, weight=style_image_weight, auth_token=auth_token
+                style_image, weight=style_image_weight, auth_kwargs=kwargs,
             )
         # handle character_ref images
         character_ref = None
         if character_image is not None:
             download_urls = upload_images_to_comfyapi(
-                character_image, max_images=4, auth_token=auth_token
+                character_image, max_images=4, auth_kwargs=kwargs,
             )
             character_ref = LumaCharacterRef(
                 identity0=LumaImageIdentity(images=download_urls)
@@ -255,7 +257,7 @@ class LumaImageGenerationNode(ComfyNodeABC):
                 style_ref=api_style_ref,
                 character_ref=character_ref,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api: LumaGeneration = operation.execute()
 
@@ -269,7 +271,7 @@ class LumaImageGenerationNode(ComfyNodeABC):
             completed_statuses=[LumaState.completed],
             failed_statuses=[LumaState.failed],
             status_extractor=lambda x: x.state,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_poll = operation.execute()
 
@@ -278,13 +280,13 @@ class LumaImageGenerationNode(ComfyNodeABC):
         return (img,)
 
     def _convert_luma_refs(
-        self, luma_ref: LumaReferenceChain, max_refs: int, auth_token=None
+        self, luma_ref: LumaReferenceChain, max_refs: int, auth_kwargs: Optional[dict[str,str]] = None
     ):
         luma_urls = []
         ref_count = 0
         for ref in luma_ref.refs:
             download_urls = upload_images_to_comfyapi(
-                ref.image, max_images=1, auth_token=auth_token
+                ref.image, max_images=1, auth_kwargs=auth_kwargs
             )
             luma_urls.append(download_urls[0])
             ref_count += 1
@@ -293,12 +295,12 @@ class LumaImageGenerationNode(ComfyNodeABC):
         return luma_ref.create_api_model(download_urls=luma_urls, max_refs=max_refs)
 
     def _convert_style_image(
-        self, style_image: torch.Tensor, weight: float, auth_token=None
+        self, style_image: torch.Tensor, weight: float, auth_kwargs: Optional[dict[str,str]] = None
     ):
         chain = LumaReferenceChain(
             first_ref=LumaReference(image=style_image, weight=weight)
         )
-        return self._convert_luma_refs(chain, max_refs=1, auth_token=auth_token)
+        return self._convert_luma_refs(chain, max_refs=1, auth_kwargs=auth_kwargs)
 
 
 class LumaImageModifyNode(ComfyNodeABC):
@@ -350,6 +352,7 @@ class LumaImageModifyNode(ComfyNodeABC):
             "optional": {},
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -360,12 +363,11 @@ class LumaImageModifyNode(ComfyNodeABC):
         image: torch.Tensor,
         image_weight: float,
         seed,
-        auth_token=None,
         **kwargs,
     ):
         # first, upload image
         download_urls = upload_images_to_comfyapi(
-            image, max_images=1, auth_token=auth_token
+            image, max_images=1, auth_kwargs=kwargs,
         )
         image_url = download_urls[0]
         # next, make Luma call with download url provided
@@ -383,7 +385,7 @@ class LumaImageModifyNode(ComfyNodeABC):
                     url=image_url, weight=round(max(min(1.0-image_weight, 0.98), 0.0), 2)
                 ),
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api: LumaGeneration = operation.execute()
 
@@ -397,7 +399,7 @@ class LumaImageModifyNode(ComfyNodeABC):
             completed_statuses=[LumaState.completed],
             failed_statuses=[LumaState.failed],
             status_extractor=lambda x: x.state,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_poll = operation.execute()
 
@@ -470,6 +472,7 @@ class LumaTextToVideoGenerationNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -483,7 +486,6 @@ class LumaTextToVideoGenerationNode(ComfyNodeABC):
         loop: bool,
         seed,
         luma_concepts: LumaConceptChain = None,
-        auth_token=None,
         **kwargs,
     ):
         validate_string(prompt, strip_whitespace=False, min_length=3)
@@ -506,7 +508,7 @@ class LumaTextToVideoGenerationNode(ComfyNodeABC):
                 loop=loop,
                 concepts=luma_concepts.create_api_model() if luma_concepts else None,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api: LumaGeneration = operation.execute()
 
@@ -520,7 +522,7 @@ class LumaTextToVideoGenerationNode(ComfyNodeABC):
             completed_statuses=[LumaState.completed],
             failed_statuses=[LumaState.failed],
             status_extractor=lambda x: x.state,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_poll = operation.execute()
 
@@ -594,6 +596,7 @@ class LumaImageToVideoGenerationNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -608,14 +611,13 @@ class LumaImageToVideoGenerationNode(ComfyNodeABC):
         first_image: torch.Tensor = None,
         last_image: torch.Tensor = None,
         luma_concepts: LumaConceptChain = None,
-        auth_token=None,
         **kwargs,
     ):
         if first_image is None and last_image is None:
             raise Exception(
                 "At least one of first_image and last_image requires an input."
             )
-        keyframes = self._convert_to_keyframes(first_image, last_image, auth_token)
+        keyframes = self._convert_to_keyframes(first_image, last_image, auth_kwargs=kwargs)
         duration = duration if model != LumaVideoModel.ray_1_6 else None
         resolution = resolution if model != LumaVideoModel.ray_1_6 else None
 
@@ -636,7 +638,7 @@ class LumaImageToVideoGenerationNode(ComfyNodeABC):
                 keyframes=keyframes,
                 concepts=luma_concepts.create_api_model() if luma_concepts else None,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api: LumaGeneration = operation.execute()
 
@@ -650,7 +652,7 @@ class LumaImageToVideoGenerationNode(ComfyNodeABC):
             completed_statuses=[LumaState.completed],
             failed_statuses=[LumaState.failed],
             status_extractor=lambda x: x.state,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_poll = operation.execute()
 
@@ -661,7 +663,7 @@ class LumaImageToVideoGenerationNode(ComfyNodeABC):
         self,
         first_image: torch.Tensor = None,
         last_image: torch.Tensor = None,
-        auth_token=None,
+        auth_kwargs: Optional[dict[str,str]] = None,
     ):
         if first_image is None and last_image is None:
             return None
@@ -669,12 +671,12 @@ class LumaImageToVideoGenerationNode(ComfyNodeABC):
         frame1 = None
         if first_image is not None:
             download_urls = upload_images_to_comfyapi(
-                first_image, max_images=1, auth_token=auth_token
+                first_image, max_images=1, auth_kwargs=auth_kwargs,
             )
             frame0 = LumaImageReference(type="image", url=download_urls[0])
         if last_image is not None:
             download_urls = upload_images_to_comfyapi(
-                last_image, max_images=1, auth_token=auth_token
+                last_image, max_images=1, auth_kwargs=auth_kwargs,
             )
             frame1 = LumaImageReference(type="image", url=download_urls[0])
         return LumaKeyframes(frame0=frame0, frame1=frame1)

--- a/comfy_api_nodes/nodes_minimax.py
+++ b/comfy_api_nodes/nodes_minimax.py
@@ -67,6 +67,7 @@ class MinimaxTextToVideoNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -84,7 +85,7 @@ class MinimaxTextToVideoNode:
         model="T2V-01",
         image: torch.Tensor=None, # used for ImageToVideo
         subject: torch.Tensor=None, # used for SubjectToVideo
-        auth_token=None,
+        **kwargs,
     ):
         '''
         Function used between MiniMax nodes - supports T2V, I2V, and S2V, based on provided arguments.
@@ -94,12 +95,12 @@ class MinimaxTextToVideoNode:
         # upload image, if passed in
         image_url = None
         if image is not None:
-            image_url = upload_images_to_comfyapi(image, max_images=1, auth_token=auth_token)[0]
+            image_url = upload_images_to_comfyapi(image, max_images=1, auth_kwargs=kwargs)[0]
 
         # TODO: figure out how to deal with subject properly, API returns invalid params when using S2V-01 model
         subject_reference = None
         if subject is not None:
-            subject_url = upload_images_to_comfyapi(subject, max_images=1, auth_token=auth_token)[0]
+            subject_url = upload_images_to_comfyapi(subject, max_images=1, auth_kwargs=kwargs)[0]
             subject_reference = [SubjectReferenceItem(image=subject_url)]
 
 
@@ -118,7 +119,7 @@ class MinimaxTextToVideoNode:
                 subject_reference=subject_reference,
                 prompt_optimizer=None,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response = video_generate_operation.execute()
 
@@ -137,7 +138,7 @@ class MinimaxTextToVideoNode:
             completed_statuses=["Success"],
             failed_statuses=["Fail"],
             status_extractor=lambda x: x.status.value,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         task_result = video_generate_operation.execute()
 
@@ -153,7 +154,7 @@ class MinimaxTextToVideoNode:
                 query_params={"file_id": int(file_id)},
             ),
             request=EmptyRequest(),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         file_result = file_retrieve_operation.execute()
 
@@ -221,6 +222,7 @@ class MinimaxImageToVideoNode(MinimaxTextToVideoNode):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -279,6 +281,7 @@ class MinimaxSubjectToVideoNode(MinimaxTextToVideoNode):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 

--- a/comfy_api_nodes/nodes_openai.py
+++ b/comfy_api_nodes/nodes_openai.py
@@ -93,7 +93,10 @@ class OpenAIDalle2(ComfyNodeABC):
                     },
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = (IO.IMAGE,)
@@ -110,7 +113,7 @@ class OpenAIDalle2(ComfyNodeABC):
         mask=None,
         n=1,
         size="1024x1024",
-        auth_token=None,
+        **kwargs
     ):
         validate_string(prompt, strip_whitespace=False)
         model = "dall-e-2"
@@ -168,7 +171,7 @@ class OpenAIDalle2(ComfyNodeABC):
                 else None
             ),
             content_type=content_type,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         response = operation.execute()
@@ -236,7 +239,10 @@ class OpenAIDalle3(ComfyNodeABC):
                     },
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = (IO.IMAGE,)
@@ -252,7 +258,7 @@ class OpenAIDalle3(ComfyNodeABC):
         style="natural",
         quality="standard",
         size="1024x1024",
-        auth_token=None,
+        **kwargs
     ):
         validate_string(prompt, strip_whitespace=False)
         model = "dall-e-3"
@@ -273,7 +279,7 @@ class OpenAIDalle3(ComfyNodeABC):
                 style=style,
                 seed=seed,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         response = operation.execute()
@@ -366,7 +372,10 @@ class OpenAIGPTImage1(ComfyNodeABC):
                     },
                 ),
             },
-            "hidden": {"auth_token": "AUTH_TOKEN_COMFY_ORG"},
+            "hidden": {
+                "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
+            },
         }
 
     RETURN_TYPES = (IO.IMAGE,)
@@ -385,7 +394,7 @@ class OpenAIGPTImage1(ComfyNodeABC):
         mask=None,
         n=1,
         size="1024x1024",
-        auth_token=None,
+        **kwargs
     ):
         validate_string(prompt, strip_whitespace=False)
         model = "gpt-image-1"
@@ -462,7 +471,7 @@ class OpenAIGPTImage1(ComfyNodeABC):
             ),
             files=files if files else None,
             content_type=content_type,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
 
         response = operation.execute()

--- a/comfy_api_nodes/nodes_pixverse.py
+++ b/comfy_api_nodes/nodes_pixverse.py
@@ -34,7 +34,7 @@ import requests
 from io import BytesIO
 
 
-def upload_image_to_pixverse(image: torch.Tensor, auth_token=None):
+def upload_image_to_pixverse(image: torch.Tensor, auth_kwargs=None):
     # first, upload image to Pixverse and get image id to use in actual generation call
     files = {
         "image": tensor_to_bytesio(image)
@@ -49,7 +49,7 @@ def upload_image_to_pixverse(image: torch.Tensor, auth_token=None):
         request=EmptyRequest(),
         files=files,
         content_type="multipart/form-data",
-        auth_token=auth_token,
+        auth_kwargs=auth_kwargs,
     )
     response_upload: PixverseImageUploadResponse = operation.execute()
 
@@ -148,6 +148,7 @@ class PixverseTextToVideoNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -161,7 +162,6 @@ class PixverseTextToVideoNode(ComfyNodeABC):
         seed,
         negative_prompt: str=None,
         pixverse_template: int=None,
-        auth_token=None,
         **kwargs,
     ):
         validate_string(prompt, strip_whitespace=False)
@@ -190,7 +190,7 @@ class PixverseTextToVideoNode(ComfyNodeABC):
                 template_id=pixverse_template,
                 seed=seed,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api = operation.execute()
 
@@ -207,7 +207,7 @@ class PixverseTextToVideoNode(ComfyNodeABC):
             completed_statuses=[PixverseStatus.successful],
             failed_statuses=[PixverseStatus.contents_moderation, PixverseStatus.failed, PixverseStatus.deleted],
             status_extractor=lambda x: x.Resp.status,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_poll = operation.execute()
 
@@ -278,6 +278,7 @@ class PixverseImageToVideoNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -291,11 +292,10 @@ class PixverseImageToVideoNode(ComfyNodeABC):
         seed,
         negative_prompt: str=None,
         pixverse_template: int=None,
-        auth_token=None,
         **kwargs,
     ):
         validate_string(prompt, strip_whitespace=False)
-        img_id = upload_image_to_pixverse(image, auth_token=auth_token)
+        img_id = upload_image_to_pixverse(image, auth_kwargs=kwargs)
 
         # 1080p is limited to 5 seconds duration
         # only normal motion_mode supported for 1080p or for non-5 second duration
@@ -322,7 +322,7 @@ class PixverseImageToVideoNode(ComfyNodeABC):
                 template_id=pixverse_template,
                 seed=seed,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api = operation.execute()
 
@@ -339,7 +339,7 @@ class PixverseImageToVideoNode(ComfyNodeABC):
             completed_statuses=[PixverseStatus.successful],
             failed_statuses=[PixverseStatus.contents_moderation, PixverseStatus.failed, PixverseStatus.deleted],
             status_extractor=lambda x: x.Resp.status,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_poll = operation.execute()
 
@@ -407,6 +407,7 @@ class PixverseTransitionVideoNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -420,12 +421,11 @@ class PixverseTransitionVideoNode(ComfyNodeABC):
         motion_mode: str,
         seed,
         negative_prompt: str=None,
-        auth_token=None,
         **kwargs,
     ):
         validate_string(prompt, strip_whitespace=False)
-        first_frame_id = upload_image_to_pixverse(first_frame, auth_token=auth_token)
-        last_frame_id = upload_image_to_pixverse(last_frame, auth_token=auth_token)
+        first_frame_id = upload_image_to_pixverse(first_frame, auth_kwargs=kwargs)
+        last_frame_id = upload_image_to_pixverse(last_frame, auth_kwargs=kwargs)
 
         # 1080p is limited to 5 seconds duration
         # only normal motion_mode supported for 1080p or for non-5 second duration
@@ -452,7 +452,7 @@ class PixverseTransitionVideoNode(ComfyNodeABC):
                 negative_prompt=negative_prompt if negative_prompt else None,
                 seed=seed,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api = operation.execute()
 
@@ -469,7 +469,7 @@ class PixverseTransitionVideoNode(ComfyNodeABC):
             completed_statuses=[PixverseStatus.successful],
             failed_statuses=[PixverseStatus.contents_moderation, PixverseStatus.failed, PixverseStatus.deleted],
             status_extractor=lambda x: x.Resp.status,
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_poll = operation.execute()
 

--- a/comfy_api_nodes/nodes_recraft.py
+++ b/comfy_api_nodes/nodes_recraft.py
@@ -43,7 +43,7 @@ def handle_recraft_file_request(
         total_pixels=4096*4096,
         timeout=1024,
         request=None,
-        auth_token=None
+        auth_kwargs: dict[str,str] = None,
     ) -> list[BytesIO]:
         """
         Handle sending common Recraft file-only request to get back file bytes.
@@ -67,7 +67,7 @@ def handle_recraft_file_request(
             request=request,
             files=files,
             content_type="multipart/form-data",
-            auth_token=auth_token,
+            auth_kwargs=auth_kwargs,
             multipart_parser=recraft_multipart_parser,
         )
         response: RecraftImageGenerationResponse = operation.execute()
@@ -485,6 +485,7 @@ class RecraftTextToImageNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -497,7 +498,6 @@ class RecraftTextToImageNode:
         recraft_style: RecraftStyle = None,
         negative_prompt: str = None,
         recraft_controls: RecraftControls = None,
-        auth_token=None,
         **kwargs,
     ):
         validate_string(prompt, strip_whitespace=False, max_length=1000)
@@ -530,7 +530,7 @@ class RecraftTextToImageNode:
                 style_id=recraft_style.style_id,
                 controls=controls_api,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response: RecraftImageGenerationResponse = operation.execute()
         images = []
@@ -620,6 +620,7 @@ class RecraftImageToImageNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -630,7 +631,6 @@ class RecraftImageToImageNode:
         n: int,
         strength: float,
         seed,
-        auth_token=None,
         recraft_style: RecraftStyle = None,
         negative_prompt: str = None,
         recraft_controls: RecraftControls = None,
@@ -668,7 +668,7 @@ class RecraftImageToImageNode:
                 image=image[i],
                 path="/proxy/recraft/images/imageToImage",
                 request=request,
-                auth_token=auth_token,
+                auth_kwargs=kwargs,
             )
             with handle_recraft_image_output():
                 images.append(torch.cat([bytesio_to_image_tensor(x) for x in sub_bytes], dim=0))
@@ -736,6 +736,7 @@ class RecraftImageInpaintingNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -746,7 +747,6 @@ class RecraftImageInpaintingNode:
         prompt: str,
         n: int,
         seed,
-        auth_token=None,
         recraft_style: RecraftStyle = None,
         negative_prompt: str = None,
         **kwargs,
@@ -781,7 +781,7 @@ class RecraftImageInpaintingNode:
                 mask=mask[i:i+1],
                 path="/proxy/recraft/images/inpaint",
                 request=request,
-                auth_token=auth_token,
+                auth_kwargs=kwargs,
             )
             with handle_recraft_image_output():
                 images.append(torch.cat([bytesio_to_image_tensor(x) for x in sub_bytes], dim=0))
@@ -860,6 +860,7 @@ class RecraftTextToVectorNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -872,7 +873,6 @@ class RecraftTextToVectorNode:
         seed,
         negative_prompt: str = None,
         recraft_controls: RecraftControls = None,
-        auth_token=None,
         **kwargs,
     ):
         validate_string(prompt, strip_whitespace=False, max_length=1000)
@@ -903,7 +903,7 @@ class RecraftTextToVectorNode:
                 substyle=recraft_style.substyle,
                 controls=controls_api,
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response: RecraftImageGenerationResponse = operation.execute()
         svg_data = []
@@ -934,13 +934,13 @@ class RecraftVectorizeImageNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
     def api_call(
         self,
         image: torch.Tensor,
-        auth_token=None,
         **kwargs,
     ):
         svgs = []
@@ -950,7 +950,7 @@ class RecraftVectorizeImageNode:
             sub_bytes = handle_recraft_file_request(
                 image=image[i],
                 path="/proxy/recraft/images/vectorize",
-                auth_token=auth_token,
+                auth_kwargs=kwargs,
             )
             svgs.append(SVG(sub_bytes))
             pbar.update(1)
@@ -1015,6 +1015,7 @@ class RecraftReplaceBackgroundNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -1024,7 +1025,6 @@ class RecraftReplaceBackgroundNode:
         prompt: str,
         n: int,
         seed,
-        auth_token=None,
         recraft_style: RecraftStyle = None,
         negative_prompt: str = None,
         **kwargs,
@@ -1054,7 +1054,7 @@ class RecraftReplaceBackgroundNode:
                 image=image[i],
                 path="/proxy/recraft/images/replaceBackground",
                 request=request,
-                auth_token=auth_token,
+                auth_kwargs=kwargs,
             )
             images.append(torch.cat([bytesio_to_image_tensor(x) for x in sub_bytes], dim=0))
             pbar.update(1)
@@ -1084,13 +1084,13 @@ class RecraftRemoveBackgroundNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
     def api_call(
         self,
         image: torch.Tensor,
-        auth_token=None,
         **kwargs,
     ):
         images = []
@@ -1100,7 +1100,7 @@ class RecraftRemoveBackgroundNode:
             sub_bytes = handle_recraft_file_request(
                 image=image[i],
                 path="/proxy/recraft/images/removeBackground",
-                auth_token=auth_token,
+                auth_kwargs=kwargs,
             )
             images.append(torch.cat([bytesio_to_image_tensor(x) for x in sub_bytes], dim=0))
             pbar.update(1)
@@ -1135,13 +1135,13 @@ class RecraftCrispUpscaleNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
     def api_call(
         self,
         image: torch.Tensor,
-        auth_token=None,
         **kwargs,
     ):
         images = []
@@ -1151,7 +1151,7 @@ class RecraftCrispUpscaleNode:
             sub_bytes = handle_recraft_file_request(
                 image=image[i],
                 path=self.RECRAFT_PATH,
-                auth_token=auth_token,
+                auth_kwargs=kwargs,
             )
             images.append(torch.cat([bytesio_to_image_tensor(x) for x in sub_bytes], dim=0))
             pbar.update(1)

--- a/comfy_api_nodes/nodes_stability.py
+++ b/comfy_api_nodes/nodes_stability.py
@@ -120,12 +120,13 @@ class StabilityStableImageUltraNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
     def api_call(self, prompt: str, aspect_ratio: str, style_preset: str, seed: int,
                  negative_prompt: str=None, image: torch.Tensor = None, image_denoise: float=None,
-                 auth_token=None):
+                 **kwargs):
         validate_string(prompt, strip_whitespace=False)
         # prepare image binary if image present
         image_binary = None
@@ -160,7 +161,7 @@ class StabilityStableImageUltraNode:
             ),
             files=files,
             content_type="multipart/form-data",
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api = operation.execute()
 
@@ -252,12 +253,13 @@ class StabilityStableImageSD_3_5Node:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
     def api_call(self, model: str, prompt: str, aspect_ratio: str, style_preset: str, seed: int, cfg_scale: float,
                  negative_prompt: str=None, image: torch.Tensor = None, image_denoise: float=None,
-                 auth_token=None):
+                 **kwargs):
         validate_string(prompt, strip_whitespace=False)
         # prepare image binary if image present
         image_binary = None
@@ -298,7 +300,7 @@ class StabilityStableImageSD_3_5Node:
             ),
             files=files,
             content_type="multipart/form-data",
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api = operation.execute()
 
@@ -368,11 +370,12 @@ class StabilityUpscaleConservativeNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
     def api_call(self, image: torch.Tensor, prompt: str, creativity: float, seed: int, negative_prompt: str=None,
-                 auth_token=None):
+                 **kwargs):
         validate_string(prompt, strip_whitespace=False)
         image_binary = tensor_to_bytesio(image, total_pixels=1024*1024).read()
 
@@ -398,7 +401,7 @@ class StabilityUpscaleConservativeNode:
             ),
             files=files,
             content_type="multipart/form-data",
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api = operation.execute()
 
@@ -473,11 +476,12 @@ class StabilityUpscaleCreativeNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
     def api_call(self, image: torch.Tensor, prompt: str, creativity: float, style_preset: str, seed: int, negative_prompt: str=None,
-                 auth_token=None):
+                 **kwargs):
         validate_string(prompt, strip_whitespace=False)
         image_binary = tensor_to_bytesio(image, total_pixels=1024*1024).read()
 
@@ -506,7 +510,7 @@ class StabilityUpscaleCreativeNode:
             ),
             files=files,
             content_type="multipart/form-data",
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api = operation.execute()
 
@@ -521,7 +525,7 @@ class StabilityUpscaleCreativeNode:
             completed_statuses=[StabilityPollStatus.finished],
             failed_statuses=[StabilityPollStatus.failed],
             status_extractor=lambda x: get_async_dummy_status(x),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_poll: StabilityResultsGetResponse = operation.execute()
 
@@ -555,11 +559,12 @@ class StabilityUpscaleFastNode:
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
     def api_call(self, image: torch.Tensor,
-                 auth_token=None):
+                 **kwargs):
         image_binary = tensor_to_bytesio(image, total_pixels=4096*4096).read()
 
         files = {
@@ -576,7 +581,7 @@ class StabilityUpscaleFastNode:
             request=EmptyRequest(),
             files=files,
             content_type="multipart/form-data",
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
         )
         response_api = operation.execute()
 

--- a/comfy_api_nodes/nodes_veo2.py
+++ b/comfy_api_nodes/nodes_veo2.py
@@ -114,6 +114,7 @@ class VeoVideoGenerationNode(ComfyNodeABC):
             },
             "hidden": {
                 "auth_token": "AUTH_TOKEN_COMFY_ORG",
+                "comfy_api_key": "API_KEY_COMFY_ORG",
             },
         }
 
@@ -133,7 +134,7 @@ class VeoVideoGenerationNode(ComfyNodeABC):
         person_generation="ALLOW",
         seed=0,
         image=None,
-        auth_token=None,
+        **kwargs,
     ):
         # Prepare the instances for the request
         instances = []
@@ -179,7 +180,7 @@ class VeoVideoGenerationNode(ComfyNodeABC):
                 instances=instances,
                 parameters=parameters
             ),
-            auth_token=auth_token
+            auth_kwargs=kwargs,
         )
 
         initial_response = initial_operation.execute()
@@ -213,7 +214,7 @@ class VeoVideoGenerationNode(ComfyNodeABC):
             request=Veo2GenVidPollRequest(
                 operationName=operation_name
             ),
-            auth_token=auth_token,
+            auth_kwargs=kwargs,
             poll_interval=5.0
         )
 

--- a/execution.py
+++ b/execution.py
@@ -146,6 +146,8 @@ def get_input_data(inputs, class_def, unique_id, outputs=None, dynprompt=None, e
                 input_data_all[x] = [unique_id]
             if h[x] == "AUTH_TOKEN_COMFY_ORG":
                 input_data_all[x] = [extra_data.get("auth_token_comfy_org", None)]
+            if h[x] == "API_KEY_COMFY_ORG":
+                input_data_all[x] = [extra_data.get("api_key_comfy_org", None)]
     return input_data_all, missing_keys
 
 map_node_over_list = None #Don't hook this please

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-comfyui-frontend-package==1.18.9
-comfyui-workflow-templates==0.1.11
+comfyui-frontend-package==1.18.10
+comfyui-workflow-templates==0.1.13
 torch
 torchsde
 torchvision

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.18.10
-comfyui-workflow-templates==0.1.13
+comfyui-workflow-templates==0.1.14
 torch
 torchsde
 torchvision


### PR DESCRIPTION
Adds improvements, fixes, and localizations for API nodes, including the ability to use API nodes with a Comfy API key.

Allowing API key based authorization will allow a wider range of users to use API nodes, including:

- Users running ComfyUI headlessly or with an alternative frontend
- Users running ComfyUI with `--listen` or over LAN
- Users using ComfyUI through a cloud deployment service
- Websites embedding ComfyUI within their app
- Apps/services using ComfyUI as a serivce/API or engine
- Users running ComfyUI in a container or in the cloud

Changes:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3801
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3815
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3836
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3792
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3838
- https://github.com/Comfy-Org/ComfyUI-private/pull/167 
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3771
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3772
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3786
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3787
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3735
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3788
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3762
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3710
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3765
- https://github.com/Comfy-Org/ComfyUI_frontend/pull/3769
  
---

How to use API key: https://docs.comfy.org/interface/user#logging-in-with-an-api-key