### PR TITLE
`.gitattributes`: auto-handle line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,13 @@
+# Auto-detect text/binary by default + respect `core.autocrlf` setting for checkout, but still commit as LF.
+* text=auto
+
+# Force UNIX line endings: both commit and checkout:
+*.sh text eol=lf
+*.py text eol=lf
+
+# Force Windows line endings on checkout, commit as LF:
+*.bat text eol=crlf
+
 /web/assets/** linguist-generated
 /web/** linguist-vendored
 comfy_api_nodes/apis/__init__.py linguist-generated


### PR DESCRIPTION
An addition to: https://github.com/comfyanonymous/ComfyUI/blob/master/.github/workflows/check-line-endings.yml

> [!NOTE]
> Windows line endings are forced on checkout for `bat` files. Probably this ☝🏻 workflow needs updating to exclude them.

... or just remove the bat line to perform the same conversion as for other text files (according to the user settings: probably, convert to CRLF on Windows, keep LF on Linux/Mac).