### PR TITLE
Add logic operation nodes

### DIFF
--- a/comfy_extras/nodes_logic_ops.py
+++ b/comfy_extras/nodes_logic_ops.py
@@ -1,0 +1,89 @@
+# Credit to pythongosssss for the AnyType code
+class AnyType(str):
+    def __ne__(self, __value: object) -> bool:
+        return False
+
+any = AnyType("*")
+
+class BooleanNOT:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("BOOLEAN", {"default": True})}}
+
+    RETURN_TYPES = ("BOOLEAN",)
+    RETURN_NAMES = ("NOT",)
+    CATEGORY = "utils/logic"
+    FUNCTION = "get_not"
+
+    def get_not(self, value: bool) -> tuple[bool]:
+        return (not value,)
+
+class BooleanLogicGate:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "value1": ("BOOLEAN", {"default": True}),
+                "value2": ("BOOLEAN", {"default": True}),
+                "mode": (["AND", "OR", "NAND", "NOR", "XOR", "XNOR"],)
+            }
+        }
+
+    RETURN_TYPES = ("BOOLEAN",)
+    RETURN_NAMES = ("output",)
+    CATEGORY = "utils/logic"
+    FUNCTION = "apply_operation"
+
+    _OPS = {
+        "AND":  lambda a, b: a and b,
+        "OR":   lambda a, b: a or b,
+        "NAND": lambda a, b: not (a and b),
+        "NOR":  lambda a, b: not (a or b),
+        "XOR":  lambda a, b: a ^ b,
+        "XNOR": lambda a, b: not (a ^ b),
+    }
+
+    def apply_operation(self, value1: bool, value2: bool, mode: str) -> tuple[bool]:
+        return (self._OPS[mode](value1, value2),)
+
+class BooleanSwitch:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"switch": ("BOOLEAN", {"default": True})},
+            "optional": {"on_true": (any,), "on_false": (any,)}
+        }
+
+    RETURN_TYPES = ("ANY",)
+    RETURN_NAMES = ("*",)
+    CATEGORY = "utils/logic"
+    FUNCTION = "switch"
+
+    def switch(self, switch: bool, on_true=None, on_false=None) -> tuple:
+        return ((on_true if switch else on_false),)
+
+class OutputExists:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"optional": {"variable": (any,)}}
+
+    RETURN_TYPES = ("BOOLEAN",)
+    CATEGORY = "utils/logic"
+    FUNCTION = "test_existence"
+
+    def test_existence(self, variable=None) -> tuple[bool]:
+        return (variable is not None,)
+
+NODE_CLASS_MAPPINGS = {
+    "BooleanNOT": BooleanNOT,
+    "BooleanLogicGate": BooleanLogicGate,
+    "BooleanSwitch": BooleanSwitch,
+    "OutputExists": OutputExists,
+    }
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "BooleanNOT": "Boolean NOT",
+    "BooleanLogicGate": "Boolean Logic Gate",
+    "BooleanSwitch": "Boolean Switch",
+    "OutputExists": "Output Exists",
+    }

--- a/comfy_extras/nodes_logic_ops.py
+++ b/comfy_extras/nodes_logic_ops.py
@@ -12,17 +12,15 @@ class BooleanLogicGate:
             "required": {
                 "value1": ("BOOLEAN", {"default": True}),
                 "value2": ("BOOLEAN", {"default": True}),
-                "mode": (["NOT", "AND", "OR", "NAND", "NOR", "XOR", "XNOR"],)
+                "mode": (["AND", "OR", "NAND", "NOR", "XOR", "XNOR"],)
             }
         }
 
     RETURN_TYPES = ("BOOLEAN",)
-    RETURN_NAMES = ("output",)
     CATEGORY = "utils/logic"
     FUNCTION = "apply_operation"
 
     _OPS = {
-        "NOT":  lambda a, b: not a,
         "AND":  lambda a, b: a and b,
         "OR":   lambda a, b: a or b,
         "NAND": lambda a, b: not (a and b),
@@ -46,7 +44,6 @@ class CompareValues:
             }
 
     RETURN_TYPES = ("BOOLEAN",)
