### PR TITLE
feat(server): add happen_at to event

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import asyncio
 import traceback
 
@@ -819,6 +820,8 @@ class PromptServer():
             await send_socket_catch_exception(self.sockets[sid].send_json, message)
 
     def send_sync(self, event, data, sid=None):
+        if isinstance(data, dict):
+            data["happen_at"] = time.time()
         self.loop.call_soon_threadsafe(
             self.messages.put_nowait, (event, data, sid))
 


### PR DESCRIPTION
Using call_soon_threadsafe in send_sync may cause a discrepancy between the time the client receives the message and the actual time the event occurred.

We add the sending timestamp so that
clients with such needs can be aware of when the event actually occurred.