### PR TITLE
[Fix] Replace call to deprecated pillow API `Image.ANTIALIAS`

### DIFF
--- a/server.py
+++ b/server.py
@@ -788,7 +788,7 @@ class PromptServer():
             if hasattr(Image, 'Resampling'):
                 resampling = Image.Resampling.BILINEAR
             else:
-                resampling = Image.ANTIALIAS
+                resampling = Image.Resampling.LANCZOS
 
             image = ImageOps.contain(image, (max_size, max_size), resampling)
         type_num = 1


### PR DESCRIPTION
ANTIALIAS was removed in Pillow 10.0.0