### PR TITLE
Bump frontend to 1.26.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.25.8
+comfyui-frontend-package==1.26.12
 comfyui-workflow-templates==0.1.60
 comfyui-embedded-docs==0.2.6
 torch


### PR DESCRIPTION
Bump frontend to 1.26.12

```
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.26.12
```

- Diff: [Comfy-Org/ComfyUI_frontend: v1.26.11...v1.26.12](https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.26.11...v1.26.12)
- PyPI Package: https://pypi.org/project/comfyui-frontend-package/1.26.12/
- npm Types: https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.26.12

## Changes

- Fix: Change manager flag from --disable-manager to --enable-manager to align with backend changes (#5635)

This hotfix ensures frontend compatibility with ComfyUI core, changing the manager startup behavior from opt-out to opt-in.