### PR TITLE
Possiblity to use numpy array in save_images.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1586,7 +1586,10 @@ class SaveImage:
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
         results = list()
         for (batch_number, image) in enumerate(images):
-            i = 255. * image.cpu().numpy()
+            if hasattr(image, "cpu"):  # torch tensor
+                i = 255. * image.cpu().numpy()
+            else:
+                i = 255. * image
             img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
             metadata = None
             if not args.disable_metadata:


### PR DESCRIPTION
added numpy array possibility in method save_images.

Context : I wanted to integrate https://github.com/KennethJAllen/proper-pixel-art into comfy UI as a custom node, since the output wasn't a tensor it crashed.
Those few lines fixed it.
<img width="2564" height="1079" alt="image" src="https://github.com/user-attachments/assets/145e0869-790d-4195-a4f3-42f5aa8a2a7a" />

