### PR TITLE
Create custom_nodes dir if does not exist

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -103,6 +103,14 @@ if not os.path.exists(input_directory):
     except:
         logging.error("Failed to create input directory")
 
+custom_nodes_paths, _ = folder_names_and_paths["custom_nodes"]
+for directory in custom_nodes_paths:
+    if not os.path.exists(directory):
+        try:
+            os.makedirs(directory)
+        except:
+            logging.error(f"Failed to create custom_nodes directory: {directory}")
+
 def set_output_directory(output_dir: str) -> None:
     global output_directory
     output_directory = output_dir


### PR DESCRIPTION
Avoids a crash from ComfyUI expecting the `custom_nodes` dir by ensuring it exists.

Relevant for people setting `--base-dir` but that location doesn't yet have a `custom_nodes` subdir
