### PR TITLE
Fix bug: don't retry request if API reports task failure

### DIFF
--- a/comfy_api_nodes/apis/client.py
+++ b/comfy_api_nodes/apis/client.py
@@ -1105,7 +1105,7 @@ class PollingOperation(Generic[T, R]):
             except Exception as e:
                 # For other errors, increment count and potentially abort
                 consecutive_errors += 1
-                if consecutive_errors >= max_consecutive_errors:
+                if consecutive_errors >= max_consecutive_errors or status == TaskStatus.FAILED:
                     raise Exception(
                         f"Polling aborted after {consecutive_errors} consecutive errors: {str(e)}"
                     ) from e


### PR DESCRIPTION
Fixes issue in which the polling retry logic is triggered when the API reports the task has failed.

This code:

https://github.com/comfyanonymous/ComfyUI/blob/98ff01e1486353a3b0ddd8fa82fcbb25401f8364/comfy_api_nodes/apis/client.py#L1074-L1077

raises exception, which is caught by the `except` at bottom of `while` block, meant for catching network-related errors. There is a counter that is incremented for consecutive errors to prevent this, but it is reset to 0 since the response technically succeeded (successful response of API reporting that the task failed on their end).

