### PR TITLE
feat(api): add /validate_prompt endpoint for pre-execution validation

### DIFF
--- a/server.py
+++ b/server.py
@@ -712,6 +712,43 @@ class PromptServer():
                     "extra_info": {}
                 }
                 return web.json_response({"error": error, "node_errors": {}}, status=400)
+            
+        @routes.post("/validate_prompt")
+        async def validate_prompt(request):
+            logging.info("validate prompt request")
+            json_data = await request.json()
+
+            if "prompt" not in json_data:
+                error = {
+                    "type": "no_prompt",
+                    "message": "No prompt provided",
+                    "details": "No prompt provided",
+                    "extra_info": {}
+                }
+                return web.json_response({"error": error, "node_errors": {}}, status=400)
+            
+            prompt = json_data["prompt"]
+            prompt_id = str(json_data.get("prompt_id", uuid.uuid4()))
+
+            partial_execution_targets = json_data.get("partial_execution_targets", None)
+
+            is_valid, error_info, good_outputs, node_errors = await execution.validate_prompt(prompt_id, prompt, partial_execution_targets)
+
+            if is_valid:
+                response = {
+                    "valid": True,
+                    "prompt_id": prompt_id,
+                    "outputs": good_outputs,
+                    "node_errors": node_errors
+                }
+                return web.json_response(response)
+            else:
+                response = {
+                    "valid": False,
+                    "error": error_info,
+                    "node_errors": node_errors
+                }
+                return web.json_response(response, status=400)
 
         @routes.post("/queue")
         async def post_queue(request):


### PR DESCRIPTION
Closes #9076

This pull request introduces a new API endpoint, `validate_prompt`, to validate the structure and integrity of a ComfyUI workflow prompt without executing it.

**What does this PR do?**

- Adds a `POST /validate_prompt` endpoint that accepts a JSON workflow prompt.
- The endpoint checks for:
      - Missing required input for all nodes.
      - Invalid values (e.g. `ckpt_name` that doesn't exist).
      - Incorrectly linked nodes or data types.
- It returns JSON response with `"valid": true` for a correct prompt or `"valid": false` along with a `node_erros` object detailing the specified issues.

**Why is this change needed?**

Currently, the only way to know if a prompt is valid is to queue it for execution. This is inefficient for both the client and server. This new endpoint provides a quick, lightweight method to pre-validate prompts, improving the user experience and reducing the server load from failed runs.   

**Testing & Verification**
The endpoint has been tested for both valid and invalid workflow scenarios using Postman.

**Valid Workflow Response**
Below is the Postman screenshot showing successful for a correctly structured workflow. The API returns `200 OK` with `"valid": true`.

<img width="1811" height="841" alt="Screenshot 2025-08-21 164148" src="https://github.com/user-attachments/assets/c7536036-0137-4e1c-ac34-0f0c03683121" />

**Invalid Workflow Response**
To ensure robust error handling, an invalid workflow was tested by removing the required `positive` input from the `KSampler` node. The API correctly identifies the error, returning a `400 Bad Request` with `"valid": false` and a detailed error message. 

<img width="1904" height="892" alt="Screenshot 2025-08-21 164329" src="https://github.com/user-attachments/assets/feade551-de77-4e61-a897-6974ab05f040" />