### PR TITLE
Fix: Handle invalid filenames during workflow save (#9434)

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -363,10 +363,17 @@ class UserManager():
             if not overwrite and os.path.exists(path):
                 return web.Response(status=409, text="File already exists")
 
-            body = await request.read()
+            try:
+                body = await request.read()
 
-            with open(path, "wb") as f:
-                f.write(body)
+                with open(path, "wb") as f:
+                    f.write(body)
+            except OSError as e:
+                logging.warning(f"Error saving file '{path}': {e}")
+                return web.Response(
+                    status=400,
+                    reason="Invalid filename. Please avoid special characters like :\\/*?\"<>|"
+                )
 
             user_path = self.get_request_user_filepath(request, None)
             if full_info:


### PR DESCRIPTION
Closes #9434 

**Problem Summary**
Currently, when a user tries to save a workflow using a filename that contains characters forbidden by the operating system (e.g., a colon : on Windows), the save operation fails silently. The UI provides no warning or error message, leading the user to believe the workflow was saved successfully. This can result in the unintentional loss of work when the user later tries to load the non-existent file.

**Solution**
This PR addresses the issue by adding error handling to the backend post_userdata endpoint.

1. Added Exception Handling: The file-writing operation is now wrapped in a try...except OSError block.
2. Informative Error Response: If an OSError is caught (which occurs with invalid filenames), the server now returns a 400 Bad Request status code along with a clear, user-friendly error message.

This ensures that the frontend receives a specific error it can display to the user, immediately notifying them of the problem so they can correct the filename and save their work successfully.

**Screenshot**
<img width="1212" height="828" alt="Screenshot 2025-08-20 145632" src="https://github.com/user-attachments/assets/d99ecacc-6e2b-4f4b-b569-8d253f6e5263" />