### PR TITLE
Upate template to 0.1.36

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.23.4
-comfyui-workflow-templates==0.1.35
+comfyui-workflow-templates==0.1.36
 comfyui-embedded-docs==0.2.4
 torch
 torchsde


### PR DESCRIPTION
## Release Summary

https://pypi.org/project/comfyui-workflow-templates/0.1.36/

### Changes since v0.1.35:

**Template Updates & Fixes:**
- Fixed lotus template link issues (https://github.com/Comfy-Org/workflow_templates/pull/130)
- Updated model links across multiple templates (https://github.com/Comfy-Org/workflow_templates/pull/129)
- Updated image 2 image template (https://github.com/Comfy-Org/workflow_templates/pull/128)
- Replaced model links (https://github.com/Comfy-Org/workflow_templates/pull/127)
- Updated hunyuan 3d template links (https://github.com/Comfy-Org/workflow_templates/pull/126)
- Updated model links in the controlnet template (https://github.com/Comfy-Org/workflow_templates/pull/125)
- VACE  frame count issues (https://github.com/Comfy-Org/workflow_templates/pull/123)
- Correct the links in all VACE templates (https://github.com/Comfy-Org/workflow_templates/pull/121)