### PR TITLE
Add Type Conversion Nodes

### DIFF
--- a/comfy_extras/nodes_types.py
+++ b/comfy_extras/nodes_types.py
@@ -1,0 +1,205 @@
+import re
+from comfy.comfy_types.node_typing import IO
+
+ROUND_MODES = ["truncate","round","bankers_rounding"]
+
+def float_to_int(value: float, mode: str) -> int:
+    if mode == "truncate":
+        return int(value)
+    elif mode == "bankers_rounding":
+        # Python’s round implements “banker’s” (tie-to-even)
+        return int(round(value))
+    elif mode == "round":
+        # half-away-from-zero
+        return int(value + 0.5) if value >= 0 else int(value - 0.5)
+    else:
+        raise ValueError(f"Unknown mode: {mode}")
+
+class IntToFloat:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("INT", {"default": 0})}}
+
+    RETURN_TYPES = ("FLOAT",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value) -> float:
+        return (float(value),)
+
+class FloatToInt:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+                    "value": ("FLOAT", {"default": 0.0, "round": False}),
+                    "mode": (ROUND_MODES,)
+                    },
+               }
+
+    RETURN_TYPES = ("INT",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value, mode) -> int:
+        return (float_to_int(value, mode),)
+
+class IntToString:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("INT", {"default": 0})}}
+
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value) -> str:
+        return (str(value),)
+
+class FloatToString:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+                    "value": ("FLOAT", {"default": 0.0, "round": False}),
+                    "round_value": ("BOOLEAN", {"default": True}),
+                    "round_to": ("INT", {"default": 2,   "min": 0})
+               }}
+
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value, round_value, round_to) -> str:
+        if round_value:
+            out = f"{value:.{round_to}f}"
+        else:
+            out = str(value)
+        return (out,)
+
+class StringToNum:
+
+    # Regex that recognises *numeric literals Python will accept as floats*:
+    #   • optional sign ([+-]?)
+    #   • one of the three mantissa forms:
+    #       – digits '.' optional-digits  (123. or 123.456)
+    #       – '.' digits                 (.456)
+    #       – digits                     (123)
+    #   • optional exponent part with its own optional sign: ([eE][+-]?\d+)?
+    #   • \Z anchors the match at the absolute end of the string so
+    #     trailing whitespace or characters invalidate the match.
+    _FLOAT_RE = re.compile(
+        r"""
+            [+-]?                  # optional sign
+            (?:\d+\.\d*|\.\d+|\d+) # mantissa
+            (?:[eE][+-]?\d+)?      # optional exponent
+            \Z                     # end of string
+        """,
+        re.VERBOSE
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+                "value": ("STRING", {"default": "0", "multiline": False}),
+                "int_mode": (ROUND_MODES,)
+               }}
+
+    RETURN_TYPES = ("INT","FLOAT",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value, int_mode):
+        s = value.strip()
+        if not self._FLOAT_RE.fullmatch(s):
+            raise ValueError(f"StringToNum: cannot parse '{value}' as a number.")
+
+        float_out = float(s)
+        int_out = float_to_int(float_out, int_mode)
+
+        return (int_out, float_out)
+
+class BoolToAll:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("BOOLEAN", {"default": False})}}
+
+    RETURN_TYPES = ("INT","FLOAT","STRING",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value):
+        return (int(value), float(value), str(value),)
+
+class IntToBool:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("INT", {"default": 0})}}
+
+    RETURN_TYPES = ("BOOLEAN",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value) -> bool:
+        return (bool(value),)
+
+class FloatToBool:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("FLOAT", {"default": 0})}}
+
+    RETURN_TYPES = ("BOOLEAN",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value) -> bool:
+        return (bool(value),)
+
+class StringToBool:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+                "value": ("STRING", {"default": "False", "multiline": False}),
+                "true_text": ("STRING", {"default": "True", "multiline": False}),
+                "case_sensitive": ("BOOLEAN", {"default": True})
+               }}
+
+    RETURN_TYPES = ("BOOLEAN",)
+    FUNCTION = "convert_type"
+    CATEGORY = "utils/type_convert"
+
+    def convert_type(self, value, true_text, case_sensitive) -> bool:
+        if case_sensitive:
+            match = (value == true_text)
+        else:
+            match = (value.casefold() == true_text.casefold())
+        return (match,)
+
+class StringToCombo:
+    '''Converts a string into a combo input that may be used with any
+       node with a list widget.
+    '''
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"text": (IO.STRING, {"multiline": False})}}
+
+    RETURN_TYPES  = (IO.ANY,)
+    RETURN_NAMES  = ("COMBO",)
+    FUNCTION      = "convert_type"
+    CATEGORY      = "utils/type_convert"
+
+    def convert_type(self, text: str):
+        items = [t.strip() for t in text.split(",") if t.strip()]
+        return (items[0] if items else "",)
+
+
+NODE_CLASS_MAPPINGS = {
+    "Boolean to All": BoolToAll,
+    "Integer to Boolean": IntToBool,
+    "Integer to Float": IntToFloat,
+    "Integer to String": IntToString,
+    "Float to Boolean": FloatToBool,
+    "Float to Integer": FloatToInt,
+    "Float to String": FloatToString,
+    "String to Boolean": StringToBool,
+    "String to Number": StringToNum,
+    "String to Combo": StringToCombo
+}

