### PR TITLE
Fix EasyCache/LazyCache crash when tensor shape/dtype/device changes during sampling

### DIFF
--- a/comfy_extras/nodes_easycache.py
+++ b/comfy_extras/nodes_easycache.py
@@ -28,6 +28,7 @@ def easycache_forward_wrapper(executor, *args, **kwargs):
     input_change = None
     do_easycache = easycache.should_do_easycache(sigmas)
     if do_easycache:
+        easycache.check_metadata(x)
         # if first cond marked this step for skipping, skip it and use appropriate cached values
         if easycache.skip_current_step:
             if easycache.verbose:
@@ -92,6 +93,7 @@ def lazycache_predict_noise_wrapper(executor, *args, **kwargs):
     input_change = None
     do_easycache = easycache.should_do_easycache(timestep)
     if do_easycache:
+        easycache.check_metadata(x)
         if easycache.has_x_prev_subsampled():
             if easycache.has_x_prev_subsampled():
                 input_change = (easycache.subsample(x, clone=False) - easycache.x_prev_subsampled).flatten().abs().mean()
@@ -194,6 +196,7 @@ class EasyCacheHolder:
         # how to deal with mismatched dims
         self.allow_mismatch = True
         self.cut_from_start = True
+        self.state_metadata = None
 
     def is_past_end_timestep(self, timestep: float) -> bool:
         return not (timestep[0] > self.end_t).item()
@@ -283,6 +286,17 @@ class EasyCacheHolder:
     def has_first_cond_uuid(self, uuids: list[UUID]) -> bool:
         return self.first_cond_uuid in uuids
 
+    def check_metadata(self, x: torch.Tensor) -> bool:
+        metadata = (x.device, x.dtype, x.shape)
+        if self.state_metadata is None:
+            self.state_metadata = metadata
+            return True
+        if metadata == self.state_metadata:
+            return True
+        logging.warn(f"{self.name} - Tensor shape, dtype or device changed, resetting state")
+        self.reset()
+        return False
+
     def reset(self):
         self.relative_transformation_rate = 0.0
         self.cumulative_change_rate = 0.0
@@ -299,6 +313,7 @@ class EasyCacheHolder:
         del self.uuid_cache_diffs
         self.uuid_cache_diffs = {}
         self.total_steps_skipped = 0
+        self.state_metadata = None
         return self
 
     def clone(self):


### PR DESCRIPTION
EasyCache (and LazyCache) currently doesn't handle the condition where the latent size (or dtype or device) changes during sampling. For example, this might occur if the sampler is doing progressive upscaling during sampling (and ComfyUI actually has a built in node for that, though I don't think anyone uses it).

This pull just keeps track of the input tensor shape/dtype/device and calls the `.reset()` method if it ever changes. Lightly tested but seems to fix the problem for me and doesn't appear to break anything.