### PR TITLE
qw_encdoer_append

### DIFF
--- a/comfy_extras/nodes_qwen.py
+++ b/comfy_extras/nodes_qwen.py
@@ -39,7 +39,7 @@ class TextEncodeQwenImageEdit:
         tokens = clip.tokenize(prompt, images=images)
         conditioning = clip.encode_from_tokens_scheduled(tokens)
         if ref_latent is not None:
-            conditioning = node_helpers.conditioning_set_values(conditioning, {"reference_latents": [ref_latent]}, append=True)
+            conditioning = node_helpers.conditioning_set_values(conditioning, {"reference_latents": [ref_latent]}, append=False)
         return (conditioning, )
 
 


### PR DESCRIPTION
The merging logic of image encoder latent in Qwen_image, set append=Ture, may cause latent contamination in certain workflows.