### PR TITLE
V3 refactor+cleanup - Drop 'V3' from names of classes intended to be commonly used, add '_' to some classes

### DIFF
--- a/comfy_api/internal/__init__.py
+++ b/comfy_api/internal/__init__.py
@@ -17,7 +17,7 @@ def first_real_override(cls: type, name: str, *, base: type=None) -> Optional[Ca
     if base_attr is None:
         return None
     base_func = base_attr.__func__
-    for c in cls.mro():                       # NodeB, NodeA, ComfyNodeV3, object …
+    for c in cls.mro():                       # NodeB, NodeA, ComfyNode, object …
         if c is base:                         # reached the placeholder – we're done
             break
         if name in c.__dict__:                # first class that *defines* the attr
@@ -27,7 +27,7 @@ def first_real_override(cls: type, name: str, *, base: type=None) -> Optional[Ca
     return None
 
 
-class ComfyNodeInternal:
+class _ComfyNodeInternal:
     """Class that all V3-based APIs inherit from for ComfyNode.
 
     This is intended to only be referenced within execution.py, as it has to handle all V3 APIs going forward."""

--- a/comfy_api/v3/io.py
+++ b/comfy_api/v3/io.py
@@ -1460,16 +1460,14 @@ class NodeOutput:
     '''
     Standardized output of a node; can pass in any number of args and/or a UIOutput into 'ui' kwarg.
     '''
-    def __init__(self, *args: Any, ui: _UIOutput | dict=None, expand: dict=None, block_execution: str=None, **kwargs):
+    def __init__(self, *args: Any, ui: _UIOutput | dict=None, expand: dict=None, block_execution: str=None):
         self.args = args
         self.ui = ui
         self.expand = expand
         self.block_execution = block_execution
-        # self.kwargs = kwargs
 
     @property
     def result(self):
-        # TODO: use kwargs to refer to outputs by id + organize in proper order
         return self.args if len(self.args) > 0 else None
 
     @classmethod

--- a/comfy_api/v3/io.py
+++ b/comfy_api/v3/io.py
@@ -85,7 +85,7 @@ class _StringIOType(str):
         b = frozenset(value.split(","))
         return not (b.issubset(a) or a.issubset(b))
 
-class ComfyType(ABC):
+class _ComfyType(ABC):
     Type = Any
     io_type: str = None
 
@@ -101,7 +101,7 @@ def comfytype(io_type: str, **kwargs):
     - class Output(OutputV3): ...
     '''
     def decorator(cls: T) -> T:
-        if isinstance(cls, ComfyType) or issubclass(cls, ComfyType):
+        if isinstance(cls, _ComfyType) or issubclass(cls, _ComfyType):
             # clone Input and Output classes to avoid modifying the original class
             new_cls = cls
             if hasattr(new_cls, "Input"):
@@ -144,7 +144,7 @@ class IO_V3:
     '''
     Base class for V3 Inputs and Outputs.
     '''
-    Parent: ComfyType = None
+    Parent: _ComfyType = None
 
     def __init__(self):
         pass
@@ -225,7 +225,7 @@ class OutputV3(IO_V3):
         return self.io_type
 
 
-class ComfyTypeI(ComfyType):
+class ComfyTypeI(_ComfyType):
     '''ComfyType subclass that only has a default Input class - intended for types that only have Inputs.'''
     class Input(InputV3):
         ...
@@ -694,7 +694,7 @@ class MultiType:
         '''
         Input that permits more than one input type; if `id` is an instance of `ComfyType.Input`, then that input will be used to create a widget (if applicable) with overridden values.
         '''
-        def __init__(self, id: str | InputV3, types: list[type[ComfyType] | ComfyType], display_name: str=None, optional=False, tooltip: str=None, lazy: bool=None, extra_dict=None):
+        def __init__(self, id: str | InputV3, types: list[type[_ComfyType] | _ComfyType], display_name: str=None, optional=False, tooltip: str=None, lazy: bool=None, extra_dict=None):
             # if id is an Input, then use that Input with overridden values
             self.input_override = None
             if isinstance(id, InputV3):
@@ -807,9 +807,9 @@ class ComboDynamicInput(DynamicInput):
 @comfytype(io_type="COMFY_MATCHTYPE_V3")
 class MatchType(ComfyTypeIO):
     class Template:
-        def __init__(self, template_id: str, allowed_types: ComfyType | list[ComfyType]):
+        def __init__(self, template_id: str, allowed_types: _ComfyType | list[_ComfyType]):
             self.template_id = template_id
-            self.allowed_types = [allowed_types] if isinstance(allowed_types, ComfyType) else allowed_types
+            self.allowed_types = [allowed_types] if isinstance(allowed_types, _ComfyType) else allowed_types
 
         def as_dict(self):
             return {

--- a/comfy_api/v3/io.py
+++ b/comfy_api/v3/io.py
@@ -140,7 +140,7 @@ def Custom(io_type: str) -> type[ComfyTypeIO]:
         ...
     return CustomComfyType
 
-class IO_V3:
+class _IO_V3:
     '''
     Base class for V3 Inputs and Outputs.
     '''
@@ -157,7 +157,7 @@ class IO_V3:
     def Type(self):
         return self.Parent.Type
 
-class InputV3(IO_V3):
+class InputV3(_IO_V3):
     '''
     Base class for a V3 Input.
     '''
@@ -206,7 +206,7 @@ class WidgetInputV3(InputV3):
         return self.widget_type if self.widget_type is not None else super().get_io_type()
 
 
-class OutputV3(IO_V3):
+class OutputV3(_IO_V3):
     def __init__(self, id: str=None, display_name: str=None, tooltip: str=None,
                  is_output_list=False):
         self.id = id

--- a/comfy_api/v3/io.py
+++ b/comfy_api/v3/io.py
@@ -932,7 +932,7 @@ class NodeInfoV3:
 
 
 @dataclass
-class SchemaV3:
+class Schema:
     """Definition of V3 node properties."""
 
     node_id: str
@@ -1128,8 +1128,8 @@ class _ComfyNodeBaseInternal(ComfyNodeInternal):
 
     @classmethod
     @abstractmethod
-    def define_schema(cls) -> SchemaV3:
-        """Override this function with one that returns a SchemaV3 instance."""
+    def define_schema(cls) -> Schema:
+        """Override this function with one that returns a Schema instance."""
         raise NotImplementedError
 
     @classmethod
@@ -1344,7 +1344,7 @@ class _ComfyNodeBaseInternal(ComfyNodeInternal):
 
     @final
     @classmethod
-    def INPUT_TYPES(cls, include_hidden=True, return_schema=False) -> dict[str, dict] | tuple[dict[str, dict], SchemaV3]:
+    def INPUT_TYPES(cls, include_hidden=True, return_schema=False) -> dict[str, dict] | tuple[dict[str, dict], Schema]:
         schema = cls.FINALIZE_SCHEMA()
         info = schema.get_v1_info(cls)
         input = info.input
@@ -1364,7 +1364,7 @@ class _ComfyNodeBaseInternal(ComfyNodeInternal):
 
     @final
     @classmethod
-    def GET_SCHEMA(cls) -> SchemaV3:
+    def GET_SCHEMA(cls) -> Schema:
         """Validate node class, finalize schema, validate schema, and set expected class properties."""
         cls.VALIDATE_CLASS()
         schema = cls.FINALIZE_SCHEMA()
@@ -1413,8 +1413,8 @@ class ComfyNodeV3(_ComfyNodeBaseInternal):
 
     @classmethod
     @abstractmethod
-    def define_schema(cls) -> SchemaV3:
-        """Override this function with one that returns a SchemaV3 instance."""
+    def define_schema(cls) -> Schema:
+        """Override this function with one that returns a Schema instance."""
         raise NotImplementedError
 
     @classmethod

--- a/comfy_api/v3/io.py
+++ b/comfy_api/v3/io.py
@@ -22,7 +22,7 @@ from comfy.samplers import CFGGuider, Sampler
 from comfy.sd import CLIP, VAE
 from comfy.sd import StyleModel as StyleModel_
 from comfy_api.input import VideoInput
-from comfy_api.internal import (ComfyNodeInternal, classproperty, copy_class, first_real_override, is_class,
+from comfy_api.internal import (_ComfyNodeInternal, classproperty, copy_class, first_real_override, is_class,
     prune_dict, shallow_clone_class)
 from comfy_api.v3.resources import Resources, ResourcesLocal
 from comfy_execution.graph import ExecutionBlocker
@@ -1116,7 +1116,7 @@ def add_to_dict_v3(io: InputV3 | OutputV3, d: dict):
 
 
 
-class _ComfyNodeBaseInternal(ComfyNodeInternal):
+class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     """Common base class for storing internal methods and properties; DO NOT USE for defining nodes."""
 
     RELATIVE_PYTHON_MODULE = None
@@ -1222,10 +1222,10 @@ class _ComfyNodeBaseInternal(ComfyNodeInternal):
 
     @final
     @classmethod
-    def PREPARE_CLASS_CLONE(cls, hidden_inputs: dict) -> type[ComfyNodeV3]:
+    def PREPARE_CLASS_CLONE(cls, hidden_inputs: dict) -> type[ComfyNode]:
         """Creates clone of real node class to prevent monkey-patching."""
-        c_type: type[ComfyNodeV3] = cls if is_class(cls) else type(cls)
-        type_clone: type[ComfyNodeV3] = shallow_clone_class(c_type)
+        c_type: type[ComfyNode] = cls if is_class(cls) else type(cls)
+        type_clone: type[ComfyNode] = shallow_clone_class(c_type)
         # set hidden
         type_clone.hidden = HiddenHolder.from_dict(hidden_inputs)
         return type_clone
@@ -1408,7 +1408,7 @@ class _ComfyNodeBaseInternal(ComfyNodeInternal):
     #############################################
 
 
-class ComfyNodeV3(_ComfyNodeBaseInternal):
+class ComfyNode(_ComfyNodeBaseInternal):
     """Common base class for all V3 nodes."""
 
     @classmethod
@@ -1453,7 +1453,7 @@ class ComfyNodeV3(_ComfyNodeBaseInternal):
     @classmethod
     def GET_BASE_CLASS(cls):
         """DO NOT override this class. Will break things in execution.py."""
-        return ComfyNodeV3
+        return ComfyNode
 
 
 class NodeOutput:

--- a/comfy_api/v3/ui.py
+++ b/comfy_api/v3/ui.py
@@ -17,7 +17,7 @@ import folder_paths
 
 # used for image preview
 from comfy.cli_args import args
-from comfy_api.v3.io import ComfyNodeV3, FolderType, Image, _UIOutput
+from comfy_api.v3.io import ComfyNode, FolderType, Image, _UIOutput
 
 
 class SavedResult(dict):
@@ -78,7 +78,7 @@ class ImageSaveHelper:
         return PILImage.fromarray(np.clip(255.0 * image_tensor.cpu().numpy(), 0, 255).astype(np.uint8))
 
     @staticmethod
-    def _create_png_metadata(cls: Type[ComfyNodeV3] | None) -> PngInfo | None:
+    def _create_png_metadata(cls: Type[ComfyNode] | None) -> PngInfo | None:
         """Creates a PngInfo object with prompt and extra_pnginfo."""
         if args.disable_metadata or cls is None or not cls.hidden:
             return None
@@ -91,7 +91,7 @@ class ImageSaveHelper:
         return metadata
 
     @staticmethod
-    def _create_animated_png_metadata(cls: Type[ComfyNodeV3] | None) -> PngInfo | None:
+    def _create_animated_png_metadata(cls: Type[ComfyNode] | None) -> PngInfo | None:
         """Creates a PngInfo object with prompt and extra_pnginfo for animated PNGs (APNG)."""
         if args.disable_metadata or cls is None or not cls.hidden:
             return None
@@ -116,7 +116,7 @@ class ImageSaveHelper:
         return metadata
 
     @staticmethod
-    def _create_webp_metadata(pil_image: PILImage.Image, cls: Type[ComfyNodeV3] | None) -> PILImage.Exif:
+    def _create_webp_metadata(pil_image: PILImage.Image, cls: Type[ComfyNode] | None) -> PILImage.Exif:
         """Creates EXIF metadata bytes for WebP images."""
         exif_data = pil_image.getexif()
         if args.disable_metadata or cls is None or cls.hidden is None:
@@ -132,7 +132,7 @@ class ImageSaveHelper:
 
     @staticmethod
     def save_images(
-        images, filename_prefix: str, folder_type: FolderType, cls: Type[ComfyNodeV3] | None, compress_level = 4,
+        images, filename_prefix: str, folder_type: FolderType, cls: Type[ComfyNode] | None, compress_level = 4,
     ) -> list[SavedResult]:
         """Saves a batch of images as individual PNG files."""
         full_output_folder, filename, counter, subfolder, _ = folder_paths.get_save_image_path(
@@ -150,7 +150,7 @@ class ImageSaveHelper:
         return results
 
     @staticmethod
-    def get_save_images_ui(images, filename_prefix: str, cls: Type[ComfyNodeV3] | None, compress_level=4) -> SavedImages:
+    def get_save_images_ui(images, filename_prefix: str, cls: Type[ComfyNode] | None, compress_level=4) -> SavedImages:
         """Saves a batch of images and returns a UI object for the node output."""
         return SavedImages(
                 ImageSaveHelper.save_images(
@@ -164,7 +164,7 @@ class ImageSaveHelper:
 
     @staticmethod
     def save_animated_png(
-        images, filename_prefix: str, folder_type: FolderType, cls: Type[ComfyNodeV3] | None, fps: float, compress_level: int
+        images, filename_prefix: str, folder_type: FolderType, cls: Type[ComfyNode] | None, fps: float, compress_level: int
     ) -> SavedResult:
         """Saves a batch of images as a single animated PNG."""
         full_output_folder, filename, counter, subfolder, _ = folder_paths.get_save_image_path(
@@ -186,7 +186,7 @@ class ImageSaveHelper:
 
     @staticmethod
     def get_save_animated_png_ui(
-        images, filename_prefix: str, cls: Type[ComfyNodeV3] | None, fps: float, compress_level: int
+        images, filename_prefix: str, cls: Type[ComfyNode] | None, fps: float, compress_level: int
     ) -> SavedImages:
         """Saves an animated PNG and returns a UI object for the node output."""
         result = ImageSaveHelper.save_animated_png(
@@ -204,7 +204,7 @@ class ImageSaveHelper:
         images,
         filename_prefix: str,
         folder_type: FolderType,
-        cls: Type[ComfyNodeV3] | None,
+        cls: Type[ComfyNode] | None,
         fps: float,
         lossless: bool,
         quality: int,
@@ -233,7 +233,7 @@ class ImageSaveHelper:
     def get_save_animated_webp_ui(
         images,
         filename_prefix: str,
-        cls: Type[ComfyNodeV3] | None,
+        cls: Type[ComfyNode] | None,
         fps: float,
         lossless: bool,
         quality: int,
@@ -262,7 +262,7 @@ class AudioSaveHelper:
         audio: dict,
         filename_prefix: str,
         folder_type: FolderType,
-        cls: Type[ComfyNodeV3] | None,
+        cls: Type[ComfyNode] | None,
         format: str = "flac",
         quality: str = "128k",
     ) -> list[SavedResult]:
@@ -364,7 +364,7 @@ class AudioSaveHelper:
 
     @staticmethod
     def get_save_audio_ui(
-        audio, filename_prefix: str, cls: Type[ComfyNodeV3] | None, format: str = "flac", quality: str = "128k",
+        audio, filename_prefix: str, cls: Type[ComfyNode] | None, format: str = "flac", quality: str = "128k",
     ) -> SavedAudios:
         """Save and instantly wrap for UI."""
         return SavedAudios(
@@ -380,7 +380,7 @@ class AudioSaveHelper:
 
 
 class PreviewImage(_UIOutput):
-    def __init__(self, image: Image.Type, animated: bool = False, cls: Type[ComfyNodeV3] = None, **kwargs):
+    def __init__(self, image: Image.Type, animated: bool = False, cls: Type[ComfyNode] = None, **kwargs):
         self.values = ImageSaveHelper.save_images(
             image,
             filename_prefix="ComfyUI_temp_" + ''.join(random.choice("abcdefghijklmnopqrstupvxyz") for _ in range(5)),
@@ -398,7 +398,7 @@ class PreviewImage(_UIOutput):
 
 
 class PreviewMask(PreviewImage):
-    def __init__(self, mask: PreviewMask.Type, animated: bool=False, cls: ComfyNodeV3=None, **kwargs):
+    def __init__(self, mask: PreviewMask.Type, animated: bool=False, cls: ComfyNode=None, **kwargs):
         preview = mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])).movedim(1, -1).expand(-1, -1, -1, 3)
         super().__init__(preview, animated, cls, **kwargs)
 
@@ -452,7 +452,7 @@ class PreviewMask(PreviewImage):
 
 
 class PreviewAudio(_UIOutput):
-    def __init__(self, audio: dict, cls: Type[ComfyNodeV3] = None, **kwargs):
+    def __init__(self, audio: dict, cls: Type[ComfyNode] = None, **kwargs):
         self.values = AudioSaveHelper.save_audio(
             audio,
             filename_prefix="ComfyUI_temp_" + "".join(random.choice("abcdefghijklmnopqrstuvwxyz") for _ in range(5)),

--- a/comfy_extras/nodes_v3_test.py
+++ b/comfy_extras/nodes_v3_test.py
@@ -9,12 +9,8 @@ import asyncio
 
 
 @io.comfytype(io_type="XYZ")
-class XYZ:
+class XYZ(io.ComfyTypeIO):
     Type = tuple[int,str]
-    class Input(io.InputV3):
-        ...
-    class Output(io.OutputV3):
-        ...
 
 
 class V3TestNode(io.ComfyNode):

--- a/comfy_extras/nodes_v3_test.py
+++ b/comfy_extras/nodes_v3_test.py
@@ -25,7 +25,7 @@ class V3TestNode(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="V3_01_TestNode1",
             display_name="V3 Test Node",
             category="v3 nodes",
@@ -94,7 +94,7 @@ class V3TestNode(io.ComfyNodeV3):
 class V3LoraLoader(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="V3_LoraLoader",
             display_name="V3 LoRA Loader",
             category="v3 nodes",
@@ -144,7 +144,7 @@ class V3LoraLoader(io.ComfyNodeV3):
 class NInputsTest(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="V3_NInputsTest",
             display_name="V3 N Inputs Test",
             inputs=[
@@ -186,7 +186,7 @@ class NInputsTest(io.ComfyNodeV3):
 class V3TestSleep(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="V3_TestSleep",
             display_name="V3 Test Sleep",
             category="_for_testing",
@@ -221,7 +221,7 @@ class V3TestSleep(io.ComfyNodeV3):
 class V3DummyStart(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="V3_DummyStart",
             display_name="V3 Dummy Start",
             category="v3 nodes",
@@ -242,7 +242,7 @@ class V3DummyEnd(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="V3_DummyEnd",
             display_name="V3 Dummy End",
             category="v3 nodes",

--- a/comfy_extras/nodes_v3_test.py
+++ b/comfy_extras/nodes_v3_test.py
@@ -17,7 +17,7 @@ class XYZ:
         ...
 
 
-class V3TestNode(io.ComfyNodeV3):
+class V3TestNode(io.ComfyNode):
     # NOTE: this is here just to test that state is not leaking
     def __init__(self):
         super().__init__()
@@ -91,7 +91,7 @@ class V3TestNode(io.ComfyNodeV3):
         return io.NodeOutput(some_int, image, ui=ui.PreviewImage(image, cls=cls))
 
 
-class V3LoraLoader(io.ComfyNodeV3):
+class V3LoraLoader(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -141,7 +141,7 @@ class V3LoraLoader(io.ComfyNodeV3):
         return io.NodeOutput(model_lora, clip_lora)
 
 
-class NInputsTest(io.ComfyNodeV3):
+class NInputsTest(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -183,7 +183,7 @@ class NInputsTest(io.ComfyNodeV3):
         return io.NodeOutput(combined_image)
 
 
-class V3TestSleep(io.ComfyNodeV3):
+class V3TestSleep(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -218,7 +218,7 @@ class V3TestSleep(io.ComfyNodeV3):
         return io.NodeOutput(value)
 
 
-class V3DummyStart(io.ComfyNodeV3):
+class V3DummyStart(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -237,7 +237,7 @@ class V3DummyStart(io.ComfyNodeV3):
         return io.NodeOutput(None)
 
 
-class V3DummyEnd(io.ComfyNodeV3):
+class V3DummyEnd(io.ComfyNode):
     COOL_VALUE = 123
 
     @classmethod
@@ -279,7 +279,7 @@ class V3DummyEndInherit(V3DummyEnd):
         return super().execute(xyz)
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     V3TestNode,
     V3LoraLoader,
     NInputsTest,

--- a/comfy_extras/v3/nodes_ace.py
+++ b/comfy_extras/v3/nodes_ace.py
@@ -7,7 +7,7 @@ import node_helpers
 from comfy_api.v3 import io
 
 
-class TextEncodeAceStepAudio(io.ComfyNodeV3):
+class TextEncodeAceStepAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -29,7 +29,7 @@ class TextEncodeAceStepAudio(io.ComfyNodeV3):
         return io.NodeOutput(conditioning)
 
 
-class EmptyAceStepLatentAudio(io.ComfyNodeV3):
+class EmptyAceStepLatentAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -51,7 +51,7 @@ class EmptyAceStepLatentAudio(io.ComfyNodeV3):
         return io.NodeOutput({"samples": latent, "type": "audio"})
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     TextEncodeAceStepAudio,
     EmptyAceStepLatentAudio,
 ]

--- a/comfy_extras/v3/nodes_ace.py
+++ b/comfy_extras/v3/nodes_ace.py
@@ -10,7 +10,7 @@ from comfy_api.v3 import io
 class TextEncodeAceStepAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="TextEncodeAceStepAudio_V3",
             category="conditioning",
             inputs=[
@@ -32,7 +32,7 @@ class TextEncodeAceStepAudio(io.ComfyNodeV3):
 class EmptyAceStepLatentAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="EmptyAceStepLatentAudio_V3",
             category="latent/audio",
             inputs=[

--- a/comfy_extras/v3/nodes_advanced_samplers.py
+++ b/comfy_extras/v3/nodes_advanced_samplers.py
@@ -45,8 +45,8 @@ class SamplerLCMUpscale(io.ComfyNodeV3):
     UPSCALE_METHODS = ["bislerp", "nearest-exact", "bilinear", "area", "bicubic"]
 
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="SamplerLCMUpscale_V3",
             category="sampling/custom_sampling/samplers",
             inputs=[
@@ -101,8 +101,8 @@ def sample_euler_pp(model, x, sigmas, extra_args=None, callback=None, disable=No
 
 class SamplerEulerCFGpp(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="SamplerEulerCFGpp_V3",
             display_name="SamplerEulerCFG++ _V3",
             category="_for_testing",

--- a/comfy_extras/v3/nodes_advanced_samplers.py
+++ b/comfy_extras/v3/nodes_advanced_samplers.py
@@ -41,7 +41,7 @@ def sample_lcm_upscale(
     return x
 
 
-class SamplerLCMUpscale(io.ComfyNodeV3):
+class SamplerLCMUpscale(io.ComfyNode):
     UPSCALE_METHODS = ["bislerp", "nearest-exact", "bilinear", "area", "bicubic"]
 
     @classmethod
@@ -99,7 +99,7 @@ def sample_euler_pp(model, x, sigmas, extra_args=None, callback=None, disable=No
     return x
 
 
-class SamplerEulerCFGpp(io.ComfyNodeV3):
+class SamplerEulerCFGpp(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(

--- a/comfy_extras/v3/nodes_align_your_steps.py
+++ b/comfy_extras/v3/nodes_align_your_steps.py
@@ -49,8 +49,8 @@ def loglinear_interp(t_steps, num_steps):
 
 class AlignYourStepsScheduler(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="AlignYourStepsScheduler_V3",
             category="sampling/custom_sampling/schedulers",
             inputs=[

--- a/comfy_extras/v3/nodes_align_your_steps.py
+++ b/comfy_extras/v3/nodes_align_your_steps.py
@@ -47,7 +47,7 @@ def loglinear_interp(t_steps, num_steps):
     return np.exp(new_ys)[::-1].copy()
 
 
-class AlignYourStepsScheduler(io.ComfyNodeV3):
+class AlignYourStepsScheduler(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(

--- a/comfy_extras/v3/nodes_apg.py
+++ b/comfy_extras/v3/nodes_apg.py
@@ -10,7 +10,7 @@ def project(v0, v1):
     return v0_parallel, v0_orthogonal
 
 
-class APG(io.ComfyNodeV3):
+class APG(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(

--- a/comfy_extras/v3/nodes_apg.py
+++ b/comfy_extras/v3/nodes_apg.py
@@ -12,8 +12,8 @@ def project(v0, v1):
 
 class APG(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="APG_V3",
             display_name="Adaptive Projected Guidance _V3",
             category="sampling/custom_sampling",

--- a/comfy_extras/v3/nodes_attention_multiply.py
+++ b/comfy_extras/v3/nodes_attention_multiply.py
@@ -17,7 +17,7 @@ def attention_multiply(attn, model, q, k, v, out):
     return m
 
 
-class UNetSelfAttentionMultiply(io.ComfyNodeV3):
+class UNetSelfAttentionMultiply(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(
@@ -39,7 +39,7 @@ class UNetSelfAttentionMultiply(io.ComfyNodeV3):
         return io.NodeOutput(attention_multiply("attn1", model, q, k, v, out))
 
 
-class UNetCrossAttentionMultiply(io.ComfyNodeV3):
+class UNetCrossAttentionMultiply(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(
@@ -61,7 +61,7 @@ class UNetCrossAttentionMultiply(io.ComfyNodeV3):
         return io.NodeOutput(attention_multiply("attn2", model, q, k, v, out))
 
 
-class CLIPAttentionMultiply(io.ComfyNodeV3):
+class CLIPAttentionMultiply(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(
@@ -95,7 +95,7 @@ class CLIPAttentionMultiply(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class UNetTemporalAttentionMultiply(io.ComfyNodeV3):
+class UNetTemporalAttentionMultiply(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(

--- a/comfy_extras/v3/nodes_attention_multiply.py
+++ b/comfy_extras/v3/nodes_attention_multiply.py
@@ -19,8 +19,8 @@ def attention_multiply(attn, model, q, k, v, out):
 
 class UNetSelfAttentionMultiply(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="UNetSelfAttentionMultiply_V3",
             category="_for_testing/attention_experiments",
             inputs=[
@@ -41,8 +41,8 @@ class UNetSelfAttentionMultiply(io.ComfyNodeV3):
 
 class UNetCrossAttentionMultiply(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="UNetCrossAttentionMultiply_V3",
             category="_for_testing/attention_experiments",
             inputs=[
@@ -63,8 +63,8 @@ class UNetCrossAttentionMultiply(io.ComfyNodeV3):
 
 class CLIPAttentionMultiply(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="CLIPAttentionMultiply_V3",
             category="_for_testing/attention_experiments",
             inputs=[
@@ -97,8 +97,8 @@ class CLIPAttentionMultiply(io.ComfyNodeV3):
 
 class UNetTemporalAttentionMultiply(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="UNetTemporalAttentionMultiply_V3",
             category="_for_testing/attention_experiments",
             inputs=[

--- a/comfy_extras/v3/nodes_audio.py
+++ b/comfy_extras/v3/nodes_audio.py
@@ -12,7 +12,7 @@ import node_helpers
 from comfy_api.v3 import io, ui
 
 
-class ConditioningStableAudio(io.ComfyNodeV3):
+class ConditioningStableAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -42,7 +42,7 @@ class ConditioningStableAudio(io.ComfyNodeV3):
         )
 
 
-class EmptyLatentAudio(io.ComfyNodeV3):
+class EmptyLatentAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -64,7 +64,7 @@ class EmptyLatentAudio(io.ComfyNodeV3):
         return io.NodeOutput({"samples": latent, "type": "audio"})
 
 
-class LoadAudio(io.ComfyNodeV3):
+class LoadAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -102,7 +102,7 @@ class LoadAudio(io.ComfyNodeV3):
         return True
 
 
-class PreviewAudio(io.ComfyNodeV3):
+class PreviewAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -121,7 +121,7 @@ class PreviewAudio(io.ComfyNodeV3):
         return io.NodeOutput(ui=ui.PreviewAudio(audio, cls=cls))
 
 
-class SaveAudioMP3(io.ComfyNodeV3):
+class SaveAudioMP3(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -146,7 +146,7 @@ class SaveAudioMP3(io.ComfyNodeV3):
         )
 
 
-class SaveAudioOpus(io.ComfyNodeV3):
+class SaveAudioOpus(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -171,7 +171,7 @@ class SaveAudioOpus(io.ComfyNodeV3):
         )
 
 
-class SaveAudio(io.ComfyNodeV3):
+class SaveAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -193,7 +193,7 @@ class SaveAudio(io.ComfyNodeV3):
         )
 
 
-class VAEDecodeAudio(io.ComfyNodeV3):
+class VAEDecodeAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -215,7 +215,7 @@ class VAEDecodeAudio(io.ComfyNodeV3):
         return io.NodeOutput({"waveform": audio, "sample_rate": 44100})
 
 
-class VAEEncodeAudio(io.ComfyNodeV3):
+class VAEEncodeAudio(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -238,7 +238,7 @@ class VAEEncodeAudio(io.ComfyNodeV3):
         return io.NodeOutput({"samples": vae.encode(waveform.movedim(1, -1))})
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     ConditioningStableAudio,
     EmptyLatentAudio,
     LoadAudio,

--- a/comfy_extras/v3/nodes_audio.py
+++ b/comfy_extras/v3/nodes_audio.py
@@ -15,7 +15,7 @@ from comfy_api.v3 import io, ui
 class ConditioningStableAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ConditioningStableAudio_V3",
             category="conditioning",
             inputs=[
@@ -45,7 +45,7 @@ class ConditioningStableAudio(io.ComfyNodeV3):
 class EmptyLatentAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="EmptyLatentAudio_V3",
             category="latent/audio",
             inputs=[
@@ -67,7 +67,7 @@ class EmptyLatentAudio(io.ComfyNodeV3):
 class LoadAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LoadAudio_V3",  # frontend expects "LoadAudio" to work
             display_name="Load Audio _V3",  # frontend ignores "display_name" for this node
             category="audio",
@@ -105,7 +105,7 @@ class LoadAudio(io.ComfyNodeV3):
 class PreviewAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PreviewAudio_V3",  # frontend expects "PreviewAudio" to work
             display_name="Preview Audio _V3",  # frontend ignores "display_name" for this node
             category="audio",
@@ -124,7 +124,7 @@ class PreviewAudio(io.ComfyNodeV3):
 class SaveAudioMP3(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SaveAudioMP3_V3",  # frontend expects "SaveAudioMP3" to work
             display_name="Save Audio(MP3) _V3",  # frontend ignores "display_name" for this node
             category="audio",
@@ -149,7 +149,7 @@ class SaveAudioMP3(io.ComfyNodeV3):
 class SaveAudioOpus(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SaveAudioOpus_V3",  # frontend expects "SaveAudioOpus" to work
             display_name="Save Audio(Opus) _V3",  # frontend ignores "display_name" for this node
             category="audio",
@@ -174,7 +174,7 @@ class SaveAudioOpus(io.ComfyNodeV3):
 class SaveAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SaveAudio_V3",  # frontend expects "SaveAudio" to work
             display_name="Save Audio _V3",  # frontend ignores "display_name" for this node
             category="audio",
@@ -196,7 +196,7 @@ class SaveAudio(io.ComfyNodeV3):
 class VAEDecodeAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="VAEDecodeAudio_V3",
             category="latent/audio",
             inputs=[
@@ -218,7 +218,7 @@ class VAEDecodeAudio(io.ComfyNodeV3):
 class VAEEncodeAudio(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="VAEEncodeAudio_V3",
             category="latent/audio",
             inputs=[

--- a/comfy_extras/v3/nodes_camera_trajectory.py
+++ b/comfy_extras/v3/nodes_camera_trajectory.py
@@ -135,7 +135,7 @@ def get_camera_motion(angle, T, speed, n=81):
     return RT
 
 
-class WanCameraEmbedding(io.ComfyNodeV3):
+class WanCameraEmbedding(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_camera_trajectory.py
+++ b/comfy_extras/v3/nodes_camera_trajectory.py
@@ -138,7 +138,7 @@ def get_camera_motion(angle, T, speed, n=81):
 class WanCameraEmbedding(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WanCameraEmbedding_V3",
             category="camera",
             inputs=[

--- a/comfy_extras/v3/nodes_canny.py
+++ b/comfy_extras/v3/nodes_canny.py
@@ -9,7 +9,7 @@ from comfy_api.v3 import io
 class Canny(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="Canny_V3",
             category="image/preprocessors",
             inputs=[

--- a/comfy_extras/v3/nodes_canny.py
+++ b/comfy_extras/v3/nodes_canny.py
@@ -6,7 +6,7 @@ import comfy.model_management
 from comfy_api.v3 import io
 
 
-class Canny(io.ComfyNodeV3):
+class Canny(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_cfg.py
+++ b/comfy_extras/v3/nodes_cfg.py
@@ -21,7 +21,7 @@ def optimized_scale(positive, negative):
     return st_star.reshape([positive.shape[0]] + [1] * (positive.ndim - 1))
 
 
-class CFGNorm(io.ComfyNodeV3):
+class CFGNorm(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(
@@ -52,7 +52,7 @@ class CFGNorm(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class CFGZeroStar(io.ComfyNodeV3):
+class CFGZeroStar(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(

--- a/comfy_extras/v3/nodes_cfg.py
+++ b/comfy_extras/v3/nodes_cfg.py
@@ -23,8 +23,8 @@ def optimized_scale(positive, negative):
 
 class CFGNorm(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="CFGNorm_V3",
             category="advanced/guidance",
             inputs=[
@@ -54,8 +54,8 @@ class CFGNorm(io.ComfyNodeV3):
 
 class CFGZeroStar(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="CFGZeroStar_V3",
             category="advanced/guidance",
             inputs=[

--- a/comfy_extras/v3/nodes_clip_sdxl.py
+++ b/comfy_extras/v3/nodes_clip_sdxl.py
@@ -7,7 +7,7 @@ from comfy_api.v3 import io
 class CLIPTextEncodeSDXL(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="CLIPTextEncodeSDXL_V3",
             category="advanced/conditioning",
             inputs=[
@@ -51,7 +51,7 @@ class CLIPTextEncodeSDXL(io.ComfyNodeV3):
 class CLIPTextEncodeSDXLRefiner(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="CLIPTextEncodeSDXLRefiner_V3",
             category="advanced/conditioning",
             inputs=[

--- a/comfy_extras/v3/nodes_clip_sdxl.py
+++ b/comfy_extras/v3/nodes_clip_sdxl.py
@@ -4,7 +4,7 @@ import nodes
 from comfy_api.v3 import io
 
 
-class CLIPTextEncodeSDXL(io.ComfyNodeV3):
+class CLIPTextEncodeSDXL(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -48,7 +48,7 @@ class CLIPTextEncodeSDXL(io.ComfyNodeV3):
         return io.NodeOutput(conditioning)
 
 
-class CLIPTextEncodeSDXLRefiner(io.ComfyNodeV3):
+class CLIPTextEncodeSDXLRefiner(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_compositing.py
+++ b/comfy_extras/v3/nodes_compositing.py
@@ -112,7 +112,7 @@ def porter_duff_composite(
     return out_image, out_alpha
 
 
-class JoinImageWithAlpha(io.ComfyNodeV3):
+class JoinImageWithAlpha(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -138,7 +138,7 @@ class JoinImageWithAlpha(io.ComfyNodeV3):
         return io.NodeOutput(torch.stack(out_images))
 
 
-class PorterDuffImageComposite(io.ComfyNodeV3):
+class PorterDuffImageComposite(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -199,7 +199,7 @@ class PorterDuffImageComposite(io.ComfyNodeV3):
         return io.NodeOutput(torch.stack(out_images), torch.stack(out_alphas))
 
 
-class SplitImageWithAlpha(io.ComfyNodeV3):
+class SplitImageWithAlpha(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_compositing.py
+++ b/comfy_extras/v3/nodes_compositing.py
@@ -115,7 +115,7 @@ def porter_duff_composite(
 class JoinImageWithAlpha(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="JoinImageWithAlpha_V3",
             display_name="Join Image with Alpha _V3",
             category="mask/compositing",
@@ -141,7 +141,7 @@ class JoinImageWithAlpha(io.ComfyNodeV3):
 class PorterDuffImageComposite(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PorterDuffImageComposite_V3",
             display_name="Porter-Duff Image Composite _V3",
             category="mask/compositing",
@@ -202,7 +202,7 @@ class PorterDuffImageComposite(io.ComfyNodeV3):
 class SplitImageWithAlpha(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SplitImageWithAlpha_V3",
             display_name="Split Image with Alpha _V3",
             category="mask/compositing",

--- a/comfy_extras/v3/nodes_cond.py
+++ b/comfy_extras/v3/nodes_cond.py
@@ -5,8 +5,8 @@ from comfy_api.v3 import io
 
 class CLIPTextEncodeControlnet(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="CLIPTextEncodeControlnet_V3",
             category="_for_testing/conditioning",
             inputs=[
@@ -32,8 +32,8 @@ class CLIPTextEncodeControlnet(io.ComfyNodeV3):
 
 class T5TokenizerOptions(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="T5TokenizerOptions_V3",
             category="_for_testing/conditioning",
             inputs=[

--- a/comfy_extras/v3/nodes_cond.py
+++ b/comfy_extras/v3/nodes_cond.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from comfy_api.v3 import io
 
 
-class CLIPTextEncodeControlnet(io.ComfyNodeV3):
+class CLIPTextEncodeControlnet(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(
@@ -30,7 +30,7 @@ class CLIPTextEncodeControlnet(io.ComfyNodeV3):
         return io.NodeOutput(c)
 
 
-class T5TokenizerOptions(io.ComfyNodeV3):
+class T5TokenizerOptions(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(

--- a/comfy_extras/v3/nodes_controlnet.py
+++ b/comfy_extras/v3/nodes_controlnet.py
@@ -3,7 +3,7 @@ from comfy.cldm.control_types import UNION_CONTROLNET_TYPES
 from comfy_api.v3 import io
 
 
-class ControlNetApplyAdvanced(io.ComfyNodeV3):
+class ControlNetApplyAdvanced(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -60,7 +60,7 @@ class ControlNetApplyAdvanced(io.ComfyNodeV3):
         return io.NodeOutput(out[0], out[1])
 
 
-class SetUnionControlNetType(io.ComfyNodeV3):
+class SetUnionControlNetType(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -134,7 +134,7 @@ class ControlNetInpaintingAliMamaApply(ControlNetApplyAdvanced):
         )
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     ControlNetApplyAdvanced,
     SetUnionControlNetType,
     ControlNetInpaintingAliMamaApply,

--- a/comfy_extras/v3/nodes_controlnet.py
+++ b/comfy_extras/v3/nodes_controlnet.py
@@ -6,7 +6,7 @@ from comfy_api.v3 import io
 class ControlNetApplyAdvanced(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ControlNetApplyAdvanced_V3",
             display_name="Apply ControlNet _V3",
             category="conditioning/controlnet",
@@ -63,7 +63,7 @@ class ControlNetApplyAdvanced(io.ComfyNodeV3):
 class SetUnionControlNetType(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SetUnionControlNetType_V3",
             category="conditioning/controlnet",
             inputs=[
@@ -90,7 +90,7 @@ class SetUnionControlNetType(io.ComfyNodeV3):
 class ControlNetInpaintingAliMamaApply(ControlNetApplyAdvanced):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ControlNetInpaintingAliMamaApply_V3",
             category="conditioning/controlnet",
             inputs=[

--- a/comfy_extras/v3/nodes_cosmos.py
+++ b/comfy_extras/v3/nodes_cosmos.py
@@ -22,8 +22,8 @@ def vae_encode_with_padding(vae, image, width, height, length, padding=0):
 
 class CosmosImageToVideoLatent(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="CosmosImageToVideoLatent_V3",
             category="conditioning/inpaint",
             inputs=[
@@ -69,8 +69,8 @@ class CosmosImageToVideoLatent(io.ComfyNodeV3):
 
 class CosmosPredict2ImageToVideoLatent(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="CosmosPredict2ImageToVideoLatent_V3",
             category="conditioning/inpaint",
             inputs=[
@@ -118,8 +118,8 @@ class CosmosPredict2ImageToVideoLatent(io.ComfyNodeV3):
 
 class EmptyCosmosLatentVideo(io.ComfyNodeV3):
     @classmethod
-    def define_schema(cls) -> io.SchemaV3:
-        return io.SchemaV3(
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
             node_id="EmptyCosmosLatentVideo_V3",
             category="latent/video",
             inputs=[

--- a/comfy_extras/v3/nodes_cosmos.py
+++ b/comfy_extras/v3/nodes_cosmos.py
@@ -20,7 +20,7 @@ def vae_encode_with_padding(vae, image, width, height, length, padding=0):
     return latent_temp[:, :, :latent_len]
 
 
-class CosmosImageToVideoLatent(io.ComfyNodeV3):
+class CosmosImageToVideoLatent(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(
@@ -67,7 +67,7 @@ class CosmosImageToVideoLatent(io.ComfyNodeV3):
         return io.NodeOutput(out_latent)
 
 
-class CosmosPredict2ImageToVideoLatent(io.ComfyNodeV3):
+class CosmosPredict2ImageToVideoLatent(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(
@@ -116,7 +116,7 @@ class CosmosPredict2ImageToVideoLatent(io.ComfyNodeV3):
         return io.NodeOutput(out_latent)
 
 
-class EmptyCosmosLatentVideo(io.ComfyNodeV3):
+class EmptyCosmosLatentVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls) -> io.Schema:
         return io.Schema(

--- a/comfy_extras/v3/nodes_differential_diffusion.py
+++ b/comfy_extras/v3/nodes_differential_diffusion.py
@@ -5,7 +5,7 @@ import torch
 from comfy_api.v3 import io
 
 
-class DifferentialDiffusion(io.ComfyNodeV3):
+class DifferentialDiffusion(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_differential_diffusion.py
+++ b/comfy_extras/v3/nodes_differential_diffusion.py
@@ -8,7 +8,7 @@ from comfy_api.v3 import io
 class DifferentialDiffusion(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="DifferentialDiffusion_V3",
             display_name="Differential Diffusion _V3",
             category="_for_testing",

--- a/comfy_extras/v3/nodes_edit_model.py
+++ b/comfy_extras/v3/nodes_edit_model.py
@@ -7,7 +7,7 @@ from comfy_api.v3 import io
 class ReferenceLatent(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ReferenceLatent_V3",
             category="advanced/conditioning/edit_models",
             description="This node sets the guiding latent for an edit model. If the model supports it you can chain multiple to set multiple reference images.",

--- a/comfy_extras/v3/nodes_edit_model.py
+++ b/comfy_extras/v3/nodes_edit_model.py
@@ -4,7 +4,7 @@ import node_helpers
 from comfy_api.v3 import io
 
 
-class ReferenceLatent(io.ComfyNodeV3):
+class ReferenceLatent(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_flux.py
+++ b/comfy_extras/v3/nodes_flux.py
@@ -28,7 +28,7 @@ PREFERED_KONTEXT_RESOLUTIONS = [
 class CLIPTextEncodeFlux(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="CLIPTextEncodeFlux_V3",
             category="advanced/conditioning/flux",
             inputs=[
@@ -53,7 +53,7 @@ class CLIPTextEncodeFlux(io.ComfyNodeV3):
 class FluxDisableGuidance(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="FluxDisableGuidance_V3",
             category="advanced/conditioning/flux",
             description="This node completely disables the guidance embed on Flux and Flux like models",
@@ -74,7 +74,7 @@ class FluxDisableGuidance(io.ComfyNodeV3):
 class FluxGuidance(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="FluxGuidance_V3",
             category="advanced/conditioning/flux",
             inputs=[
@@ -95,7 +95,7 @@ class FluxGuidance(io.ComfyNodeV3):
 class FluxKontextImageScale(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="FluxKontextImageScale_V3",
             category="advanced/conditioning/flux",
             description="This node resizes the image to one that is more optimal for flux kontext.",

--- a/comfy_extras/v3/nodes_flux.py
+++ b/comfy_extras/v3/nodes_flux.py
@@ -25,7 +25,7 @@ PREFERED_KONTEXT_RESOLUTIONS = [
 ]
 
 
-class CLIPTextEncodeFlux(io.ComfyNodeV3):
+class CLIPTextEncodeFlux(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -50,7 +50,7 @@ class CLIPTextEncodeFlux(io.ComfyNodeV3):
         return io.NodeOutput(clip.encode_from_tokens_scheduled(tokens, add_dict={"guidance": guidance}))
 
 
-class FluxDisableGuidance(io.ComfyNodeV3):
+class FluxDisableGuidance(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -71,7 +71,7 @@ class FluxDisableGuidance(io.ComfyNodeV3):
         return io.NodeOutput(c)
 
 
-class FluxGuidance(io.ComfyNodeV3):
+class FluxGuidance(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -92,7 +92,7 @@ class FluxGuidance(io.ComfyNodeV3):
         return io.NodeOutput(c)
 
 
-class FluxKontextImageScale(io.ComfyNodeV3):
+class FluxKontextImageScale(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_freelunch.py
+++ b/comfy_extras/v3/nodes_freelunch.py
@@ -31,7 +31,7 @@ def Fourier_filter(x, threshold, scale):
 class FreeU(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="FreeU_V3",
             category="model_patches/unet",
             inputs=[
@@ -76,7 +76,7 @@ class FreeU(io.ComfyNodeV3):
 class FreeU_V2(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="FreeU_V2_V3",
             category="model_patches/unet",
             inputs=[

--- a/comfy_extras/v3/nodes_freelunch.py
+++ b/comfy_extras/v3/nodes_freelunch.py
@@ -28,7 +28,7 @@ def Fourier_filter(x, threshold, scale):
     return x_filtered.to(x.dtype)
 
 
-class FreeU(io.ComfyNodeV3):
+class FreeU(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -73,7 +73,7 @@ class FreeU(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class FreeU_V2(io.ComfyNodeV3):
+class FreeU_V2(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_fresca.py
+++ b/comfy_extras/v3/nodes_fresca.py
@@ -56,7 +56,7 @@ def Fourier_filter(x, scale_low=1.0, scale_high=1.5, freq_cutoff=20):
     return x_filtered
 
 
-class FreSca(io.ComfyNodeV3):
+class FreSca(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_fresca.py
+++ b/comfy_extras/v3/nodes_fresca.py
@@ -59,7 +59,7 @@ def Fourier_filter(x, scale_low=1.0, scale_high=1.5, freq_cutoff=20):
 class FreSca(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="FreSca_V3",
             display_name="FreSca _V3",
             category="_for_testing",

--- a/comfy_extras/v3/nodes_gits.py
+++ b/comfy_extras/v3/nodes_gits.py
@@ -339,7 +339,7 @@ NOISE_LEVELS = {
 class GITSScheduler(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="GITSScheduler_V3",
             category="sampling/custom_sampling/schedulers",
             inputs=[

--- a/comfy_extras/v3/nodes_gits.py
+++ b/comfy_extras/v3/nodes_gits.py
@@ -336,7 +336,7 @@ NOISE_LEVELS = {
 }
 
 
-class GITSScheduler(io.ComfyNodeV3):
+class GITSScheduler(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_hidream.py
+++ b/comfy_extras/v3/nodes_hidream.py
@@ -6,7 +6,7 @@ import folder_paths
 from comfy_api.v3 import io
 
 
-class CLIPTextEncodeHiDream(io.ComfyNodeV3):
+class CLIPTextEncodeHiDream(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -33,7 +33,7 @@ class CLIPTextEncodeHiDream(io.ComfyNodeV3):
         return io.NodeOutput(clip.encode_from_tokens_scheduled(tokens))
 
 
-class QuadrupleCLIPLoader(io.ComfyNodeV3):
+class QuadrupleCLIPLoader(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_hidream.py
+++ b/comfy_extras/v3/nodes_hidream.py
@@ -9,7 +9,7 @@ from comfy_api.v3 import io
 class CLIPTextEncodeHiDream(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="CLIPTextEncodeHiDream_V3",
             category="advanced/conditioning",
             inputs=[
@@ -36,7 +36,7 @@ class CLIPTextEncodeHiDream(io.ComfyNodeV3):
 class QuadrupleCLIPLoader(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="QuadrupleCLIPLoader_V3",
             category="advanced/loaders",
             description="[Recipes]\n\nhidream: long clip-l, long clip-g, t5xxl, llama_8b_3.1_instruct",

--- a/comfy_extras/v3/nodes_images.py
+++ b/comfy_extras/v3/nodes_images.py
@@ -13,7 +13,7 @@ from comfy_api.v3 import io, ui
 from server import PromptServer
 
 
-class GetImageSize(io.ComfyNodeV3):
+class GetImageSize(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -46,7 +46,7 @@ class GetImageSize(io.ComfyNodeV3):
         return io.NodeOutput(width, height, batch_size)
 
 
-class ImageAddNoise(io.ComfyNodeV3):
+class ImageAddNoise(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -79,7 +79,7 @@ class ImageAddNoise(io.ComfyNodeV3):
         return io.NodeOutput(s)
 
 
-class ImageCrop(io.ComfyNodeV3):
+class ImageCrop(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -105,7 +105,7 @@ class ImageCrop(io.ComfyNodeV3):
         return io.NodeOutput(image[:, y:to_y, x:to_x, :])
 
 
-class ImageFlip(io.ComfyNodeV3):
+class ImageFlip(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -129,7 +129,7 @@ class ImageFlip(io.ComfyNodeV3):
         return io.NodeOutput(image)
 
 
-class ImageFromBatch(io.ComfyNodeV3):
+class ImageFromBatch(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -153,7 +153,7 @@ class ImageFromBatch(io.ComfyNodeV3):
         return io.NodeOutput(s)
 
 
-class ImageRotate(io.ComfyNodeV3):
+class ImageRotate(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -180,7 +180,7 @@ class ImageRotate(io.ComfyNodeV3):
         return io.NodeOutput(torch.rot90(image, k=rotate_by, dims=[2, 1]))
 
 
-class ImageStitch(io.ComfyNodeV3):
+class ImageStitch(io.ComfyNode):
     """Upstreamed from https://github.com/kijai/ComfyUI-KJNodes"""
 
     @classmethod
@@ -350,7 +350,7 @@ class ImageStitch(io.ComfyNodeV3):
         return io.NodeOutput(torch.cat(images, dim=concat_dim))
 
 
-class LoadImage(io.ComfyNodeV3):
+class LoadImage(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -438,7 +438,7 @@ class LoadImage(io.ComfyNodeV3):
         return True
 
 
-class LoadImageOutput(io.ComfyNodeV3):
+class LoadImageOutput(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -527,7 +527,7 @@ class LoadImageOutput(io.ComfyNodeV3):
         return True
 
 
-class PreviewImage(io.ComfyNodeV3):
+class PreviewImage(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -547,7 +547,7 @@ class PreviewImage(io.ComfyNodeV3):
         return io.NodeOutput(ui=ui.PreviewImage(images, cls=cls))
 
 
-class RepeatImageBatch(io.ComfyNodeV3):
+class RepeatImageBatch(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -566,7 +566,7 @@ class RepeatImageBatch(io.ComfyNodeV3):
         return io.NodeOutput(image.repeat((amount, 1, 1, 1)))
 
 
-class ResizeAndPadImage(io.ComfyNodeV3):
+class ResizeAndPadImage(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -611,7 +611,7 @@ class ResizeAndPadImage(io.ComfyNodeV3):
         return io.NodeOutput(padded.permute(0, 2, 3, 1))
 
 
-class SaveAnimatedPNG(io.ComfyNodeV3):
+class SaveAnimatedPNG(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -641,7 +641,7 @@ class SaveAnimatedPNG(io.ComfyNodeV3):
         )
 
 
-class SaveAnimatedWEBP(io.ComfyNodeV3):
+class SaveAnimatedWEBP(io.ComfyNode):
     COMPRESS_METHODS = {"default": 4, "fastest": 0, "slowest": 6}
 
     @classmethod
@@ -677,7 +677,7 @@ class SaveAnimatedWEBP(io.ComfyNodeV3):
         )
 
 
-class SaveImage(io.ComfyNodeV3):
+class SaveImage(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -708,7 +708,7 @@ class SaveImage(io.ComfyNodeV3):
         )
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     GetImageSize,
     ImageAddNoise,
     ImageCrop,

--- a/comfy_extras/v3/nodes_images.py
+++ b/comfy_extras/v3/nodes_images.py
@@ -16,7 +16,7 @@ from server import PromptServer
 class GetImageSize(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="GetImageSize_V3",
             display_name="Get Image Size _V3",
             description="Returns width and height of the image, and passes it through unchanged.",
@@ -49,7 +49,7 @@ class GetImageSize(io.ComfyNodeV3):
 class ImageAddNoise(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageAddNoise_V3",
             display_name="Image Add Noise _V3",
             category="image",
@@ -82,7 +82,7 @@ class ImageAddNoise(io.ComfyNodeV3):
 class ImageCrop(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageCrop_V3",
             display_name="Image Crop _V3",
             category="image/transform",
@@ -108,7 +108,7 @@ class ImageCrop(io.ComfyNodeV3):
 class ImageFlip(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageFlip_V3",
             display_name="Image Flip _V3",
             category="image/transform",
@@ -132,7 +132,7 @@ class ImageFlip(io.ComfyNodeV3):
 class ImageFromBatch(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageFromBatch_V3",
             display_name="Image From Batch _V3",
             category="image/batch",
@@ -156,7 +156,7 @@ class ImageFromBatch(io.ComfyNodeV3):
 class ImageRotate(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageRotate_V3",
             display_name="Image Rotate _V3",
             category="image/transform",
@@ -185,7 +185,7 @@ class ImageStitch(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageStitch_V3",
             display_name="Image Stitch _V3",
             description="Stitches image2 to image1 in the specified direction. "
@@ -353,7 +353,7 @@ class ImageStitch(io.ComfyNodeV3):
 class LoadImage(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LoadImage_V3",
             display_name="Load Image _V3",
             category="image",
@@ -441,7 +441,7 @@ class LoadImage(io.ComfyNodeV3):
 class LoadImageOutput(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LoadImageOutput_V3",
             display_name="Load Image (from Outputs) _V3",
             description="Load an image from the output folder. "
@@ -530,7 +530,7 @@ class LoadImageOutput(io.ComfyNodeV3):
 class PreviewImage(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PreviewImage_V3",
             display_name="Preview Image _V3",
             description="Preview the input images.",
@@ -550,7 +550,7 @@ class PreviewImage(io.ComfyNodeV3):
 class RepeatImageBatch(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="RepeatImageBatch_V3",
             display_name="Repeat Image Batch _V3",
             category="image/batch",
@@ -569,7 +569,7 @@ class RepeatImageBatch(io.ComfyNodeV3):
 class ResizeAndPadImage(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ResizeAndPadImage_V3",
             display_name="Resize and Pad Image _V3",
             category="image/transform",
@@ -614,7 +614,7 @@ class ResizeAndPadImage(io.ComfyNodeV3):
 class SaveAnimatedPNG(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SaveAnimatedPNG_V3",
             display_name="Save Animated PNG _V3",
             category="image/animation",
@@ -646,7 +646,7 @@ class SaveAnimatedWEBP(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SaveAnimatedWEBP_V3",
             display_name="Save Animated WEBP _V3",
             category="image/animation",
@@ -680,7 +680,7 @@ class SaveAnimatedWEBP(io.ComfyNodeV3):
 class SaveImage(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SaveImage_V3",
             display_name="Save Image _V3",
             description="Saves the input images to your ComfyUI output directory.",

--- a/comfy_extras/v3/nodes_latent.py
+++ b/comfy_extras/v3/nodes_latent.py
@@ -20,7 +20,7 @@ def reshape_latent_to(target_shape, latent, repeat_batch=True):
 class LatentAdd(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentAdd_V3",
             category="latent/advanced",
             inputs=[
@@ -47,7 +47,7 @@ class LatentAdd(io.ComfyNodeV3):
 class LatentApplyOperation(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentApplyOperation_V3",
             category="latent/advanced/operations",
             is_experimental=True,
@@ -72,7 +72,7 @@ class LatentApplyOperation(io.ComfyNodeV3):
 class LatentApplyOperationCFG(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentApplyOperationCFG_V3",
             category="latent/advanced/operations",
             is_experimental=True,
@@ -104,7 +104,7 @@ class LatentApplyOperationCFG(io.ComfyNodeV3):
 class LatentBatch(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentBatch_V3",
             category="latent/batch",
             inputs=[
@@ -133,7 +133,7 @@ class LatentBatch(io.ComfyNodeV3):
 class LatentBatchSeedBehavior(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentBatchSeedBehavior_V3",
             category="latent/advanced",
             inputs=[
@@ -162,7 +162,7 @@ class LatentBatchSeedBehavior(io.ComfyNodeV3):
 class LatentInterpolate(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentInterpolate_V3",
             category="latent/advanced",
             inputs=[
@@ -201,7 +201,7 @@ class LatentInterpolate(io.ComfyNodeV3):
 class LatentMultiply(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentMultiply_V3",
             category="latent/advanced",
             inputs=[
@@ -225,7 +225,7 @@ class LatentMultiply(io.ComfyNodeV3):
 class LatentOperationSharpen(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentOperationSharpen_V3",
             category="latent/advanced/operations",
             is_experimental=True,
@@ -267,7 +267,7 @@ class LatentOperationSharpen(io.ComfyNodeV3):
 class LatentOperationTonemapReinhard(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentOperationTonemapReinhard_V3",
             category="latent/advanced/operations",
             is_experimental=True,
@@ -302,7 +302,7 @@ class LatentOperationTonemapReinhard(io.ComfyNodeV3):
 class LatentSubtract(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentSubtract_V3",
             category="latent/advanced",
             inputs=[

--- a/comfy_extras/v3/nodes_latent.py
+++ b/comfy_extras/v3/nodes_latent.py
@@ -17,7 +17,7 @@ def reshape_latent_to(target_shape, latent, repeat_batch=True):
     return latent
 
 
-class LatentAdd(io.ComfyNodeV3):
+class LatentAdd(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -44,7 +44,7 @@ class LatentAdd(io.ComfyNodeV3):
         return io.NodeOutput(samples_out)
 
 
-class LatentApplyOperation(io.ComfyNodeV3):
+class LatentApplyOperation(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -69,7 +69,7 @@ class LatentApplyOperation(io.ComfyNodeV3):
         return io.NodeOutput(samples_out)
 
 
-class LatentApplyOperationCFG(io.ComfyNodeV3):
+class LatentApplyOperationCFG(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -101,7 +101,7 @@ class LatentApplyOperationCFG(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class LatentBatch(io.ComfyNodeV3):
+class LatentBatch(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -130,7 +130,7 @@ class LatentBatch(io.ComfyNodeV3):
         return io.NodeOutput(samples_out)
 
 
-class LatentBatchSeedBehavior(io.ComfyNodeV3):
+class LatentBatchSeedBehavior(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -159,7 +159,7 @@ class LatentBatchSeedBehavior(io.ComfyNodeV3):
         return io.NodeOutput(samples_out)
 
 
-class LatentInterpolate(io.ComfyNodeV3):
+class LatentInterpolate(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -198,7 +198,7 @@ class LatentInterpolate(io.ComfyNodeV3):
         return io.NodeOutput(samples_out)
 
 
-class LatentMultiply(io.ComfyNodeV3):
+class LatentMultiply(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -222,7 +222,7 @@ class LatentMultiply(io.ComfyNodeV3):
         return io.NodeOutput(samples_out)
 
 
-class LatentOperationSharpen(io.ComfyNodeV3):
+class LatentOperationSharpen(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -264,7 +264,7 @@ class LatentOperationSharpen(io.ComfyNodeV3):
         return io.NodeOutput(sharpen)
 
 
-class LatentOperationTonemapReinhard(io.ComfyNodeV3):
+class LatentOperationTonemapReinhard(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -299,7 +299,7 @@ class LatentOperationTonemapReinhard(io.ComfyNodeV3):
         return io.NodeOutput(tonemap_reinhard)
 
 
-class LatentSubtract(io.ComfyNodeV3):
+class LatentSubtract(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_lt.py
+++ b/comfy_extras/v3/nodes_lt.py
@@ -86,7 +86,7 @@ def preprocess(image: torch.Tensor, crf=29):
     return torch.tensor(image_array, dtype=image.dtype, device=image.device) / 255.0
 
 
-class EmptyLTXVLatentVideo(io.ComfyNodeV3):
+class EmptyLTXVLatentVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -112,7 +112,7 @@ class EmptyLTXVLatentVideo(io.ComfyNodeV3):
         return io.NodeOutput({"samples": latent})
 
 
-class LTXVAddGuide(io.ComfyNodeV3):
+class LTXVAddGuide(io.ComfyNode):
     NUM_PREFIX_FRAMES = 2
     PATCHIFIER = SymmetricPatchifier(1)
 
@@ -275,7 +275,7 @@ class LTXVAddGuide(io.ComfyNodeV3):
         return latent_image, noise_mask
 
 
-class LTXVConditioning(io.ComfyNodeV3):
+class LTXVConditioning(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -299,7 +299,7 @@ class LTXVConditioning(io.ComfyNodeV3):
         return io.NodeOutput(positive, negative)
 
 
-class LTXVCropGuides(io.ComfyNodeV3):
+class LTXVCropGuides(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -335,7 +335,7 @@ class LTXVCropGuides(io.ComfyNodeV3):
         return io.NodeOutput(positive, negative, {"samples": latent_image, "noise_mask": noise_mask})
 
 
-class LTXVImgToVideo(io.ComfyNodeV3):
+class LTXVImgToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -383,7 +383,7 @@ class LTXVImgToVideo(io.ComfyNodeV3):
         return io.NodeOutput(positive, negative, {"samples": latent, "noise_mask": conditioning_latent_frames_mask})
 
 
-class LTXVPreprocess(io.ComfyNodeV3):
+class LTXVPreprocess(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -408,7 +408,7 @@ class LTXVPreprocess(io.ComfyNodeV3):
         return io.NodeOutput(torch.stack(output_images))
 
 
-class LTXVScheduler(io.ComfyNodeV3):
+class LTXVScheduler(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -471,7 +471,7 @@ class LTXVScheduler(io.ComfyNodeV3):
         return io.NodeOutput(sigmas)
 
 
-class ModelSamplingLTXV(io.ComfyNodeV3):
+class ModelSamplingLTXV(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_lt.py
+++ b/comfy_extras/v3/nodes_lt.py
@@ -89,7 +89,7 @@ def preprocess(image: torch.Tensor, crf=29):
 class EmptyLTXVLatentVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="EmptyLTXVLatentVideo_V3",
             category="latent/video/ltxv",
             inputs=[
@@ -118,7 +118,7 @@ class LTXVAddGuide(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LTXVAddGuide_V3",
             category="conditioning/video_models",
             inputs=[
@@ -278,7 +278,7 @@ class LTXVAddGuide(io.ComfyNodeV3):
 class LTXVConditioning(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LTXVConditioning_V3",
             category="conditioning/video_models",
             inputs=[
@@ -302,7 +302,7 @@ class LTXVConditioning(io.ComfyNodeV3):
 class LTXVCropGuides(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LTXVCropGuides_V3",
             category="conditioning/video_models",
             inputs=[
@@ -338,7 +338,7 @@ class LTXVCropGuides(io.ComfyNodeV3):
 class LTXVImgToVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LTXVImgToVideo_V3",
             category="conditioning/video_models",
             inputs=[
@@ -386,7 +386,7 @@ class LTXVImgToVideo(io.ComfyNodeV3):
 class LTXVPreprocess(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LTXVPreprocess_V3",
             category="image",
             inputs=[
@@ -411,7 +411,7 @@ class LTXVPreprocess(io.ComfyNodeV3):
 class LTXVScheduler(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LTXVScheduler_V3",
             category="sampling/custom_sampling/schedulers",
             inputs=[
@@ -474,7 +474,7 @@ class LTXVScheduler(io.ComfyNodeV3):
 class ModelSamplingLTXV(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelSamplingLTXV_V3",
             category="advanced/model",
             inputs=[

--- a/comfy_extras/v3/nodes_mask.py
+++ b/comfy_extras/v3/nodes_mask.py
@@ -57,7 +57,7 @@ def composite(destination, source, x, y, mask=None, multiplier=8, resize_source=
     return destination
 
 
-class CropMask(io.ComfyNodeV3):
+class CropMask(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -80,7 +80,7 @@ class CropMask(io.ComfyNodeV3):
         return io.NodeOutput(mask[:, y : y + height, x : x + width])
 
 
-class FeatherMask(io.ComfyNodeV3):
+class FeatherMask(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -125,7 +125,7 @@ class FeatherMask(io.ComfyNodeV3):
         return io.NodeOutput(output)
 
 
-class GrowMask(io.ComfyNodeV3):
+class GrowMask(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -158,7 +158,7 @@ class GrowMask(io.ComfyNodeV3):
         return io.NodeOutput(torch.stack(out, dim=0))
 
 
-class ImageColorToMask(io.ComfyNodeV3):
+class ImageColorToMask(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -183,7 +183,7 @@ class ImageColorToMask(io.ComfyNodeV3):
         return io.NodeOutput(torch.where(temp == color, 1.0, 0).float())
 
 
-class ImageCompositeMasked(io.ComfyNodeV3):
+class ImageCompositeMasked(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -209,7 +209,7 @@ class ImageCompositeMasked(io.ComfyNodeV3):
         return io.NodeOutput(output)
 
 
-class ImageToMask(io.ComfyNodeV3):
+class ImageToMask(io.ComfyNode):
     CHANNELS = ["red", "green", "blue", "alpha"]
 
     @classmethod
@@ -230,7 +230,7 @@ class ImageToMask(io.ComfyNodeV3):
         return io.NodeOutput(image[:, :, :, cls.CHANNELS.index(channel)])
 
 
-class InvertMask(io.ComfyNodeV3):
+class InvertMask(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -248,7 +248,7 @@ class InvertMask(io.ComfyNodeV3):
         return io.NodeOutput(1.0 - mask)
 
 
-class LatentCompositeMasked(io.ComfyNodeV3):
+class LatentCompositeMasked(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -275,7 +275,7 @@ class LatentCompositeMasked(io.ComfyNodeV3):
         return io.NodeOutput(output)
 
 
-class MaskComposite(io.ComfyNodeV3):
+class MaskComposite(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -335,7 +335,7 @@ class MaskComposite(io.ComfyNodeV3):
         return io.NodeOutput(torch.clamp(output, 0.0, 1.0))
 
 
-class MaskPreview(io.ComfyNodeV3):
+class MaskPreview(io.ComfyNode):
     """Mask Preview - original implement in ComfyUI_essentials.
 
     https://github.com/cubiq/ComfyUI_essentials/blob/9d9f4bedfc9f0321c19faf71855e228c93bd0dc9/mask.py#L81
@@ -360,7 +360,7 @@ class MaskPreview(io.ComfyNodeV3):
         return io.NodeOutput(ui=ui.PreviewMask(masks))
 
 
-class MaskToImage(io.ComfyNodeV3):
+class MaskToImage(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -378,7 +378,7 @@ class MaskToImage(io.ComfyNodeV3):
         return io.NodeOutput(mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])).movedim(1, -1).expand(-1, -1, -1, 3))
 
 
-class SolidMask(io.ComfyNodeV3):
+class SolidMask(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -398,7 +398,7 @@ class SolidMask(io.ComfyNodeV3):
         return io.NodeOutput(torch.full((1, height, width), value, dtype=torch.float32, device="cpu"))
 
 
-class ThresholdMask(io.ComfyNodeV3):
+class ThresholdMask(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -417,7 +417,7 @@ class ThresholdMask(io.ComfyNodeV3):
         return io.NodeOutput((mask > value).float())
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     CropMask,
     FeatherMask,
     GrowMask,

--- a/comfy_extras/v3/nodes_mask.py
+++ b/comfy_extras/v3/nodes_mask.py
@@ -60,7 +60,7 @@ def composite(destination, source, x, y, mask=None, multiplier=8, resize_source=
 class CropMask(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="CropMask_V3",
             display_name="Crop Mask _V3",
             category="mask",
@@ -83,7 +83,7 @@ class CropMask(io.ComfyNodeV3):
 class FeatherMask(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="FeatherMask_V3",
             display_name="Feather Mask _V3",
             category="mask",
@@ -128,7 +128,7 @@ class FeatherMask(io.ComfyNodeV3):
 class GrowMask(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="GrowMask_V3",
             display_name="Grow Mask _V3",
             category="mask",
@@ -161,7 +161,7 @@ class GrowMask(io.ComfyNodeV3):
 class ImageColorToMask(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageColorToMask_V3",
             display_name="Image Color to Mask _V3",
             category="mask",
@@ -186,7 +186,7 @@ class ImageColorToMask(io.ComfyNodeV3):
 class ImageCompositeMasked(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageCompositeMasked_V3",
             display_name="Image Composite Masked _V3",
             category="image",
@@ -214,7 +214,7 @@ class ImageToMask(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageToMask_V3",
             display_name="Convert Image to Mask _V3",
             category="mask",
@@ -233,7 +233,7 @@ class ImageToMask(io.ComfyNodeV3):
 class InvertMask(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="InvertMask_V3",
             display_name="Invert Mask _V3",
             category="mask",
@@ -251,7 +251,7 @@ class InvertMask(io.ComfyNodeV3):
 class LatentCompositeMasked(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LatentCompositeMasked_V3",
             display_name="Latent Composite Masked _V3",
             category="latent",
@@ -278,7 +278,7 @@ class LatentCompositeMasked(io.ComfyNodeV3):
 class MaskComposite(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="MaskComposite_V3",
             display_name="Mask Composite _V3",
             category="mask",
@@ -344,7 +344,7 @@ class MaskPreview(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="MaskPreview_V3",
             display_name="Preview Mask _V3",
             category="mask",
@@ -363,7 +363,7 @@ class MaskPreview(io.ComfyNodeV3):
 class MaskToImage(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="MaskToImage_V3",
             display_name="Convert Mask to Image _V3",
             category="mask",
@@ -381,7 +381,7 @@ class MaskToImage(io.ComfyNodeV3):
 class SolidMask(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SolidMask_V3",
             display_name="Solid Mask _V3",
             category="mask",
@@ -401,7 +401,7 @@ class SolidMask(io.ComfyNodeV3):
 class ThresholdMask(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ThresholdMask_V3",
             display_name="Threshold Mask _V3",
             category="mask",

--- a/comfy_extras/v3/nodes_mochi.py
+++ b/comfy_extras/v3/nodes_mochi.py
@@ -7,7 +7,7 @@ import nodes
 from comfy_api.v3 import io
 
 
-class EmptyMochiLatentVideo(io.ComfyNodeV3):
+class EmptyMochiLatentVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_mochi.py
+++ b/comfy_extras/v3/nodes_mochi.py
@@ -10,7 +10,7 @@ from comfy_api.v3 import io
 class EmptyMochiLatentVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="EmptyMochiLatentVideo_V3",
             category="latent/video",
             inputs=[

--- a/comfy_extras/v3/nodes_model_advanced.py
+++ b/comfy_extras/v3/nodes_model_advanced.py
@@ -60,7 +60,7 @@ class ModelSamplingDiscreteDistilled(comfy.model_sampling.ModelSamplingDiscrete)
 class ModelComputeDtype(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelComputeDtype_V3",
             category="advanced/debug/model",
             inputs=[
@@ -82,7 +82,7 @@ class ModelComputeDtype(io.ComfyNodeV3):
 class ModelSamplingContinuousEDM(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelSamplingContinuousEDM_V3",
             category="advanced/model",
             inputs=[
@@ -134,7 +134,7 @@ class ModelSamplingContinuousEDM(io.ComfyNodeV3):
 class ModelSamplingContinuousV(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelSamplingContinuousV_V3",
             category="advanced/model",
             inputs=[
@@ -168,7 +168,7 @@ class ModelSamplingContinuousV(io.ComfyNodeV3):
 class ModelSamplingDiscrete(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelSamplingDiscrete_V3",
             category="advanced/model",
             inputs=[
@@ -210,7 +210,7 @@ class ModelSamplingDiscrete(io.ComfyNodeV3):
 class ModelSamplingFlux(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelSamplingFlux_V3",
             category="advanced/model",
             inputs=[
@@ -250,7 +250,7 @@ class ModelSamplingFlux(io.ComfyNodeV3):
 class ModelSamplingSD3(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelSamplingSD3_V3",
             category="advanced/model",
             inputs=[
@@ -281,7 +281,7 @@ class ModelSamplingSD3(io.ComfyNodeV3):
 class ModelSamplingAuraFlow(ModelSamplingSD3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelSamplingAuraFlow_V3",
             category="advanced/model",
             inputs=[
@@ -301,7 +301,7 @@ class ModelSamplingAuraFlow(ModelSamplingSD3):
 class ModelSamplingStableCascade(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ModelSamplingStableCascade_V3",
             category="advanced/model",
             inputs=[
@@ -332,7 +332,7 @@ class ModelSamplingStableCascade(io.ComfyNodeV3):
 class RescaleCFG(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="RescaleCFG_V3",
             category="advanced/model",
             inputs=[

--- a/comfy_extras/v3/nodes_model_advanced.py
+++ b/comfy_extras/v3/nodes_model_advanced.py
@@ -57,7 +57,7 @@ class ModelSamplingDiscreteDistilled(comfy.model_sampling.ModelSamplingDiscrete)
         return log_sigma.exp().to(timestep.device)
 
 
-class ModelComputeDtype(io.ComfyNodeV3):
+class ModelComputeDtype(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -79,7 +79,7 @@ class ModelComputeDtype(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class ModelSamplingContinuousEDM(io.ComfyNodeV3):
+class ModelSamplingContinuousEDM(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -131,7 +131,7 @@ class ModelSamplingContinuousEDM(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class ModelSamplingContinuousV(io.ComfyNodeV3):
+class ModelSamplingContinuousV(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -165,7 +165,7 @@ class ModelSamplingContinuousV(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class ModelSamplingDiscrete(io.ComfyNodeV3):
+class ModelSamplingDiscrete(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -207,7 +207,7 @@ class ModelSamplingDiscrete(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class ModelSamplingFlux(io.ComfyNodeV3):
+class ModelSamplingFlux(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -247,7 +247,7 @@ class ModelSamplingFlux(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class ModelSamplingSD3(io.ComfyNodeV3):
+class ModelSamplingSD3(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -298,7 +298,7 @@ class ModelSamplingAuraFlow(ModelSamplingSD3):
         return super().execute(model, shift, multiplier)
 
 
-class ModelSamplingStableCascade(io.ComfyNodeV3):
+class ModelSamplingStableCascade(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -329,7 +329,7 @@ class ModelSamplingStableCascade(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class RescaleCFG(io.ComfyNodeV3):
+class RescaleCFG(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_model_downscale.py
+++ b/comfy_extras/v3/nodes_model_downscale.py
@@ -9,7 +9,7 @@ class PatchModelAddDownscale(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PatchModelAddDownscale_V3",
             display_name="PatchModelAddDownscale (Kohya Deep Shrink) _V3",
             category="model_patches/unet",

--- a/comfy_extras/v3/nodes_model_downscale.py
+++ b/comfy_extras/v3/nodes_model_downscale.py
@@ -4,7 +4,7 @@ import comfy.utils
 from comfy_api.v3 import io
 
 
-class PatchModelAddDownscale(io.ComfyNodeV3):
+class PatchModelAddDownscale(io.ComfyNode):
     UPSCALE_METHODS = ["bicubic", "nearest-exact", "bilinear", "area", "bislerp"]
 
     @classmethod

--- a/comfy_extras/v3/nodes_morphology.py
+++ b/comfy_extras/v3/nodes_morphology.py
@@ -16,7 +16,7 @@ import comfy.model_management
 from comfy_api.v3 import io
 
 
-class ImageRGBToYUV(io.ComfyNodeV3):
+class ImageRGBToYUV(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -38,7 +38,7 @@ class ImageRGBToYUV(io.ComfyNodeV3):
         return io.NodeOutput(out[..., 0:1].expand_as(image), out[..., 1:2].expand_as(image), out[..., 2:3].expand_as(image))
 
 
-class ImageYUVToRGB(io.ComfyNodeV3):
+class ImageYUVToRGB(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -60,7 +60,7 @@ class ImageYUVToRGB(io.ComfyNodeV3):
         return io.NodeOutput(kornia.color.ycbcr_to_rgb(image.movedim(-1, 1)).movedim(1, -1))
 
 
-class Morphology(io.ComfyNodeV3):
+class Morphology(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_morphology.py
+++ b/comfy_extras/v3/nodes_morphology.py
@@ -19,7 +19,7 @@ from comfy_api.v3 import io
 class ImageRGBToYUV(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageRGBToYUV_V3",
             category="image/batch",
             inputs=[
@@ -41,7 +41,7 @@ class ImageRGBToYUV(io.ComfyNodeV3):
 class ImageYUVToRGB(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageYUVToRGB_V3",
             category="image/batch",
             inputs=[
@@ -63,7 +63,7 @@ class ImageYUVToRGB(io.ComfyNodeV3):
 class Morphology(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="Morphology_V3",
             display_name="ImageMorphology _V3",
             category="image/postprocessing",

--- a/comfy_extras/v3/nodes_optimalsteps.py
+++ b/comfy_extras/v3/nodes_optimalsteps.py
@@ -29,7 +29,7 @@ NOISE_LEVELS = {
 class OptimalStepsScheduler(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="OptimalStepsScheduler_V3",
             category="sampling/custom_sampling/schedulers",
             inputs=[

--- a/comfy_extras/v3/nodes_optimalsteps.py
+++ b/comfy_extras/v3/nodes_optimalsteps.py
@@ -26,7 +26,7 @@ NOISE_LEVELS = {
 }
 
 
-class OptimalStepsScheduler(io.ComfyNodeV3):
+class OptimalStepsScheduler(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_pag.py
+++ b/comfy_extras/v3/nodes_pag.py
@@ -13,7 +13,7 @@ from comfy_api.v3 import io
 class PerturbedAttentionGuidance(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PerturbedAttentionGuidance_V3",
             category="model_patches/unet",
             inputs=[

--- a/comfy_extras/v3/nodes_pag.py
+++ b/comfy_extras/v3/nodes_pag.py
@@ -10,7 +10,7 @@ from comfy_api.v3 import io
 #My modified one here is more basic but has fewer chances of breaking with ComfyUI updates.
 
 
-class PerturbedAttentionGuidance(io.ComfyNodeV3):
+class PerturbedAttentionGuidance(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_perpneg.py
+++ b/comfy_extras/v3/nodes_perpneg.py
@@ -84,7 +84,7 @@ class Guider_PerpNeg(comfy.samplers.CFGGuider):
 class PerpNegGuider(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PerpNegGuider_V3",
             category="_for_testing",
             inputs=[

--- a/comfy_extras/v3/nodes_perpneg.py
+++ b/comfy_extras/v3/nodes_perpneg.py
@@ -81,7 +81,7 @@ class Guider_PerpNeg(comfy.samplers.CFGGuider):
         return cfg_result
 
 
-class PerpNegGuider(io.ComfyNodeV3):
+class PerpNegGuider(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_photomaker.py
+++ b/comfy_extras/v3/nodes_photomaker.py
@@ -121,7 +121,7 @@ class PhotoMakerIDEncoder(comfy.clip_model.CLIPVisionModelProjection):
         return self.fuse_module(prompt_embeds, id_embeds, class_tokens_mask)
 
 
-class PhotoMakerEncode(io.ComfyNodeV3):
+class PhotoMakerEncode(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -173,7 +173,7 @@ class PhotoMakerEncode(io.ComfyNodeV3):
         return io.NodeOutput([[out, {"pooled_output": pooled}]])
 
 
-class PhotoMakerLoader(io.ComfyNodeV3):
+class PhotoMakerLoader(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_photomaker.py
+++ b/comfy_extras/v3/nodes_photomaker.py
@@ -124,7 +124,7 @@ class PhotoMakerIDEncoder(comfy.clip_model.CLIPVisionModelProjection):
 class PhotoMakerEncode(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PhotoMakerEncode_V3",
             category="_for_testing/photomaker",
             inputs=[
@@ -176,7 +176,7 @@ class PhotoMakerEncode(io.ComfyNodeV3):
 class PhotoMakerLoader(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PhotoMakerLoader_V3",
             category="_for_testing/photomaker",
             inputs=[

--- a/comfy_extras/v3/nodes_pixart.py
+++ b/comfy_extras/v3/nodes_pixart.py
@@ -4,7 +4,7 @@ import nodes
 from comfy_api.v3 import io
 
 
-class CLIPTextEncodePixArtAlpha(io.ComfyNodeV3):
+class CLIPTextEncodePixArtAlpha(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_pixart.py
+++ b/comfy_extras/v3/nodes_pixart.py
@@ -7,7 +7,7 @@ from comfy_api.v3 import io
 class CLIPTextEncodePixArtAlpha(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="CLIPTextEncodePixArtAlpha_V3",
             category="advanced/conditioning",
             description="Encodes text and sets the resolution conditioning for PixArt Alpha. Does not apply to PixArt Sigma.",

--- a/comfy_extras/v3/nodes_post_processing.py
+++ b/comfy_extras/v3/nodes_post_processing.py
@@ -23,7 +23,7 @@ def gaussian_kernel(kernel_size: int, sigma: float, device=None):
 class Blend(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageBlend_V3",
             category="image/postprocessing",
             inputs=[
@@ -77,7 +77,7 @@ class Blend(io.ComfyNodeV3):
 class Blur(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageBlur_V3",
             category="image/postprocessing",
             inputs=[
@@ -115,7 +115,7 @@ class ImageScaleToTotalPixels(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageScaleToTotalPixels_V3",
             category="image/upscaling",
             inputs=[
@@ -144,7 +144,7 @@ class ImageScaleToTotalPixels(io.ComfyNodeV3):
 class Quantize(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageQuantize_V3",
             category="image/postprocessing",
             inputs=[
@@ -208,7 +208,7 @@ class Quantize(io.ComfyNodeV3):
 class Sharpen(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="ImageSharpen_V3",
             category="image/postprocessing",
             inputs=[

--- a/comfy_extras/v3/nodes_post_processing.py
+++ b/comfy_extras/v3/nodes_post_processing.py
@@ -20,7 +20,7 @@ def gaussian_kernel(kernel_size: int, sigma: float, device=None):
     return g / g.sum()
 
 
-class Blend(io.ComfyNodeV3):
+class Blend(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -74,7 +74,7 @@ class Blend(io.ComfyNodeV3):
         return torch.where(x <= 0.25, ((16 * x - 12) * x + 4) * x, torch.sqrt(x))
 
 
-class Blur(io.ComfyNodeV3):
+class Blur(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -109,7 +109,7 @@ class Blur(io.ComfyNodeV3):
         return io.NodeOutput(blurred.to(comfy.model_management.intermediate_device()))
 
 
-class ImageScaleToTotalPixels(io.ComfyNodeV3):
+class ImageScaleToTotalPixels(io.ComfyNode):
     upscale_methods = ["nearest-exact", "bilinear", "area", "bicubic", "lanczos"]
     crop_methods = ["disabled", "center"]
 
@@ -141,7 +141,7 @@ class ImageScaleToTotalPixels(io.ComfyNodeV3):
         return io.NodeOutput(s.movedim(1,-1))
 
 
-class Quantize(io.ComfyNodeV3):
+class Quantize(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -205,7 +205,7 @@ class Quantize(io.ComfyNodeV3):
         return io.NodeOutput(result)
 
 
-class Sharpen(io.ComfyNodeV3):
+class Sharpen(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_preview_any.py
+++ b/comfy_extras/v3/nodes_preview_any.py
@@ -12,7 +12,7 @@ class PreviewAny(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PreviewAny_V3",  # frontend expects "PreviewAny" to work
             display_name="Preview Any _V3",  # frontend ignores "display_name" for this node
             description="Preview any type of data by converting it to a readable text format.",

--- a/comfy_extras/v3/nodes_preview_any.py
+++ b/comfy_extras/v3/nodes_preview_any.py
@@ -5,7 +5,7 @@ import json
 from comfy_api.v3 import io, ui
 
 
-class PreviewAny(io.ComfyNodeV3):
+class PreviewAny(io.ComfyNode):
     """Originally implement from https://github.com/rgthree/rgthree-comfy/blob/main/py/display_any.py
 
     upstream requested in https://github.com/Kosinkadink/rfcs/blob/main/rfcs/0000-corenodes.md#preview-nodes"""
@@ -42,6 +42,6 @@ class PreviewAny(io.ComfyNodeV3):
         return io.NodeOutput(ui=ui.PreviewText(value))
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     PreviewAny,
 ]

--- a/comfy_extras/v3/nodes_primitive.py
+++ b/comfy_extras/v3/nodes_primitive.py
@@ -8,7 +8,7 @@ from comfy_api.v3 import io
 class String(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PrimitiveString_V3",
             display_name="String _V3",
             category="utils/primitive",
@@ -26,7 +26,7 @@ class String(io.ComfyNodeV3):
 class StringMultiline(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PrimitiveStringMultiline_V3",
             display_name="String (Multiline) _V3",
             category="utils/primitive",
@@ -44,7 +44,7 @@ class StringMultiline(io.ComfyNodeV3):
 class Int(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PrimitiveInt_V3",
             display_name="Int _V3",
             category="utils/primitive",
@@ -62,7 +62,7 @@ class Int(io.ComfyNodeV3):
 class Float(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PrimitiveFloat_V3",
             display_name="Float _V3",
             category="utils/primitive",
@@ -80,7 +80,7 @@ class Float(io.ComfyNodeV3):
 class Boolean(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="PrimitiveBoolean_V3",
             display_name="Boolean _V3",
             category="utils/primitive",

--- a/comfy_extras/v3/nodes_primitive.py
+++ b/comfy_extras/v3/nodes_primitive.py
@@ -5,7 +5,7 @@ import sys
 from comfy_api.v3 import io
 
 
-class String(io.ComfyNodeV3):
+class String(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -23,7 +23,7 @@ class String(io.ComfyNodeV3):
         return io.NodeOutput(value)
 
 
-class StringMultiline(io.ComfyNodeV3):
+class StringMultiline(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -41,7 +41,7 @@ class StringMultiline(io.ComfyNodeV3):
         return io.NodeOutput(value)
 
 
-class Int(io.ComfyNodeV3):
+class Int(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -59,7 +59,7 @@ class Int(io.ComfyNodeV3):
         return io.NodeOutput(value)
 
 
-class Float(io.ComfyNodeV3):
+class Float(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -77,7 +77,7 @@ class Float(io.ComfyNodeV3):
         return io.NodeOutput(value)
 
 
-class Boolean(io.ComfyNodeV3):
+class Boolean(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -95,7 +95,7 @@ class Boolean(io.ComfyNodeV3):
         return io.NodeOutput(value)
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     String,
     StringMultiline,
     Int,

--- a/comfy_extras/v3/nodes_rebatch.py
+++ b/comfy_extras/v3/nodes_rebatch.py
@@ -8,7 +8,7 @@ from comfy_api.v3 import io
 class ImageRebatch(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="RebatchImages_V3",
             display_name="Rebatch Images _V3",
             category="image/batch",
@@ -41,7 +41,7 @@ class ImageRebatch(io.ComfyNodeV3):
 class LatentRebatch(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="RebatchLatents_V3",
             display_name="Rebatch Latents _V3",
             category="latent/batch",

--- a/comfy_extras/v3/nodes_rebatch.py
+++ b/comfy_extras/v3/nodes_rebatch.py
@@ -5,7 +5,7 @@ import torch
 from comfy_api.v3 import io
 
 
-class ImageRebatch(io.ComfyNodeV3):
+class ImageRebatch(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -38,7 +38,7 @@ class ImageRebatch(io.ComfyNodeV3):
         return io.NodeOutput(output_list)
 
 
-class LatentRebatch(io.ComfyNodeV3):
+class LatentRebatch(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_sag.py
+++ b/comfy_extras/v3/nodes_sag.py
@@ -111,7 +111,7 @@ def gaussian_blur_2d(img, kernel_size, sigma):
     return F.conv2d(img, kernel2d, groups=img.shape[-3])
 
 
-class SelfAttentionGuidance(io.ComfyNodeV3):
+class SelfAttentionGuidance(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_sag.py
+++ b/comfy_extras/v3/nodes_sag.py
@@ -114,7 +114,7 @@ def gaussian_blur_2d(img, kernel_size, sigma):
 class SelfAttentionGuidance(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SelfAttentionGuidance_V3",
             display_name="Self-Attention Guidance _V3",
             category="_for_testing",

--- a/comfy_extras/v3/nodes_sd3.py
+++ b/comfy_extras/v3/nodes_sd3.py
@@ -10,7 +10,7 @@ from comfy_api.v3 import io
 from comfy_extras.v3.nodes_slg import SkipLayerGuidanceDiT
 
 
-class CLIPTextEncodeSD3(io.ComfyNodeV3):
+class CLIPTextEncodeSD3(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -54,7 +54,7 @@ class CLIPTextEncodeSD3(io.ComfyNodeV3):
         return io.NodeOutput(clip.encode_from_tokens_scheduled(tokens))
 
 
-class EmptySD3LatentImage(io.ComfyNodeV3):
+class EmptySD3LatentImage(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -109,7 +109,7 @@ class SkipLayerGuidanceSD3(SkipLayerGuidanceDiT):
         )
 
 
-class TripleCLIPLoader(io.ComfyNodeV3):
+class TripleCLIPLoader(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_sd3.py
+++ b/comfy_extras/v3/nodes_sd3.py
@@ -13,7 +13,7 @@ from comfy_extras.v3.nodes_slg import SkipLayerGuidanceDiT
 class CLIPTextEncodeSD3(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="CLIPTextEncodeSD3_V3",
             category="advanced/conditioning",
             inputs=[
@@ -57,7 +57,7 @@ class CLIPTextEncodeSD3(io.ComfyNodeV3):
 class EmptySD3LatentImage(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="EmptySD3LatentImage_V3",
             category="latent/sd3",
             inputs=[
@@ -86,7 +86,7 @@ class SkipLayerGuidanceSD3(SkipLayerGuidanceDiT):
     """
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SkipLayerGuidanceSD3_V3",
             category="advanced/guidance",
             inputs=[
@@ -112,7 +112,7 @@ class SkipLayerGuidanceSD3(SkipLayerGuidanceDiT):
 class TripleCLIPLoader(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="TripleCLIPLoader_V3",
             category="advanced/loaders",
             description="[Recipes]\n\nsd3: clip-l, clip-g, t5",

--- a/comfy_extras/v3/nodes_sdupscale.py
+++ b/comfy_extras/v3/nodes_sdupscale.py
@@ -6,7 +6,7 @@ import comfy.utils
 from comfy_api.v3 import io
 
 
-class SD_4XUpscale_Conditioning(io.ComfyNodeV3):
+class SD_4XUpscale_Conditioning(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_sdupscale.py
+++ b/comfy_extras/v3/nodes_sdupscale.py
@@ -9,7 +9,7 @@ from comfy_api.v3 import io
 class SD_4XUpscale_Conditioning(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SD_4XUpscale_Conditioning_V3",
             category="conditioning/upscale_diffusion",
             inputs=[

--- a/comfy_extras/v3/nodes_slg.py
+++ b/comfy_extras/v3/nodes_slg.py
@@ -16,7 +16,7 @@ class SkipLayerGuidanceDiT(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SkipLayerGuidanceDiT_V3",
             category="advanced/guidance",
             description="Generic version of SkipLayerGuidance node that can be used on every DiT model.",
@@ -97,7 +97,7 @@ class SkipLayerGuidanceDiTSimple(io.ComfyNodeV3):
 
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SkipLayerGuidanceDiTSimple_V3",
             category="advanced/guidance",
             description="Simple version of the SkipLayerGuidanceDiT node that only modifies the uncond pass.",

--- a/comfy_extras/v3/nodes_slg.py
+++ b/comfy_extras/v3/nodes_slg.py
@@ -7,7 +7,7 @@ import comfy.samplers
 from comfy_api.v3 import io
 
 
-class SkipLayerGuidanceDiT(io.ComfyNodeV3):
+class SkipLayerGuidanceDiT(io.ComfyNode):
     """
     Enhance guidance towards detailed dtructure by having another set of CFG negative with skipped layers.
     Inspired by Perturbed Attention Guidance (https://arxiv.org/abs/2403.17377)
@@ -92,7 +92,7 @@ class SkipLayerGuidanceDiT(io.ComfyNodeV3):
         return io.NodeOutput(m)
 
 
-class SkipLayerGuidanceDiTSimple(io.ComfyNodeV3):
+class SkipLayerGuidanceDiTSimple(io.ComfyNode):
     """Simple version of the SkipLayerGuidanceDiT node that only modifies the uncond pass."""
 
     @classmethod

--- a/comfy_extras/v3/nodes_stable_cascade.py
+++ b/comfy_extras/v3/nodes_stable_cascade.py
@@ -23,7 +23,7 @@ import nodes
 from comfy_api.v3 import io
 
 
-class StableCascade_EmptyLatentImage(io.ComfyNodeV3):
+class StableCascade_EmptyLatentImage(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -48,7 +48,7 @@ class StableCascade_EmptyLatentImage(io.ComfyNodeV3):
         return io.NodeOutput({"samples": c_latent}, {"samples": b_latent})
 
 
-class StableCascade_StageC_VAEEncode(io.ComfyNodeV3):
+class StableCascade_StageC_VAEEncode(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -79,7 +79,7 @@ class StableCascade_StageC_VAEEncode(io.ComfyNodeV3):
         return io.NodeOutput({"samples": c_latent}, {"samples": b_latent})
 
 
-class StableCascade_StageB_Conditioning(io.ComfyNodeV3):
+class StableCascade_StageB_Conditioning(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -105,7 +105,7 @@ class StableCascade_StageB_Conditioning(io.ComfyNodeV3):
         return io.NodeOutput(c)
 
 
-class StableCascade_SuperResolutionControlnet(io.ComfyNodeV3):
+class StableCascade_SuperResolutionControlnet(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -135,7 +135,7 @@ class StableCascade_SuperResolutionControlnet(io.ComfyNodeV3):
         return io.NodeOutput(controlnet_input, {"samples": c_latent}, {"samples": b_latent})
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [
+NODES_LIST: list[type[io.ComfyNode]] = [
     StableCascade_EmptyLatentImage,
     StableCascade_StageB_Conditioning,
     StableCascade_StageC_VAEEncode,

--- a/comfy_extras/v3/nodes_stable_cascade.py
+++ b/comfy_extras/v3/nodes_stable_cascade.py
@@ -26,7 +26,7 @@ from comfy_api.v3 import io
 class StableCascade_EmptyLatentImage(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="StableCascade_EmptyLatentImage_V3",
             category="latent/stable_cascade",
             inputs=[
@@ -51,7 +51,7 @@ class StableCascade_EmptyLatentImage(io.ComfyNodeV3):
 class StableCascade_StageC_VAEEncode(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="StableCascade_StageC_VAEEncode_V3",
             category="latent/stable_cascade",
             inputs=[
@@ -82,7 +82,7 @@ class StableCascade_StageC_VAEEncode(io.ComfyNodeV3):
 class StableCascade_StageB_Conditioning(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="StableCascade_StageB_Conditioning_V3",
             category="conditioning/stable_cascade",
             inputs=[
@@ -108,7 +108,7 @@ class StableCascade_StageB_Conditioning(io.ComfyNodeV3):
 class StableCascade_SuperResolutionControlnet(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="StableCascade_SuperResolutionControlnet_V3",
             category="_for_testing/stable_cascade",
             is_experimental=True,

--- a/comfy_extras/v3/nodes_video.py
+++ b/comfy_extras/v3/nodes_video.py
@@ -15,7 +15,7 @@ from comfy_api.util import VideoCodec, VideoComponents, VideoContainer
 from comfy_api.v3 import io, ui
 
 
-class CreateVideo(io.ComfyNodeV3):
+class CreateVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -44,7 +44,7 @@ class CreateVideo(io.ComfyNodeV3):
         ))
 
 
-class GetVideoComponents(io.ComfyNodeV3):
+class GetVideoComponents(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -68,7 +68,7 @@ class GetVideoComponents(io.ComfyNodeV3):
         return io.NodeOutput(components.images, components.audio, float(components.frame_rate))
 
 
-class LoadVideo(io.ComfyNodeV3):
+class LoadVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         input_dir = folder_paths.get_input_directory()
@@ -105,7 +105,7 @@ class LoadVideo(io.ComfyNodeV3):
         return True
 
 
-class SaveVideo(io.ComfyNodeV3):
+class SaveVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -152,7 +152,7 @@ class SaveVideo(io.ComfyNodeV3):
         return io.NodeOutput(ui=ui.PreviewVideo([ui.SavedResult(file, subfolder, io.FolderType.output)]))
 
 
-class SaveWEBM(io.ComfyNodeV3):
+class SaveWEBM(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_video.py
+++ b/comfy_extras/v3/nodes_video.py
@@ -18,7 +18,7 @@ from comfy_api.v3 import io, ui
 class CreateVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="CreateVideo_V3",
             display_name="Create Video _V3",
             category="image/video",
@@ -47,7 +47,7 @@ class CreateVideo(io.ComfyNodeV3):
 class GetVideoComponents(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="GetVideoComponents_V3",
             display_name="Get Video Components _V3",
             category="image/video",
@@ -74,7 +74,7 @@ class LoadVideo(io.ComfyNodeV3):
         input_dir = folder_paths.get_input_directory()
         files = [f for f in os.listdir(input_dir) if os.path.isfile(os.path.join(input_dir, f))]
         files = folder_paths.filter_files_content_types(files, ["video"])
-        return io.SchemaV3(
+        return io.Schema(
             node_id="LoadVideo_V3",
             display_name="Load Video _V3",
             category="image/video",
@@ -108,7 +108,7 @@ class LoadVideo(io.ComfyNodeV3):
 class SaveVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SaveVideo_V3",
             display_name="Save Video _V3",
             category="image/video",
@@ -155,7 +155,7 @@ class SaveVideo(io.ComfyNodeV3):
 class SaveWEBM(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="SaveWEBM_V3",
             category="image/video",
             is_experimental=True,

--- a/comfy_extras/v3/nodes_wan.py
+++ b/comfy_extras/v3/nodes_wan.py
@@ -11,7 +11,7 @@ import nodes
 from comfy_api.v3 import io
 
 
-class TrimVideoLatent(io.ComfyNodeV3):
+class TrimVideoLatent(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -36,7 +36,7 @@ class TrimVideoLatent(io.ComfyNodeV3):
         return io.NodeOutput(samples_out)
 
 
-class WanCameraImageToVideo(io.ComfyNodeV3):
+class WanCameraImageToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -88,7 +88,7 @@ class WanCameraImageToVideo(io.ComfyNodeV3):
         return io.NodeOutput(positive, negative, out_latent)
 
 
-class WanFirstLastFrameToVideo(io.ComfyNodeV3):
+class WanFirstLastFrameToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -159,7 +159,7 @@ class WanFirstLastFrameToVideo(io.ComfyNodeV3):
         return io.NodeOutput(positive, negative, out_latent)
 
 
-class WanFunControlToVideo(io.ComfyNodeV3):
+class WanFunControlToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -213,7 +213,7 @@ class WanFunControlToVideo(io.ComfyNodeV3):
         return io.NodeOutput(positive, negative, out_latent)
 
 
-class WanFunInpaintToVideo(io.ComfyNodeV3):
+class WanFunInpaintToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -244,7 +244,7 @@ class WanFunInpaintToVideo(io.ComfyNodeV3):
         return flfv.execute(positive, negative, vae, width, height, length, batch_size, start_image=start_image, end_image=end_image, clip_vision_start_image=clip_vision_output)
 
 
-class WanImageToVideo(io.ComfyNodeV3):
+class WanImageToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -292,7 +292,7 @@ class WanImageToVideo(io.ComfyNodeV3):
         return io.NodeOutput(positive, negative, out_latent)
 
 
-class WanPhantomSubjectToVideo(io.ComfyNodeV3):
+class WanPhantomSubjectToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -336,7 +336,7 @@ class WanPhantomSubjectToVideo(io.ComfyNodeV3):
         return io.NodeOutput(positive, cond2, negative, out_latent)
 
 
-class WanVaceToVideo(io.ComfyNodeV3):
+class WanVaceToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(

--- a/comfy_extras/v3/nodes_wan.py
+++ b/comfy_extras/v3/nodes_wan.py
@@ -14,7 +14,7 @@ from comfy_api.v3 import io
 class TrimVideoLatent(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="TrimVideoLatent_V3",
             category="latent/video",
             is_experimental=True,
@@ -39,7 +39,7 @@ class TrimVideoLatent(io.ComfyNodeV3):
 class WanCameraImageToVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WanCameraImageToVideo_V3",
             category="conditioning/video_models",
             inputs=[
@@ -91,7 +91,7 @@ class WanCameraImageToVideo(io.ComfyNodeV3):
 class WanFirstLastFrameToVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WanFirstLastFrameToVideo_V3",
             category="conditioning/video_models",
             inputs=[
@@ -162,7 +162,7 @@ class WanFirstLastFrameToVideo(io.ComfyNodeV3):
 class WanFunControlToVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WanFunControlToVideo_V3",
             category="conditioning/video_models",
             inputs=[
@@ -216,7 +216,7 @@ class WanFunControlToVideo(io.ComfyNodeV3):
 class WanFunInpaintToVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WanFunInpaintToVideo_V3",
             category="conditioning/video_models",
             inputs=[
@@ -247,7 +247,7 @@ class WanFunInpaintToVideo(io.ComfyNodeV3):
 class WanImageToVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WanImageToVideo_V3",
             category="conditioning/video_models",
             inputs=[
@@ -295,7 +295,7 @@ class WanImageToVideo(io.ComfyNodeV3):
 class WanPhantomSubjectToVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WanPhantomSubjectToVideo_V3",
             category="conditioning/video_models",
             inputs=[
@@ -339,7 +339,7 @@ class WanPhantomSubjectToVideo(io.ComfyNodeV3):
 class WanVaceToVideo(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WanVaceToVideo_V3",
             category="conditioning/video_models",
             is_experimental=True,

--- a/comfy_extras/v3/nodes_webcam.py
+++ b/comfy_extras/v3/nodes_webcam.py
@@ -10,7 +10,7 @@ import nodes
 from comfy_api.v3 import io
 
 
-class WebcamCapture(io.ComfyNodeV3):
+class WebcamCapture(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
@@ -89,4 +89,4 @@ class WebcamCapture(io.ComfyNodeV3):
         return True
 
 
-NODES_LIST: list[type[io.ComfyNodeV3]] = [WebcamCapture]
+NODES_LIST: list[type[io.ComfyNode]] = [WebcamCapture]

--- a/comfy_extras/v3/nodes_webcam.py
+++ b/comfy_extras/v3/nodes_webcam.py
@@ -13,7 +13,7 @@ from comfy_api.v3 import io
 class WebcamCapture(io.ComfyNodeV3):
     @classmethod
     def define_schema(cls):
-        return io.SchemaV3(
+        return io.Schema(
             node_id="WebcamCapture_V3",
             display_name="Webcam Capture _V3",
             category="image",

--- a/nodes.py
+++ b/nodes.py
@@ -2162,7 +2162,7 @@ def load_custom_node(module_path: str, ignore=set(), module_parent="custom_nodes
         # V3 node definition
         elif getattr(module, "NODES_LIST", None) is not None:
             for node_cls in module.NODES_LIST:
-                node_cls: io.ComfyNodeV3
+                node_cls: io.ComfyNode
                 schema = node_cls.GET_SCHEMA()
                 if schema.node_id not in ignore:
                     NODE_CLASS_MAPPINGS[schema.node_id] = node_cls

--- a/server.py
+++ b/server.py
@@ -30,7 +30,7 @@ from comfy_api import feature_flags
 import node_helpers
 from comfyui_version import __version__
 from app.frontend_management import FrontendManager
-from comfy_api.internal import ComfyNodeInternal
+from comfy_api.internal import _ComfyNodeInternal
 
 from app.user_manager import UserManager
 from app.model_manager import ModelFileManager
@@ -590,7 +590,7 @@ class PromptServer():
 
         def node_info(node_class):
             obj_class = nodes.NODE_CLASS_MAPPINGS[node_class]
-            if issubclass(obj_class, ComfyNodeInternal):
+            if issubclass(obj_class, _ComfyNodeInternal):
                 return obj_class.GET_NODE_INFO_V1()
             info = {}
             info['input'] = obj_class.INPUT_TYPES()


### PR DESCRIPTION
- SchemaV3 -> Schema
- ComfyNodeV3 -> ComfyNode
- ComfyNodeInternal -> _ComfyNodeInternal
- ComfyType -> _ComfyType
- IO_V3 -> _IO_V3
- Removed some unnecessary **kwargs from io.py

These renames should make v3 typehints more useful.