-    RETURN_NAMES = ("output",)
     CATEGORY = "utils/logic"
     FUNCTION = "compare"
 
@@ -69,21 +66,6 @@ class CompareValues:
 
         return (self._OPS[mode](valueA, valueB),)
 
-class BooleanSwitch:
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {"switch": ("BOOLEAN", {"default": True})},
-            "optional": {"on_true": (any,), "on_false": (any,)}
-        }
-
-    RETURN_TYPES = (any,)
-    CATEGORY = "utils/logic"
-    FUNCTION = "switch"
-
-    def switch(self, switch: bool, on_true=None, on_false=None) -> tuple:
-        return ((on_true if switch else on_false),)
-
 class OutputExists:
     @classmethod
     def INPUT_TYPES(cls):
@@ -99,13 +81,11 @@ class OutputExists:
 NODE_CLASS_MAPPINGS = {
     "BooleanLogicGate": BooleanLogicGate,
     "CompareValues": CompareValues,
-    "BooleanSwitch": BooleanSwitch,
     "OutputExists": OutputExists,
     }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "BooleanLogicGate": "Boolean Logic Gate",
     "CompareValues": "Compare Values",
-    "BooleanSwitch": "Boolean Switch",
     "OutputExists": "Output Exists",
     }

--- a/comfy_extras/nodes_logic_ops.py
+++ b/comfy_extras/nodes_logic_ops.py
@@ -34,6 +34,41 @@ class BooleanLogicGate:
     def apply_operation(self, value1: bool, value2: bool, mode: str) -> tuple[bool]:
         return (self._OPS[mode](value1, value2),)
 
+class CompareValues:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "valueA": (any, ),
+                "valueB": (any, ),
+                "mode": (["A == B", "A != B", "A > b", "A >= b", "a < B", "a <= B"],)
+                }
+            }
+
+    RETURN_TYPES = ("BOOLEAN",)
+    RETURN_NAMES = ("output",)
+    CATEGORY = "utils/logic"
+    FUNCTION = "compare"
+
+    _OPS = {
+        "A == B": lambda a, b: a == b,
+        "A != B": lambda a, b: a != b,
+        "A > b":  lambda a, b: a > b,
+        "A >= b": lambda a, b: a >= b,
+        "a < B":  lambda a, b: a < b,
+        "a <= B": lambda a, b: a <= b,
+    }
+
+    def compare(self, valueA, valueB, mode: str) -> tuple[bool]:
+        if isinstance(valueA, str) and isinstance(valueB, (int, float)):
+            try: valueA = float(valueA)
+            except ValueError as e: raise ValueError("Failed to convert valueA to float.") from e
+        elif isinstance(valueB, str) and isinstance(valueA, (int, float)):
+            try: valueB = float(valueB)
+            except ValueError as e: raise ValueError("Failed to convert valueB to float.") from e
+
+        return (self._OPS[mode](valueA, valueB),)
+
 class BooleanSwitch:
     @classmethod
     def INPUT_TYPES(cls):
@@ -63,12 +98,14 @@ class OutputExists:
 
 NODE_CLASS_MAPPINGS = {
     "BooleanLogicGate": BooleanLogicGate,
+    "CompareValues": CompareValues,
     "BooleanSwitch": BooleanSwitch,
     "OutputExists": OutputExists,
     }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "BooleanLogicGate": "Boolean Logic Gate",
+    "CompareValues": "Compare Values",
     "BooleanSwitch": "Boolean Switch",
     "OutputExists": "Output Exists",
     }

--- a/comfy_extras/nodes_logic_ops.py
+++ b/comfy_extras/nodes_logic_ops.py
@@ -5,19 +5,6 @@ class AnyType(str):
 
 any = AnyType("*")
 
