### PR TITLE
Accept prompt_id in interrupt handler

### DIFF
--- a/server.py
+++ b/server.py
@@ -729,7 +729,35 @@ class PromptServer():
 
         @routes.post("/interrupt")
         async def post_interrupt(request):
-            nodes.interrupt_processing()
+            logging.info("got interrupt")
+            try:
+                json_data = await request.json()
+            except json.JSONDecodeError:
+                json_data = {}
+
+            # Check if a specific prompt_id was provided for targeted interruption
+            prompt_id = json_data.get('prompt_id')
+            if prompt_id:
+                currently_running, _ = self.prompt_queue.get_current_queue()
+
+                # Check if the prompt_id matches any currently running prompt
+                should_interrupt = False
+                for item in currently_running:
+                    # item structure: (number, prompt_id, prompt, extra_data, outputs_to_execute)
+                    if item[1] == prompt_id:
+                        logging.info(f"Interrupting prompt {prompt_id}")
+                        should_interrupt = True
+                        break
+
+                if should_interrupt:
+                    nodes.interrupt_processing()
+                else:
+                    logging.info(f"Prompt {prompt_id} is not currently running, skipping interrupt")
+            else:
+                # No prompt_id provided, do a global interrupt
+                logging.info("Global interrupt (no prompt_id specified)")
+                nodes.interrupt_processing()
+
             return web.Response(status=200)
 
         @routes.post("/free")

--- a/server.py
+++ b/server.py
@@ -729,7 +729,6 @@ class PromptServer():
 
         @routes.post("/interrupt")
         async def post_interrupt(request):
-            logging.info("got interrupt")
             try:
                 json_data = await request.json()
             except json.JSONDecodeError:


### PR DESCRIPTION
If "prompt_id" is provided in the interrupt call, check first if it matches the currently running prompt. Ignore the interrupt if prompt id does not match. This prevents race conditions where the prompt that was intended to be interrupted had finished already.

If no prompt_id is provided, the behavior remains same as before.

Manual tests:
- Using curl, checked that
  - providing no json body works (old behavior)
  - wrong prompt_id does not interrupt executing job
  - correct prompt_id does interrupt executing job
- Tested with latest frontend. Job cancellation works both using queue>right-click>delete, and clicking the red X button beside Run.