### PR TITLE
Fix link from docs (due to document updates)

### DIFF
--- a/comfy_api_nodes/README.md
+++ b/comfy_api_nodes/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction 
 
-Below are a collection of nodes that work by calling external APIs. More information available in our [docs](https://docs.comfy.org/tutorials/api-nodes/overview#api-nodes).
+Below are a collection of nodes that work by calling external APIs. More information available in our [docs](https://docs.comfy.org/tutorials/api-nodes/overview).
 
 ## Development
 


### PR DESCRIPTION
This PR removes the removed anchor part after the hash in the link, which was found in https://github.com/Comfy-Org/docs/pull/287