### PR TITLE
[V3] convert nodes_upscale_model.py to V3 schema

### DIFF
--- a/comfy_extras/nodes_upscale_model.py
+++ b/comfy_extras/nodes_upscale_model.py
@@ -4,6 +4,8 @@ from comfy import model_management
 import torch
 import comfy.utils
 import folder_paths
+from typing_extensions import override
+from comfy_api.latest import ComfyExtension, io
 
 try:
     from spandrel_extra_arches import EXTRA_REGISTRY
@@ -13,17 +15,23 @@ try:
 except:
     pass
 
-class UpscaleModelLoader:
+class UpscaleModelLoader(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": { "model_name": (folder_paths.get_filename_list("upscale_models"), ),
-                             }}
-    RETURN_TYPES = ("UPSCALE_MODEL",)
-    FUNCTION = "load_model"
+    def define_schema(cls):
+        return io.Schema(
+            node_id="UpscaleModelLoader",
+            display_name="Load Upscale Model",
+            category="loaders",
+            inputs=[
+                io.Combo.Input("model_name", options=folder_paths.get_filename_list("upscale_models")),
+            ],
+            outputs=[
+                io.UpscaleModel.Output(),
+            ],
+        )
 
-    CATEGORY = "loaders"
-
-    def load_model(self, model_name):
+    @classmethod
+    def execute(cls, model_name) -> io.NodeOutput:
         model_path = folder_paths.get_full_path_or_raise("upscale_models", model_name)
         sd = comfy.utils.load_torch_file(model_path, safe_load=True)
         if "module.layers.0.residual_group.blocks.0.norm1.weight" in sd:
@@ -33,21 +41,29 @@ class UpscaleModelLoader:
         if not isinstance(out, ImageModelDescriptor):
             raise Exception("Upscale model must be a single-image model.")
 
-        return (out, )
+        return io.NodeOutput(out)
+
+    load_model = execute  # TODO: remove
 
 
-class ImageUpscaleWithModel:
+class ImageUpscaleWithModel(io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {"required": { "upscale_model": ("UPSCALE_MODEL",),
-                              "image": ("IMAGE",),
-                              }}
-    RETURN_TYPES = ("IMAGE",)
-    FUNCTION = "upscale"
+    def define_schema(cls):
+        return io.Schema(
+            node_id="ImageUpscaleWithModel",
+            display_name="Upscale Image (using Model)",
+            category="image/upscaling",
+            inputs=[
+                io.UpscaleModel.Input("upscale_model"),
+                io.Image.Input("image"),
+            ],
+            outputs=[
+                io.Image.Output(),
+            ],
+        )
 
-    CATEGORY = "image/upscaling"
-
-    def upscale(self, upscale_model, image):
+    @classmethod
+    def execute(cls, upscale_model, image) -> io.NodeOutput:
         device = model_management.get_torch_device()
 
         memory_required = model_management.module_size(upscale_model.model)
@@ -75,9 +91,19 @@ class ImageUpscaleWithModel:
 
         upscale_model.to("cpu")
         s = torch.clamp(s.movedim(-3,-1), min=0, max=1.0)
-        return (s,)
+        return io.NodeOutput(s)
 
-NODE_CLASS_MAPPINGS = {
-    "UpscaleModelLoader": UpscaleModelLoader,
-    "ImageUpscaleWithModel": ImageUpscaleWithModel
-}
+    upscale = execute  # TODO: remove
+
+
+class UpscaleModelExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            UpscaleModelLoader,
+            ImageUpscaleWithModel,
+        ]
+
+
+async def comfy_entrypoint() -> UpscaleModelExtension:
+    return UpscaleModelExtension()

--- a/nodes.py
+++ b/nodes.py
@@ -2027,7 +2027,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "DiffControlNetLoader": "Load ControlNet Model (diff)",
     "StyleModelLoader": "Load Style Model",
     "CLIPVisionLoader": "Load CLIP Vision",
-    "UpscaleModelLoader": "Load Upscale Model",
     "UNETLoader": "Load Diffusion Model",
     # Conditioning
     "CLIPVisionEncode": "CLIP Vision Encode",
@@ -2065,7 +2064,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "LoadImageOutput": "Load Image (from Outputs)",
     "ImageScale": "Upscale Image",
     "ImageScaleBy": "Upscale Image By",
-    "ImageUpscaleWithModel": "Upscale Image (using Model)",
     "ImageInvert": "Invert Image",
     "ImagePadForOutpaint": "Pad Image for Outpainting",
     "ImageBatch": "Batch Images",


### PR DESCRIPTION
Nodes were tests after conversion:

<img width="2790" height="1064" alt="Screenshot From 2025-10-01 20-23-08" src="https://github.com/user-attachments/assets/5bba0409-311c-4ca3-afde-535c1a7dc0be" />

Git diff:

```
diff --git a/v3_object_info.json b/master_object_info.json
index 6f6a385..29b4d21 100644
--- a/v3_object_info.json
+++ b/master_object_info.json
@@ -4253,13 +4253,9 @@
         "input": {
             "required": {
                 "model_name": [
-                    "COMBO",
-                    {
-                        "multiselect": false,
-                        "options": [
-                            "4x-UltraSharp.pth"
-                        ]
-                    }
+                    [
+                        "4x-UltraSharp.pth"
+                    ]
                 ]
             }
         },
@@ -4277,29 +4273,21 @@
         "output_name": [
             "UPSCALE_MODEL"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "UpscaleModelLoader",
         "display_name": "Load Upscale Model",
         "description": "",
         "python_module": "comfy_extras.nodes_upscale_model",
         "category": "loaders",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "ImageUpscaleWithModel": {
         "input": {
             "required": {
                 "upscale_model": [
-                    "UPSCALE_MODEL",
-                    {}
+                    "UPSCALE_MODEL"
                 ],
                 "image": [
-                    "IMAGE",
-                    {}
+                    "IMAGE"
                 ]
             }
         },
@@ -4318,18 +4306,12 @@
         "output_name": [
             "IMAGE"
         ],
-        "output_tooltips": [
-            null
-        ],
         "name": "ImageUpscaleWithModel",
         "display_name": "Upscale Image (using Model)",
         "description": "",
         "python_module": "comfy_extras.nodes_upscale_model",
         "category": "image/upscaling",
-        "output_node": false,
-        "deprecated": false,
-        "experimental": false,
-        "api_node": false
+        "output_node": false
     },
     "ImageBlend": {
         "input": {
```