### PR TITLE
Allow HuMo 14B to work with embedded image for I2V

### DIFF
--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -1080,7 +1080,7 @@ class WAN21_HuMo(WAN21_T2V):
     }
 
     def get_model(self, state_dict, prefix="", device=None):
-        out = model_base.WAN21_HuMo(self, image_to_video=True, device=device)
+        out = model_base.WAN21_HuMo(self, image_to_video=False, device=device)
         return out
 
 class WAN22_S2V(WAN21_T2V):


### PR DESCRIPTION
Just throwing this out there. I tested it and it works and doesn't affect HuMo basic functionality when not adding I2V embeds. There is a bit of flashing from the first frame, maybe I made a small mistake somewhere so feel free to correct if needed. Image can be added just by chaining the WanImageToVideo node. Can be used for reasonable continuation of HuMo video generations (see 2 video example below with i2v used for second half with the same seed).
<img width="1127" height="762" alt="image" src="https://github.com/user-attachments/assets/9b4ee1dd-42de-4fe8-94a9-d4d0546f2c8d" />

https://github.com/user-attachments/assets/42ae08af-b5a6-4fa9-a355-1e45991afec9

