### PR TITLE
import numpy Float64DType to avoid Hunyuan Avatar to crash

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -41,7 +41,8 @@ if hasattr(torch.serialization, "add_safe_globals"):  # TODO: this was added in 
 
     from numpy.core.multiarray import scalar
     from numpy import dtype
-    from numpy.dtypes import Float64DType
+    import numpy as np
+    Float64DType = np.float64
     from _codecs import encode
 
     torch.serialization.add_safe_globals([ModelCheckpoint, scalar, dtype, Float64DType, encode])


### PR DESCRIPTION
import numpy Float64DType to avoid Hunyuan Avatar to crash if your numpy version is < 2.0