### PR TITLE
[V3] convert nodes_optimalsteps.py to V3 schema

### DIFF
--- a/comfy_extras/nodes_optimalsteps.py
+++ b/comfy_extras/nodes_optimalsteps.py
@@ -1,8 +1,11 @@
 # from https://github.com/bebebe666/OptimalSteps
 
-
 import numpy as np
 import torch
+
+from typing_extensions import override
+from comfy_api.latest import ComfyExtension, io
+
 
 def loglinear_interp(t_steps, num_steps):
     """
@@ -23,25 +26,28 @@ NOISE_LEVELS = {"FLUX": [0.9968, 0.9886, 0.9819, 0.975, 0.966, 0.9471, 0.9158, 0
 "Chroma": [0.992, 0.99, 0.988, 0.985, 0.982, 0.978, 0.973, 0.968, 0.961, 0.953, 0.943, 0.931, 0.917, 0.9, 0.881, 0.858, 0.832, 0.802, 0.769, 0.731, 0.69, 0.646, 0.599, 0.55, 0.501, 0.451, 0.402, 0.355, 0.311, 0.27, 0.232, 0.199, 0.169, 0.143, 0.12, 0.101, 0.084, 0.07, 0.058, 0.048, 0.001],
 }
 
-class OptimalStepsScheduler:
+class OptimalStepsScheduler(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required":
-                    {"model_type": (["FLUX", "Wan", "Chroma"], ),
-                     "steps": ("INT", {"default": 20, "min": 3, "max": 1000}),
-                     "denoise": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
-                      }
-               }
-    RETURN_TYPES = ("SIGMAS",)
-    CATEGORY = "sampling/custom_sampling/schedulers"
+    def define_schema(cls):
+        return io.Schema(
+            node_id="OptimalStepsScheduler",
+            category="sampling/custom_sampling/schedulers",
+            inputs=[
+                io.Combo.Input("model_type", options=["FLUX", "Wan", "Chroma"]),
+                io.Int.Input("steps", default=20, min=3, max=1000),
+                io.Float.Input("denoise", default=1.0, min=0.0, max=1.0, step=0.01),
+            ],
+            outputs=[
+                io.Sigmas.Output(),
+            ],
+        )
 
-    FUNCTION = "get_sigmas"
-
-    def get_sigmas(self, model_type, steps, denoise):
+    @classmethod
+    def execute(cls, model_type, steps, denoise) ->io.NodeOutput:
         total_steps = steps
         if denoise < 1.0:
             if denoise <= 0.0:
-                return (torch.FloatTensor([]),)
+                return io.NodeOutput(torch.FloatTensor([]))
             total_steps = round(steps * denoise)
 
         sigmas = NOISE_LEVELS[model_type][:]
@@ -50,8 +56,16 @@ class OptimalStepsScheduler:
 
         sigmas = sigmas[-(total_steps + 1):]
         sigmas[-1] = 0
-        return (torch.FloatTensor(sigmas), )
+        return io.NodeOutput(torch.FloatTensor(sigmas))
 
-NODE_CLASS_MAPPINGS = {
-    "OptimalStepsScheduler": OptimalStepsScheduler,
-}
+
+class OptimalStepsExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            OptimalStepsScheduler,
+        ]
+
+
+async def comfy_entrypoint() -> OptimalStepsExtension:
+    return OptimalStepsExtension()


### PR DESCRIPTION
Git diff:

```
diff --git a/v3_object_info.json b/master_object_info.json
index ed72c87..c2d91f9 100644
--- a/v3_object_info.json
+++ b/master_object_info.json
@@ -25822,15 +25822,11 @@
         "input": {
             "required": {
                 "model_type": [
-                    "COMBO",
-                    {
-                        "multiselect": false,
-                        "options": [
-                            "FLUX",
-                            "Wan",
-                            "Chroma"
-                        ]
-                    }
+                    [
+                        "FLUX",
+                        "Wan",
+                        "Chroma"
+                    ]
                 ],
                 "steps": [
                     "INT",
@@ -25867,18 +25863,12 @@
         "output_name": [
             "SIGMAS"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "OptimalStepsScheduler",
-        "display_name": null,
+        "display_name": "OptimalStepsScheduler",
         "description": "",
         "python_module": "comfy_extras.nodes_optimalsteps",
         "category": "sampling/custom_sampling/schedulers",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "QuadrupleCLIPLoader": {
         "input": {
```