-class BooleanNOT:
-    @classmethod
-    def INPUT_TYPES(cls):
-        return {"required": {"value": ("BOOLEAN", {"default": True})}}
-
-    RETURN_TYPES = ("BOOLEAN",)
-    RETURN_NAMES = ("NOT",)
-    CATEGORY = "utils/logic"
-    FUNCTION = "get_not"
-
-    def get_not(self, value: bool) -> tuple[bool]:
-        return (not value,)
-
 class BooleanLogicGate:
     @classmethod
     def INPUT_TYPES(cls):
@@ -25,7 +12,7 @@ class BooleanLogicGate:
             "required": {
                 "value1": ("BOOLEAN", {"default": True}),
                 "value2": ("BOOLEAN", {"default": True}),
-                "mode": (["AND", "OR", "NAND", "NOR", "XOR", "XNOR"],)
+                "mode": (["NOT", "AND", "OR", "NAND", "NOR", "XOR", "XNOR"],)
             }
         }
 
@@ -35,6 +22,7 @@ class BooleanLogicGate:
     FUNCTION = "apply_operation"
 
     _OPS = {
+        "NOT":  lambda a, b: not a,
         "AND":  lambda a, b: a and b,
         "OR":   lambda a, b: a or b,
         "NAND": lambda a, b: not (a and b),
@@ -74,14 +62,12 @@ class OutputExists:
         return (variable is not None,)
 
 NODE_CLASS_MAPPINGS = {
-    "BooleanNOT": BooleanNOT,
     "BooleanLogicGate": BooleanLogicGate,
     "BooleanSwitch": BooleanSwitch,
     "OutputExists": OutputExists,
     }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "BooleanNOT": "Boolean NOT",
     "BooleanLogicGate": "Boolean Logic Gate",
     "BooleanSwitch": "Boolean Switch",
     "OutputExists": "Output Exists",

--- a/comfy_extras/nodes_logic_ops.py
+++ b/comfy_extras/nodes_logic_ops.py
@@ -54,8 +54,7 @@ class BooleanSwitch:
             "optional": {"on_true": (any,), "on_false": (any,)}
         }
 
-    RETURN_TYPES = ("ANY",)
-    RETURN_NAMES = ("*",)
+    RETURN_TYPES = (any,)
     CATEGORY = "utils/logic"
     FUNCTION = "switch"
 

--- a/nodes.py
+++ b/nodes.py
@@ -2278,6 +2278,7 @@ def init_builtin_extra_nodes():
         "nodes_preview_any.py",
         "nodes_ace.py",
         "nodes_string.py",
+        "nodes_logic_ops.py",
         "nodes_camera_trajectory.py",
     ]
 


### PR DESCRIPTION
This is a continuation of a now dormant PR draft, #8024. This is intended to be a more streamlined and simplified version, and currently I am only focused on adding three logic nodes involving booleans for the moment.

### Boolean Logic Gate
![2025-06-20_14-27](https://github.com/user-attachments/assets/573c89a3-678b-44bf-8f5b-400001cd5131)

In the original PR, these were all a bunch of nodes that were simply cumbersome to go through. This node effectively combines it into one node right here. We can select AND, OR, NAND, NOR, XOR, and XNOR, all the logic functions we could ask for.

(screenshot is currently inaccurate, NOT was added but then removed, it's behavior here at least can be replicated with NAND, will have to wait for V3 schema to be able to add it back)
### Compare Values
![Screenshot_20250625_005431](https://github.com/user-attachments/assets/04d6ae36-7ea8-4514-b45f-c4fbc2da449b)

Compares values of any types together. Completely agnostic to the input type, just tests based on the conditions the user gives. With strings, it will attempt to convert them to floats if one of the other values is a number.

### Output Exists
![2025-06-16_18-56_2](https://github.com/user-attachments/assets/882f05f2-72de-47ac-954d-2318e75de5c1)

And here is the most dead-simple, yet a node I would argue is quite helpful, the Output Exists node. Does an output from a node exist? Then it's true. If it doesn't? Then it's false, simple as that.