### PR TITLE
Update frontend to v1.25.10 and revert navigation mode override

### DIFF
--- a/app/app_settings.py
+++ b/app/app_settings.py
@@ -25,7 +25,7 @@ class AppSettings():
                 logging.error(f"The user settings file is corrupted: {file}")
                 return {}
         else:
-            return {"Comfy.Canvas.NavigationMode": "legacy"}
+            return {}
 
     def save_settings(self, request, settings):
         file = self.user_manager.get_request_user_filepath(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.25.9
+comfyui-frontend-package==1.25.10
 comfyui-workflow-templates==0.1.65
 comfyui-embedded-docs==0.2.6
 torch


### PR DESCRIPTION
## Summary
Updates the frontend package to v1.25.10 and reverts the forced legacy navigation mode from PR #9518.

## Changes
- **Update frontend version**:  from 1.25.9 to 1.25.10
- **Revert navigation override**: Remove forced legacy navigation mode from app_settings.py

## Reasoning
Frontend v1.25.10 includes:
- Proper navigation mode defaults and improved display text ("Drag Navigation" instead of "Left-Click Pan (Legacy)")
- Bug fixes for missing UI components (minimap cleanup issues)
- Language reactivity fixes for bottom panel tab titles

With these frontend improvements, the forced legacy mode override in PR #9518 is no longer needed and should be removed