### PR TITLE
Add missing category for T5TokenizerOption

### DIFF
--- a/comfy_extras/nodes_cond.py
+++ b/comfy_extras/nodes_cond.py
@@ -31,6 +31,7 @@ class T5TokenizerOptions:
             }
         }
 
+    CATEGORY = "_for_testing/conditioning"
     RETURN_TYPES = ("CLIP",)
     FUNCTION = "set_options"
 


### PR DESCRIPTION
Change it if you need to but it should at least have a category.