### PR TITLE
Allow specifying any frontend semver suffixes

### DIFF
--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -230,7 +230,7 @@ comfyui-workflow-templates is not installed.
         Raises:
             argparse.ArgumentTypeError: If the version string is invalid.
         """
-        VERSION_PATTERN = r"^([a-zA-Z0-9][a-zA-Z0-9-]{0,38})/([a-zA-Z0-9_.-]+)@(v?\d+\.\d+\.\d+|latest)$"
+        VERSION_PATTERN = r"^([a-zA-Z0-9][a-zA-Z0-9-]{0,38})/([a-zA-Z0-9_.-]+)@(v?\d+\.\d+\.\d+[-._a-zA-Z0-9]*|latest)$"
         match_result = re.match(VERSION_PATTERN, value)
         if match_result is None:
             raise argparse.ArgumentTypeError(f"Invalid version string: {value}")


### PR DESCRIPTION
Allows frontend packages with standard semver suffixes (pre-release).

Has already been tested in the wild by users testing subgraph (by pulling the branch).