### PR TITLE
Remove tokens from history items

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -1045,6 +1045,12 @@ class PromptQueue:
             if status is not None:
                 status_dict = copy.deepcopy(status._asdict())
 
+            # Remove auth tokens from extra_data before storing in history
+            if "auth_token_comfy_org" in prompt[3]:
+                del prompt[3]["auth_token_comfy_org"]
+            if "api_key_comfy_org" in prompt[3]:
+                del prompt[3]["api_key_comfy_org"]
+
             self.history[prompt[1]] = {
                 "prompt": prompt,
                 "outputs": {},


### PR DESCRIPTION
Remove `auth_token_comfy_org` and `api_key_comfy_org` from extra_data before storing prompt history, in case history items are ever persisted to disk in the future and to protect users with open network.