### PR TITLE
[AMD][Windows] Fix AttributeError: module 'torch.distributed' has no attribute 'is_initialized' on PyTorch with AMD cards on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ torchvision
 torchaudio
 numpy>=1.25.0
 einops
-transformers>=4.55.3
+transformers>=4.56.0
 tokenizers>=0.13.3
 sentencepiece
 safetensors>=0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ torchvision
 torchaudio
 numpy>=1.25.0
 einops
-transformers>=4.54.1
+transformers>=4.55.3
 tokenizers>=0.13.3
 sentencepiece
 safetensors>=0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ torchvision
 torchaudio
 numpy>=1.25.0
 einops
-transformers>=4.37.2
+transformers>=4.54.1
 tokenizers>=0.13.3
 sentencepiece
 safetensors>=0.4.2


### PR DESCRIPTION
This change updates transformers version in requirements.txt
Newest version contains a check which prevents the error: 
```
AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
```
when used with PyTorch with ROCm on Windows build.