### PR TITLE
api nodes(Ideogram): add Ideogram Character

### DIFF
--- a/comfy_api_nodes/apis/__init__.py
+++ b/comfy_api_nodes/apis/__init__.py
@@ -2680,7 +2680,7 @@ class ReleaseNote(BaseModel):
 
 
 class RenderingSpeed(str, Enum):
-    BALANCED = 'BALANCED'
+    DEFAULT = 'DEFAULT'
     TURBO = 'TURBO'
     QUALITY = 'QUALITY'
 

--- a/comfy_api_nodes/nodes_ideogram.py
+++ b/comfy_api_nodes/nodes_ideogram.py
@@ -615,8 +615,8 @@ class IdeogramV3(comfy_io.ComfyNode):
                 ),
                 comfy_io.Combo.Input(
                     "rendering_speed",
-                    options=["BALANCED", "TURBO", "QUALITY"],
-                    default="BALANCED",
+                    options=["DEFAULT", "TURBO", "QUALITY"],
+                    default="DEFAULT",
                     tooltip="Controls the trade-off between generation speed and quality",
                     optional=True,
                 ),
@@ -652,7 +652,7 @@ class IdeogramV3(comfy_io.ComfyNode):
         magic_prompt_option="AUTO",
         seed=0,
         num_images=1,
-        rendering_speed="BALANCED",
+        rendering_speed="DEFAULT",
         character_image=None,
         character_mask=None,
     ):
@@ -660,6 +660,8 @@ class IdeogramV3(comfy_io.ComfyNode):
             "auth_token": cls.hidden.auth_token_comfy_org,
             "comfy_api_key": cls.hidden.api_key_comfy_org,
         }
+        if rendering_speed == "BALANCED":  # for backward compatibility
+            rendering_speed = "DEFAULT"
 
         character_img_binary = None
         character_mask_binary = None


### PR DESCRIPTION
This PR adds support for Ideogram V3 [Character Reference](https://docs.ideogram.ai/using-ideogram/generation-settings/character-reference) feature.

This PR also fixes an issue with prices not being displayed due to the `api_node=True` flag being lost when converting these nodes to V3.

Fronted part: https://github.com/Comfy-Org/ComfyUI_frontend/pull/5241


We changed the `Rendering speed` value to `default `in accordance with  our backend repository. Backend repository still support the old value as a fallback for API workflows that are already in production. (screenshot is old, before the value was renamed

<img width="1311" height="1163" alt="Screenshot from 2025-08-29 08-36-02" src="https://github.com/user-attachments/assets/158b683c-4a8c-45c2-bbb7-53c6065aa4ab" />
