### PR TITLE
Fix Kontext aspect ratio only works as widget

### DIFF
--- a/comfy_api_nodes/nodes_bfl.py
+++ b/comfy_api_nodes/nodes_bfl.py
@@ -346,20 +346,6 @@ class FluxKontextProImageNode(ComfyNodeABC):
             },
         }
 
-    @classmethod
-    def VALIDATE_INPUTS(cls, aspect_ratio: str):
-        try:
-            validate_aspect_ratio(
-                aspect_ratio,
-                minimum_ratio=cls.MINIMUM_RATIO,
-                maximum_ratio=cls.MAXIMUM_RATIO,
-                minimum_ratio_str=cls.MINIMUM_RATIO_STR,
-                maximum_ratio_str=cls.MAXIMUM_RATIO_STR,
-            )
-        except Exception as e:
-            return str(e)
-        return True
-
     RETURN_TYPES = (IO.IMAGE,)
     DESCRIPTION = cleandoc(__doc__ or "")  # Handle potential None value
     FUNCTION = "api_call"
@@ -380,6 +366,13 @@ class FluxKontextProImageNode(ComfyNodeABC):
         unique_id: Union[str, None] = None,
         **kwargs,
     ):
+        aspect_ratio = validate_aspect_ratio(
+            aspect_ratio,
+            minimum_ratio=self.MINIMUM_RATIO,
+            maximum_ratio=self.MAXIMUM_RATIO,
+            minimum_ratio_str=self.MINIMUM_RATIO_STR,
+            maximum_ratio_str=self.MAXIMUM_RATIO_STR,
+        )
         if input_image is None:
             validate_string(prompt, strip_whitespace=False)
         operation = SynchronousOperation(
@@ -395,13 +388,7 @@ class FluxKontextProImageNode(ComfyNodeABC):
                 guidance=round(guidance, 1),
                 steps=steps,
                 seed=seed,
-                aspect_ratio=validate_aspect_ratio(
-                    aspect_ratio,
-                    minimum_ratio=self.MINIMUM_RATIO,
-                    maximum_ratio=self.MAXIMUM_RATIO,
-                    minimum_ratio_str=self.MINIMUM_RATIO_STR,
-                    maximum_ratio_str=self.MAXIMUM_RATIO_STR,
-                ),
+                aspect_ratio=aspect_ratio,
                 input_image=(
                     input_image
                     if input_image is None


### PR DESCRIPTION
Changes Kontext nodes to validate inputs during node execution rather than during validation of prompt. If the user wants to use a link for an input (rather than widget), `VALIDATE_INPUTS` will likely fail and raise an error since the value is not available yet (issue detailed here: https://github.com/comfyanonymous/ComfyUI/issues/7888).

Fixes https://github.com/comfyanonymous/ComfyUI/issues/8490, Fixes https://github.com/comfyanonymous/ComfyUI/issues/8488

### Testing after the change:

**Node works with `aspect_ratio` as a widget**:

![Selection_1506](https://github.com/user-attachments/assets/14ae0641-8b42-42af-8dbf-416e41ea9c4a)

**Node works with `aspect_ratio` as a linked input**:

![Selection_1505](https://github.com/user-attachments/assets/c8006750-e890-47ef-b1a3-4750858c3fec)

**Validation still works, just is deferred until execution**:

Fails on lower bound:

![Selection_1507](https://github.com/user-attachments/assets/3ead0744-9a0e-4a03-bf18-4ccc26377130)

Fails on upper bound:

![Selection_1508](https://github.com/user-attachments/assets/992b2fa4-f6e8-4853-90af-85a06cf7e7a2)

