### PR TITLE
Fix memory leak by explicitly detaching model finalizer.

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -645,7 +645,9 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
             if loaded_model.model.is_clone(current_loaded_models[i].model):
                 to_unload = [i] + to_unload
         for i in to_unload:
-            current_loaded_models.pop(i).model.detach(unpatch_all=False)
+            model_to_unload = current_loaded_models.pop(i)
+            model_to_unload.model.detach(unpatch_all=False)
+            model_to_unload.model_finalizer.detach()
 
     total_memory_required = {}
     for loaded_model in models_to_load:


### PR DESCRIPTION
## What:
Explicitly call `detach()` on unloaded model's `model_finalizer` to avoid memory leak.

## Why:
When unloading models in `load_models_gpu()`, the model finalizer was not being explicitly detached, leading to a memory leak. This caused linear memory consumption increase over time as models are repeatedly loaded and unloaded.
This change prevents orphaned finalizer references from accumulating in memory during model switching operations.

## Graphs:
I created graphs of `weakref.finalize` total objects count using `gc.get_objects()` before and after the change.
As you can see, `finalize` objects count is increasing as we are rerunning a workflow.

(Before evaluating the objects count I called `gc.collect()` to avoid noise).

#### before:
<img width="640" height="480" alt="finalize_count_before" src="https://github.com/user-attachments/assets/56806b8e-81cf-40d1-ba38-2935b7bd27db" />

#### after:
<img width="640" height="480" alt="finalize_count_after" src="https://github.com/user-attachments/assets/770afafd-7a00-4ffa-bbd4-63f4726455a9" />

#### workflow:
I used this workflow to create the graph, but there's nothing special about it, and the memory leak is only getting worse as the workflow becomes more complex.
<img width="7106" height="2272" alt="workflow_memleak" src="https://github.com/user-attachments/assets/b0683129-7703-4eca-bd77-e87b43f943fc" />
