### PR TITLE
[V3] convert nodes_mochi.py to V3 schema

### DIFF
--- a/comfy_extras/nodes_mochi.py
+++ b/comfy_extras/nodes_mochi.py
@@ -1,23 +1,40 @@
-import nodes
+from typing_extensions import override
 import torch
 import comfy.model_management
+import nodes
+from comfy_api.latest import ComfyExtension, io
 
-class EmptyMochiLatentVideo:
+
+class EmptyMochiLatentVideo(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": { "width": ("INT", {"default": 848, "min": 16, "max": nodes.MAX_RESOLUTION, "step": 16}),
-                              "height": ("INT", {"default": 480, "min": 16, "max": nodes.MAX_RESOLUTION, "step": 16}),
-                              "length": ("INT", {"default": 25, "min": 7, "max": nodes.MAX_RESOLUTION, "step": 6}),
-                              "batch_size": ("INT", {"default": 1, "min": 1, "max": 4096})}}
-    RETURN_TYPES = ("LATENT",)
-    FUNCTION = "generate"
+    def define_schema(cls):
+        return io.Schema(
+            node_id="EmptyMochiLatentVideo",
+            category="latent/video",
+            inputs=[
+                io.Int.Input("width", default=848, min=16, max=nodes.MAX_RESOLUTION, step=16),
+                io.Int.Input("height", default=480, min=16, max=nodes.MAX_RESOLUTION, step=16),
+                io.Int.Input("length", default=25, min=7, max=nodes.MAX_RESOLUTION, step=6),
+                io.Int.Input("batch_size", default=1, min=1, max=4096),
+            ],
+            outputs=[
+                io.Latent.Output(),
+            ],
+        )
 
-    CATEGORY = "latent/video"
-
-    def generate(self, width, height, length, batch_size=1):
+    @classmethod
+    def execute(cls, width, height, length, batch_size=1) -> io.NodeOutput:
         latent = torch.zeros([batch_size, 12, ((length - 1) // 6) + 1, height // 8, width // 8], device=comfy.model_management.intermediate_device())
-        return ({"samples":latent}, )
+        return io.NodeOutput({"samples": latent})
 
-NODE_CLASS_MAPPINGS = {
-    "EmptyMochiLatentVideo": EmptyMochiLatentVideo,
-}
+
+class MochiExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            EmptyMochiLatentVideo,
+        ]
+
+
+async def comfy_entrypoint() -> MochiExtension:
+    return MochiExtension()


### PR DESCRIPTION
Node was tested after conversion:

<img width="1538" height="896" alt="Screenshot From 2025-09-28 09-54-01" src="https://github.com/user-attachments/assets/4981619f-673d-45ae-b6f9-b04deea050fb" />


Git diff:

```
diff --git a/v3_object_info.json b/master_object_info.json
index 34579ea..c2d91f9 100644
--- a/v3_object_info.json
+++ b/master_object_info.json
@@ -20735,18 +20735,12 @@
         "output_name": [
             "LATENT"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "EmptyMochiLatentVideo",
-        "display_name": null,
+        "display_name": "EmptyMochiLatentVideo",
         "description": "",
         "python_module": "comfy_extras.nodes_mochi",
         "category": "latent/video",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "SkipLayerGuidanceDiT": {
         "input": {
```