### PR TITLE
allow tcfg node to skip shorter unconditional prediction

### DIFF
--- a/comfy_extras/nodes_tcfg.py
+++ b/comfy_extras/nodes_tcfg.py
@@ -49,7 +49,7 @@ class TCFG(ComfyNodeABC):
             #  Assume [cond, uncond, ...]
             x = args["input"]
             conds_out = args["conds_out"]
-            if len(conds_out) <= 1 or None in args["conds"][:2]:
+            if len(conds_out) <= 1 or None in args["conds"][:2] or not args["conds_out"][1].any():
                 # Skip when either cond or uncond is None
                 return conds_out
             cond_pred = conds_out[0]


### PR DESCRIPTION
Hello,

When shortening the timesteps the unconditional prediction is actually a latent space of zeros.

This let's the function skip the operation in that case.


Example workflow in this image:

<img width="1024" height="1024" alt="I_00001__0024" src="https://github.com/user-attachments/assets/b4dbd9c5-727c-4657-ba58-f934572bd1dd" />

So like this:

<img width="1284" height="681" alt="image" src="https://github.com/user-attachments/assets/241f5514-c774-4244-871e-972178ffc2bb" />


Related to [PR9467](https://github.com/comfyanonymous/ComfyUI/pull/9467)
