### PR TITLE
Make torch.compile LoRA/key-compatible

### DIFF
--- a/comfy_api/torch_helpers/__init__.py
+++ b/comfy_api/torch_helpers/__init__.py
@@ -1,0 +1,5 @@
+from .torch_compile import set_torch_compile_wrapper
+
+__all__ = [
+    "set_torch_compile_wrapper",
+]

--- a/comfy_api/torch_helpers/torch_compile.py
+++ b/comfy_api/torch_helpers/torch_compile.py
@@ -39,7 +39,6 @@ def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Option
     When keys is None, it will default to using ["diffusion_model"], compiling the whole diffusion_model.
     When a list of keys is provided, it will perform torch.compile on only the selected modules.
     '''
-    torch.compile()
     # clear out any other torch.compile wrappers
     model.remove_wrappers_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY)
     # if no keys, default to 'diffusion_model'

--- a/comfy_api/torch_helpers/torch_compile.py
+++ b/comfy_api/torch_helpers/torch_compile.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 COMPILE_KEY = "torch.compile"
-ATTACHMENT_TORCH_COMPILE_KWARGS = "torch_compile_kwargs"
+TORCH_COMPILE_KWARGS = "torch_compile_kwargs"
 
 
 def apply_torch_compile_factory(compiled_module_dict: dict[str, Callable]) -> Callable:
@@ -65,4 +65,4 @@ def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Option
         compiled_module_dict=compiled_modules,
     )
     model.add_wrapper_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY, wrapper_func)
-    model.set_attachments(ATTACHMENT_TORCH_COMPILE_KWARGS, compile_kwargs)
+    model.model_options[TORCH_COMPILE_KWARGS] = compile_kwargs

--- a/comfy_api/torch_helpers/torch_compile.py
+++ b/comfy_api/torch_helpers/torch_compile.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import torch
+
+from comfy.patcher_extension import WrappersMP
+from typing import TYPE_CHECKING, Callable, Optional
+if TYPE_CHECKING:
+    from comfy.model_patcher import ModelPatcher
+    from comfy.patcher_extension import WrapperExecutor
+
+
+COMPILE_KEY = "torch.compile"
+
+
+def apply_torch_compile_factory(compiled_diffusion_model: Callable) -> Callable:
+    '''
+    Create a wrapper that will refer to the compiled_diffusion_model
+    '''
+    def apply_torch_compile_wrapper(executor: WrapperExecutor, *args, **kwargs):
+        try:
+            orig_diffusion_model = executor.class_obj.diffusion_model
+            executor.class_obj.diffusion_model = compiled_diffusion_model
+            return executor(*args, **kwargs)
+        finally:
+            executor.class_obj.diffusion_model = orig_diffusion_model
+    return apply_torch_compile_wrapper
+
+
+def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Optional[dict[str,str]]=None, *args, **kwargs):
+    # clear out any other torch.compile wrappers
+    model.remove_wrappers_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY)
+    # add torch.compile wrapper
+    wrapper_func = apply_torch_compile_factory(
+        torch.compile(
+                model=model.get_model_object("diffusion_model"),
+                backend=backend,
+                options=options,
+            ),
+        )
+    model.add_wrapper_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY, wrapper_func)

--- a/comfy_api/torch_helpers/torch_compile.py
+++ b/comfy_api/torch_helpers/torch_compile.py
@@ -15,7 +15,7 @@ TORCH_COMPILE_KWARGS = "torch_compile_kwargs"
 
 def apply_torch_compile_factory(compiled_module_dict: dict[str, Callable]) -> Callable:
     '''
-    Create a wrapper that will refer to the compiled_diffusion_model
+    Create a wrapper that will refer to the compiled_diffusion_model.
     '''
     def apply_torch_compile_wrapper(executor: WrapperExecutor, *args, **kwargs):
         try:
@@ -37,7 +37,7 @@ def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Option
     Perform torch.compile that will be applied at sample time for either the whole model or specific params of the BaseModel instance.
 
     When keys is None, it will default to using ["diffusion_model"], compiling the whole diffusion_model.
-    When a list of keys is provided, it will perform torch.compile on only the selected params.
+    When a list of keys is provided, it will perform torch.compile on only the selected modules.
     '''
     torch.compile()
     # clear out any other torch.compile wrappers
