### PR TITLE
fix(WAN-nodes): invalid nodeid for WanTrackToVideo

### DIFF
--- a/comfy_extras/nodes_wan.py
+++ b/comfy_extras/nodes_wan.py
@@ -699,7 +699,7 @@ class WanTrackToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
-            node_id="WanPhantomSubjectToVideo",
+            node_id="WanTrackToVideo",
             category="conditioning/video_models",
             inputs=[
                 io.Conditioning.Input("positive"),


### PR DESCRIPTION
Resolves #9382

There was a small typo introduced while rebasing the V3 WAN PR onto the main branch, after a new node had been added there.