### PR TITLE
[V3] convert nodes_flux to V3 schema

### DIFF
--- a/comfy_extras/nodes_flux.py
+++ b/comfy_extras/nodes_flux.py
@@ -1,60 +1,80 @@
 import node_helpers
 import comfy.utils
+from typing_extensions import override
+from comfy_api.latest import ComfyExtension, io
 
-class CLIPTextEncodeFlux:
+
+class CLIPTextEncodeFlux(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {
-            "clip": ("CLIP", ),
-            "clip_l": ("STRING", {"multiline": True, "dynamicPrompts": True}),
-            "t5xxl": ("STRING", {"multiline": True, "dynamicPrompts": True}),
-            "guidance": ("FLOAT", {"default": 3.5, "min": 0.0, "max": 100.0, "step": 0.1}),
-            }}
-    RETURN_TYPES = ("CONDITIONING",)
-    FUNCTION = "encode"
+    def define_schema(cls):
+        return io.Schema(
+            node_id="CLIPTextEncodeFlux",
+            category="advanced/conditioning/flux",
+            inputs=[
+                io.Clip.Input("clip"),
+                io.String.Input("clip_l", multiline=True, dynamic_prompts=True),
+                io.String.Input("t5xxl", multiline=True, dynamic_prompts=True),
+                io.Float.Input("guidance", default=3.5, min=0.0, max=100.0, step=0.1),
+            ],
+            outputs=[
+                io.Conditioning.Output(),
+            ],
+        )
 
-    CATEGORY = "advanced/conditioning/flux"
-
-    def encode(self, clip, clip_l, t5xxl, guidance):
+    @classmethod
+    def execute(cls, clip, clip_l, t5xxl, guidance) -> io.NodeOutput:
         tokens = clip.tokenize(clip_l)
         tokens["t5xxl"] = clip.tokenize(t5xxl)["t5xxl"]
 
-        return (clip.encode_from_tokens_scheduled(tokens, add_dict={"guidance": guidance}), )
+        return io.NodeOutput(clip.encode_from_tokens_scheduled(tokens, add_dict={"guidance": guidance}))
 
-class FluxGuidance:
+    encode = execute  # TODO: remove
+
+
+class FluxGuidance(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {
-            "conditioning": ("CONDITIONING", ),
-            "guidance": ("FLOAT", {"default": 3.5, "min": 0.0, "max": 100.0, "step": 0.1}),
-            }}
+    def define_schema(cls):
+        return io.Schema(
+            node_id="FluxGuidance",
+            category="advanced/conditioning/flux",
+            inputs=[
+                io.Conditioning.Input("conditioning"),
+                io.Float.Input("guidance", default=3.5, min=0.0, max=100.0, step=0.1),
+            ],
+            outputs=[
+                io.Conditioning.Output(),
+            ],
+        )
 
-    RETURN_TYPES = ("CONDITIONING",)
-    FUNCTION = "append"
-
-    CATEGORY = "advanced/conditioning/flux"
-
-    def append(self, conditioning, guidance):
+    @classmethod
+    def execute(cls, conditioning, guidance) -> io.NodeOutput:
         c = node_helpers.conditioning_set_values(conditioning, {"guidance": guidance})
-        return (c, )
+        return io.NodeOutput(c)
+
+    append = execute  # TODO: remove
 
 
-class FluxDisableGuidance:
+class FluxDisableGuidance(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {
-            "conditioning": ("CONDITIONING", ),
-            }}
+    def define_schema(cls):
+        return io.Schema(
+            node_id="FluxDisableGuidance",
+            category="advanced/conditioning/flux",
+            description="This node completely disables the guidance embed on Flux and Flux like models",
+            inputs=[
+                io.Conditioning.Input("conditioning"),
+            ],
+            outputs=[
+                io.Conditioning.Output(),
+            ],
+        )
 
