### PR TITLE
Update fix for potential XSS on /view

### DIFF
--- a/server.py
+++ b/server.py
@@ -477,7 +477,7 @@ class PromptServer():
                         content_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
 
                         # For security, force certain mimetypes to download instead of display
-                        if or content_type in {'text/html', 'text/html-sandboxed', 'application/xhtml+xml', 'text/javascript', 'text/css'}:
+                        if content_type in {'text/html', 'text/html-sandboxed', 'application/xhtml+xml', 'text/javascript', 'text/css'}:
                             content_type = 'application/octet-stream'  # Forces download
 
                         return web.FileResponse(


### PR DESCRIPTION
This PR is an extension of #6035. This PR uses mimetypes to add more restricted filetypes to prevent from being served, since mimetypes are what browsers use to determine how to serve files. It also adds XHTML documents to the list of restricted filetypes.

### Reproduction steps

1. Create an XHTML file titled `test.xhtml` in the `ComfyUI/output` folder with the following contents:
```html
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
    <head>
        <meta charset="utf-8" />
        <meta name="viewport" content="width=device-width" />
        <title>Test XHTML document</title>
    </head>
    <body>
        <p>Test XHTML document.</p>
    </body>
    <script>
        alert("Hello, world!");
    </script>
</html>
```
3. Run ComfyUI
4. Navigate to `http://localhost:8188/api/view?filename=test.xhtml&type=output&subfolder=` in any web browser
5. The page is loaded in the current main branch of ComfyUI, while in the patched version, it is downloaded instead.

### Note
As per #6035, you must clear your browser cache whenever you are switching between ComfyUI instances while testing this patch.