### PR TITLE
[feat] Add GetImageSize node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1831,7 +1831,6 @@ class ImageInvert:
         s = 1.0 - image
         return (s,)
 
-
 class ImageBatch:
 
     @classmethod
@@ -2068,6 +2067,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ImageQuantize": "Image Quantize",
     "ImageSharpen": "Image Sharpen",
     "ImageScaleToTotalPixels": "Scale Image to Total Pixels",
+    "GetImageSize": "Get Image Size",
     # _for_testing
     "VAEDecodeTiled": "VAE Decode (Tiled)",
     "VAEEncodeTiled": "VAE Encode (Tiled)",

--- a/nodes.py
+++ b/nodes.py
@@ -1831,6 +1831,7 @@ class ImageInvert:
         s = 1.0 - image
         return (s,)
 
+
 class ImageBatch:
 
     @classmethod

--- a/tests-unit/comfy_extras_test/image_stitch_test.py
+++ b/tests-unit/comfy_extras_test/image_stitch_test.py
@@ -5,7 +5,10 @@ from unittest.mock import patch, MagicMock
 mock_nodes = MagicMock()
 mock_nodes.MAX_RESOLUTION = 16384
 
-with patch.dict('sys.modules', {'nodes': mock_nodes}):
+# Mock server module for PromptServer
+mock_server = MagicMock()
+
+with patch.dict('sys.modules', {'nodes': mock_nodes, 'server': mock_server}):
     from comfy_extras.nodes_images import ImageStitch
 
 


### PR DESCRIPTION
Simple node that returns width and height dimensions of input images. Displays dimensions on the node UI and provides width/height outputs for further processing.

![Selection_1462](https://github.com/user-attachments/assets/694056fc-89a7-47b8-a34a-d4216aef8a7f)