-    RETURN_TYPES = ("CONDITIONING",)
-    FUNCTION = "append"
-
-    CATEGORY = "advanced/conditioning/flux"
-    DESCRIPTION = "This node completely disables the guidance embed on Flux and Flux like models"
-
-    def append(self, conditioning):
+    @classmethod
+    def execute(cls, conditioning) -> io.NodeOutput:
         c = node_helpers.conditioning_set_values(conditioning, {"guidance": None})
-        return (c, )
+        return io.NodeOutput(c)
+
+    append = execute  # TODO: remove
 
 
 PREFERED_KONTEXT_RESOLUTIONS = [
@@ -78,52 +98,73 @@ PREFERED_KONTEXT_RESOLUTIONS = [
 ]
 
 
-class FluxKontextImageScale:
+class FluxKontextImageScale(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {"image": ("IMAGE", ),
-                            },
-               }
+    def define_schema(cls):
+        return io.Schema(
+            node_id="FluxKontextImageScale",
+            category="advanced/conditioning/flux",
+            description="This node resizes the image to one that is more optimal for flux kontext.",
+            inputs=[
+                io.Image.Input("image"),
+            ],
+            outputs=[
+                io.Image.Output(),
+            ],
+        )
 
-    RETURN_TYPES = ("IMAGE",)
-    FUNCTION = "scale"
-
-    CATEGORY = "advanced/conditioning/flux"
-    DESCRIPTION = "This node resizes the image to one that is more optimal for flux kontext."
-
-    def scale(self, image):
+    @classmethod
+    def execute(cls, image) -> io.NodeOutput:
         width = image.shape[2]
         height = image.shape[1]
         aspect_ratio = width / height
         _, width, height = min((abs(aspect_ratio - w / h), w, h) for w, h in PREFERED_KONTEXT_RESOLUTIONS)
         image = comfy.utils.common_upscale(image.movedim(-1, 1), width, height, "lanczos", "center").movedim(1, -1)
-        return (image, )
+        return io.NodeOutput(image)
+
+    scale = execute  # TODO: remove
 
 
-class FluxKontextMultiReferenceLatentMethod:
+class FluxKontextMultiReferenceLatentMethod(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {
-            "conditioning": ("CONDITIONING", ),
-            "reference_latents_method": (("offset", "index", "uxo/uno"), ),
-            }}
+    def define_schema(cls):
+        return io.Schema(
+            node_id="FluxKontextMultiReferenceLatentMethod",
+            category="advanced/conditioning/flux",
+            inputs=[
+                io.Conditioning.Input("conditioning"),
+                io.Combo.Input(
+                    "reference_latents_method",
+                    options=["offset", "index", "uxo/uno"],
+                ),
+            ],
+            outputs=[
+                io.Conditioning.Output(),
+            ],
+            is_experimental=True,
+        )
 
-    RETURN_TYPES = ("CONDITIONING",)
-    FUNCTION = "append"
-    EXPERIMENTAL = True
-
-    CATEGORY = "advanced/conditioning/flux"
-
-    def append(self, conditioning, reference_latents_method):
+    @classmethod
+    def execute(cls, conditioning, reference_latents_method) -> io.NodeOutput:
         if "uxo" in reference_latents_method or "uso" in reference_latents_method:
             reference_latents_method = "uxo"
         c = node_helpers.conditioning_set_values(conditioning, {"reference_latents_method": reference_latents_method})
-        return (c, )
+        return io.NodeOutput(c)
 
-NODE_CLASS_MAPPINGS = {
-    "CLIPTextEncodeFlux": CLIPTextEncodeFlux,
-    "FluxGuidance": FluxGuidance,
-    "FluxDisableGuidance": FluxDisableGuidance,
-    "FluxKontextImageScale": FluxKontextImageScale,
-    "FluxKontextMultiReferenceLatentMethod": FluxKontextMultiReferenceLatentMethod,
-}
+    append = execute  # TODO: remove
+
+
+class FluxExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            CLIPTextEncodeFlux,
+            FluxGuidance,
+            FluxDisableGuidance,
+            FluxKontextImageScale,
+            FluxKontextMultiReferenceLatentMethod,
+        ]
+
+
+async def comfy_entrypoint() -> FluxExtension:
+    return FluxExtension()


