### PR TITLE
Bump template to 0.1.23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.20.7
-comfyui-workflow-templates==0.1.22
+comfyui-workflow-templates==0.1.23
 torch
 torchsde
 torchvision


### PR DESCRIPTION
This PR is to correct some settings in the previous VACE template according to the user report #8345 

- Update the note in the workflows to ensure that users know the CausVid LoRA can be disabled.
- Correct the settings in the `WanVaceToVideo` node to ensure that the `reference_image` can work properly.
- Update the `strength_model` in the LoRA loader for different templates.