### PR TITLE
[fix] increase Kling API polling timeout to prevent user timeouts

### DIFF
--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -132,6 +132,8 @@ def poll_until_finished(
         result_url_extractor=result_url_extractor,
         estimated_duration=estimated_duration,
         node_id=node_id,
+        poll_interval=16.0,
+        max_poll_attempts=256,
     ).execute()
 
 


### PR DESCRIPTION
Extends Kling API polling duration from 10 minutes to ~68 minutes by increasing polling attempts to 256 and interval to 16 seconds. This resolves frequent timeout issues users were experiencing with longer-running Kling operations.