### PR TITLE
V3 update - fix super() not working within v3's execute classmethod

### DIFF
--- a/comfy_api/internal/__init__.py
+++ b/comfy_api/internal/__init__.py
@@ -84,13 +84,12 @@ class classproperty(object):
 # NOTE: this was ai generated and validated by hand
 def shallow_clone_class(cls, new_name=None):
     '''
-    Shallow clone a class.
+    Shallow clone a class while preserving super() functionality.
     '''
-    return type(
-        new_name or f"{cls.__name__}Clone",
-        cls.__bases__,
-        dict(cls.__dict__)
-    )
+    new_name = new_name or f"{cls.__name__}Clone"
+    # Include the original class in the bases to maintain proper inheritance
+    new_bases = (cls,) + cls.__bases__
+    return type(new_name, new_bases, dict(cls.__dict__))
 
 # NOTE: this was ai generated and validated by hand
 def lock_class(cls):

--- a/comfy_extras/nodes_v3_test.py
+++ b/comfy_extras/nodes_v3_test.py
@@ -218,9 +218,73 @@ class V3TestSleep(io.ComfyNodeV3):
         return io.NodeOutput(value)
 
 
+class V3DummyStart(io.ComfyNodeV3):
+    @classmethod
+    def define_schema(cls):
+        return io.SchemaV3(
+            node_id="V3_DummyStart",
+            display_name="V3 Dummy Start",
+            category="v3 nodes",
+            description="This is a dummy start node.",
+            inputs=[],
+            outputs=[
+                io.Custom("XYZ").Output(),
+            ],
+        )
+
+    @classmethod
+    def execute(cls):
+        return io.NodeOutput(None)
+
+
+class V3DummyEnd(io.ComfyNodeV3):
+    COOL_VALUE = 123
+
+    @classmethod
+    def define_schema(cls):
+        return io.SchemaV3(
+            node_id="V3_DummyEnd",
+            display_name="V3 Dummy End",
+            category="v3 nodes",
+            description="This is a dummy end node.",
+            inputs=[
+                io.Custom("XYZ").Input("xyz"),
+            ],
+            outputs=[],
+            is_output_node=True,
+        )
+
+    @classmethod
+    def custom_action(cls):
+        return 456
+
+    @classmethod
+    def execute(cls, xyz: io.Custom("XYZ").Type):
+        logging.info(f"V3DummyEnd: {cls.COOL_VALUE}")
+        logging.info(f"V3DummyEnd: {cls.custom_action()}")
+        return
+
+
+class V3DummyEndInherit(V3DummyEnd):
+    @classmethod
+    def define_schema(cls):
+        schema = super().define_schema()
+        schema.node_id = "V3_DummyEndInherit"
+        schema.display_name = "V3 Dummy End Inherit"
+        return schema
+
+    @classmethod
+    def execute(cls, xyz: io.Custom("XYZ").Type):
+        logging.info(f"V3DummyEndInherit: {cls.COOL_VALUE}")
+        return super().execute(xyz)
+
+
 NODES_LIST: list[type[io.ComfyNodeV3]] = [
     V3TestNode,
     V3LoraLoader,
     NInputsTest,
     V3TestSleep,
+    V3DummyStart,
+    V3DummyEnd,
+    V3DummyEndInherit,
 ]

--- a/execution.py
+++ b/execution.py
@@ -276,7 +276,6 @@ async def _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, f
                             dynamic_list.append(real_inputs.pop(d.id, None))
                         dynamic_list = [x for x in dynamic_list if x is not None]
                         inputs = {**real_inputs, add_key: dynamic_list}
-                # TODO: make checkign for async work, this will currently always return False for iscoroutinefunction
                 f = make_locked_method_func(type_obj, func, class_clone)
             # V1
             else:


### PR DESCRIPTION
The AI-generated shallow_clone_class did not set up the new_bases properly, hate to see it. Now another AI 'fixed' it, lovely.

Added some dummy classes to test it, will all be removed when v3 PR gets merged.