### PR TITLE
Separate denoised and noise estimation in Euler CFG++

### DIFF
--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -1211,38 +1211,20 @@ def sample_deis(model, x, sigmas, extra_args=None, callback=None, disable=None, 
 
 
 @torch.no_grad()
-def sample_euler_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None):
-    extra_args = {} if extra_args is None else extra_args
-
-    temp = [0]
-    def post_cfg_function(args):
-        temp[0] = args["uncond_denoised"]
-        return args["denoised"]
-
-    model_options = extra_args.get("model_options", {}).copy()
-    extra_args["model_options"] = comfy.model_patcher.set_model_options_post_cfg_function(model_options, post_cfg_function, disable_cfg1_optimization=True)
-
-    s_in = x.new_ones([x.shape[0]])
-    for i in trange(len(sigmas) - 1, disable=disable):
-        sigma_hat = sigmas[i]
-        denoised = model(x, sigma_hat * s_in, **extra_args)
-        d = to_d(x, sigma_hat, temp[0])
-        if callback is not None:
-            callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigma_hat, 'denoised': denoised})
-        # Euler method
-        x = denoised + d * sigmas[i + 1]
-    return x
-
-@torch.no_grad()
 def sample_euler_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
-    """Ancestral sampling with Euler method steps."""
+    """Ancestral sampling with Euler method steps (CFG++)."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
     noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
 
-    temp = [0]
+    model_sampling = model.inner_model.model_patcher.get_model_object("model_sampling")
+    lambda_fn = partial(sigma_to_half_log_snr, model_sampling=model_sampling)
+
+    uncond_denoised = None
+
     def post_cfg_function(args):
-        temp[0] = args["uncond_denoised"]
+        nonlocal uncond_denoised
+        uncond_denoised = args["uncond_denoised"]
         return args["denoised"]
 
     model_options = extra_args.get("model_options", {}).copy()
@@ -1251,15 +1233,33 @@ def sample_euler_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback=No
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)
-        sigma_down, sigma_up = get_ancestral_step(sigmas[i], sigmas[i + 1], eta=eta)
         if callback is not None:
             callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised})
-        d = to_d(x, sigmas[i], temp[0])
-        # Euler method
-        x = denoised + d * sigma_down
-        if sigmas[i + 1] > 0:
-            x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * s_noise * sigma_up
+        if sigmas[i + 1] == 0:
+            # Denoising step
+            x = denoised
+        else:
+            alpha_s = sigmas[i] * lambda_fn(sigmas[i]).exp()
+            alpha_t = sigmas[i + 1] * lambda_fn(sigmas[i + 1]).exp()
+            d = to_d(x, sigmas[i], alpha_s * uncond_denoised)   # to noise
+
+            # DDIM stochastic sampling
+            sigma_down, sigma_up = get_ancestral_step(sigmas[i] / alpha_s, sigmas[i + 1] / alpha_t, eta=eta)
+            sigma_down = alpha_t * sigma_down
+
+            # Euler method
+            x = alpha_t * denoised + sigma_down * d
+            if eta > 0 and s_noise > 0:
+                x = x + alpha_t * noise_sampler(sigmas[i], sigmas[i + 1]) * s_noise * sigma_up
     return x
+
+
+@torch.no_grad()
+def sample_euler_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None):
+    """Euler method steps (CFG++)."""
+    return sample_euler_ancestral_cfg_pp(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=0.0, s_noise=0.0, noise_sampler=None)
+
+
 @torch.no_grad()
 def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""


### PR DESCRIPTION
> This will change their behavior with the sampling `CONST` type. It also combines Euler CFG++ and Euler ancestral CFG++ into one main function.

### The current CFG++
The current Euler CFG++ can work on the `CONST` sampling type (RF), which matches the algorithm from the appendix of the paper, but the guidance scale must be very low (~0.1), and it’s unstable.
It tends to oversaturate when given more steps under the same guidance scales that seem to work with fewer steps.

<img width="1867" height="1636" alt="ComfyUI_current_cfgpp_00001_resized" src="https://github.com/user-attachments/assets/49c3d3fb-8b8d-4cc5-ad30-453ab2f57c33" />

### CFG++ for flow models
Recently, the [official](https://github.com/CFGpp-diffusion/CFGpp/issues/12#issuecomment-3075778811) proposed a new approach for flow models, which separates denoised and noise estimation during sampling.

It changes the algorithm back to
```
eps_uncond = (x_s - alpha_s * uncond_denoised) / sigma_s
x_t = alpha_t * denoised_cfg + sigma_t * eps_uncond
```
instead of
```
x_t = denoised_cfg + sigma_t * v_uncond
```

With this change, the behavior of the guidance scale is more similar to the other sampling types.
<img width="1932" height="2680" alt="ComfyUI_pr_cfgpp_00001_resized" src="https://github.com/user-attachments/assets/0fd72200-728e-4d1d-8711-c4fbee649fb5" />

This should make it more usable with flow.

### Euler ancestral CFG++
The current `euler_ancestral_RF` is more similar to the "Overshoot Sampling" approach (from the [AMO sampler](https://arxiv.org/abs/2411.19415)), which takes a larger step along the velocity and rescales to the next state with noise compensation.
This method doesn't separate denoised and noise, so it's probably not suitable for CFG++.
```
alpha_ratio * (denoised_cfg + sigma_down * v_uncond) + renoise
```

Euler ancestral in k-diffusion seems to implement DDIM's `eta` parameter, which controls the interpolation between deterministic DDIM (`eta = 0`) and stochastic DDPM (`eta = 1`). A simple strategy is to preserve the original algorithm and apply RF's alpha and sigma, just like SANA's adaptation of dpm-solver to flow-dpm-solver. It can also match the "Stochastic Curved Euler Sampler", a DDPM variant for RF. (Algorithm 1 in [2506.15864](https://arxiv.org/abs/2506.15864)).
<img width="1605" height="791" alt="圖片" src="https://github.com/user-attachments/assets/d28877f5-1fef-49ed-a159-8e4cc61bafe7" />

The ancestral CFG++ seems fine in the current implementation.
<img width="3864" height="1184" alt="ComfyUI_pr_cfgpp_ancestral_00001_" src="https://github.com/user-attachments/assets/3271b94d-d9d5-4df4-b929-5dd0eff21599" />


All the examples are generated by SD3.5 medium with simple scheduler.