### PR TITLE
[V3] refactoring of the images save nodes

### DIFF
--- a/comfy_extras/v3/nodes_cfg.py
+++ b/comfy_extras/v3/nodes_cfg.py
@@ -31,7 +31,7 @@ class CFGNorm(io.ComfyNodeV3):
                 io.Model.Input("model"),
                 io.Float.Input("strength", default=1.0, min=0.0, max=100.0, step=0.01),
             ],
-            outputs=[io.Model.Output("patched_model", display_name="patched_model")],
+            outputs=[io.Model.Output(display_name="patched_model")],
             is_experimental=True,
         )
 
@@ -61,7 +61,7 @@ class CFGZeroStar(io.ComfyNodeV3):
             inputs=[
                 io.Model.Input("model"),
             ],
-            outputs=[io.Model.Output("patched_model", display_name="patched_model")],
+            outputs=[io.Model.Output(display_name="patched_model")],
         )
 
     @classmethod

--- a/comfy_extras/v3/nodes_controlnet.py
+++ b/comfy_extras/v3/nodes_controlnet.py
@@ -21,8 +21,8 @@ class ControlNetApplyAdvanced(io.ComfyNodeV3):
                 io.Vae.Input("vae", optional=True),
             ],
             outputs=[
-                io.Conditioning.Output("positive_out", display_name="positive"),
-                io.Conditioning.Output("negative_out", display_name="negative"),
+                io.Conditioning.Output(display_name="positive"),
+                io.Conditioning.Output(display_name="negative"),
             ],
         )
 
@@ -71,7 +71,7 @@ class SetUnionControlNetType(io.ComfyNodeV3):
                 io.Combo.Input("type", options=["auto"] + list(UNION_CONTROLNET_TYPES.keys())),
             ],
             outputs=[
-                io.ControlNet.Output("control_net_out"),
+                io.ControlNet.Output(),
             ],
         )
 
@@ -105,8 +105,8 @@ class ControlNetInpaintingAliMamaApply(ControlNetApplyAdvanced):
                 io.Float.Input("end_percent", default=1.0, min=0.0, max=1.0, step=0.001),
             ],
             outputs=[
-                io.Conditioning.Output("positive_out", display_name="positive"),
-                io.Conditioning.Output("negative_out", display_name="negative"),
+                io.Conditioning.Output(display_name="positive"),
+                io.Conditioning.Output(display_name="negative"),
             ],
         )
 

--- a/comfy_extras/v3/nodes_rebatch.py
+++ b/comfy_extras/v3/nodes_rebatch.py
@@ -18,7 +18,7 @@ class ImageRebatch(io.ComfyNodeV3):
                 io.Int.Input("batch_size", default=1, min=1, max=4096),
             ],
             outputs=[
-                io.Image.Output("IMAGE", display_name="IMAGE", is_output_list=True),
+                io.Image.Output(display_name="IMAGE", is_output_list=True),
             ],
         )
 

--- a/comfy_extras/v3/nodes_stable_cascade.py
+++ b/comfy_extras/v3/nodes_stable_cascade.py
@@ -36,8 +36,8 @@ class StableCascade_EmptyLatentImage(io.ComfyNodeV3):
                 io.Int.Input("batch_size", default=1, min=1, max=4096),
             ],
             outputs=[
-                io.Latent.Output("stage_c", display_name="stage_c"),
-                io.Latent.Output("stage_b", display_name="stage_b"),
+                io.Latent.Output(display_name="stage_c"),
+                io.Latent.Output(display_name="stage_b"),
             ],
         )
 
@@ -60,8 +60,8 @@ class StableCascade_StageC_VAEEncode(io.ComfyNodeV3):
                 io.Int.Input("compression", default=42, min=4, max=128, step=1),
             ],
             outputs=[
-                io.Latent.Output("stage_c", display_name="stage_c"),
-                io.Latent.Output("stage_b", display_name="stage_b"),
+                io.Latent.Output(display_name="stage_c"),
+                io.Latent.Output(display_name="stage_b"),
             ],
         )
 
