### PR TITLE
[V3] convert nodes_qwen.py to V3 schema

### DIFF
--- a/comfy_extras/nodes_qwen.py
+++ b/comfy_extras/nodes_qwen.py
@@ -1,24 +1,29 @@
 import node_helpers
 import comfy.utils
 import math
+from typing_extensions import override
+from comfy_api.latest import ComfyExtension, io
 
 
-class TextEncodeQwenImageEdit:
+class TextEncodeQwenImageEdit(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {
-            "clip": ("CLIP", ),
-            "prompt": ("STRING", {"multiline": True, "dynamicPrompts": True}),
-            },
-            "optional": {"vae": ("VAE", ),
-                         "image": ("IMAGE", ),}}
+    def define_schema(cls):
+        return io.Schema(
+            node_id="TextEncodeQwenImageEdit",
+            category="advanced/conditioning",
+            inputs=[
+                io.Clip.Input("clip"),
+                io.String.Input("prompt", multiline=True, dynamic_prompts=True),
+                io.Vae.Input("vae", optional=True),
+                io.Image.Input("image", optional=True),
+            ],
+            outputs=[
+                io.Conditioning.Output(),
+            ],
+        )
 
-    RETURN_TYPES = ("CONDITIONING",)
-    FUNCTION = "encode"
-
-    CATEGORY = "advanced/conditioning"
-
-    def encode(self, clip, prompt, vae=None, image=None):
+    @classmethod
+    def execute(cls, clip, prompt, vae=None, image=None) -> io.NodeOutput:
         ref_latent = None
         if image is None:
             images = []
@@ -40,28 +45,30 @@ class TextEncodeQwenImageEdit:
         conditioning = clip.encode_from_tokens_scheduled(tokens)
         if ref_latent is not None:
             conditioning = node_helpers.conditioning_set_values(conditioning, {"reference_latents": [ref_latent]}, append=True)
-        return (conditioning, )
+        return io.NodeOutput(conditioning)
 
 
-class TextEncodeQwenImageEditPlus:
+class TextEncodeQwenImageEditPlus(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {
-            "clip": ("CLIP", ),
-            "prompt": ("STRING", {"multiline": True, "dynamicPrompts": True}),
-            },
-            "optional": {"vae": ("VAE", ),
-                         "image1": ("IMAGE", ),
-                         "image2": ("IMAGE", ),
-                         "image3": ("IMAGE", ),
-                         }}
+    def define_schema(cls):
+        return io.Schema(
+            node_id="TextEncodeQwenImageEditPlus",
+            category="advanced/conditioning",
+            inputs=[
+                io.Clip.Input("clip"),
+                io.String.Input("prompt", multiline=True, dynamic_prompts=True),
+                io.Vae.Input("vae", optional=True),
+                io.Image.Input("image1", optional=True),
+                io.Image.Input("image2", optional=True),
+                io.Image.Input("image3", optional=True),
+            ],
+            outputs=[
+                io.Conditioning.Output(),
+            ],
+        )
 
-    RETURN_TYPES = ("CONDITIONING",)
-    FUNCTION = "encode"
-
-    CATEGORY = "advanced/conditioning"
-
-    def encode(self, clip, prompt, vae=None, image1=None, image2=None, image3=None):
+    @classmethod
+    def execute(cls, clip, prompt, vae=None, image1=None, image2=None, image3=None) -> io.NodeOutput:
         ref_latents = []
         images = [image1, image2, image3]
         images_vl = []
@@ -94,10 +101,17 @@ class TextEncodeQwenImageEditPlus:
         conditioning = clip.encode_from_tokens_scheduled(tokens)
         if len(ref_latents) > 0:
             conditioning = node_helpers.conditioning_set_values(conditioning, {"reference_latents": ref_latents}, append=True)
-        return (conditioning, )
+        return io.NodeOutput(conditioning)
 
 
-NODE_CLASS_MAPPINGS = {
-    "TextEncodeQwenImageEdit": TextEncodeQwenImageEdit,
-    "TextEncodeQwenImageEditPlus": TextEncodeQwenImageEditPlus,
-}
+class QwenExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            TextEncodeQwenImageEdit,
+            TextEncodeQwenImageEditPlus,
+        ]
+
+
+async def comfy_entrypoint() -> QwenExtension:
+    return QwenExtension()


### PR DESCRIPTION
One node of two was tested after conversion(_second node is almost the same_):

<img width="1829" height="1107" alt="Screenshot from 2025-09-20 11-08-48" src="https://github.com/user-attachments/assets/c7f2a046-c794-45b2-b226-322c0abe097c" />


git diff:
```
diff --git a/v3_object_info.json b/master_object_info.json
index 1e7b5ce..5e3cb67 100644
--- a/v3_object_info.json
+++ b/master_object_info.json
@@ -26342,8 +26342,7 @@
         "input": {
             "required": {
                 "clip": [
-                    "CLIP",
-                    {}
+                    "CLIP"
                 ],
                 "prompt": [
                     "STRING",
@@ -26355,12 +26354,10 @@
             },
             "optional": {
                 "vae": [
-                    "VAE",
-                    {}
+                    "VAE"
                 ],
                 "image": [
-                    "IMAGE",
-                    {}
+                    "IMAGE"
                 ]
             }
         },
@@ -26383,25 +26380,18 @@
         "output_name": [
             "CONDITIONING"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "TextEncodeQwenImageEdit",
-        "display_name": null,
+        "display_name": "TextEncodeQwenImageEdit",
         "description": "",
         "python_module": "comfy_extras.nodes_qwen",
         "category": "advanced/conditioning",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "TextEncodeQwenImageEditPlus": {
         "input": {
             "required": {
                 "clip": [
-                    "CLIP",
-                    {}
+                    "CLIP"
                 ],
                 "prompt": [
                     "STRING",
@@ -26413,20 +26403,16 @@
             },
             "optional": {
                 "vae": [
-                    "VAE",
-                    {}
+                    "VAE"
                 ],
                 "image1": [
-                    "IMAGE",
-                    {}
+                    "IMAGE"
                 ],
                 "image2": [
-                    "IMAGE",
-                    {}
+                    "IMAGE"
                 ],
                 "image3": [
-                    "IMAGE",
-                    {}
+                    "IMAGE"
                 ]
             }
         },
@@ -26451,18 +26437,12 @@
         "output_name": [
             "CONDITIONING"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "TextEncodeQwenImageEditPlus",
-        "display_name": null,
+        "display_name": "TextEncodeQwenImageEditPlus",
         "description": "",
         "python_module": "comfy_extras.nodes_qwen",
         "category": "advanced/conditioning",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "EmptyChromaRadianceLatentImage": {
         "input": {
```