### PR TITLE
Remove extraneous `aspect_ratio` field from Kling I2V

### DIFF
--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -671,7 +671,6 @@ class KlingImage2VideoNode(KlingNodeBase):
                 negative_prompt=negative_prompt if negative_prompt else None,
                 cfg_scale=cfg_scale,
                 mode=KlingVideoGenMode(mode),
-                aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
                 duration=KlingVideoGenDuration(duration),
                 camera_control=camera_control,
             ),


### PR DESCRIPTION
Kling has informed that `aspect_ratio` is not used in the I2V, which is also explicitly stated [in this section](https://app.klingai.com/global/dev/document-api/apiReference/model/imageToVideo) of their docs. We should remove the extraneous field from the request body to guard against potential future bugs.