@@ -117,9 +117,9 @@ class StableCascade_SuperResolutionControlnet(io.ComfyNodeV3):
                 io.Vae.Input("vae"),
             ],
             outputs=[
-                io.Image.Output("controlnet_input", display_name="controlnet_input"),
-                io.Latent.Output("stage_c", display_name="stage_c"),
-                io.Latent.Output("stage_b", display_name="stage_b"),
+                io.Image.Output(display_name="controlnet_input"),
+                io.Latent.Output(display_name="stage_c"),
+                io.Latent.Output(display_name="stage_b"),
             ],
         )
 


### PR DESCRIPTION
This pull request refactors the image and animation saving logic for V3 nodes by introducing a centralized `ImageSaveHelper` class. This consolidation addresses code duplication in the `SaveImage`, `SaveAnimatedPNG`, `SaveAnimatedWEBP`, and `PreviewImage` nodes, leading to cleaner code, consistent behavior, and easier maintenance.

#### Key Changes:

1.  **New `ImageSaveHelper` Class in `comfy_api/v3/ui.py`:**
    *   A new helper class has been created to encapsulate all image-saving functionalities.
    *   It centralizes logic for:
        *   Converting image tensors to PIL images.
        *   Creating and embedding metadata for PNG, APNG (animated PNG), and WebP formats.
        *   Handling file path generation and writing files to disk.
    *   The `execute` methods in `SaveImage`, `SaveAnimatedPNG`, `SaveAnimatedWEBP`, and the `__init__` method of `PreviewImage` have been refactored to use this new helper class.

2.  **Behavioral Consistency and Simplification:**
    *   **`SaveAnimatedWEBP`:** The `num_frames` parameter and its associated logic, which allowed splitting frames into multiple WebP files, has been removed(*it was not used in V1*). The node now consistently outputs a **single animated WebP file** containing all input frames. This removes the previous inconsistency with `SaveAnimatedPNG` and simplifies the node's function.
    *   **`SaveAnimatedPNG`:** The `animated` flag in the UI output is now dynamic. It will be `False` if only one image is provided, ensuring its behavior is identical to `SaveAnimatedWEBP`. Previously, it was always hardcoded to `True`.
    *   Both animated save nodes now consistently return a list containing a single `SavedResult` object, reflecting the creation of a single animated file.
      

Visual test:

<img width="1584" height="1262" alt="Screenshot from 2025-07-20 11-06-55" src="https://github.com/user-attachments/assets/3897df99-209a-48a9-871d-6ef675efc04c" />

note: `SaveAnimatedWebp` **results are ok**, they just displaying different frames.

---
Preview nodes, **the results is ok**, file size between V1 and V3 nodes did not change:

```
ls -la ../temp/

1289996 Jul 20 10:55 ComfyUI_temp_oybok_00001_.png
1293843 Jul 20 10:55 ComfyUI_temp_oybok_00002_.png
1289996 Jul 20 10:55 ComfyUI_temp_yzvkk_00001_.png
1293843 Jul 20 10:55 ComfyUI_temp_yzvkk_00002_.png
```

Image Save(+APNG, +WEBP) nodes,  **the results is ok**, file size between V1 and V3 nodes did not change:

```
~/Comfy/ComfyUI/output$ ls -la 
2404355 Jul 20 10:55 test_animated_mult_V1_00001_.png
1596004 Jul 20 10:55 test_animated_mult_V1_00002_.webp
1596004 Jul 20 10:55 test_animated_mult_V3_00001_.webp
2404355 Jul 20 10:55 test_animated_mult_V3_00002_.png
1304190 Jul 20 10:55 test_animated_solo_V1_00001_.png
814040  Jul 20 10:55 test_animated_solo_V1_00002_.webp
1304190 Jul 20 10:55 test_animated_solo_V3_00001_.png
814040  Jul 20 10:55 test_animated_solo_V3_00002_.webp
1380986 Jul 20 10:55 test_mult_V1_00001_.png
1145540 Jul 20 10:55 test_mult_V1_00002_.png
1380986 Jul 20 10:55 test_mult_V3_00001_.png
1145540 Jul 20 10:55 test_mult_V3_00002_.png
1380986 Jul 20 10:55 test_solo_V1_00001_.png
1380986 Jul 20 10:55 test_solo_V3_00001_.png
```