### PR DESCRIPTION
Most nodes were tested after conversion:

<img width="2720" height="1213" alt="Screenshot From 2025-09-30 14-27-00" src="https://github.com/user-attachments/assets/2f40eab6-1348-4d97-86be-1e519152fd54" />

Git diff:

```
diff --git a/v3_object_info.json b/master_object_info.json
index 0ed4c93..d83baaf 100644
--- a/v3_object_info.json
+++ b/master_object_info.json
@@ -20418,8 +20418,7 @@
         "input": {
             "required": {
                 "clip": [
-                    "CLIP",
-                    {}
+                    "CLIP"
                 ],
                 "clip_l": [
                     "STRING",
@@ -20463,25 +20462,18 @@
         "output_name": [
             "CONDITIONING"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "CLIPTextEncodeFlux",
-        "display_name": null,
+        "display_name": "CLIPTextEncodeFlux",
         "description": "",
         "python_module": "comfy_extras.nodes_flux",
         "category": "advanced/conditioning/flux",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "FluxGuidance": {
         "input": {
             "required": {
                 "conditioning": [
-                    "CONDITIONING",
-                    {}
+                    "CONDITIONING"
                 ],
                 "guidance": [
                     "FLOAT",
@@ -20509,25 +20501,18 @@
         "output_name": [
             "CONDITIONING"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "FluxGuidance",
-        "display_name": null,
+        "display_name": "FluxGuidance",
         "description": "",
         "python_module": "comfy_extras.nodes_flux",
         "category": "advanced/conditioning/flux",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "FluxDisableGuidance": {
         "input": {
             "required": {
                 "conditioning": [
-                    "CONDITIONING",
-                    {}
+                    "CONDITIONING"
                 ]
             }
         },
@@ -20545,25 +20530,18 @@
         "output_name": [
             "CONDITIONING"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "FluxDisableGuidance",
-        "display_name": null,
+        "display_name": "FluxDisableGuidance",
         "description": "This node completely disables the guidance embed on Flux and Flux like models",
         "python_module": "comfy_extras.nodes_flux",
         "category": "advanced/conditioning/flux",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "FluxKontextImageScale": {
         "input": {
             "required": {
                 "image": [
-                    "IMAGE",
-                    {}
+                    "IMAGE"
                 ]
             }
         },
@@ -20581,36 +20559,25 @@
         "output_name": [
             "IMAGE"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "FluxKontextImageScale",
-        "display_name": null,
+        "display_name": "FluxKontextImageScale",
         "description": "This node resizes the image to one that is more optimal for flux kontext.",
         "python_module": "comfy_extras.nodes_flux",
         "category": "advanced/conditioning/flux",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "FluxKontextMultiReferenceLatentMethod": {
         "input": {
             "required": {
                 "conditioning": [
-                    "CONDITIONING",
-                    {}
+                    "CONDITIONING"
                 ],
                 "reference_latents_method": [
-                    "COMBO",
-                    {
-                        "multiselect": false,
-                        "options": [
-                            "offset",
-                            "index",
-                            "uxo/uno"
-                        ]
-                    }
+                    [
+                        "offset",
+                        "index",
+                        "uxo/uno"
+                    ]
                 ]
             }
         },
@@ -20629,18 +20596,13 @@
         "output_name": [
             "CONDITIONING"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "FluxKontextMultiReferenceLatentMethod",
-        "display_name": null,
+        "display_name": "FluxKontextMultiReferenceLatentMethod",
         "description": "",
         "python_module": "comfy_extras.nodes_flux",
         "category": "advanced/conditioning/flux",
         "output_node": false,
-        "deprecated": false,
-        "experimental": true,
-        "api_node": false
+        "experimental": true
     },
     "LoraSave": {
         "input": {
```