### PR TITLE
Fix datetime placeholders when piped from other nodes

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import time
 import mimetypes
 import logging
@@ -376,6 +377,21 @@ def get_save_image_path(filename_prefix: str, output_dir: str, image_width=0, im
         input = input.replace("%hour%", str(now.tm_hour).zfill(2))
         input = input.replace("%minute%", str(now.tm_min).zfill(2))
         input = input.replace("%second%", str(now.tm_sec).zfill(2))
+
+        # Handle %date:FORMAT%
+        def date_repl(match):
+            fmt = match.group(1)
+            # Map Java-like formatting to strftime where possible
+            fmt = (fmt.replace("yyyy", "%Y")
+                    .replace("MM", "%m")
+                    .replace("dd", "%d")
+                    .replace("hh", "%H")
+                    .replace("mm", "%M")
+                    .replace("ss", "%S"))
+            return time.strftime(fmt, now)
+
+        input = re.sub(r"%date:(.*?)%", date_repl, input)
+
         return input
 
     if "%" in filename_prefix:


### PR DESCRIPTION
**Currently**: `%date:FORMAT%` placeholders in fields like `filename_prefix` **_are only expanded when entered directly in the node UI_**. This works because the frontend handles the substitution before passing the value to the backend.

However, if the same string is piped in from another node (e.g. String, Combine Text, etc.), **_the placeholder is passed to the backend unchanged_**. Since the backend’s [compute_vars function](https://github.com/comfyanonymous/ComfyUI/blob/master/folder_paths.py#L369) only supports a fixed set of tokens (%year%, %month%, %day%, etc.), %date:...% values are not resolved. This leads to incorrect or invalid filenames such as:

`yyyy-MM-ddhhmmss_00001.png`


or, on Windows, runtime errors like:

`OSError: [Errno 22] Invalid argument: '...\\%date:yyyy-MM-dd%_%date:hhmmss%__00001.png'`

<img width="982" height="469" alt="Current" src="https://github.com/user-attachments/assets/6edab7ea-e17d-4209-be3d-cff4192f3f79" />

---

## Fix

This PR adds **backend support** for %date:FORMAT%.

- Introduces a regex-based handler for %date:...%

- Maps common Java/ISO-style patterns (yyyy, MM, dd, hh, mm, ss) to Python’s strftime equivalents

- Ensures consistent substitution regardless of the source of the format string

## Result

With this change, both direct inputs and piped inputs produce correctly formatted filenames. For example:

Input:

WAN/%date:yyyy-MM-dd%%date:hhmmss%


Output:

WAN/2025-08-23_143752_00001.png


This makes datetime substitution consistent across all nodes and prevents invalid filenames.

<img width="980" height="513" alt="Fixed" src="https://github.com/user-attachments/assets/bb769e9e-c904-4468-af09-e1ba3f8e7600" />
