### PR TITLE
Add Multiline String Node

### DIFF
--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -2,6 +2,22 @@ import re
 
 from comfy.comfy_types.node_typing import IO
 
+class StringMultiline():
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "string": (IO.STRING, {"multiline": True})
+                }
+            }
+
+    RETURN_TYPES = (IO.STRING,)
+    FUNCTION = "execute"
+    CATEGORY = "utils/string"
+
+    def execute(self, string, **kwargs):
+        return string,
+
 class StringConcatenate():
     @classmethod
     def INPUT_TYPES(s):
@@ -296,6 +312,7 @@ class RegexExtract():
         return result,
 
 NODE_CLASS_MAPPINGS = {
+    "StringMultiline": StringMultiline,
     "StringConcatenate": StringConcatenate,
     "StringSubstring": StringSubstring,
     "StringLength": StringLength,
@@ -309,6 +326,7 @@ NODE_CLASS_MAPPINGS = {
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
+    "StringMultiline": "Multiline String",
     "StringConcatenate": "Concatenate",
     "StringSubstring": "Substring",
     "StringLength": "Length",


### PR DESCRIPTION
https://github.com/comfyanonymous/ComfyUI/pull/7952 was quite an interesting PR for just adding some functionalities to strings that should be in default Comfy. Curiously however, there was not a single line added pertaining to a multiline string node, which comfy lacks.

The following behaves identically to the current string primitive, with one main difference: being multiline. It's easier for larger amounts of text to be handled, and shouldn't be too big of an addition elsewise.
![2025-05-13_23-37](https://github.com/user-attachments/assets/848bad31-536d-4040-9569-2c853f150595)
