### PR TITLE
Fix av library being a required import at startup

### DIFF
--- a/comfy_api/latest/_input/video_types.py
+++ b/comfy_api/latest/_input/video_types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 import io
-import av
 from comfy_api.util import VideoContainer, VideoCodec, VideoComponents
 
 class VideoInput(ABC):
@@ -80,6 +79,7 @@ class VideoInput(ABC):
             Container format as string
         """
         # Default implementation - subclasses should override for better performance
+        import av
         source = self.get_stream_source()
         with av.open(source, mode="r") as container:
             return container.format.name


### PR DESCRIPTION
Summary:
- Move av import from module level to method level in VideoInput.get_container_format()
- Preserves the optional nature of video dependencies
- Allows ComfyUI to start without av installed

Problem:
PR #9069 added import av at the module level in comfy_api/input/video_types.py, which made av a required dependency for ComfyUI startup. This broke the design where video features should degrade gracefully when av is not installed.

Solution:
Defer the av import to only when get_container_format() is called. This maintains backward compatibility while keeping av as an optional dependency.