### PR TITLE
Add Convert Data Type Node

### DIFF
--- a/comfy_extras/nodes_convert_type.py
+++ b/comfy_extras/nodes_convert_type.py
@@ -1,0 +1,89 @@
+import re
+import nodes
+from comfy.comfy_types.node_typing import IO
+
+# Portions of this code is derived from Itdrdata/ComfyUI-Impact-Pack,
+# specifically the handling of anytype and parts of the ConvertDataType
+# node.
+
+class AnyType(str):
+    def __ne__(self, __value: object) -> bool:
+        return False
+
+any_typ = AnyType("*")
+
+class ConvertDataType:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": (any_typ,),
+                             "int_mode": (["truncate","round","bankers_rounding"],),
+                             "string_round_value": ("BOOLEAN", {"default": True}),
+                             "string_round_to": ("INT", {"default": 2,   "min": 0})
+                             }}
+
+    RETURN_TYPES = ("STRING", "FLOAT", "INT", "BOOLEAN", IO.ANY,)
+    RETURN_NAMES = ("STRING", "FLOAT", "INT", "BOOLEAN", "COMBO",)
+    FUNCTION = "convert_type"
+
+    CATEGORY = "utils/primitive"
+
+    @staticmethod
+    def is_number(string):
+        pattern = re.compile(r'^[-+]?[0-9]*\.?[0-9]+$')
+        return bool(pattern.match(string))
+
+    def convert_type(self, value, int_mode, string_round_value, string_round_to):
+        # Initialize all outputs, necessary in the case of converting a string,
+        # and the string is not a number.
+        float_out  = None
+        int_out    = None
+        string_out = None
+
+        if isinstance(value, str):
+            if self.is_number(value):
+                float_out = float(value)
+            else:
+                string_out = value
+        elif isinstance(value, (int, float)):
+            float_out = float(value)
+        else:
+            string_out = str(value)
+
+        if float_out is not None:
+            v = float_out
+            if int_mode == "truncate":
+                int_out = int(v)
+            elif int_mode == "bankers_rounding":
+                int_out = int(round(v))
+            elif int_mode == "round":
+                int_out = int(v + 0.5) if v >= 0 else int(v - 0.5)
+            else:
+                raise ValueError(f"Unknown mode: {int_mode}")
+
+            if string_round_value:
+                string_out = f"{v:.{string_round_to}f}"
+            else:
+                string_out = str(v)
+
+        if float_out is not None:
+            boolean_out = bool(float_out)
+        elif string_out is not None:
+            boolean_out = bool(string_out)
+        else:
+            boolean_out = False
+
+        items   = (
+            [t.strip() for t in string_out.split(",") if t.strip()]
+            if isinstance(string_out, str) else
+            []
+        )
+        combo_out = items[0] if items else ""
+
+        return (string_out, float_out, int_out, boolean_out, combo_out)
+
+NODE_CLASS_MAPPINGS = {
+    "Convert Data Type": ConvertDataType
+}

--- a/nodes.py
+++ b/nodes.py
@@ -2266,6 +2266,7 @@ def init_builtin_extra_nodes():
         "nodes_ace.py",
         "nodes_string.py",
         "nodes_camera_trajectory.py",
+        "nodes_convert_type.py",
     ]
 
     import_failed = []


### PR DESCRIPTION
Per my previous PR, I initially created five nodes, though it became obvious that it couldn't work out. I then learned of the existence of Impact Pack's Convert Data Type node, which is what this node is largely based upon. I decided to add more options to the float as per my previous PR had, as well as the ability to also output a combo. Returns null on int and float output if the string cannot be converted to a float.

![2025-05-19_14-45](https://github.com/user-attachments/assets/9dcd3ce3-1344-41ab-b677-c89f22ff713a)

The main functions this introduces:
1. The user is able to choose what rounding type to use on a float or a string representing a float before it is converted to an integer. We are able to choose to just truncate, round, or do banker's rounding on a float.
2. The user is able to choose if a float is to be rounded before being converted to a string, and to choose how many decimal points, or to just display the full float.

Mainly, this is meant to be an extremely simple method to convert data types without needing a node for each type to be converted.