### PR TITLE
Enable pytorch attention in VAE for AMD RDNA 4

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -348,7 +348,7 @@ try:
 #                    if any((a in arch) for a in ["gfx1201"]):
 #                        ENABLE_PYTORCH_ATTENTION = True
         if torch_version_numeric >= (2, 7) and rocm_version >= (6, 4):
-            if any((a in arch) for a in ["gfx1201", "gfx942", "gfx950"]):  # TODO: more arches
+            if any((a in arch) for a in ["gfx1200", "gfx1201", "gfx942", "gfx950"]):  # TODO: more arches
                 SUPPORT_FP8_OPS = True
 
 except:
@@ -1112,7 +1112,7 @@ def pytorch_attention_enabled():
     return ENABLE_PYTORCH_ATTENTION
 
 def pytorch_attention_enabled_vae():
-    if is_amd():
+    if is_amd() and not amd_min_version(device=None, min_rdna_version=4):
         return False  # enabling pytorch attention on AMD currently causes crash when doing high res
     return pytorch_attention_enabled()
 


### PR DESCRIPTION
Crashes occur with or without PyTorch attention in high-res.
But for normal image sizes, it is significantly faster.

Partially reverts “Disable PyTorch attention in VAE for AMD.” (commit [1cd6cd6](https://github.com/comfyanonymous/ComfyUI/commit/1cd6cd608086a8ff8789b747b8d4f8b9273e576e)) for RDNA4.