### PR TITLE
Add elementwise fusions

### DIFF
--- a/comfy/ldm/qwen_image/model.py
+++ b/comfy/ldm/qwen_image/model.py
@@ -216,7 +216,7 @@ class QwenImageTransformerBlock(nn.Module):
 
     def _modulate(self, x, mod_params):
         shift, scale, gate = mod_params.chunk(3, dim=-1)
-        return x * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1), gate.unsqueeze(1)
+        return torch.addcmul(shift.unsqueeze(1), x, (1 + scale.unsqueeze(1))), gate.unsqueeze(1)
 
     def forward(
         self,


### PR DESCRIPTION
Enable some elementwise fusions to accelerate SD3.5, Qwen and WAN

| Model             | Off      | On       | Speedup |
|-------------------|----------|----------|---------|
| Qwen              | 18621.99 | 17923.49 | 104%    |
| SD3.5M            | 2967.57  | 2705.65  | 110%    |
| SD3.5L            | 7480.96  | 7432.2   | 101%    |
| SD3.5M Scaled FP8 | 2466.09  | 2194.93  | 112%    |