### PR TITLE
Fix custom node blocker for multi-GPU inference using multi-processing

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,9 +8,11 @@ import time
 from comfy.cli_args import args
 from app.logger import setup_logger
 import itertools
-import utils.extra_config
 import logging
 import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+import utils.extra_config
 
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI, they are for custom nodes.


### PR DESCRIPTION
**Why these changes are needed**
--
We have created a set of custom ComfyUI nodes around [FastVideo](https://github.com/hao-ai-lab/FastVideo), a framework for multi-GPU video generation using sequence parallelism.

This fixes `import` failures that were occurring when child processes attempted to import modules, since spawned processes get their own Python interpreter and don't inherit the same import context as the parent process.

Custom Node: [https://github.com/kevin314/ComfyUI-FastVideo](https://github.com/kevin314/ComfyUI-FastVideo)

**Changes**
--
Adds the directory containing main.py to Python's module search path to ensure spawned processes from multiprocessing can correctly find and import local modules. 

We don't want to have users install a comfyui fork so would like to upstream this fix

Thanks

