### PR TITLE
fix: Should gracefully handle missing data dirs

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -93,12 +93,6 @@ def map_legacy(folder_name: str) -> str:
               "clip": "text_encoders"}
     return legacy.get(folder_name, folder_name)
 
-if not os.path.exists(input_directory):
-    try:
-        os.makedirs(input_directory)
-    except:
-        logging.error("Failed to create input directory")
-
 def set_output_directory(output_dir: str) -> None:
     global output_directory
     output_directory = output_dir


### PR DESCRIPTION
- `input/` + `temp/` directories moved to a common function call run after `apply_custom_paths()`.
  - These were both implicitly created at startup at different locations. It seemed better to co-locate?
  - The `input/` dir was created before it could be updated by the CLI arg. Now it will not create another directory before the input dir path is changed.
- `custom_nodes/` is another default directory that caused ComfyUI to crash if it did not exist when it's contents was checked. Instead prefer to skip empty custom node directories at startup.

---

Slight inconsistency observed with the `user/` directory.

`--user-directory` is a newer option added to the CLI (8 months ago) after [the related ones](https://github.com/comfyanonymous/ComfyUI/blob/f3ff5c40db3b68449b47112591eef31094cffe70/comfy/cli_args.py#L47-L49) (2 years ago). For some reason it was not co-located with the existing options (_affects list order in help output_) and unlike the other related options it enforces a check on the given path to exist, rather than create when missing.

https://github.com/comfyanonymous/ComfyUI/blob/f3ff5c40db3b68449b47112591eef31094cffe70/comfy/cli_args.py#L194

I could likewise shift that user dir logic into the common setup function and co-locate the CLI arg? (_normalizing on your preference of enforcing the path given to exist or not_)