### PR TITLE
Fix vae load with --cpu-vae with AMD GPU

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -913,7 +913,7 @@ def vae_dtype(device=None, allowed_dtypes=[]):
         return torch.float16
     elif args.bf16_vae:
         return torch.bfloat16
-    elif args.fp32_vae:
+    elif args.fp32_vae or (device and is_device_cpu(device)):
         return torch.float32
 
     for d in allowed_dtypes:


### PR DESCRIPTION
When running on AMD and using `--cpu-vae`, `amd_min_version` later in the code will cause a check on `device`, leading to `Expected a cuda device, but got: cpu`. `is_amd` does not catch this because the actual generation *is* happening on an AMD GPU.

This change mitigates this by always returning float32 if vae is done on CPU.
There may be cleaner ways to fix this; I am open to opinions on the matter.