### PR TITLE
api_nodes: add kling-v2-1 and v2-1-master

### DIFF
--- a/comfy_api_nodes/apis/__init__.py
+++ b/comfy_api_nodes/apis/__init__.py
@@ -1315,6 +1315,7 @@ class KlingTaskStatus(str, Enum):
 class KlingTextToVideoModelName(str, Enum):
     kling_v1 = 'kling-v1'
     kling_v1_6 = 'kling-v1-6'
+    kling_v2_1_master = 'kling-v2-1-master'
 
 
 class KlingVideoGenAspectRatio(str, Enum):
@@ -1347,6 +1348,8 @@ class KlingVideoGenModelName(str, Enum):
     kling_v1_5 = 'kling-v1-5'
     kling_v1_6 = 'kling-v1-6'
     kling_v2_master = 'kling-v2-master'
+    kling_v2_1 = 'kling-v2-1'
+    kling_v2_1_master = 'kling-v2-1-master'
 
 
 class KlingVideoResult(BaseModel):

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -421,6 +421,8 @@ class KlingTextToVideoNode(KlingNodeBase):
             "pro mode / 10s duration / kling-v2-master": ("pro", "10", "kling-v2-master"),
             "standard mode / 5s duration / kling-v2-master": ("std", "5", "kling-v2-master"),
             "standard mode / 10s duration / kling-v2-master": ("std", "10", "kling-v2-master"),
+            "pro mode / 5s duration / kling-v2-1-master": ("pro", "5", "kling-v2-1-master"),
+            "pro mode / 10s duration / kling-v2-1-master": ("pro", "10", "kling-v2-1-master"),
         }
 
     @classmethod


### PR DESCRIPTION
Kling API reference:
[https://app.klingai.com/global/dev/document-api/apiReference/model/skillsMap](https://app.klingai.com/global/dev/document-api/apiReference/model/skillsMap)

Currently, Text-to-Video is supported only by the **flagship** model, so I added only that one to the `KlingTextToVideoModelName` model.

I added both models to the `KlingVideoGenModelName` since both support Image-to-Video and produce very nice results.

Note: `kling-v2-1-master` does not have `std` or `pro` modes. For consistency, I labeled it as `pro` since this model outputs only `1080p` resolution videos, and in other Kling nodes such output resolution corresponds to `pro` mode.

Video showcasing the new models:

https://github.com/user-attachments/assets/ee55dabc-2ab2-4d3f-8394-32ad86333cb2



