### PR TITLE
allow shorter timesteps on uncond

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -361,8 +361,10 @@ def cfg_function(model, cond_pred, uncond_pred, cond_scale, x, timestep, model_o
         args = {"cond": x - cond_pred, "uncond": x - uncond_pred, "cond_scale": cond_scale, "timestep": timestep, "input": x, "sigma": timestep,
                 "cond_denoised": cond_pred, "uncond_denoised": uncond_pred, "model": model, "model_options": model_options}
         cfg_result = x - model_options["sampler_cfg_function"](args)
-    else:
+    elif uncond_pred.any():
         cfg_result = uncond_pred + (cond_pred - uncond_pred) * cond_scale
+    else:
+        cfg_result = cond_pred
 
     for fn in model_options.get("sampler_post_cfg_function", []):
         args = {"denoised": cfg_result, "cond": cond, "uncond": uncond, "cond_scale": cond_scale, "model": model, "uncond_denoised": uncond_pred, "cond_denoised": cond_pred,


### PR DESCRIPTION
Hello,

This simple modification allows to shorten the unconditional prediction and speed-up any generation making use of the cfg function.

using the set timestep range node like this:

<img width="1499" height="641" alt="image" src="https://github.com/user-attachments/assets/0dfce615-0079-41ee-a01e-29fa3aa77013" />


Example result with/without:

<img width="1024" height="1024" alt="I_00001__0022" src="https://github.com/user-attachments/assets/0b15f76e-04f4-41ab-b28a-8baaff48c631" />


<img width="1024" height="1024" alt="I_00001__0023" src="https://github.com/user-attachments/assets/5909197a-ebd0-44b3-ac12-5b319870404f" />

