### PR TITLE
Add delimiter to concatenate node

### DIFF
--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -8,7 +8,8 @@ class StringConcatenate():
         return {
             "required": {
                 "string_a": (IO.STRING, {"multiline": True}),
-                "string_b": (IO.STRING, {"multiline": True})
+                "string_b": (IO.STRING, {"multiline": True}),
+                "delimiter": (IO.STRING, {"multiline": False, "default": ", "})
             }
         }
 
@@ -16,8 +17,8 @@ class StringConcatenate():
     FUNCTION = "execute"
     CATEGORY = "utils/string"
 
-    def execute(self, string_a, string_b, **kwargs):
-        return string_a + string_b,
+    def execute(self, string_a, string_b, delimiter, **kwargs):
+        return delimiter.join((string_a, string_b)),
 
 class StringSubstring():
     @classmethod


### PR DESCRIPTION
This is strangely missing from the current default node, pretty much every custom node suite with a concatenate node has one. Without it, it makes structuring the words and such weirder and sometimes trickier when sending around some text nodes. Adds a simple delimiter functionality to the node.
![2025-05-17_14-10](https://github.com/user-attachments/assets/e2386ead-79b5-47f6-b157-e4e3f66f0417)
