### PR TITLE
Avoid torch compile graphbreak for older pytorch versions

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -41,9 +41,11 @@ try:
 
         SDPA_BACKEND_PRIORITY.insert(0, SDPBackend.CUDNN_ATTENTION)
 
-        @sdpa_kernel(backends=SDPA_BACKEND_PRIORITY, set_priority=True)
         def scaled_dot_product_attention(q, k, v, *args, **kwargs):
-            return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)
+            # Use this (rather than the decorator syntax) to eliminate graph
+            # break for pytorch < 2.9
+            with sdpa_kernel(SDPA_BACKEND_PRIORITY, set_priority=True):
+                return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)
 except (ModuleNotFoundError, TypeError):
     logging.warning("Could not set sdpa backend priority.")
 


### PR DESCRIPTION
Turns out torch.compile has some gaps in context manager decorator syntax support. I've sent [patches to fix that in PyTorch](https://github.com/pytorch/pytorch/pull/160703), but it won't be available for all the folks running older versions of PyTorch, hence this trivial patch.