### PR TITLE
Remove blocking call from timestep embedding of Chroma

### DIFF
--- a/comfy/ldm/chroma/model.py
+++ b/comfy/ldm/chroma/model.py
@@ -163,7 +163,7 @@ class Chroma(nn.Module):
         distil_guidance = timestep_embedding(guidance.detach().clone(), 16).to(img.device, img.dtype)
 
         # get all modulation index
-        modulation_index = timestep_embedding(torch.arange(mod_index_length), 32).to(img.device, img.dtype)
+        modulation_index = timestep_embedding(torch.arange(mod_index_length, device=img.device), 32).to(img.device, img.dtype)
         # we need to broadcast the modulation index here so each batch has all of the index
         modulation_index = modulation_index.unsqueeze(0).repeat(img.shape[0], 1, 1).to(img.device, img.dtype)
         # and we need to broadcast timestep and guidance along too


### PR DESCRIPTION
This creates a tensor on device to avoid an unnecessary sync in the Chroma model forward pass. Part of a series of PRs I'm creating. Combined with #7152, another PR to make a CPU copy of sampler sigmas for use in control flow (since control flow needs these as python scalars to work), and optionally code to support computing latent previews/transferring them to CPU on a separate CUDA stream as I did [here](https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/2844) for webui forge (may be more complicated since comfyui doesn't seem to process previews in a separate thread from the main one), I am seeing a roughly 7% overall speed boost.