### PR TITLE
Update execution.py

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -112,6 +112,9 @@ def get_input_data(inputs, class_def, unique_id, outputs=None, dynprompt=None, e
     for x in inputs:
         input_data = inputs[x]
         _, input_category, input_info = get_input_info(class_def, x, valid_inputs)
+        # patch to parse widget values not just input values
+        if isinstance(input_data, dict) and "__value__" in input_data:
+            input_data = input_data["__value__"]
         def mark_missing():
             missing_keys[x] = True
             input_data_all[x] = (None,)


### PR DESCRIPTION
Problem:

With the new "input slots on widgets" system, during execution, only inputs (connected) are checked for values during the parse from Javascript frontend.

That means widgets, with no input, are not properly converted from their JSON return values. Since LIST types are mangled in the frontend into a dict entry of {__value__: [JSON LIST]} their values are passed, on execute, into the python functions as DICT, and not proper LISTs.

Soltion:

This is a patch to parse widget values not just input slot values. This allows inputs/widget values to serialize to a proper list (i.e. convert if the value is dict with a {"value"} entry) just like inputs.