### PR TITLE
fix(Kling Image API Node): do not pass "image_type" when no image

### DIFF
--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -1692,6 +1692,8 @@ class KlingImageGenerationNode(KlingImageGenerationBase):
 
         if image is None:
             image_type = None
+        elif model_name == KlingImageGenModelName.kling_v1:
+            raise ValueError(f"The model {KlingImageGenModelName.kling_v1.value} does not support reference images.")
         else:
             image = tensor_to_base64_string(image)
 

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -1690,7 +1690,9 @@ class KlingImageGenerationNode(KlingImageGenerationBase):
     ):
         self.validate_prompt(prompt, negative_prompt)
 
-        if image is not None:
+        if image is None:
+            image_type = None
+        else:
             image = tensor_to_base64_string(image)
 
         initial_operation = SynchronousOperation(


### PR DESCRIPTION
Currently, the `KlingImageGenerationNode` node always passes `image_type` to the Kling API, which **forces users to provide a reference image**, even though the Kling API supports generation from prompts alone and the reference image is optional.

Without this PR, the following error can occur when trying to generate an image:

<img width="3448" height="2094" alt="image" src="https://github.com/user-attachments/assets/6a6e9c00-0506-4400-a83f-a24d5089d388" />

Tested with this PR that fix are fine and does not break anything:

<img width="2266" height="1160" alt="Screenshot from 2025-08-10 08-44-39" src="https://github.com/user-attachments/assets/0ad41566-f733-45af-af02-3677261ab31e" />

Since the `Kling-v1` model does not support image references, tests with it were skipped in some parts, as shown in the screenshot.