### PR TITLE
Update template to 0.1.47

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.23.4
-comfyui-workflow-templates==0.1.45
+comfyui-workflow-templates==0.1.47
 comfyui-embedded-docs==0.2.4
 torch
 torchsde


### PR DESCRIPTION
Added WAN2.2 FLF2V template

<img width="1726" height="955" alt="image" src="https://github.com/user-attachments/assets/39f2decc-eaeb-41be-95ff-837b0c66ac18" />

- Update some old video templates to use the save video node, which most users are more familiar with.
- Reduce package size 75MB => 65MB