### PR TITLE
Add USO flux template and wan2.2 fun 5b template

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.25.11
-comfyui-workflow-templates==0.1.70
+comfyui-workflow-templates==0.1.71
 comfyui-embedded-docs==0.2.6
 torch
 torchsde


### PR DESCRIPTION
## Fixed some template issues
- Fixed hidream template link issue

## Added some new template

<img width="1723" height="953" alt="image" src="https://github.com/user-attachments/assets/6793b223-208e-4ab1-a152-c16c4dff1c56" />
<img width="1458" height="864" alt="image" src="https://github.com/user-attachments/assets/21da95a1-aa9e-4950-85f5-add278547fe9" />

- [flux1_dev_uso_reference_image_gen.json](https://raw.githubusercontent.com/Comfy-Org/workflow_templates/refs/heads/main/templates/flux1_dev_uso_reference_image_gen.json)


<img width="1725" height="958" alt="image" src="https://github.com/user-attachments/assets/7cad3903-ede4-4536-80b9-4777041e73df" />

<img width="1563" height="708" alt="image" src="https://github.com/user-attachments/assets/a48f4945-0c32-47bc-b52e-d746ef05689a" />

- [video_wan2_2_5B_fun_inpaint.json](https://raw.githubusercontent.com/Comfy-Org/workflow_templates/refs/heads/main/templates/video_wan2_2_5B_fun_inpaint.json)

<img width="1559" height="703" alt="image" src="https://github.com/user-attachments/assets/b395ebcd-67a2-4f22-9e62-314d7bc1dcc2" />

- [video_wan2_2_5B_fun_control.json)](https://raw.githubusercontent.com/Comfy-Org/workflow_templates/refs/heads/main/templates/video_wan2_2_5B_fun_control.json)
