### PR TITLE
auto register web folder from pyproject

### DIFF
--- a/comfy_config/types.py
+++ b/comfy_config/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List, Optional
 
@@ -50,6 +50,7 @@ class ComfyConfig(BaseModel):
     icon: str = Field(default="", alias="Icon")
     models: List[Model] = Field(default_factory=list, alias="Models")
     includes: List[str] = Field(default_factory=list)
+    web: Optional[str] = None
 
 
 class License(BaseModel):
@@ -65,6 +66,18 @@ class ProjectConfig(BaseModel):
     dependencies: List[str] = Field(default_factory=list)
     license: License = Field(default_factory=License)
     urls: URLs = Field(default_factory=URLs)
+
+    @field_validator('license', mode='before')
+    @classmethod
+    def validate_license(cls, v):
+        if isinstance(v, str):
+            return License(text=v)
+        elif isinstance(v, dict):
+            return License(**v)
+        elif isinstance(v, License):
+            return v
+        else:
+            return License()
 
 
 class PyProjectConfig(BaseModel):

--- a/nodes.py
+++ b/nodes.py
@@ -38,6 +38,8 @@ import folder_paths
 import latent_preview
 import node_helpers
 
+from comfy_config import config_parser
+
 def before_node_execution():
     comfy.model_management.throw_exception_if_processing_interrupted()
 
@@ -2124,6 +2126,20 @@ def load_custom_node(module_path: str, ignore=set(), module_parent="custom_nodes
         module_spec.loader.exec_module(module)
 
         LOADED_MODULE_DIRS[module_name] = os.path.abspath(module_dir)
+
+        project_config = config_parser.extract_node_configuration(module_path)
+
+        web_dir_name = project_config.tool_comfy.web
+
+        if web_dir_name:
+            web_dir_path = os.path.join(module_path, web_dir_name)
+
+            if os.path.isdir(web_dir_path):
+                project_name = project_config.project.name
+
+                EXTENSION_WEB_DIRS[project_name] = web_dir_path
+
+                logging.info("Automatically register web folder {} for {}".format(web_dir_name, project_name))
 
         if hasattr(module, "WEB_DIRECTORY") and getattr(module, "WEB_DIRECTORY") is not None:
             web_dir = os.path.abspath(os.path.join(module_dir, getattr(module, "WEB_DIRECTORY")))

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ spandrel
 soundfile
 av>=14.2.0
 pydantic~=2.0
+pydantic-settings~=2.0


### PR DESCRIPTION
Two changes here:
1. improve the logic of parsing pyproject license, as tested, some custom nodes, for example, https://github.com/cubiq/ComfyUI_IPAdapter_plus/blob/a0f451a5113cf9becb0847b92884cb10cbdec0ef/pyproject.toml#L5 using `license = "GPL-3.0 license"` format which is not allowed previously (has validation error).
2. Automatically register web folder from pyproject if web="xx" configured in pyproject.toml, which is requested by @robinjhuang 

It should have cli PR here https://github.com/Comfy-Org/comfy-cli/pull/284 merged at the same time

Tested with https://github.com/Comfy-Org/ComfyUI-React-Extension-Template/pull/12

Additonally, why do we still need this web folder read from pyproject after we have the logic of `hasattr(module, "WEB_DIRECTORY")` below? 
From my understanding, the biggest benefit is that pyproject files can be used for ComfyRegister, and we can do additional security checks on these frontend files on the server side in the future.