### PR TITLE
Update .gitignore for those who use pyenv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ web_custom_versions/
 openapi.yaml
 filtered-openapi.yaml
 uv.lock
+.python-version


### PR DESCRIPTION
That's all.
Because of requirements, ComfyUI supports max Python 3.12.