### PR TITLE
Update template to 0.1.32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.23.4
-comfyui-workflow-templates==0.1.31
+comfyui-workflow-templates==0.1.32
 comfyui-embedded-docs==0.2.3
 torch
 torchsde


### PR DESCRIPTION
- Fix wrong model links.
- Use the new model file links that allow users to directly download the models.

Solved https://github.com/comfyanonymous/ComfyUI/issues/8732

![image](https://github.com/user-attachments/assets/185d48d6-47fd-47cf-a203-1a8372d6a90e)
![image](https://github.com/user-attachments/assets/7e81a2c3-0346-4d57-987f-2d83036a1da0)

https://pypi.org/project/comfyui-workflow-templates/0.1.32/