### PR TITLE
Fix MaskComposite error when destination has 2 dimensions

### DIFF
--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -247,7 +247,7 @@ class MaskComposite:
         visible_width, visible_height = (right - left, bottom - top,)
 
         source_portion = source[:, :visible_height, :visible_width]
-        destination_portion = destination[:, top:bottom, left:right]
+        destination_portion = output[:, top:bottom, left:right]
 
         if operation == "multiply":
             output[:, top:bottom, left:right] = destination_portion * source_portion


### PR DESCRIPTION
Fix code that is using the original `destination` input instead of the reshaped value.

If destination has 2 dimensions, then `MaskComposite` will throw

```
22:43:41.657 [Warning] [ComfyUI-0/STDERR]   File "G:\Apps\SwarmUI\dlbackend\comfy\ComfyUI\comfy_extras\nodes_mask.py", line 250, in combine
22:43:41.657 [Warning] [ComfyUI-0/STDERR]     destination_portion = destination[:, top:bottom, left:right]
22:43:41.658 [Warning] [ComfyUI-0/STDERR]                           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
22:43:41.659 [Warning] [ComfyUI-0/STDERR] IndexError: too many indices for tensor of dimension 2
22:43:41.660 [Warning] [ComfyUI-0/STDERR]
```

because, even though it reshapes the input, it accidentally uses the original input when computing the `destination_portion` to be affected by the operation.