### PR TITLE
[V3] convert nodes_perpneg.py to V3 schema

### DIFF
--- a/comfy_extras/nodes_perpneg.py
+++ b/comfy_extras/nodes_perpneg.py
@@ -5,6 +5,9 @@ import comfy.samplers
 import comfy.utils
 import node_helpers
 import math
+from typing_extensions import override
+from comfy_api.latest import ComfyExtension, io
+
 
 def perp_neg(x, noise_pred_pos, noise_pred_neg, noise_pred_nocond, neg_scale, cond_scale):
     pos = noise_pred_pos - noise_pred_nocond
@@ -16,20 +19,27 @@ def perp_neg(x, noise_pred_pos, noise_pred_neg, noise_pred_nocond, neg_scale, co
     return cfg_result
 
 #TODO: This node should be removed, it has been replaced with PerpNegGuider
-class PerpNeg:
+class PerpNeg(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {"model": ("MODEL", ),
-                             "empty_conditioning": ("CONDITIONING", ),
-                             "neg_scale": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 100.0, "step": 0.01}),
-                            }}
-    RETURN_TYPES = ("MODEL",)
-    FUNCTION = "patch"
+    def define_schema(cls):
+        return io.Schema(
+            node_id="PerpNeg",
+            display_name="Perp-Neg (DEPRECATED by PerpNegGuider)",
+            category="_for_testing",
+            inputs=[
+                io.Model.Input("model"),
+                io.Conditioning.Input("empty_conditioning"),
+                io.Float.Input("neg_scale", default=1.0, min=0.0, max=100.0, step=0.01),
+            ],
+            outputs=[
+                io.Model.Output(),
+            ],
+            is_experimental=True,
+            is_deprecated=True,
+        )
 
-    CATEGORY = "_for_testing"
-    DEPRECATED = True
-
-    def patch(self, model, empty_conditioning, neg_scale):
+    @classmethod
+    def execute(cls, model, empty_conditioning, neg_scale) -> io.NodeOutput:
         m = model.clone()
         nocond = comfy.sampler_helpers.convert_cond(empty_conditioning)
 
@@ -50,7 +60,7 @@ class PerpNeg:
 
         m.set_model_sampler_cfg_function(cfg_function)
 
-        return (m, )
+        return io.NodeOutput(m)
 
 
 class Guider_PerpNeg(comfy.samplers.CFGGuider):
@@ -112,35 +122,42 @@ class Guider_PerpNeg(comfy.samplers.CFGGuider):
 
         return cfg_result
 
-class PerpNegGuider:
+class PerpNegGuider(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required":
-                    {"model": ("MODEL",),
-                    "positive": ("CONDITIONING", ),
-                    "negative": ("CONDITIONING", ),
-                    "empty_conditioning": ("CONDITIONING", ),
-                    "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0, "step":0.1, "round": 0.01}),
-                    "neg_scale": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 100.0, "step": 0.01}),
-                     }
-                }
+    def define_schema(cls):
+        return io.Schema(
+            node_id="PerpNegGuider",
+            category="_for_testing",
+            inputs=[
+                io.Model.Input("model"),
+                io.Conditioning.Input("positive"),
+                io.Conditioning.Input("negative"),
+                io.Conditioning.Input("empty_conditioning"),
+                io.Float.Input("cfg", default=8.0, min=0.0, max=100.0, step=0.1, round=0.01),
+                io.Float.Input("neg_scale", default=1.0, min=0.0, max=100.0, step=0.01),
+            ],
+            outputs=[
+                io.Guider.Output(),
+            ],
+            is_experimental=True,
+        )
 
-    RETURN_TYPES = ("GUIDER",)
-
-    FUNCTION = "get_guider"
-    CATEGORY = "_for_testing"
-
-    def get_guider(self, model, positive, negative, empty_conditioning, cfg, neg_scale):
+    @classmethod
+    def execute(cls, model, positive, negative, empty_conditioning, cfg, neg_scale) -> io.NodeOutput:
         guider = Guider_PerpNeg(model)
         guider.set_conds(positive, negative, empty_conditioning)
         guider.set_cfg(cfg, neg_scale)
-        return (guider,)
+        return io.NodeOutput(guider)
 
-NODE_CLASS_MAPPINGS = {
-    "PerpNeg": PerpNeg,
-    "PerpNegGuider": PerpNegGuider,
-}
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "PerpNeg": "Perp-Neg (DEPRECATED by PerpNegGuider)",
-}
+class PerpNegExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            PerpNeg,
+            PerpNegGuider,
+        ]
+
+
+async def comfy_entrypoint() -> PerpNegExtension:
+    return PerpNegExtension()


### PR DESCRIPTION
Non-deprecated node was tested after conversion:

<img width="2064" height="825" alt="Screenshot From 2025-09-28 17-46-47" src="https://github.com/user-attachments/assets/c478b68a-e02c-4705-9892-1ced05806b62" />


Git diff:

```
diff --git a/v3_object_info.json b/master_object_info.json
index 10aa85e..820d8c2 100644
--- a/v3_object_info.json
+++ b/master_object_info.json
@@ -10455,12 +10455,10 @@
         "input": {
             "required": {
                 "model": [
-                    "MODEL",
-                    {}
+                    "MODEL"
                 ],
                 "empty_conditioning": [
-                    "CONDITIONING",
-                    {}
+                    "CONDITIONING"
                 ],
                 "neg_scale": [
                     "FLOAT",
@@ -10489,37 +10487,28 @@
         "output_name": [
             "MODEL"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "PerpNeg",
         "display_name": "Perp-Neg (DEPRECATED by PerpNegGuider)",
         "description": "",
         "python_module": "comfy_extras.nodes_perpneg",
         "category": "_for_testing",
         "output_node": false,
-        "deprecated": true,
-        "experimental": true,
-        "api_node": false
+        "deprecated": true
     },
     "PerpNegGuider": {
         "input": {
             "required": {
                 "model": [
-                    "MODEL",
-                    {}
+                    "MODEL"
                 ],
                 "positive": [
-                    "CONDITIONING",
-                    {}
+                    "CONDITIONING"
                 ],
                 "negative": [
-                    "CONDITIONING",
-                    {}
+                    "CONDITIONING"
                 ],
                 "empty_conditioning": [
-                    "CONDITIONING",
-                    {}
+                    "CONDITIONING"
                 ],
                 "cfg": [
                     "FLOAT",
@@ -10561,18 +10550,12 @@
         "output_name": [
             "GUIDER"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "PerpNegGuider",
-        "display_name": null,
+        "display_name": "PerpNegGuider",
         "description": "",
         "python_module": "comfy_extras.nodes_perpneg",
         "category": "_for_testing",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": true,
-        "api_node": false
+        "output_node": false
     },
     "StableZero123_Conditioning": {
         "input": {
```