@@ -64,5 +64,7 @@ def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Option
     wrapper_func = apply_torch_compile_factory(
         compiled_module_dict=compiled_modules,
     )
+    # store wrapper to run on BaseModel's apply_model function
     model.add_wrapper_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY, wrapper_func)
+    # keep compile kwargs for reference
     model.model_options[TORCH_COMPILE_KWARGS] = compile_kwargs

--- a/comfy_api/torch_helpers/torch_compile.py
+++ b/comfy_api/torch_helpers/torch_compile.py
@@ -3,7 +3,7 @@ import torch
 
 import comfy.utils
 from comfy.patcher_extension import WrappersMP
-from typing import TYPE_CHECKING, Callable, Union, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 if TYPE_CHECKING:
     from comfy.model_patcher import ModelPatcher
     from comfy.patcher_extension import WrapperExecutor

--- a/comfy_api/torch_helpers/torch_compile.py
+++ b/comfy_api/torch_helpers/torch_compile.py
@@ -1,39 +1,68 @@
 from __future__ import annotations
 import torch
 
+import comfy.utils
 from comfy.patcher_extension import WrappersMP
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable, Union, Optional
 if TYPE_CHECKING:
     from comfy.model_patcher import ModelPatcher
     from comfy.patcher_extension import WrapperExecutor
 
 
 COMPILE_KEY = "torch.compile"
+ATTACHMENT_TORCH_COMPILE_KWARGS = "torch_compile_kwargs"
 
 
-def apply_torch_compile_factory(compiled_diffusion_model: Callable) -> Callable:
+def apply_torch_compile_factory(compiled_module_dict: dict[str, Callable]) -> Callable:
     '''
     Create a wrapper that will refer to the compiled_diffusion_model
     '''
     def apply_torch_compile_wrapper(executor: WrapperExecutor, *args, **kwargs):
         try:
-            orig_diffusion_model = executor.class_obj.diffusion_model
-            executor.class_obj.diffusion_model = compiled_diffusion_model
+            orig_modules = {}
+            for key, value in compiled_module_dict.items():
+                orig_modules[key] = comfy.utils.get_attr(executor.class_obj, key)
+                comfy.utils.set_attr(executor.class_obj, key, value)
             return executor(*args, **kwargs)
         finally:
-            executor.class_obj.diffusion_model = orig_diffusion_model
+            for key, value in orig_modules.items():
+                comfy.utils.set_attr(executor.class_obj, key, value)
     return apply_torch_compile_wrapper
 
 
-def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Optional[dict[str,str]]=None, *args, **kwargs):
+def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Optional[dict[str,str]]=None,
+                              mode: Optional[str]=None, fullgraph=False, dynamic: Optional[bool]=None,
+                              keys: list[str]=["diffusion_model"], *args, **kwargs):
+    '''
+    Perform torch.compile that will be applied at sample time for either the whole model or specific params of the BaseModel instance.
+
+    When keys is None, it will default to using ["diffusion_model"], compiling the whole diffusion_model.
+    When a list of keys is provided, it will perform torch.compile on only the selected params.
+    '''
+    torch.compile()
     # clear out any other torch.compile wrappers
     model.remove_wrappers_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY)
+    # if no keys, default to 'diffusion_model'
+    if not keys:
+        keys = ["diffusion_model"]
+    # create kwargs dict that can be referenced later
+    compile_kwargs = {
+        "backend": backend,
+        "options": options,
+        "mode": mode,
+        "fullgraph": fullgraph,
+        "dynamic": dynamic,
+    }
+    # get a dict of compiled keys
+    compiled_modules = {}
+    for key in keys:
+        compiled_modules[key] = torch.compile(
+                model=model.get_model_object(key),
+                **compile_kwargs,
+            )
     # add torch.compile wrapper
     wrapper_func = apply_torch_compile_factory(
-        torch.compile(
-                model=model.get_model_object("diffusion_model"),
-                backend=backend,
-                options=options,
-            ),
-        )
+        compiled_module_dict=compiled_modules,
+    )
     model.add_wrapper_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY, wrapper_func)
+    model.set_attachments(ATTACHMENT_TORCH_COMPILE_KWARGS, compile_kwargs)

--- a/comfy_extras/nodes_torch_compile.py
+++ b/comfy_extras/nodes_torch_compile.py
@@ -1,4 +1,39 @@
+from __future__ import annotations
 import torch
