### PR TITLE
Enable FP8 compute on AMD

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1355,7 +1355,7 @@ def supports_fp8_compute(device=None):
     if SUPPORT_FP8_OPS:
         return True
 
-    if not is_nvidia():
+    if not (is_nvidia() or is_amd()):
         return False
 
     props = torch.cuda.get_device_properties(device)


### PR DESCRIPTION
This enables FP8 compute on AMD too, using native PyTorch via [TheRock](https://github.com/ROCm/TheRock) wheels.

Based on this [issue](https://github.com/ROCm/TheRock/issues/1485), ComfyUI originally doesn't support FP8 on AMD, per:
https://github.com/comfyanonymous/ComfyUI/blob/a39ac59c3e3fddc8b278899814f0bd5371abb11f/comfy/model_management.py#L1358-L1359
