### PR TITLE
allow extra settings from pyproject.toml

### DIFF
--- a/comfy_config/types.py
+++ b/comfy_config/types.py
@@ -90,4 +90,4 @@ class PyProjectSettings(BaseSettings):
 
     tool: dict = Field(default_factory=dict)
 
-    model_config = SettingsConfigDict()
+    model_config = SettingsConfigDict(extra='allow')


### PR DESCRIPTION
due to some custom nodes have their own settings in pyproject.toml, we need to allow them, otherwise https://github.com/comfyanonymous/ComfyUI/issues/8514#issuecomment-2970202184