### PR TITLE
Manual model lowvram hint node

### DIFF
--- a/comfy_extras/nodes_model_advanced.py
+++ b/comfy_extras/nodes_model_advanced.py
@@ -316,6 +316,32 @@ class ModelComputeDtype:
         return (m, )
 
 
+class ModelLowvramHint:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": ("MODEL", ),
+                "hints": ("STRING", {"default": "img_mlp.\ntxt_mlp.\n", "multiline": True}),
+            }
+        }
+
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "set_hints"
+    EXPERIMENTAL = True
+
+    DESCRIPTION = "Force some weights to always use lowvram. One rule per line."
+    CATEGORY = "advanced/debug/model"
+
+    def set_hints(self, model, hints=""):
+        hints = [x.strip() for x in hints.split("\n") if x.strip()]
+        if not hints:
+            return model
+
+        m = model.clone()
+        m.add_object_patch("lowvram_hints", hints)
+        return (m, )
+
 NODE_CLASS_MAPPINGS = {
     "ModelSamplingDiscrete": ModelSamplingDiscrete,
     "ModelSamplingContinuousEDM": ModelSamplingContinuousEDM,
@@ -326,4 +352,5 @@ NODE_CLASS_MAPPINGS = {
     "ModelSamplingFlux": ModelSamplingFlux,
     "RescaleCFG": RescaleCFG,
     "ModelComputeDtype": ModelComputeDtype,
+    "ModelLowvramHint": ModelLowvramHint,
 }


### PR DESCRIPTION
This PR is an attempt at some similar logic to what llama.cpp (https://github.com/ggml-org/llama.cpp/pull/11397) uses.

<img width="1008" height="331" alt="image" src="https://github.com/user-attachments/assets/02d44198-95dd-405f-9a3a-0180c29319f3" />


In case of ComfyUI, it means forcing some weights to use `lowvram` by default. The idea here is that when you're low on VRAM to begin with, the default logic ends up marking all tensors past a certain point as lowvram. If we allocate some of the larger tensors as lowvram to begin with, we can reduce the total *number* of lowvram weights.

Testing with qwen image and marking the two FFN blocks (`img_mlp` + `txt_mlp`) manually, I get a total of 324 lowvram weights instead of the 640 I get with the default logic.

Now, diffusion models are almost all compute bound, and lowvram weights are still moved to the GPU, so this probably doesn't help much (I get about ~2 seconds faster generations at best). The main usecase would be if for some reason each individual `CPU`<->`CUDA` copy op has high-ish overhead (Might be the case on PCIe 3.0 or with weird cross NUMA access?).

This may still be useful for debugging lowvram without restarts, though.