### PR TITLE
Added CORS header 'Access-Control-Allow-Private-Network'

### DIFF
--- a/server.py
+++ b/server.py
@@ -79,6 +79,7 @@ def create_cors_middleware(allowed_origin: str):
         response.headers['Access-Control-Allow-Methods'] = 'POST, GET, DELETE, PUT, OPTIONS'
         response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
         response.headers['Access-Control-Allow-Credentials'] = 'true'
+        response.headers['Access-Control-Allow-Private-Network'] = 'true'
         return response
 
     return cors_middleware


### PR DESCRIPTION
With the changes described in [Private Network Access: introducing preflights](https://developer.chrome.com/blog/private-network-access-preflight), Google Chrome requires one additional CORS HTTP header when trying to access a locally running ComfyUI in the context of an externally hosted site.

This PR adds this header.

As the other headers are not put behind special configuration, neither is this. The allowed-origin must still be matched - strictly, even, as just the wildcard isn't accepted anymore either.
Due to this, security is not reduced in a relevant way.