### PR TITLE
Add note about cuda version while installing torch

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ This is the command to install the Pytorch xpu nightly which might have some per
 
 Nvidia users should install stable pytorch using this command:
 
+> **NOTE**: The --index-url depends on your CUDA version. 
+
 ```pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu129```
 
 This is the command to install pytorch nightly instead which might have performance improvements.


### PR DESCRIPTION
Pytorch installation instructions uses `cu129` in the index url. 

The index-url depends on the system's CUDA version. 

Updated instructions to add a note to the user to use the right url based on their CUDA version.