### PR TITLE
Improve logic for concatenate node + add wildcard node

### DIFF
--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -1,4 +1,5 @@
 import re
+import random
 
 from comfy.comfy_types.node_typing import IO
 
@@ -16,9 +17,12 @@ class StringConcatenate():
     RETURN_TYPES = (IO.STRING,)
     FUNCTION = "execute"
     CATEGORY = "utils/string"
-
+    
     def execute(self, string_a, string_b, delimiter, **kwargs):
-        return delimiter.join((string_a, string_b)),
+        all_strings = [value for key, value in locals().items() if key.startswith("string_")]
+        non_empty = [s for s in all_strings if s]
+        result = delimiter.join(non_empty)
+        return result,
 
 class StringSubstring():
     @classmethod
@@ -331,6 +335,32 @@ class RegexReplace():
         result = re.sub(regex_pattern, replace, string, count=count, flags=flags)
         return result,
 
+class Wildcard():
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "text": (IO.STRING, {"multiline": True}),
+                "seed": (IO.INT, {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "use_newline_as_separator": (IO.BOOLEAN, {"default": True}),
+                "separator_if_not_newline": (IO.STRING, {"multiline": False, "default": " "})
+                }
+            }
+
+    RETURN_TYPES = (IO.STRING,)
+    FUNCTION = "execute"
+    CATEGORY = "utils/string"
+
+    def execute(self, text, seed, use_newline_as_separator, separator_if_not_newline, **kwargs):
+        if use_newline_as_separator:
+            wildcard = text.splitlines()
+        else:
+            wildcard = text.split(separator_if_not_newline)
+
+        random.seed(seed)
+        i = random.randint(0, (len(wildcard)-1))
+        return (wildcard[i]),
+
 NODE_CLASS_MAPPINGS = {
     "StringConcatenate": StringConcatenate,
     "StringSubstring": StringSubstring,
@@ -343,6 +373,7 @@ NODE_CLASS_MAPPINGS = {
     "RegexMatch": RegexMatch,
     "RegexExtract": RegexExtract,
     "RegexReplace": RegexReplace,
+    "Wildcard": Wildcard,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -357,4 +388,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "RegexMatch": "Regex Match",
     "RegexExtract": "Regex Extract",
     "RegexReplace": "Regex Replace",
+    "Wildcard": "Wildcard",
 }


### PR DESCRIPTION
One thing I severely overlooked with implementing the current logic for the delimiter is that it still applies if either string_a or string_b are null. This logic effectively fixes that, and also enables great flexibility.
![2025-05-31_17-36](https://github.com/user-attachments/assets/829db661-f15d-430a-aee0-fd84ccf770e3)

Secondly, I would like to introduce the Wildcard node, also to be added as a string node. It is not really based on any current custom node implementations for Comfy, rather it is meant to be much simpler in practice. The rudimentary idea of it is simple: take a string, turn it into a list based on a given separator (by default we just use newline), and randomly select an index.
![2025-05-31_17-44](https://github.com/user-attachments/assets/3452158e-d6d8-4833-9e09-0cf9e97f2aaa)

This of course, is not meant to be the "best" implementation but it is a very simple implementation, and just gives a straight string output, making it useful for prompts and such. Could possibly be made more useful if a Load String node were to exist or if a Load String node from a custom node suite is used as the text input for the Wildcard node.
