### PR TITLE
add fetch node

### DIFF
--- a/comfy_extras/nodes_api.py
+++ b/comfy_extras/nodes_api.py
@@ -1,0 +1,33 @@
+from comfy.comfy_types import IO, ComfyNodeABC
+
+class FetchApi(ComfyNodeABC):
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {
+            "type": (IO.COMBO, {"options": ["input", "output"]}),
+            "subfolder": (IO.STRING, {}),
+            "filename": (IO.STRING, {}),
+            "auto_download": (IO.BOOLEAN, {}),
+        }}
+
+    FUNCTION = "process"
+    OUTPUT_NODE = True
+
+    RETURN_TYPES = ()
+
+    CATEGORY = "utils/api"
+
+    def process(self, type, subfolder, filename, auto_download, **kwargs):
+        return {
+            "ui": {
+                "result": [type, subfolder, filename]
+            }
+        }
+
+NODE_CLASS_MAPPINGS = {
+    "FetchApi": FetchApi
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "FetchApi": "Fetch"
+}

--- a/nodes.py
+++ b/nodes.py
@@ -2257,6 +2257,7 @@ def init_builtin_extra_nodes():
         "nodes_ace.py",
         "nodes_string.py",
         "nodes_camera_trajectory.py",
+        "nodes_api.py",
     ]
 
     import_failed = []


### PR DESCRIPTION
BE change for https://github.com/Comfy-Org/ComfyUI_frontend/pull/3976
Add one fetch node. Why do we need this node?
In certain situations, such as in cloud environments (RunningHub, ComfyDeploy, etc.), users cannot directly access the local disk. For some nodes, like the upcoming Tripo convert node which only provides functionality to save to local storage, in these cases we need to provide a way for users to download these files through ComfyUI's built-in fetch API.
Screenshot is
![image](https://github.com/user-attachments/assets/b44783a9-60f0-4e12-91ac-f3699e5adc79)