### PR TITLE
[V3]: primitive nodes

### DIFF
--- a/comfy_extras/v3/nodes_audio.py
+++ b/comfy_extras/v3/nodes_audio.py
@@ -65,14 +65,14 @@ class EmptyLatentAudio_V3(io.ComfyNodeV3):
     def execute(cls, seconds, batch_size) -> io.NodeOutput:
         length = round((seconds * 44100 / 2048) / 2) * 2
         latent = torch.zeros([batch_size, 64, length], device=comfy.model_management.intermediate_device())
-        return io.NodeOutput({"samples":latent, "type": "audio"})
+        return io.NodeOutput({"samples": latent, "type": "audio"})
 
 
 class LoadAudio_V3(io.ComfyNodeV3):
     @classmethod
     def DEFINE_SCHEMA(cls):
         return io.SchemaV3(
-            node_id="LoadAudio_V3",         # frontend expects "LoadAudio" to work
+            node_id="LoadAudio_V3",  # frontend expects "LoadAudio" to work
             display_name="Load Audio _V3",  # frontend ignores "display_name" for this node
             category="audio",
             inputs=[
@@ -110,7 +110,7 @@ class PreviewAudio_V3(io.ComfyNodeV3):
     @classmethod
     def DEFINE_SCHEMA(cls):
         return io.SchemaV3(
-            node_id="PreviewAudio_V3",         # frontend expects "PreviewAudio" to work
+            node_id="PreviewAudio_V3",  # frontend expects "PreviewAudio" to work
             display_name="Preview Audio _V3",  # frontend ignores "display_name" for this node
             category="audio",
             inputs=[
@@ -129,7 +129,7 @@ class SaveAudioMP3_V3(io.ComfyNodeV3):
     @classmethod
     def DEFINE_SCHEMA(cls):
         return io.SchemaV3(
-            node_id="SaveAudioMP3_V3",           # frontend expects "SaveAudioMP3" to work
+            node_id="SaveAudioMP3_V3",  # frontend expects "SaveAudioMP3" to work
             display_name="Save Audio(MP3) _V3",  # frontend ignores "display_name" for this node
             category="audio",
             inputs=[
@@ -150,7 +150,7 @@ class SaveAudioOpus_V3(io.ComfyNodeV3):
     @classmethod
     def DEFINE_SCHEMA(cls):
         return io.SchemaV3(
-            node_id="SaveAudioOpus_V3",           # frontend expects "SaveAudioOpus" to work
+            node_id="SaveAudioOpus_V3",  # frontend expects "SaveAudioOpus" to work
             display_name="Save Audio(Opus) _V3",  # frontend ignores "display_name" for this node
             category="audio",
             inputs=[
@@ -171,7 +171,7 @@ class SaveAudio_V3(io.ComfyNodeV3):
     @classmethod
     def DEFINE_SCHEMA(cls):
         return io.SchemaV3(
-            node_id="SaveAudio_V3",         # frontend expects "SaveAudio" to work
+            node_id="SaveAudio_V3",  # frontend expects "SaveAudio" to work
             display_name="Save Audio _V3",  # frontend ignores "display_name" for this node
             category="audio",
             inputs=[
@@ -203,7 +203,7 @@ class VAEDecodeAudio_V3(io.ComfyNodeV3):
     @classmethod
     def execute(cls, vae, samples) -> io.NodeOutput:
         audio = vae.decode(samples["samples"]).movedim(-1, 1)
-        std = torch.std(audio, dim=[1,2], keepdim=True) * 5.0
+        std = torch.std(audio, dim=[1, 2], keepdim=True) * 5.0
         std[std < 1.0] = 1.0
         audio /= std
         return io.NodeOutput({"waveform": audio, "sample_rate": 44100})
@@ -250,7 +250,7 @@ def _save_audio(cls, audio, filename_prefix="ComfyUI", format="flac", quality="1
     OPUS_RATES = [8000, 12000, 16000, 24000, 48000]
 
     results = []
-    for (batch_number, waveform) in enumerate(audio["waveform"].cpu()):
+    for batch_number, waveform in enumerate(audio["waveform"].cpu()):
         filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
         file = f"{filename_with_batch_num}_{counter:05}_.{format}"
         output_path = os.path.join(full_output_folder, file)
@@ -277,7 +277,7 @@ def _save_audio(cls, audio, filename_prefix="ComfyUI", format="flac", quality="1
 
         # Create output with specified format
         output_buffer = BytesIO()
-        output_container = av.open(output_buffer, mode='w', format=format)
+        output_container = av.open(output_buffer, mode="w", format=format)
 
         # Set metadata on the container
         for key, value in metadata.items():
@@ -299,19 +299,19 @@ def _save_audio(cls, audio, filename_prefix="ComfyUI", format="flac", quality="1
         elif format == "mp3":
             out_stream = output_container.add_stream("libmp3lame", rate=sample_rate)
             if quality == "V0":
-                #TODO i would really love to support V3 and V5 but there doesn't seem to be a way to set the qscale level, the property below is a bool
+                # TODO i would really love to support V3 and V5 but there doesn't seem to be a way to set the qscale level, the property below is a bool
                 out_stream.codec_context.qscale = 1
             elif quality == "128k":
                 out_stream.bit_rate = 128000
             elif quality == "320k":
                 out_stream.bit_rate = 320000
-        else: # format == "flac":
+        else:  # format == "flac":
             out_stream = output_container.add_stream("flac", rate=sample_rate)
 
         frame = av.AudioFrame.from_ndarray(
             waveform.movedim(0, 1).reshape(1, -1).float().numpy(),
-            format='flt',
-            layout='mono' if waveform.shape[0] == 1 else 'stereo',
+            format="flt",
+            layout="mono" if waveform.shape[0] == 1 else "stereo",
         )
         frame.sample_rate = sample_rate
         frame.pts = 0
@@ -325,7 +325,7 @@ def _save_audio(cls, audio, filename_prefix="ComfyUI", format="flac", quality="1
 
         # Write the output to file
         output_buffer.seek(0)
-        with open(output_path, 'wb') as f:
+        with open(output_path, "wb") as f:
             f.write(output_buffer.getbuffer())
 
         results.append(ui.SavedResult(file, subfolder, io.FolderType.output))

--- a/comfy_extras/v3/nodes_controlnet.py
+++ b/comfy_extras/v3/nodes_controlnet.py
@@ -1,5 +1,5 @@
-from comfy.cldm.control_types import UNION_CONTROLNET_TYPES
 import comfy.utils
+from comfy.cldm.control_types import UNION_CONTROLNET_TYPES
 from comfy_api.v3 import io
 
 
@@ -27,11 +27,13 @@ class ControlNetApplyAdvanced_V3(io.ComfyNodeV3):
         )
 
     @classmethod
-    def execute(cls, positive, negative, control_net, image, strength, start_percent, end_percent, vae=None, extra_concat=[]) -> io.NodeOutput:
+    def execute(
+        cls, positive, negative, control_net, image, strength, start_percent, end_percent, vae=None, extra_concat=[]
+    ) -> io.NodeOutput:
         if strength == 0:
             return io.NodeOutput(positive, negative)
 
-        control_hint = image.movedim(-1,1)
+        control_hint = image.movedim(-1, 1)
         cnets = {}
 
         out = []
@@ -40,16 +42,18 @@ class ControlNetApplyAdvanced_V3(io.ComfyNodeV3):
             for t in conditioning:
                 d = t[1].copy()
 
-                prev_cnet = d.get('control', None)
+                prev_cnet = d.get("control", None)
                 if prev_cnet in cnets:
                     c_net = cnets[prev_cnet]
                 else:
-                    c_net = control_net.copy().set_cond_hint(control_hint, strength, (start_percent, end_percent), vae=vae, extra_concat=extra_concat)
+                    c_net = control_net.copy().set_cond_hint(
+                        control_hint, strength, (start_percent, end_percent), vae=vae, extra_concat=extra_concat
+                    )
                     c_net.set_previous_controlnet(prev_cnet)
                     cnets[prev_cnet] = c_net
 
-                d['control'] = c_net
-                d['control_apply_to_uncond'] = False
+                d["control"] = c_net
+                d["control_apply_to_uncond"] = False
                 n = [t[0], d]
                 c.append(n)
             out.append(c)
@@ -107,7 +111,9 @@ class ControlNetInpaintingAliMamaApply_V3(ControlNetApplyAdvanced_V3):
         )
 
     @classmethod
-    def execute(cls, positive, negative, control_net, vae, image, mask, strength, start_percent, end_percent) -> io.NodeOutput:
+    def execute(
+        cls, positive, negative, control_net, vae, image, mask, strength, start_percent, end_percent
+    ) -> io.NodeOutput:
         extra_concat = []
         if control_net.concat_mask:
             mask = 1.0 - mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1]))
@@ -115,7 +121,17 @@ class ControlNetInpaintingAliMamaApply_V3(ControlNetApplyAdvanced_V3):
             image = image * mask_apply.movedim(1, -1).repeat(1, 1, 1, image.shape[3])
             extra_concat = [mask]
 
-        return super().execute(positive, negative, control_net, image, strength, start_percent, end_percent, vae=vae, extra_concat=extra_concat)
+        return super().execute(
+            positive,
+            negative,
+            control_net,
+            image,
+            strength,
+            start_percent,
+            end_percent,
+            vae=vae,
+            extra_concat=extra_concat,
+        )
 
 
 NODES_LIST: list[type[io.ComfyNodeV3]] = [

--- a/comfy_extras/v3/nodes_primitive.py
+++ b/comfy_extras/v3/nodes_primitive.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+
+from comfy_api.v3 import io
+
+
+class String_V3(io.ComfyNodeV3):
+    @classmethod
+    def DEFINE_SCHEMA(cls):
+        return io.SchemaV3(
+            node_id="PrimitiveString_V3",
+            display_name="String _V3",
+            category="utils/primitive",
+            inputs=[
+                io.String.Input("value"),
+            ],
+            outputs=[io.String.Output()],
+        )
+
+    @classmethod
+    def execute(cls, value: str) -> io.NodeOutput:
+        return io.NodeOutput(value)
+
+
+class StringMultiline_V3(io.ComfyNodeV3):
+    @classmethod
+    def DEFINE_SCHEMA(cls):
+        return io.SchemaV3(
+            node_id="PrimitiveStringMultiline_V3",
+            display_name="String (Multiline) _V3",
+            category="utils/primitive",
+            inputs=[
+                io.String.Input("value", multiline=True),
+            ],
+            outputs=[io.String.Output()],
+        )
+
+    @classmethod
+    def execute(cls, value: str) -> io.NodeOutput:
+        return io.NodeOutput(value)
+
+
+class Int_V3(io.ComfyNodeV3):
+    @classmethod
+    def DEFINE_SCHEMA(cls):
+        return io.SchemaV3(
+            node_id="PrimitiveInt_V3",
+            display_name="Int _V3",
+            category="utils/primitive",
+            inputs=[
+                io.Int.Input("value", min=-sys.maxsize, max=sys.maxsize, control_after_generate=True),
+            ],
+            outputs=[io.Int.Output()],
+        )
+
+    @classmethod
+    def execute(cls, value: int) -> io.NodeOutput:
+        return io.NodeOutput(value)
+
+
+class Float_V3(io.ComfyNodeV3):
+    @classmethod
+    def DEFINE_SCHEMA(cls):
+        return io.SchemaV3(
+            node_id="PrimitiveFloat_V3",
+            display_name="Float _V3",
+            category="utils/primitive",
+            inputs=[
+                io.Float.Input("value", min=-sys.maxsize, max=sys.maxsize),
+            ],
+            outputs=[io.Float.Output()],
+        )
+
+    @classmethod
+    def execute(cls, value: float) -> io.NodeOutput:
+        return io.NodeOutput(value)
+
+
+class Boolean_V3(io.ComfyNodeV3):
+    @classmethod
+    def DEFINE_SCHEMA(cls):
+        return io.SchemaV3(
+            node_id="PrimitiveBoolean_V3",
+            display_name="Boolean _V3",
+            category="utils/primitive",
+            inputs=[
+                io.Boolean.Input("value"),
+            ],
+            outputs=[io.Boolean.Output()],
+        )
+
+    @classmethod
+    def execute(cls, value: bool) -> io.NodeOutput:
+        return io.NodeOutput(value)
+
+
+NODES_LIST: list[type[io.ComfyNodeV3]] = [
+    String_V3,
+    StringMultiline_V3,
+    Int_V3,
+    Float_V3,
+    Boolean_V3,
+]

--- a/comfy_extras/v3/nodes_stable_cascade.py
+++ b/comfy_extras/v3/nodes_stable_cascade.py
@@ -1,25 +1,25 @@
 """
-    This file is part of ComfyUI.
-    Copyright (C) 2024 Stability AI
+This file is part of ComfyUI.
+Copyright (C) 2024 Stability AI
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import torch
-import nodes
-import comfy.utils
 
+import comfy.utils
+import nodes
 from comfy_api.v3 import io
 
 
@@ -30,7 +30,7 @@ class StableCascade_EmptyLatentImage_V3(io.ComfyNodeV3):
             node_id="StableCascade_EmptyLatentImage_V3",
             category="latent/stable_cascade",
             inputs=[
-                io.Int.Input("width", default=1024,min=256,max=nodes.MAX_RESOLUTION, step=8),
+                io.Int.Input("width", default=1024, min=256, max=nodes.MAX_RESOLUTION, step=8),
                 io.Int.Input("height", default=1024, min=256, max=nodes.MAX_RESOLUTION, step=8),
                 io.Int.Input("compression", default=42, min=4, max=128, step=1),
                 io.Int.Input("batch_size", default=1, min=1, max=4096),
@@ -72,9 +72,9 @@ class StableCascade_StageC_VAEEncode_V3(io.ComfyNodeV3):
         out_width = (width // compression) * vae.downscale_ratio
         out_height = (height // compression) * vae.downscale_ratio
 
-        s = comfy.utils.common_upscale(image.movedim(-1,1), out_width, out_height, "bicubic", "center").movedim(1,-1)
+        s = comfy.utils.common_upscale(image.movedim(-1, 1), out_width, out_height, "bicubic", "center").movedim(1, -1)
 
-        c_latent = vae.encode(s[:,:,:,:3])
+        c_latent = vae.encode(s[:, :, :, :3])
         b_latent = torch.zeros([c_latent.shape[0], 4, (height // 8) * 2, (width // 8) * 2])
         return io.NodeOutput({"samples": c_latent}, {"samples": b_latent})
 
@@ -90,7 +90,7 @@ class StableCascade_StageB_Conditioning_V3(io.ComfyNodeV3):
                 io.Latent.Input("stage_c"),
             ],
             outputs=[
-              io.Conditioning.Output(),
+                io.Conditioning.Output(),
             ],
         )
 
@@ -99,7 +99,7 @@ class StableCascade_StageB_Conditioning_V3(io.ComfyNodeV3):
         c = []
         for t in conditioning:
             d = t[1].copy()
-            d['stable_cascade_prior'] = stage_c['samples']
+            d["stable_cascade_prior"] = stage_c["samples"]
             n = [t[0], d]
             c.append(n)
         return io.NodeOutput(c)
@@ -128,7 +128,7 @@ class StableCascade_SuperResolutionControlnet_V3(io.ComfyNodeV3):
         width = image.shape[-2]
         height = image.shape[-3]
         batch_size = image.shape[0]
-        controlnet_input = vae.encode(image[:,:,:,:3]).movedim(1, -1)
+        controlnet_input = vae.encode(image[:, :, :, :3]).movedim(1, -1)
 
         c_latent = torch.zeros([batch_size, 16, height // 16, width // 16])
         b_latent = torch.zeros([batch_size, 4, height // 2, width // 2])

--- a/comfy_extras/v3/nodes_webcam.py
+++ b/comfy_extras/v3/nodes_webcam.py
@@ -1,14 +1,13 @@
 import hashlib
-import torch
 
 import numpy as np
+import torch
 from PIL import Image, ImageOps, ImageSequence
 
-from comfy_api.v3 import io
-import nodes
 import folder_paths
 import node_helpers
-
+import nodes
+from comfy_api.v3 import io
 
 MAX_RESOLUTION = nodes.MAX_RESOLUTION
 
@@ -51,12 +50,12 @@ class WebcamCapture_V3(io.ComfyNodeV3):
         output_masks = []
         w, h = None, None
 
-        excluded_formats = ['MPO']
+        excluded_formats = ["MPO"]
 
         for i in ImageSequence.Iterator(img):
             i = node_helpers.pillow(ImageOps.exif_transpose, i)
 
-            if i.mode == 'I':
+            if i.mode == "I":
                 i = i.point(lambda i: i * (1 / 255))
             image = i.convert("RGB")
 
@@ -69,12 +68,12 @@ class WebcamCapture_V3(io.ComfyNodeV3):
 
             image = np.array(image).astype(np.float32) / 255.0
             image = torch.from_numpy(image)[None,]
-            if 'A' in i.getbands():
-                mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
-                mask = 1. - torch.from_numpy(mask)
-            elif i.mode == 'P' and 'transparency' in i.info:
-                mask = np.array(i.convert('RGBA').getchannel('A')).astype(np.float32) / 255.0
-                mask = 1. - torch.from_numpy(mask)
+            if "A" in i.getbands():
+                mask = np.array(i.getchannel("A")).astype(np.float32) / 255.0
+                mask = 1.0 - torch.from_numpy(mask)
+            elif i.mode == "P" and "transparency" in i.info:
+                mask = np.array(i.convert("RGBA").getchannel("A")).astype(np.float32) / 255.0
+                mask = 1.0 - torch.from_numpy(mask)
             else:
                 mask = torch.zeros((64, 64), dtype=torch.float32, device="cpu")
             output_images.append(image)
@@ -93,7 +92,7 @@ class WebcamCapture_V3(io.ComfyNodeV3):
     def fingerprint_inputs(s, image, width, height, capture_on_queue):
         image_path = folder_paths.get_annotated_filepath(image)
         m = hashlib.sha256()
-        with open(image_path, 'rb') as f:
+        with open(image_path, "rb") as f:
             m.update(f.read())
         return m.digest().hex()
 

--- a/nodes.py
+++ b/nodes.py
@@ -2303,6 +2303,7 @@ def init_builtin_extra_nodes():
         "v3/nodes_controlnet.py",
         "v3/nodes_images.py",
         "v3/nodes_mask.py",
+        "v3/nodes_primitive.py",
         "v3/nodes_webcam.py",
         "v3/nodes_stable_cascade.py",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ documentation = "https://docs.comfy.org/"
 
 [tool.ruff]
 lint.select = [
+  "E",    # pycodestyle errors
+  "I",    # isort
   "N805", # invalid-first-argument-name-for-method
   "S307", # suspicious-eval-usage
   "S102", # exec
@@ -22,3 +24,8 @@ lint.select = [
   "F",
 ]
 exclude = ["*.ipynb"]
+line-length = 120
+lint.pycodestyle.ignore-overlong-task-comments = true
+
+[tool.ruff.lint.per-file-ignores]
+"!comfy_extras/v3/*" = ["E", "I"]  # enable these rules only for V3 nodes


### PR DESCRIPTION
1. Added `ruff` rules to format code and sort imported objects (V3 nodes folder only).
2. `nodes_primitive.py` file was created by Claude Code to test the possibility of automatic converting simple nodes to V3 schema.

Manually tested new nodes, all looks ok:

<img width="1906" height="1059" alt="Screenshot from 2025-07-15 17-42-36" src="https://github.com/user-attachments/assets/99991ea8-449c-44ab-b8db-ae3eda7c9796" />

Formatting of files was done with **ruff format**, like:

`ruff format comfy_extras/v3/nodes_controlnet.py`

