### PR TITLE
Make Float min and max use correct typing

### DIFF
--- a/comfy_extras/nodes_primitive.py
+++ b/comfy_extras/nodes_primitive.py
@@ -66,7 +66,7 @@ class Float(io.ComfyNode):
             display_name="Float",
             category="utils/primitive",
             inputs=[
-                io.Float.Input("value", min=-sys.maxsize, max=sys.maxsize),
+                io.Float.Input("value", min=float(-sys.maxsize), max=float(sys.maxsize)),
             ],
             outputs=[io.Float.Output()],
         )


### PR DESCRIPTION
Due to how floating point works with rounding, setting min to `-sys.maxsize` and max to `sys.maxsize` will result in following error:
```
* PrimitiveFloat 969:
  - Value -9.223372036854776e+18 smaller than min of -9223372036854775807: value
```

The error arises because the floating-point approximation (-9.223372036854776e+18) is slightly smaller (i.e., more negative) than the precise integer value of -sys.maxsize (-9223372036854775807). 

Alternative approach would be to use sys.float_info.min and sys.float_info.max instead but that range might seem a bit excessive for a primitive node.