### PR TITLE
Option to run live preview in a CUDA stream for better performance.

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -100,6 +100,8 @@ parser.add_argument("--preview-method", type=LatentPreviewMethod, default=Latent
 
 parser.add_argument("--preview-size", type=int, default=512, help="Sets the maximum preview size for sampler nodes.")
 
+parser.add_argument("--preview-stream", action="store_true", help="Use a CUDA Stream to reduce performance cost of previews.")
+
 cache_group = parser.add_mutually_exclusive_group()
 cache_group.add_argument("--cache-classic", action="store_true", help="Use the old style (aggressive) caching.")
 cache_group.add_argument("--cache-lru", type=int, default=0, help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.")

--- a/latent_preview.py
+++ b/latent_preview.py
@@ -6,18 +6,29 @@ import comfy.model_management
 import folder_paths
 import comfy.utils
 import logging
+from contextlib import nullcontext
+import threading
 
 MAX_PREVIEW_RESOLUTION = args.preview_size
 
-def preview_to_image(latent_image):
-        latents_ubyte = (((latent_image + 1.0) / 2.0).clamp(0, 1)  # change scale from -1..1 to 0..1
-                            .mul(0xFF)  # to 0..255
-                            )
-        if comfy.model_management.directml_enabled:
-                latents_ubyte = latents_ubyte.to(dtype=torch.uint8)
-        latents_ubyte = latents_ubyte.to(device="cpu", dtype=torch.uint8, non_blocking=comfy.model_management.device_supports_non_blocking(latent_image.device))
+if args.preview_stream:
+    preview_stream = torch.cuda.Stream()
+    preview_context = torch.cuda.stream(preview_stream)
+else:
+    preview_context = nullcontext()
 
-        return Image.fromarray(latents_ubyte.numpy())
+def preview_to_image(preview_image: torch.Tensor):
+        # no reason why any of this has to happen on GPU, also non-blocking transfers to cpu aren't safe ever
+        # but we don't care about it blocking because the main stream is fine
+        preview_image = preview_image.cpu()
+
+        preview_image.add_(1.0)
+        preview_image.div_(2.0)
+        preview_image.clamp_(0, 1) # change scale from -1..1 to 0..1 and clamp
+        preview_image.mul_(255.) # change to uint8 range
+        preview_image.round_() # default behavior when casting is truncate which is wrong for image processing
+
+        return Image.fromarray(preview_image.to(dtype=torch.uint8).numpy())
 
 class LatentPreviewer:
     def decode_latent_to_preview(self, x0):
@@ -97,12 +108,23 @@ def prepare_callback(model, steps, x0_output_dict=None):
 
     pbar = comfy.utils.ProgressBar(steps)
     def callback(step, x0, x, total_steps):
-        if x0_output_dict is not None:
-            x0_output_dict["x0"] = x0
+        @torch.inference_mode
+        def worker():
+            if x0_output_dict is not None:
+                x0_output_dict["x0"] = x0
 
-        preview_bytes = None
-        if previewer:
-            preview_bytes = previewer.decode_latent_to_preview_image(preview_format, x0)
-        pbar.update_absolute(step + 1, total_steps, preview_bytes)
+            preview_bytes = None
+            if previewer:
+                with preview_context:
+                    preview_bytes = previewer.decode_latent_to_preview_image(preview_format, x0)
+            pbar.update_absolute(step + 1, total_steps, preview_bytes)
+
+        if args.preview_stream:
+            # must wait for default stream to catch up else we will decode a garbage tensor
+            # the default stream will not, under any circumstances, stop because of this
+            preview_stream.wait_stream(torch.cuda.default_stream())
+            threading.Thread(target=worker, daemon=True).start()
+        else: worker() # no point in threading this off if there's no separate stream
+        
     return callback
 


### PR DESCRIPTION
This adds a new CLI flag, --preview-stream, which will attempt to use a CUDA stream to run whatever live preview method is in use and to handle transfer of the preview image back to the host. Running the preview model in parallel helps slightly with covering up tail effects and gaps between kernel executions on the main thread, but the main advantage is that this is actually the only safe way to transfer tensors from device to host asynchronously, which you will want to do for live previews. With this enabled on a device that can support it, live previews have basically no noticeable performance impact.

I did correct a minor oversight in the preview_to_image function in that it was not rounding before casting to uint8, default pytorch behavior is to truncate floats which effectively makes everything half a shade darker than it should be, and notably you'll almost never see 255 show up. The correct thing to do for image processing is to round to the nearest int. But that's fixed now. Other than that nothing happens differently unless you enable the flag.

If the flag is enabled, the live preview update is done on a daemon thread, because we do need a separate thread to actually carry on with the default stream's execution after we move the tensor. Probably not the most clean way to do it but I have tested it and it does work. To avoid issues I don't spawn a thread for it if we're not trying to use a cudastream.

Nsight systems report for before (it's on a separate stream here but not on its own thread so it doesn't make a difference yet, and this is also with other things to remove blocking calls that I have not yet finished and PR'd):
![image](https://github.com/user-attachments/assets/16b55278-6d39-492c-b65a-fcff5934d69c)

After breaking it off into a thread. Note that the memcpy is no longer able to block the main thread. Areas where both streams overlap have more consistent 100% GPU utilization.
![image](https://github.com/user-attachments/assets/be990f0f-aeb0-4e07-9c94-a4427178f64f)
