### PR TITLE
[V3] hunyuan3d: make Voxel and Mesh types strict

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -619,13 +619,23 @@ class LossMap(ComfyTypeIO):
         loss: list[torch.Tensor]
     Type = LossMapDict
 
+
 @comfytype(io_type="VOXEL")
 class Voxel(ComfyTypeIO):
-    Type = Any # TODO: VOXEL class is defined in comfy_extras/nodes_hunyuan3d.py; should be moved to somewhere else before referenced directly in v3
+    class VoxelDict(TypedDict):
+        data: torch.Tensor
+
+    Type = VoxelDict
+
 
 @comfytype(io_type="MESH")
 class Mesh(ComfyTypeIO):
-    Type = Any # TODO: MESH class is defined in comfy_extras/nodes_hunyuan3d.py; should be moved to somewhere else before referenced directly in v3
+    class MeshDict(TypedDict):
+        vertices: list[torch.Tensor]
+        faces: list[torch.Tensor]
+
+    Type = MeshDict
+
 
 @comfytype(io_type="HOOKS")
 class Hooks(ComfyTypeIO):


### PR DESCRIPTION
PR with suggestion to define the `VOXEL` and `MESH` types in the V3 schema as typed dictionaries.

Anything typed is easier to check with linters and AI to get more correct context.

These V3 nodes do not work with V1, but since we plan to replace V1 with V3, nothing should break in existing workflows for community.

Tested changes: files produced by V1 and V3 nodes are identical.

_**If necessary**, we can accept both the old `VOXEL`/`MESH`, which is defined as a classes, and the new  ones which is a typed dicts - so that compatibility would be perfect._

<img width="2112" height="1021" alt="Screenshot from 2025-07-26 11-53-38" src="https://github.com/user-attachments/assets/aef03a23-b11d-4f4e-bfea-fd22debfb4ed" />
