### PR TITLE
Use proper python executable and paths

### DIFF
--- a/tests/inference/extra_model_paths.yaml
+++ b/tests/inference/extra_model_paths.yaml
@@ -1,4 +1,4 @@
 # Config for testing nodes
 testing:
-    custom_nodes: tests/inference/testing_nodes
+    custom_nodes: testing_nodes
 

--- a/tests/inference/test_execution.py
+++ b/tests/inference/test_execution.py
@@ -14,6 +14,10 @@ import urllib.request
 import urllib.parse
 import urllib.error
 from comfy_execution.graph_utils import GraphBuilder, Node
+import os
+import sys
+
+PYTHON_EXECUTABLE_PATH = os.path.realpath(sys.executable)
 
 class RunResult:
     def __init__(self, prompt_id: str):
@@ -125,7 +129,7 @@ class TestExecution:
     def _server(self, args_pytest, request):
         # Start server
         pargs = [
-            'python','main.py',
+            PYTHON_EXECUTABLE_PATH,'main.py',
             '--output-directory', args_pytest["output_dir"],
             '--listen', args_pytest["listen"],
             '--port', str(args_pytest["port"]),

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -14,6 +14,8 @@ import websocket #NOTE: websocket-client (https://github.com/websocket-client/we
 import uuid
 import urllib.request
 import urllib.parse
+import sys
+
 
 
 from comfy.samplers import KSampler
@@ -21,6 +23,7 @@ from comfy.samplers import KSampler
 """
 These tests generate and save images through a range of parameters
 """
+PYTHON_EXECUTABLE_PATH = os.path.realpath(sys.executable)
 
 class ComfyGraph:
     def __init__(self,
@@ -152,7 +155,7 @@ class TestInference:
     def _server(self, args_pytest):
         # Start server
         p = subprocess.Popen([
-                'python','main.py',
+                PYTHON_EXECUTABLE_PATH,'main.py',
                 '--output-directory', args_pytest["output_dir"],
                 '--listen', args_pytest["listen"],
                 '--port', str(args_pytest["port"]),


### PR DESCRIPTION
When running tests with pytest:

```
pytest tests/inference
```

The test runner was just using "python" which works for when the system python is the thing running the tests. It doesn't work if the tests are run inside a virtualenv. Or if a different python was used.

This now uses the same python executable that the test files are running on, respecting virtualenvs, or alternate python installs.

It also fixes the paths in the `tests/inference/extra_model_paths.yaml` file to be properly mapped. The path should be relative to the extras file.