### PR TITLE
Add Support for OneTrainers Output Embedding

### DIFF
--- a/comfy/sd1_clip.py
+++ b/comfy/sd1_clip.py
@@ -226,8 +226,8 @@ class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
                         # For output embeddings, store their position and data for later.
                         # Insert placeholder tokens to maintain sequence length.
                         output_embeds_for_prompt.append((index, y["data"]))
-                        tokens_temp.extend([self.special_tokens["pad"]] * num_tokens_in_embed)
-                        attention_mask.extend([1] * num_tokens_in_embed)
+                        placeholder_data = torch.zeros_like(y["data"])
+                        other_embeds.append((index, {"type": "embedding", "data": placeholder_data}))
                     else: # Regular input embedding
                         other_embeds.append((index, y))
                     index += num_tokens_in_embed


### PR DESCRIPTION
This pull request introduces the support for **output embedding**, which is a technique that applies the embedding at the **output** of the TE rather than the input.

This approach is expected to provide **superior results** for large text encoders.

An example of [style T5 output embeddings trained on Chroma](https://huggingface.co/Koratahi/Style_T5_Output_Embedding).

<img width="416" height="608" alt="ComfyUI_00165_" src="https://github.com/user-attachments/assets/9d74621a-f373-4894-b976-47fd90ffa151" />
<img width="416" height="608" alt="ComfyUI_00177_" src="https://github.com/user-attachments/assets/3bf13507-86bb-4a90-b01d-8b90a22aa83a" />