### PR TITLE
Bump frontend to 1.25.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.25.8
+comfyui-frontend-package==1.25.9
 comfyui-workflow-templates==0.1.60
 comfyui-embedded-docs==0.2.6
 torch


### PR DESCRIPTION
Bump frontend to 1.25.9

```
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.25.9
```

- Diff: [Comfy-Org/ComfyUI_frontend: v1.25.8...v1.25.9](https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.25.8...v1.25.9)
- PyPI Package: https://pypi.org/project/comfyui-frontend-package/1.25.9/
- npm Types: https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.25.9

## Changes

- Fix: group nodes can't execute