### PR TITLE
Support res_multistep_ancestral on RF and fix its discretization

### DIFF
--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -1344,7 +1344,6 @@ def res_multistep(model, x, sigmas, extra_args=None, callback=None, disable=None
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
-    sigma_fn = partial(half_log_snr_to_sigma, model_sampling=model_sampling)
     lambda_fn = partial(sigma_to_half_log_snr, model_sampling=model_sampling)
     sigmas = offset_first_sigma_for_snr(sigmas, model_sampling)
 


### PR DESCRIPTION
Current implementation of `res_multistep_ancestral` sampler seems not to work appropriately with RF-based models. 

The original RES paper formulates its theory in VE format, and this restores VP/RF-style formulation of RES in which alpha appears, with `eta` accordingly to match the definition of the one already in `dpmpp_2m_sde`. Another change is the integrating variable from negative log-sigma to actual negative log-SNR. 

This results in small difference in ODE sampling (no changes in VE) like in the other samplers, but makes notable difference in stochastic samplers on both RF and VE models. I've checked some results on FLUX Krea and SDXL and it seems to produce images well on ancestral sampling while keeping similar aesthetics in both models.

Example results in FLUX Krea:

before, res_multistep_ancestral (step=20, eta=1.0)             |  after, res_multistep_ancestral (step=20, eta=1.0)
:-------------------------:|:-------------------------:
<img width="1024" height="1024" alt="flux_krea_res_multistep_ancestral_s20_before" src="https://github.com/user-attachments/assets/052eb1b1-2dfa-4ff2-a47c-6c9c41e42cc8" />  |  <img width="1024" height="1024" alt="flux_krea_res_multistep_ancestral_s20_after" src="https://github.com/user-attachments/assets/bd8912fc-6912-451f-9ad6-8b7d6b33c5aa" />

before, res_multistep (step=20)              |  after, res_multistep (step=20)
:-------------------------:|:-------------------------:
<img width="1024" height="1024" alt="flux_krea_res_multistep_s20_before" src="https://github.com/user-attachments/assets/7e75e036-9aca-41bd-8220-c075cc6cd41e" />  |  <img width="1024" height="1024" alt="flux_krea_res_multistep_s20_after" src="https://github.com/user-attachments/assets/e2f1bdb9-4e53-4d4a-af2a-3ddee2e51b4c" />

Example results in SDXL:

before, res_multistep_ancestral (step=25, eta=1.0)             |  after, res_multistep_ancestral (step=25, eta=1.0)
:-------------------------:|:-------------------------:
<img width="1024" height="1024" alt="sdxl_res_multistep_ancestral_s25_before" src="https://github.com/user-attachments/assets/b057b9ba-cf61-435f-8971-cb9fbd2e9ec9" />  |  <img width="1024" height="1024" alt="sdxl_res_multistep_ancestral_s25_after" src="https://github.com/user-attachments/assets/797ffd28-bb54-4fff-8058-cc23893f1b40" />

before, res_multistep (step=25)              |  after, res_multistep (step=25)
:-------------------------:|:-------------------------:
<img width="1024" height="1024" alt="sdxl_res_multistep_s25_before" src="https://github.com/user-attachments/assets/b1719e4f-9de5-4c46-9e2b-e4834dfcb3c2" />  |  <img width="1024" height="1024" alt="sdxl_res_multistep_s25_after" src="https://github.com/user-attachments/assets/c8cf6f65-f3e1-43ce-94f7-68cc7620dfda" />