### PR TITLE
Alternative Skip Layer Guidance (SLG) node implementation

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -379,6 +379,9 @@ class ModelPatcher:
     def set_model_sampler_pre_cfg_function(self, pre_cfg_function, disable_cfg1_optimization=False):
         self.model_options = set_model_options_pre_cfg_function(self.model_options, pre_cfg_function, disable_cfg1_optimization)
 
+    def set_model_sampler_calc_cond_batch_function(self, sampler_calc_cond_batch_function):
+        self.model_options["sampler_calc_cond_batch_function"] = sampler_calc_cond_batch_function
+
     def set_model_unet_function_wrapper(self, unet_wrapper_function: UnetWrapperFunction):
         self.model_options["model_function_wrapper"] = unet_wrapper_function
 

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -373,7 +373,11 @@ def sampling_function(model, x, timestep, uncond, cond, cond_scale, model_option
         uncond_ = uncond
 
     conds = [cond, uncond_]
-    out = calc_cond_batch(model, conds, x, timestep, model_options)
+    if "sampler_calc_cond_batch_function" in model_options:
+        args = {"conds": conds, "input": x, "sigma": timestep, "model": model, "model_options": model_options}
+        out = model_options["sampler_calc_cond_batch_function"](args)
+    else:
+        out = calc_cond_batch(model, conds, x, timestep, model_options)
 
     for fn in model_options.get("sampler_pre_cfg_function", []):
         args = {"conds":conds, "conds_out": out, "cond_scale": cond_scale, "timestep": timestep,


### PR DESCRIPTION
This PR adds a version of skip layer guidance (SLG) that only runs two passes, instead of running an extra one (current master). This cuts down on some of the compute overhead[1].

It also matches the logic found in https://github.com/deepbeepmeep/Wan2GP/pull/61 and the results are closer to the outputs of [ComfyUI-WanVideoWrapper](https://github.com/kijai/ComfyUI-WanVideoWrapper) by @kijai 

I was playing around with this for a bit, and was getting better outputs when using it with Wan 2.1 than I was with the current `SkipLayerGuidanceDiT` node, though it works with other DiT models as well since the code is generic.

Here are some samples for comparison: ([imgsli link](https://imgsli.com/Mzk0MjY5/2/3))

![slg_comp](https://github.com/user-attachments/assets/1c00651c-dec6-4870-8cb3-52e2947e761c)

<details>

<summary>Workflow screenshots</summary>

No SLG
![no_slg](https://github.com/user-attachments/assets/85e4ae5b-2ccc-4dd0-9283-9bee9d7496f3)

Old SLG
![old_slg](https://github.com/user-attachments/assets/ba2c995d-a3fe-45e8-bf9c-a1850303f93e)

New SLG
![new_slg](https://github.com/user-attachments/assets/b1b7de98-b68f-4b76-9a87-abb0517827a2)

Kijai SLG
![kijai_slg](https://github.com/user-attachments/assets/56218506-73a0-4a7b-bd5a-2dc9e8242a20)

</details>


Speed figures for the L40 GPU I was testing on via runpod:

| slg mode | speed                          |
| -------- | ------------------------------ |
| None     | 20/20 [00:50<00:00,  2.53s/it] |
| Old      | 20/20 [01:16<00:00,  3.83s/it] |
| New      | 20/20 [00:51<00:00,  2.56s/it] |


---

**[1]** I had to add a way to replace `calc_cond_batch` to do this, because that's the only place where `cond`/`uncond` are clearly separated and `model_options` is exposed.

Other ideas I considered:
 - `pre_cfg_function` - can replace `uncond` here with a separate pass, but that still has the compute overhead - Could add a `force_cfg1_optimization` arg to model options that forces skipping uncond, but that could cause issues for other things using `pre_cfg_function` depending on the order.
 - `model_function_wrapper` applied [here](https://github.com/comfyanonymous/ComfyUI/blob/772de7c00653fc3a825762f555e836d071a4dc80/comfy/samplers.py#L323) - only exposes transformer options, would have to manually add skip block to only the uncond. Separating cond/uncond here is also messy if they're batched.
 - Inside the actual model where `blocks_replace` gets applied - replacement function doesn't have access to transformer_options / same issue with `cond`/`uncond` being batched
 - Custom guider - too much code duplication, annoying to refactor workflows around custom sampler just to use SLG.

I think it might be better to use a wrapper/hook but I haven't used that system enough to know whether it's possible or not. Tagging @Kosinkadink based on the PR for the original hooks update in case there's a better way, though I think this current version is relatively clean.