### PR TITLE
remove creation of non-used asyncio_loop

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -646,8 +646,6 @@ class PromptExecutor:
             self.add_message("execution_error", mes, broadcast=False)
 
     def execute(self, prompt, prompt_id, extra_data={}, execute_outputs=[]):
-        asyncio_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(asyncio_loop)
         asyncio.run(self.execute_async(prompt, prompt_id, extra_data, execute_outputs))
 
     async def execute_async(self, prompt, prompt_id, extra_data={}, execute_outputs=[]):


### PR DESCRIPTION
According to the documentation of [asyncio.run](https://docs.python.org/3.12/library/asyncio-runner.html#asyncio.run) - it does not use the current `event loop` at all.
Starting from the `Python 3.12` we can pass the desired event loop as _loop_factory_ argument, but if we do not pass it, **by default** the `asyncio.run` always create a new `event_loop`

