### PR TITLE
Update request_logger.py

### DIFF
--- a/comfy_api_nodes/apis/request_logger.py
+++ b/comfy_api_nodes/apis/request_logger.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import logging
 import folder_paths
+import re
 
 # Get the logger instance
 logger = logging.getLogger(__name__)
@@ -55,7 +56,8 @@ def log_request_response(
     """
     log_dir = get_log_directory()
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-    filename = f"{timestamp}_{operation_id.replace('/', '_').replace(':', '_')}.log"
+    safe_operation_id = re.sub(r'[^A-Za-z0-9._-]', '_', operation_id)
+    filename = f"{timestamp}_{safe_operation_id}"[:220]+".log"
     filepath = os.path.join(log_dir, filename)
 
     log_content = []


### PR DESCRIPTION
Fix for "Error writing API log to: ......"

Saving api logs failed when Seedream4 official template was used on windows machine, due to the forbidden "=?:" characters in the filename, as well as the filename being too long.

Regex keeps only usable characters, and 220 arbitrary max filename length is added.

<img width="969" height="441" alt="api log fails" src="https://github.com/user-attachments/assets/aa922136-0ea2-46b7-b12a-7dc44ef967a8" />
