### PR TITLE
fix(Rodin3D-Gen2): missing "task_uuid" parameter

### DIFF
--- a/comfy_api_nodes/nodes_rodin.py
+++ b/comfy_api_nodes/nodes_rodin.py
@@ -540,7 +540,7 @@ class Rodin3D_Gen2(Rodin3DAPI):
                                                                 **kwargs)
         await self.poll_for_task_status(subscription_key, **kwargs)
         download_list = await self.get_rodin_download_list(task_uuid, **kwargs)
-        model = await self.download_files(download_list)
+        model = await self.download_files(download_list, task_uuid)
 
         return (model,)
 


### PR DESCRIPTION
Fixes this error:

```
  File "/Users/shurik/PycharmProjects/ComfyUI/comfy_api_nodes/nodes_rodin.py", line 543, in api_call
    model = await self.download_files(download_list, task_uuid)
TypeError: download_files() missing 1 required positional argument: 'task_uuid'
```