### PR TITLE
[V3] convert Canny node to V3 schema

### DIFF
--- a/comfy_extras/nodes_canny.py
+++ b/comfy_extras/nodes_canny.py
@@ -1,25 +1,41 @@
 from kornia.filters import canny
+from typing_extensions import override
+
 import comfy.model_management
+from comfy_api.latest import ComfyExtension, io
 
 
-class Canny:
+class Canny(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {"image": ("IMAGE",),
-                                "low_threshold": ("FLOAT", {"default": 0.4, "min": 0.01, "max": 0.99, "step": 0.01}),
-                                "high_threshold": ("FLOAT", {"default": 0.8, "min": 0.01, "max": 0.99, "step": 0.01})
-                                }}
+    def define_schema(cls):
+        return io.Schema(
+            node_id="Canny",
+            category="image/preprocessors",
+            inputs=[
+                io.Image.Input("image"),
+                io.Float.Input("low_threshold", default=0.4, min=0.01, max=0.99, step=0.01),
+                io.Float.Input("high_threshold", default=0.8, min=0.01, max=0.99, step=0.01),
+            ],
+            outputs=[io.Image.Output()],
+        )
 
-    RETURN_TYPES = ("IMAGE",)
-    FUNCTION = "detect_edge"
+    @classmethod
+    def detect_edge(cls, image, low_threshold, high_threshold):
+        # Deprecated: use the V3 schema's `execute` method instead of this.
+        return cls.execute(image, low_threshold, high_threshold)
 
-    CATEGORY = "image/preprocessors"
-
-    def detect_edge(self, image, low_threshold, high_threshold):
+    @classmethod
+    def execute(cls, image, low_threshold, high_threshold) -> io.NodeOutput:
         output = canny(image.to(comfy.model_management.get_torch_device()).movedim(-1, 1), low_threshold, high_threshold)
         img_out = output[1].to(comfy.model_management.intermediate_device()).repeat(1, 3, 1, 1).movedim(1, -1)
-        return (img_out,)
+        return io.NodeOutput(img_out)
 
-NODE_CLASS_MAPPINGS = {
-    "Canny": Canny,
-}
+
+class CannyExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [Canny]
+
+
+async def comfy_entrypoint() -> CannyExtension:
+    return CannyExtension()


### PR DESCRIPTION
`MyTestNode` was created only to test that nothing breaks for community.

Sources of MyTestNode node:

```python
@classmethod
def execute(cls, image, low_threshold, high_threshold) -> io.NodeOutput:
    from nodes import NODE_CLASS_MAPPINGS

    canny2 = NODE_CLASS_MAPPINGS["Canny"]()  # community nodes create Canny node likes this
    return canny2.detect_edge(
        low_threshold=low_threshold,
        high_threshold=high_threshold,
        image=image,
    )  # and calls like this
```

<img width="1660" height="878" alt="Screenshot from 2025-09-06 20-37-08" src="https://github.com/user-attachments/assets/b2b4f9e8-77e8-4288-847e-e1bd53a387c7" />


Example of community usage:

https://github.com/nunchaku-tech/ComfyUI-nunchaku/blob/90fb8ccf455a4bffa5fb832b84e54951d1e2949d/tests/scripts/nunchaku-flux1-canny.py#L157-L162