+
+from comfy.patcher_extension import WrappersMP, WrapperExecutor
+from typing import TYPE_CHECKING, Callable, Optional
+if TYPE_CHECKING:
+    from comfy.model_patcher import ModelPatcher
+
+
+COMPILE_KEY = "torch.compile"
+
+
+def apply_torch_compile_factory(compiled_diffusion_model: Callable) -> Callable:
+    def apply_torch_compile_wrapper(executor: WrapperExecutor, *args, **kwargs):
+        try:
+            orig_diffusion_model = executor.class_obj.diffusion_model
+            executor.class_obj.diffusion_model = compiled_diffusion_model
+            return executor(*args, **kwargs)
+        finally:
+            executor.class_obj.diffusion_model = orig_diffusion_model
+    return apply_torch_compile_wrapper
+
+
+def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Optional[dict[str,str]]=None, *args, **kwargs):
+    # clear out any other torch.compile wrappers
+    model.remove_wrappers_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY)
+    # add torch.compile wrapper
+    wrapper_func = apply_torch_compile_factory(
+        torch.compile(
+                model=model.get_model_object("diffusion_model"),
+                backend=backend,
+                options=options,
+            ),
+        )
+    model.add_wrapper_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY, wrapper_func)
+
 
 class TorchCompileModel:
     @classmethod
@@ -14,7 +49,7 @@ class TorchCompileModel:
 
     def patch(self, model, backend):
         m = model.clone()
-        m.add_object_patch("diffusion_model", torch.compile(model=m.get_model_object("diffusion_model"), backend=backend))
+        set_torch_compile_wrapper(model=m, backend=backend)
         return (m, )
 
 NODE_CLASS_MAPPINGS = {

--- a/comfy_extras/nodes_torch_compile.py
+++ b/comfy_extras/nodes_torch_compile.py
@@ -1,38 +1,4 @@
-from __future__ import annotations
-import torch
-
-from comfy.patcher_extension import WrappersMP, WrapperExecutor
-from typing import TYPE_CHECKING, Callable, Optional
-if TYPE_CHECKING:
-    from comfy.model_patcher import ModelPatcher
-
-
-COMPILE_KEY = "torch.compile"
-
-
-def apply_torch_compile_factory(compiled_diffusion_model: Callable) -> Callable:
-    def apply_torch_compile_wrapper(executor: WrapperExecutor, *args, **kwargs):
-        try:
-            orig_diffusion_model = executor.class_obj.diffusion_model
-            executor.class_obj.diffusion_model = compiled_diffusion_model
-            return executor(*args, **kwargs)
-        finally:
-            executor.class_obj.diffusion_model = orig_diffusion_model
-    return apply_torch_compile_wrapper
-
-
-def set_torch_compile_wrapper(model: ModelPatcher, backend: str, options: Optional[dict[str,str]]=None, *args, **kwargs):
-    # clear out any other torch.compile wrappers
-    model.remove_wrappers_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY)
-    # add torch.compile wrapper
-    wrapper_func = apply_torch_compile_factory(
-        torch.compile(
-                model=model.get_model_object("diffusion_model"),
-                backend=backend,
-                options=options,
-            ),
-        )
-    model.add_wrapper_with_key(WrappersMP.APPLY_MODEL, COMPILE_KEY, wrapper_func)
+from comfy_api.torch_helpers import set_torch_compile_wrapper
 
 
 class TorchCompileModel:


### PR DESCRIPTION
Originally, torch.compile was implemented as an object_patch because there was no other built-in way to deal with changing an internal object to another without monkey patching.

However, this means the entirety of diffusion_model is changed to the OptimizedModel class as soon as the model begins to load, even before any weight patches are applied. The actual 'diffusion_model' is stored on the OptimizedModel's ._orig_mod parameter. So, anything relating to keys no longer applies, whether it be loras, hooks, or a simple get attr call.

This PR replaces the object_patch usage with a built-in wrapper that got added late last year as part of the hooks PR. It replaces diffusion_model with the torch.compile'd OptimizedModel object only when it gets to BaseModel.apply_model function, and replaces it with the original diffusion_model as soon as it leaves, for every step of sampling. This is only a reference swap so has basically no cost, and this is about as deep in the sampling code the existing wrappers allow for (meaning very little should be broken now by torch.compile).

The OptimizedModel object gets reused from the torch.compile call same as before.