### PR TITLE
Don't cache new locale-based templates entry point files

### DIFF
--- a/middleware/cache_middleware.py
+++ b/middleware/cache_middleware.py
@@ -26,11 +26,12 @@ async def cache_control(
     """Cache control middleware that sets appropriate cache headers based on file type and response status"""
     response: web.Response = await handler(request)
 
-    if (
-        request.path.endswith(".js")
-        or request.path.endswith(".css")
-        or request.path.endswith("index.json")
-    ):
+    path_filename = request.path.rsplit("/", 1)[-1]
+    is_entry_point = path_filename.startswith("index") and path_filename.endswith(
+        ".json"
+    )
+
+    if request.path.endswith(".js") or request.path.endswith(".css") or is_entry_point:
         response.headers.setdefault("Cache-Control", "no-cache")
         return response
 

--- a/tests-unit/server_test/test_cache_control.py
+++ b/tests-unit/server_test/test_cache_control.py
@@ -48,6 +48,13 @@ CACHE_SCENARIOS = [
         "expected_cache": "no-cache",
         "should_have_header": True,
     },
+    {
+        "name": "localized_index_json_no_cache",
+        "path": "/templates/index.zh.json",
+        "status": 200,
+        "expected_cache": "no-cache",
+        "should_have_header": True,
+    },
     # Non-matching files
     {
         "name": "html_no_header",


### PR DESCRIPTION
The workflow templates now serves different index entrypoints depending on locale (e.g., [French entrypoint](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/index.fr.json)).

Change the cache middleware to treat every `index*.json` entry point as non-cacheable, as opposed to previous `index.json` only.
