### PR TITLE
fix: custom comfy-api-base works with subpath

### DIFF
--- a/comfy_api_nodes/apis/client.py
+++ b/comfy_api_nodes/apis/client.py
@@ -327,7 +327,9 @@ class ApiClient:
             ApiServerError: If the API server is unreachable but internet is working
             Exception: For other request failures
         """
-        url = urljoin(self.base_url, path)
+        # Use urljoin but ensure path is relative to avoid absolute path behavior
+        relative_path = path.lstrip('/')
+        url = urljoin(self.base_url, relative_path)
         self.check_auth(self.auth_token, self.comfy_api_key)
         # Combine default headers with any provided headers
         request_headers = self.get_headers()


### PR DESCRIPTION
## Fix URL joining issue in API client causing incorrect endpoint paths

### Problem
When using API endpoints with paths starting with `/`, the `urljoin` function was incorrectly treating them as absolute paths, causing the base URL path to be stripped out.

**Example:**
- Base URL: `https://api.comfydeploy.com/api/comfy-org/`
- Path: `/proxy/stability/v2beta/stable-image/generate/ultra`
- **Before:** `https://api.comfydeploy.com/proxy/stability/v2beta/stable-image/generate/ultra` ❌
- **After:** `https://api.comfydeploy.com/api/comfy-org/proxy/stability/v2beta/stable-image/generate/ultra` ✅

### Root Cause
Python's `urljoin()` follows RFC 3986 standards where paths starting with `/` are treated as absolute paths, replacing the entire path portion of the base URL instead of appending to it.

### Solution
Modified the `ApiClient.request()` method to strip leading slashes from paths before passing them to `urljoin`, ensuring all paths are treated as relative.

```python
# Before
url = urljoin(self.base_url, path)

# After  
relative_path = path.lstrip('/')
url = urljoin(self.base_url, relative_path)
```

### Impact
- ✅ Fixes API endpoint URL construction for paths starting with `/`
- ✅ Maintains backward compatibility with existing relative paths
- ✅ Preserves `urljoin` functionality for proper URL handling
- ✅ No breaking changes to existing API integrations

### Files Changed
- `comfy_api_nodes/apis/client.py`

---
