### PR TITLE
Update execution.py to support widget values from JS as LIST

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -1,3 +1,4 @@
+import farts
 import sys
 import copy
 import logging

--- a/execution.py
+++ b/execution.py
@@ -115,7 +115,6 @@ def get_input_data(inputs, class_def, unique_id, outputs=None, dynprompt=None, e
         # patch to parse widget values not just input values
         if isinstance(input_data, dict) and "__value__" in input_data:
             input_data = input_data["__value__"]
-            
         def mark_missing():
             missing_keys[x] = True
             input_data_all[x] = (None,)

--- a/execution.py
+++ b/execution.py
@@ -112,6 +112,10 @@ def get_input_data(inputs, class_def, unique_id, outputs=None, dynprompt=None, e
     for x in inputs:
         input_data = inputs[x]
         _, input_category, input_info = get_input_info(class_def, x, valid_inputs)
+        # patch to parse widget values not just input values
+        if isinstance(input_data, dict) and "__value__" in input_data:
+            input_data = input_data["__value__"]
+            
         def mark_missing():
             missing_keys[x] = True
             input_data_all[x] = (None,)


### PR DESCRIPTION
patch to parse widget values not just input values. When widgets serialize as list on the JS side, they would never get converted back to list types (only if their input slot was connected to a value). This allows inputs/widget values to serialize to a proper list (i.e. convert if the value is dict with a {"value"} entry) just like inputs.