### PR TITLE
Add workflow templates version tracking to system_stats

### DIFF
--- a/app/frontend_management.py
+++ b/app/frontend_management.py
@@ -42,6 +42,7 @@ def get_installed_frontend_version():
     frontend_version_str = version("comfyui-frontend-package")
     return frontend_version_str
 
+
 def get_required_frontend_version():
     """Get the required frontend version from requirements.txt."""
     try:
@@ -62,6 +63,7 @@ def get_required_frontend_version():
     except Exception as e:
         logging.error(f"Error reading requirements.txt: {e}")
         return None
+
 
 def check_frontend_version():
     """Check if the frontend version is up to date."""
@@ -202,6 +204,37 @@ class FrontendManager:
     def get_required_frontend_version(cls) -> str:
         """Get the required frontend package version."""
         return get_required_frontend_version()
+
+    @classmethod
+    def get_installed_templates_version(cls) -> str:
+        """Get the currently installed workflow templates package version."""
+        try:
+            templates_version_str = version("comfyui-workflow-templates")
+            return templates_version_str
+        except Exception:
+            return None
+
+    @classmethod
+    def get_required_templates_version(cls) -> str:
+        """Get the required workflow templates version from requirements.txt."""
+        try:
+            with open(requirements_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("comfyui-workflow-templates=="):
+                        version_str = line.split("==")[-1]
+                        if not is_valid_version(version_str):
+                            logging.error(f"Invalid templates version format in requirements.txt: {version_str}")
+                            return None
+                        return version_str
+                logging.error("comfyui-workflow-templates not found in requirements.txt")
+                return None
+        except FileNotFoundError:
+            logging.error("requirements.txt not found. Cannot determine required templates version.")
+            return None
+        except Exception as e:
+            logging.error(f"Error reading requirements.txt: {e}")
+            return None
 
     @classmethod
     def default_frontend_path(cls) -> str:

--- a/server.py
+++ b/server.py
@@ -554,6 +554,8 @@ class PromptServer():
             vram_total, torch_vram_total = comfy.model_management.get_total_memory(device, torch_total_too=True)
             vram_free, torch_vram_free = comfy.model_management.get_free_memory(device, torch_free_too=True)
             required_frontend_version = FrontendManager.get_required_frontend_version()
+            installed_templates_version = FrontendManager.get_installed_templates_version()
+            required_templates_version = FrontendManager.get_required_templates_version()
 
             system_stats = {
                 "system": {
@@ -562,6 +564,8 @@ class PromptServer():
                     "ram_free": ram_free,
                     "comfyui_version": __version__,
                     "required_frontend_version": required_frontend_version,
+                    "installed_templates_version": installed_templates_version,
+                    "required_templates_version": required_templates_version,
                     "python_version": sys.version,
                     "pytorch_version": comfy.model_management.torch_version,
                     "embedded_python": os.path.split(os.path.split(sys.executable)[0])[1] == "python_embeded",

--- a/tests-unit/app_test/frontend_manager_test.py
+++ b/tests-unit/app_test/frontend_manager_test.py
@@ -205,3 +205,74 @@ numpy"""
 
     # Assert
     assert version is None
+
+
+def test_get_templates_version():
+    # Arrange
+    expected_version = "0.1.41"
+    mock_requirements_content = """torch
+torchsde
+comfyui-frontend-package==1.25.0
+comfyui-workflow-templates==0.1.41
+other-package==1.0.0
+numpy"""
+
+    # Act
+    with patch("builtins.open", mock_open(read_data=mock_requirements_content)):
+        version = FrontendManager.get_required_templates_version()
+
+    # Assert
+    assert version == expected_version
+
+
+def test_get_templates_version_not_found():
+    # Arrange
+    mock_requirements_content = """torch
+torchsde
+comfyui-frontend-package==1.25.0
+other-package==1.0.0
+numpy"""
+
+    # Act
+    with patch("builtins.open", mock_open(read_data=mock_requirements_content)):
+        version = FrontendManager.get_required_templates_version()
+
+    # Assert
+    assert version is None
+
+
+def test_get_templates_version_invalid_semver():
+    # Arrange
+    mock_requirements_content = """torch
+torchsde
+comfyui-workflow-templates==1.0.0.beta
+other-package==1.0.0
+numpy"""
+
+    # Act
+    with patch("builtins.open", mock_open(read_data=mock_requirements_content)):
+        version = FrontendManager.get_required_templates_version()
+
+    # Assert
+    assert version is None
+
+
+def test_get_installed_templates_version():
+    # Arrange
+    expected_version = "0.1.40"
+
+    # Act
+    with patch("app.frontend_management.version", return_value=expected_version):
+        version = FrontendManager.get_installed_templates_version()
+
+    # Assert
+    assert version == expected_version
+
+
+def test_get_installed_templates_version_not_installed():
+    # Act
+    with patch("app.frontend_management.version", side_effect=Exception("Package not found")):
+        version = FrontendManager.get_installed_templates_version()
+
+    # Assert
+    assert version is None


### PR DESCRIPTION
## Summary
- Adds workflow templates version information to the `/system_stats` endpoint
- Enables frontend to detect and notify users when their templates package is outdated

## Changes
- Added `get_installed_templates_version()` and `get_required_templates_version()` methods to `FrontendManager` class
- Updated `/system_stats` endpoint to include:
  - `installed_templates_version`: Currently installed version (or null if not installed)
  - `required_templates_version`: Version specified in requirements.txt
- Added comprehensive unit tests for the new functionality

## Test plan
- [x] All existing frontend manager tests pass
- [x] New unit tests added and passing
- [x] Verified version detection works correctly (detects installed: 0.1.39, required: 0.1.41)
- [x] Linting passes with `ruff check`