### PR TITLE
Replace manual x * sigmoid(x) with torch silu in VAE nonlinearity

### DIFF
--- a/comfy/ldm/cosmos/cosmos_tokenizer/utils.py
+++ b/comfy/ldm/cosmos/cosmos_tokenizer/utils.py
@@ -58,7 +58,8 @@ def is_odd(n: int) -> bool:
 
 
 def nonlinearity(x):
-    return x * torch.sigmoid(x)
+    # x * sigmoid(x)
+    return torch.nn.functional.silu(x)
 
 
 def Normalize(in_channels, num_groups=32):

--- a/comfy/ldm/modules/diffusionmodules/model.py
+++ b/comfy/ldm/modules/diffusionmodules/model.py
@@ -36,7 +36,7 @@ def get_timestep_embedding(timesteps, embedding_dim):
 
 def nonlinearity(x):
     # swish
-    return x*torch.sigmoid(x)
+    return torch.nn.functional.silu(x)
 
 
 def Normalize(in_channels, num_groups=32):


### PR DESCRIPTION
5b4e3127494674e9a3f2e668e8fb49b278e079a9 replaced `nonlinearity` with SiLU in `ResnetBlock`, but both `Encoder` and `Decoder` still have a call to `nonlinearity`. This PR also changes the `nonlinearity` in the old Cosmos vae.

Might be related to an old issue #1147.
