### PR TITLE
refactor magic numbers with tile variable references

### DIFF
--- a/comfy_extras/nodes_upscale_model.py
+++ b/comfy_extras/nodes_upscale_model.py
@@ -49,10 +49,10 @@ class ImageUpscaleWithModel:
 
     def upscale(self, upscale_model, image):
         device = model_management.get_torch_device()
-        
+
         tile = 512
         overlap = 32
-        
+
         memory_required = model_management.module_size(upscale_model.model)
         memory_required += (tile * tile * 3) * image.element_size() * max(upscale_model.scale, 1.0) * 384.0 #The 384.0 is an estimate of how much some of these models take, TODO: make it more accurate
         memory_required += image.nelement() * image.element_size()


### PR DESCRIPTION
Fixed the tile variable usage to replace magic numbers with tile variable references.

I personally use a tile size of 1024 for SDXL, FLUX, etc., and with this change, I only have to adjust one line for a correct memory calculation.