### PR TITLE
V3 update - Changed class cloning/locking, renames/typehint improvements

### DIFF
--- a/comfy_api/v3/io.py
+++ b/comfy_api/v3/io.py
@@ -1178,7 +1178,7 @@ class ComfyNodeV3:
             raise Exception(f"Invalid return type from node: {type(to_return)}")
 
     @classmethod
-    def prepare_class_clone(cls, hidden_inputs: dict) -> type[ComfyNodeV3]:
+    def PREPARE_CLASS_CLONE(cls, hidden_inputs: dict) -> type[ComfyNodeV3]:
         """Creates clone of real node class to prevent monkey-patching."""
         c_type: type[ComfyNodeV3] = cls if is_class(cls) else type(cls)
         type_clone: type[ComfyNodeV3] = shallow_clone_class(c_type)

--- a/comfy_extras/nodes_v3_test.py
+++ b/comfy_extras/nodes_v3_test.py
@@ -104,7 +104,10 @@ class V3TestNode(io.ComfyNodeV3):
             raise Exception("The 'cls' variable leaked instance state between runs!")
         if hasattr(cls, "doohickey"):
             raise Exception("The 'cls' variable leaked state on class properties between runs!")
-        cls.doohickey = "LOLJK"
+        try:
+            cls.doohickey = "LOLJK"
+        except AttributeError:
+            pass
         return io.NodeOutput(some_int, image, ui=ui.PreviewImage(image, cls=cls))
 
 

--- a/execution.py
+++ b/execution.py
@@ -229,12 +229,12 @@ def _map_node_over_list(obj, input_data_all, func, allow_interrupt=False, execut
                 if is_class(obj):
                     type_obj = obj
                     obj.VALIDATE_CLASS()
-                    class_clone = obj.prepare_class_clone(hidden_inputs)
+                    class_clone = obj.PREPARE_CLASS_CLONE(hidden_inputs)
                 # otherwise, use class instance to populate/reuse some fields
                 else:
                     type_obj = type(obj)
                     type_obj.VALIDATE_CLASS()
-                    class_clone = type_obj.prepare_class_clone(hidden_inputs)
+                    class_clone = type_obj.PREPARE_CLASS_CLONE(hidden_inputs)
                     # NOTE: this is a mock of state management; for local, just stores NodeStateLocal on node instance
                     if hasattr(obj, "local_state"):
                         if obj.local_state is None:


### PR DESCRIPTION
- Changed class cloning and locking to be less restrictive towards class references
- Renamed prepare_class_clone to PREPARE_CLASS_CLONE for usage consistency (internal only)
- Made a wrapper around execute so that the output received is always a NodeOutput
- Small typehint improvement by adding ComfyTypeI for types that only have Input but no Output class