### PR TITLE
Add Output to V3 Combo type to match what is possible with V1

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -331,7 +331,7 @@ class String(ComfyTypeIO):
             })
 
 @comfytype(io_type="COMBO")
-class Combo(ComfyTypeI):
+class Combo(ComfyTypeIO):
     Type = str
     class Input(WidgetInput):
         """Combo input (dropdown)."""
@@ -360,6 +360,14 @@ class Combo(ComfyTypeI):
                 "remote": self.remote.as_dict() if self.remote else None,
             })
 
+    class Output(Output):
+        def __init__(self, id: str=None, display_name: str=None, options: list[str]=None, tooltip: str=None, is_output_list=False):
+            super().__init__(id, display_name, tooltip, is_output_list)
+            self.options = options if options is not None else []
+
+        @property
+        def io_type(self):
+            return self.options
 
 @comfytype(io_type="COMBO")
 class MultiCombo(ComfyTypeI):


### PR DESCRIPTION
Example usage:

```
import comfy.samplers
class ComboOutputTest(io.ComfyNode):
    @classmethod
    def define_schema(cls) -> io.Schema:
        return io.Schema(
            node_id="ComboOutputTest",
            display_name="ComboOutputTest",
            category="advanced/debug/model",
            inputs=[
                io.Combo.Input("scheduler", options=comfy.samplers.KSampler.SCHEDULERS),
            ],
            outputs=[
                io.Combo.Output(display_name="scheduler", options=comfy.samplers.KSampler.SCHEDULERS),
            ],
        )

    @classmethod
    def execute(cls, scheduler: str) -> io.NodeOutput:
        return io.NodeOutput(scheduler)
```