### PR TITLE
Improve performance with large number of queued prompts

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -953,6 +953,14 @@ class PromptQueue:
             self.history[prompt[1]].update(history_result)
             self.server.queue_updated()
 
+    # Note: slow
+    def get_current_queue(self):
+        with self.mutex:
+            out = []
+            for x in self.currently_running.values():
+                out += [x]
+            return (out, copy.deepcopy(self.queue))
+
     # read-safe as long as queue items are immutable
     def get_current_queue_volatile(self):
         with self.mutex:

--- a/execution.py
+++ b/execution.py
@@ -909,7 +909,6 @@ class PromptQueue:
         self.currently_running = {}
         self.history = {}
         self.flags = {}
-        server.prompt_queue = self
 
     def put(self, item):
         with self.mutex:
@@ -954,12 +953,12 @@ class PromptQueue:
             self.history[prompt[1]].update(history_result)
             self.server.queue_updated()
 
-    def get_current_queue(self):
+    # read-safe as long as queue items are immutable
+    def get_current_queue_volatile(self):
         with self.mutex:
-            out = []
-            for x in self.currently_running.values():
-                out += [x]
-            return (out, copy.deepcopy(self.queue))
+            running = [x for x in self.currently_running.values()]
+            queued = copy.copy(self.queue)
+            return (running, queued)
 
     def get_tasks_remaining(self):
         with self.mutex:

--- a/main.py
+++ b/main.py
@@ -260,7 +260,6 @@ def start_comfyui(asyncio_loop=None):
         asyncio_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(asyncio_loop)
     prompt_server = server.PromptServer(asyncio_loop)
-    q = execution.PromptQueue(prompt_server)
 
     hook_breaker_ac10a0.save_functions()
     nodes.init_extra_nodes(init_custom_nodes=not args.disable_all_custom_nodes, init_api_nodes=not args.disable_api_nodes)
@@ -271,7 +270,7 @@ def start_comfyui(asyncio_loop=None):
     prompt_server.add_routes()
     hijack_progress(prompt_server)
 
-    threading.Thread(target=prompt_worker, daemon=True, args=(q, prompt_server,)).start()
+    threading.Thread(target=prompt_worker, daemon=True, args=(prompt_server.prompt_queue, prompt_server,)).start()
 
     if args.quick_test_for_ci:
         exit(0)

--- a/server.py
+++ b/server.py
@@ -29,6 +29,8 @@ import comfy.model_management
 import node_helpers
 from comfyui_version import __version__
 from app.frontend_management import FrontendManager
+from execution import PromptQueue
+
 from app.user_manager import UserManager
 from app.model_manager import ModelFileManager
 from app.custom_node_manager import CustomNodeManager
@@ -159,7 +161,7 @@ class PromptServer():
         self.custom_node_manager = CustomNodeManager()
         self.internal_routes = InternalRoutes(self)
         self.supports = ["custom_nodes_from_web"]
-        self.prompt_queue = None
+        self.prompt_queue = PromptQueue(self)
         self.loop = loop
         self.messages = asyncio.Queue()
         self.client_session:Optional[aiohttp.ClientSession] = None
@@ -621,7 +623,7 @@ class PromptServer():
         @routes.get("/queue")
         async def get_queue(request):
             queue_info = {}
-            current_queue = self.prompt_queue.get_current_queue()
+            current_queue = self.prompt_queue.get_current_queue_volatile()
             queue_info['queue_running'] = current_queue[0]
             queue_info['queue_pending'] = current_queue[1]
             return web.json_response(queue_info)

--- a/server.py
+++ b/server.py
@@ -29,7 +29,6 @@ import comfy.model_management
 import node_helpers
 from comfyui_version import __version__
 from app.frontend_management import FrontendManager
-from execution import PromptQueue
 
 from app.user_manager import UserManager
 from app.model_manager import ModelFileManager
@@ -161,7 +160,7 @@ class PromptServer():
         self.custom_node_manager = CustomNodeManager()
         self.internal_routes = InternalRoutes(self)
         self.supports = ["custom_nodes_from_web"]
-        self.prompt_queue = PromptQueue(self)
+        self.prompt_queue = execution.PromptQueue(self)
         self.loop = loop
         self.messages = asyncio.Queue()
         self.client_session:Optional[aiohttp.ClientSession] = None


### PR DESCRIPTION
Mitigates https://github.com/Comfy-Org/ComfyUI_frontend/issues/2435

ComfyUI's web app exhibits significant lag when a large number of prompts are queued. I verified what was found in the linked thread, pinpointing the slowdown to the specific call `api.getQueue()` as the number of prompts grows. Every time a prompt is submitted, the front-end synchronizes the entire queue state by making this call.

Profiling the back-end, I found most of the time is spent executing `copy.deepcopy` inside PromptQueue while a mutex is held.

![GetQueue_Before](https://github.com/user-attachments/assets/720b59c1-c836-469a-ba99-3ec6b8fbbe5c)

This PR adds a new version of PromptQueue's `get_current_queue` method that performs `copy.copy` instead of `copy.deepcopy`. Allowing read-only shared access is safe as long as `PromptQueue` treats its queue items as immutable, which it does by returning deep copies in its other methods. I named the new version `get_current_queue_volatile` to remind callers they must only read and release these values.

Using the updated method allows Comfy to respond much faster to requests to the `/queue` route. The web app remains usable on my machine with several hundred queue items. I enqueued 300 prompts for these benchmarks.

Notice how the whole `deepcopy` block is gone, and you can actually see Comfy working on other stuff:
![After change](https://github.com/user-attachments/assets/d636cab8-1fb4-49b3-a8da-aa2105ed30d7)


Caching the JSON representations may be another 80/20 fix. I could look into that in the future. A more complex but optimized solution would be to rewrite state sync so the front end only requests a diff with updates to the queue instead of a full sync. Still, this quick fix helps a lot.