### PR TITLE
Reduce Peak WAN inference VRAM usage - part II

### DIFF
--- a/comfy/ldm/flux/math.py
+++ b/comfy/ldm/flux/math.py
@@ -37,7 +37,10 @@ def rope(pos: Tensor, dim: int, theta: int) -> Tensor:
 
 def apply_rope1(x: Tensor, freqs_cis: Tensor):
     x_ = x.to(dtype=freqs_cis.dtype).reshape(*x.shape[:-1], -1, 1, 2)
-    x_out = freqs_cis[..., 0] * x_[..., 0] + freqs_cis[..., 1] * x_[..., 1]
+
+    x_out = freqs_cis[..., 0] * x_[..., 0]
+    x_out.addcmul_(freqs_cis[..., 1], x_[..., 1])
+
     return x_out.reshape(*x.shape).type_as(x)
 
 def apply_rope(xq: Tensor, xk: Tensor, freqs_cis: Tensor):

--- a/comfy/ldm/wan/model.py
+++ b/comfy/ldm/wan/model.py
@@ -237,6 +237,7 @@ class WanAttentionBlock(nn.Module):
             freqs, transformer_options=transformer_options)
 
         x = torch.addcmul(x, y, repeat_e(e[2], x))
+        del y
 
         # cross-attention & ffn
         x = x + self.cross_attn(self.norm3(x), context, context_img_len=context_img_len, transformer_options=transformer_options)


### PR DESCRIPTION
This change further reduces the peak VRAM usage of WAN and increases the maximum latent size in constrained VRAM conditions, following on from my previous PR for the same (https://github.com/comfyanonymous/ComfyUI/pull/9898).

Example Test Conditions:

RTX3060
--novram mode
WAN2.2 I2V 14B Q4_K_S GGUF + lightx2v 4steps LoRA (based on video_wan2_2_14B_i2v template)
1024x1024x77f video generation

Without this change, this VRAM OOMs:

```
  File "/home/rattus/ComfyUI/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ldm/wan/model.py", line 235, in forward
    y = self.self_attn(
        ^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ldm/wan/model.py", line 79, in forward
    k = qkv_fn_k(x)
        ^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ldm/wan/model.py", line 73, in qkv_fn_k
    return apply_rope1(k, freqs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ldm/flux/math.py", line 40, in apply_rope1
    x_out = freqs_cis[..., 0] * x_[..., 0] + freqs_cis[..., 1] * x_[..., 1]
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch.OutOfMemoryError: Allocation on device 

Got an OOM, unloading all loaded models.
Prompt executed in 114.26 seconds
```

<img width="1598" height="815" alt="image" src="https://github.com/user-attachments/assets/02ad6abb-8d07-4fdf-9e66-7cc2120f67cf" />



with the changes, this now comfortably fits in VRAM:



<img width="960" height="511" alt="image" src="https://github.com/user-attachments/assets/65c6f713-8476-4818-8d4f-2929068b814c" />

<img width="1854" height="786" alt="image" src="https://github.com/user-attachments/assets/c0106d1d-ca91-49f5-8808-2b6e6a844d5e" />


The first change works by using inplace addition right on the peak of the rope VRAM usage (I should have done this last time). Following that change, the VRAM peak moved to FFN. The second change further improves RAM by freeing the already-digested self-attention result before starting cross-attention and FFN.

More VRAM savings to come.