### PR TITLE
[V3] convert nodes_audio_encoder.py to V3 schema

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -1605,6 +1605,7 @@ class _IO:
     Model = Model
     ClipVision = ClipVision
     ClipVisionOutput = ClipVisionOutput
+    AudioEncoder = AudioEncoder
     AudioEncoderOutput = AudioEncoderOutput
     StyleModel = StyleModel
     Gligen = Gligen


### PR DESCRIPTION
Nodes were tested after conversion:


https://github.com/user-attachments/assets/1b5255bc-d008-4c82-a12a-8227ed7a4fd7


Git diff:

```
diff --git a/v3_object_info.json b/master_object_info.json
index 24e07cb..557d07e 100644
--- a/v3_object_info.json
+++ b/master_object_info.json
@@ -28026,11 +28026,7 @@
         "input": {
             "required": {
                 "audio_encoder_name": [
-                    "COMBO",
-                    {
-                        "multiselect": false,
-                        "options": []
-                    }
+                    []
                 ]
             }
         },
@@ -28048,29 +28044,21 @@
         "output_name": [
             "AUDIO_ENCODER"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "AudioEncoderLoader",
-        "display_name": null,
+        "display_name": "AudioEncoderLoader",
         "description": "",
         "python_module": "comfy_extras.nodes_audio_encoder",
         "category": "loaders",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "AudioEncoderEncode": {
         "input": {
             "required": {
                 "audio_encoder": [
-                    "AUDIO_ENCODER",
-                    {}
+                    "AUDIO_ENCODER"
                 ],
                 "audio": [
-                    "AUDIO",
-                    {}
+                    "AUDIO"
                 ]
             }
         },
@@ -28089,18 +28077,12 @@
         "output_name": [
             "AUDIO_ENCODER_OUTPUT"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "AudioEncoderEncode",
-        "display_name": null,
+        "display_name": "AudioEncoderEncode",
         "description": "",
         "python_module": "comfy_extras.nodes_audio_encoder",
         "category": "conditioning",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "IdeogramV1": {
         "input": {
```