### PR TITLE
Bump frontend to 1.27.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.26.13
+comfyui-frontend-package==1.27.7
 comfyui-workflow-templates==0.1.91
 comfyui-embedded-docs==0.2.6
 torch


### PR DESCRIPTION
Bump frontend to 1.27.7
```
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.27.7
```
- Diff: [v1.26.13...v1.27.7](<https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.26.13...v1.27.7>)
- PyPI Package: <https://pypi.org/project/comfyui-frontend-package/1.27.7/>
- npm Types: https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.27.7

## Changes (v1.26.13 → v1.27.7)
### New Features and QoL
- Adds a new subgraph publishing functionality
- Improves the Floating Selection Toolbox
- Reworks the theme menu
- Introduces a new adaptive lod threshold
- Adds new navigation settings for left click and scroll wheel
- Upgrades Tailwind to v4
- Enable mouse gestures over video previews
- Fix clicks near DOMWidgets being swallowed
- When converting single group to subgraph, also convert children
- Adds dynamic icon support for NavItem components
- Adds lucide icon support via iconify plugin
- Improves UX for disabled node packs in Manager dialog
- Auto-close LoadWorkflowWarning dialog when all missing nodes are installed
- When Bypassing or Muting a group of nodes, set all before toggling
- Changes the Run button / ActionBar to dock by default
- Adds sortOrder for setting item by
- Adds terminal context menu
- Adds focus state and aria to select components
- Adds a copy button to the terminal

### Bugfixes
- Fixes double click primitive widgets with subgraphs
- Fixes incorrect id resolution for preview images
- Fixes toolbox node detection
- Fixes onNodeRemoved not being called when loading new graph (and tearing down previous)
- Fixes prompt execution when virtual nodes, like primitives, are bypassed
- Fixes missing dropdown size control on Select components
- Fixes copy & paste not functioning from desktop app start
- Fixes light_theme changing default node background
