### PR TITLE
Allow optionally specifying a prompt id in `/interrupt` endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -685,7 +685,14 @@ class PromptServer():
 
         @routes.post("/interrupt")
         async def post_interrupt(request):
-            nodes.interrupt_processing()
+            json_data = await request.json()
+            if "id" in json_data:
+                current_queue = self.prompt_queue.get_current_queue_volatile()
+                queue_running = current_queue[0]
+                if len(queue_running) > 0 and queue_running[0][1] == json_data["id"]:
+                    nodes.interrupt_processing()
+            else:
+                nodes.interrupt_processing()
             return web.Response(status=200)
 
         @routes.post("/free")

--- a/server.py
+++ b/server.py
@@ -692,6 +692,8 @@ class PromptServer():
                     queue_running = current_queue[0]
                     if len(queue_running) > 0 and queue_running[0][1] == json_data["id"]:
                         nodes.interrupt_processing()
+                else:
+                    nodes.interrupt_processing()
             else:
                 nodes.interrupt_processing()
             return web.Response(status=200)

--- a/server.py
+++ b/server.py
@@ -685,12 +685,13 @@ class PromptServer():
 
         @routes.post("/interrupt")
         async def post_interrupt(request):
-            json_data = await request.json()
-            if "id" in json_data:
-                current_queue = self.prompt_queue.get_current_queue_volatile()
-                queue_running = current_queue[0]
-                if len(queue_running) > 0 and queue_running[0][1] == json_data["id"]:
-                    nodes.interrupt_processing()
+            if request.can_read_body:
+                json_data = await request.json()
+                if "id" in json_data:
+                    current_queue = self.prompt_queue.get_current_queue_volatile()
+                    queue_running = current_queue[0]
+                    if len(queue_running) > 0 and queue_running[0][1] == json_data["id"]:
+                        nodes.interrupt_processing()
             else:
                 nodes.interrupt_processing()
             return web.Response(status=200)


### PR DESCRIPTION
I'm using ComfyUI via the API for a task, and I found that sometimes I need to cancel/interrupt a running task. So I fetch the data from `/queue`, but the problem is this data is immediately stale, so a call to `/interrupt` could cancel the wrong task.

Ideally I'd be able to use the `prompt_id` of the running item that I got from `/queue`, to ensure that I don't accidentally cancel the *next* item in the case where the running task *just* finished the moment after I got the `/queue` data.

Please feel free to close this issue if there's a better approach - I don't know much about ComfyUI internals, and so have made this pull request more as a "sketch" of what I'm talking about, than any sort of implicit claim that I think this is a good way to solve this race condition issue.