--- a/comfy_extras/nodes_types.py
+++ b/comfy_extras/nodes_types.py
@@ -104,26 +104,6 @@ class BoolToAll:
     def convert_type(self, value):
         return (int(value), float(value), str(value),)
 
-class StringToBool:
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {"required": {
-                "value": ("STRING", {"default": "False", "multiline": False}),
-                "true_text": ("STRING", {"default": "True", "multiline": False}),
-                "case_sensitive": ("BOOLEAN", {"default": True})
-               }}
-
-    RETURN_TYPES = ("BOOLEAN",)
-    FUNCTION = "convert_type"
-    CATEGORY = "utils/type_convert"
-
-    def convert_type(self, value, true_text, case_sensitive) -> bool:
-        if case_sensitive:
-            match = (value == true_text)
-        else:
-            match = (value.casefold() == true_text.casefold())
-        return (match,)
-
 class StringToCombo:
     '''Converts a string into a combo input that may be used with any
        node with a list widget.
@@ -146,7 +126,6 @@ NODE_CLASS_MAPPINGS = {
     "Boolean to All": BoolToAll,
     "Integer to All": IntToAll,
     "Float to All": FloatToAll,
-    "String to Boolean": StringToBool,
     "String to Number": StringToNum,
     "String to Combo": StringToCombo
 }

--- a/comfy_extras/nodes_types.py
+++ b/comfy_extras/nodes_types.py
@@ -15,65 +15,40 @@ def float_to_int(value: float, mode: str) -> int:
     else:
         raise ValueError(f"Unknown mode: {mode}")
 
-class IntToFloat:
+class IntToAll:
     @classmethod
     def INPUT_TYPES(cls):
         return {"required": {"value": ("INT", {"default": 0})}}
 
-    RETURN_TYPES = ("FLOAT",)
+    RETURN_TYPES = ("BOOLEAN","FLOAT","STRING",)
     FUNCTION = "convert_type"
     CATEGORY = "utils/type_convert"
 
-    def convert_type(self, value) -> float:
-        return (float(value),)
+    def convert_type(self, value):
+        return (bool(value), float(value), str(value),)
 
-class FloatToInt:
+class FloatToAll:
     @classmethod
     def INPUT_TYPES(cls):
         return {"required": {
                     "value": ("FLOAT", {"default": 0.0, "round": False}),
-                    "mode": (ROUND_MODES,)
+                    "mode": (ROUND_MODES,),
+                    "string_round_value": ("BOOLEAN", {"default": True}),
+                    "string_round_to": ("INT", {"default": 2,   "min": 0})
                     },
                }
 
-    RETURN_TYPES = ("INT",)
+    RETURN_TYPES = ("BOOLEAN","INT","STRING",)
     FUNCTION = "convert_type"
     CATEGORY = "utils/type_convert"
 
-    def convert_type(self, value, mode) -> int:
-        return (float_to_int(value, mode),)
-
-class IntToString:
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {"required": {"value": ("INT", {"default": 0})}}
-
-    RETURN_TYPES = ("STRING",)
-    FUNCTION = "convert_type"
-    CATEGORY = "utils/type_convert"
-
-    def convert_type(self, value) -> str:
-        return (str(value),)
-
-class FloatToString:
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {"required": {
-                    "value": ("FLOAT", {"default": 0.0, "round": False}),
-                    "round_value": ("BOOLEAN", {"default": True}),
-                    "round_to": ("INT", {"default": 2,   "min": 0})
-               }}
-
-    RETURN_TYPES = ("STRING",)
-    FUNCTION = "convert_type"
-    CATEGORY = "utils/type_convert"
-
-    def convert_type(self, value, round_value, round_to) -> str:
-        if round_value:
-            out = f"{value:.{round_to}f}"
+    def convert_type(self, value, mode, string_round_value, string_round_to):
+        if string_round_value:
+            string_out = f"{value:.{string_round_to}f}"
         else:
-            out = str(value)
-        return (out,)
+            string_out = str(value)
+
+        return (bool(value), float_to_int(value, mode), string_out,)
 
 class StringToNum:
 
@@ -129,30 +104,6 @@ class BoolToAll:
     def convert_type(self, value):
         return (int(value), float(value), str(value),)
 
-class IntToBool:
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {"required": {"value": ("INT", {"default": 0})}}
-
-    RETURN_TYPES = ("BOOLEAN",)
-    FUNCTION = "convert_type"
-    CATEGORY = "utils/type_convert"
-
-    def convert_type(self, value) -> bool:
-        return (bool(value),)
-
-class FloatToBool:
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {"required": {"value": ("FLOAT", {"default": 0})}}
-
-    RETURN_TYPES = ("BOOLEAN",)
-    FUNCTION = "convert_type"
-    CATEGORY = "utils/type_convert"
-
-    def convert_type(self, value) -> bool:
-        return (bool(value),)
-
 class StringToBool:
     @classmethod
     def INPUT_TYPES(cls):
@@ -193,12 +144,8 @@ class StringToCombo:
 
 NODE_CLASS_MAPPINGS = {
     "Boolean to All": BoolToAll,
-    "Integer to Boolean": IntToBool,
-    "Integer to Float": IntToFloat,
-    "Integer to String": IntToString,
-    "Float to Boolean": FloatToBool,
-    "Float to Integer": FloatToInt,
-    "Float to String": FloatToString,
+    "Integer to All": IntToAll,
+    "Float to All": FloatToAll,
     "String to Boolean": StringToBool,
     "String to Number": StringToNum,
     "String to Combo": StringToCombo

--- a/nodes.py
+++ b/nodes.py
@@ -2266,6 +2266,7 @@ def init_builtin_extra_nodes():
         "nodes_ace.py",
         "nodes_string.py",
         "nodes_camera_trajectory.py",
+        "nodes_types.py",
     ]
 
     import_failed = []


### PR DESCRIPTION
Considering that there is an open PR for logic nodes, as well as new string nodes added, it only makes sense that these nodes should be native to Comfy for the ease of manipulation of types and such. I've decided to add some features to these nodes that current custom node implementations are lacking, mainly with floats and bools.

### Self-Explanatory Nodes
I do not feel like these ones in specific need much of explanation as they are very simple type conversions.
![2025-05-18_13-31](https://github.com/user-attachments/assets/296ff71b-b31c-42d1-ab9b-cacb5aa56230)

### Float to All
There are essentially three ways we can convert a float into an int:

1. Truncation
2. Rounding
3. Banker's Rounding (round-half-to-even)

This essentially allows for users to decide which one they would like to do for a specific float when converting to an integer. For a string, we allow the user to choose how many decimal points to round to for the string, or to just display the full float.
![2025-05-18_13-32](https://github.com/user-attachments/assets/bac14611-a3b8-42b9-ab95-0a590eaf5b44)

### String to Number
Converts a string into both an integer and a float, has a simple check to ensure that the string is going to be able to be converted into a float before it begins. Has the same rounding options as Float to Integer.
![2025-05-18_01-58](https://github.com/user-attachments/assets/b2e2bf0f-2ca3-4645-8a64-0ecd0bc608f7)

### String to Combo
I have only ever seen one implementation of this, in Comfyroll Studio to be precise. The idea of this node is simple: allow widgets that contain lists to be broken out and given a string input. This allows for more flexibility when working with these widgets.
![2025-05-18_02-03](https://github.com/user-attachments/assets/5bed636c-7e66-4e38-8dce-dc07c4276afb)



