### PR TITLE
[refactor] remove version prefixes from Ideogram node categories

### DIFF
--- a/comfy_api_nodes/nodes_ideogram.py
+++ b/comfy_api_nodes/nodes_ideogram.py
@@ -324,7 +324,7 @@ class IdeogramV1(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "api_call"
-    CATEGORY = "api node/image/Ideogram/v1"
+    CATEGORY = "api node/image/Ideogram"
     DESCRIPTION = cleandoc(__doc__ or "")
     API_NODE = True
 
@@ -483,7 +483,7 @@ class IdeogramV2(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "api_call"
-    CATEGORY = "api node/image/Ideogram/v2"
+    CATEGORY = "api node/image/Ideogram"
     DESCRIPTION = cleandoc(__doc__ or "")
     API_NODE = True
 
@@ -649,7 +649,7 @@ class IdeogramV3(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "api_call"
-    CATEGORY = "api node/image/Ideogram/v3"
+    CATEGORY = "api node/image/Ideogram"
     DESCRIPTION = cleandoc(__doc__ or "")
     API_NODE = True
 


### PR DESCRIPTION
This is a request from Design.

Consolidates all Ideogram nodes (V1, V2, V3) under a single category 'api node/image/Ideogram' instead of useless single-item separate version-specific subcategories, simplifying node organization in the UI.