### PR TITLE
[assets] drop PgSQL 14, unite migration for SQLite and PgSQL

### DIFF
--- a/.github/workflows/test-assets.yml
+++ b/.github/workflows/test-assets.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.9', '3.12']
-        pgsql: ['14', '16']
+        pgsql: ['16', '18']
 
     services:
       postgres:

--- a/app/alembic_db/versions/0001_assets.py
+++ b/app/alembic_db/versions/0001_assets.py
@@ -26,16 +26,7 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=False), nullable=False),
         sa.CheckConstraint("size_bytes >= 0", name="ck_assets_size_nonneg"),
     )
-    if op.get_bind().dialect.name == "postgresql":
-        op.create_index(
-            "uq_assets_hash_not_null",
-            "assets",
-            ["hash"],
-            unique=True,
-            postgresql_where=sa.text("hash IS NOT NULL"),
-        )
-    else:
-        op.create_index("uq_assets_hash", "assets", ["hash"], unique=True)
+    op.create_index("uq_assets_hash", "assets", ["hash"], unique=True)
     op.create_index("ix_assets_mime_type", "assets", ["mime_type"])
 
     # ASSETS_INFO: user-visible references
@@ -179,9 +170,6 @@ def downgrade() -> None:
     op.drop_index("ix_assets_info_owner_id", table_name="assets_info")
     op.drop_table("assets_info")
 
-    if op.get_bind().dialect.name == "postgresql":
-        op.drop_index("uq_assets_hash_not_null", table_name="assets")
-    else:
-        op.drop_index("uq_assets_hash", table_name="assets")
+    op.drop_index("uq_assets_hash", table_name="assets")
     op.drop_index("ix_assets_mime_type", table_name="assets")
     op.drop_table("assets")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -77,6 +77,7 @@ class Asset(Base):
     )
 
     __table_args__ = (
+        Index("uq_assets_hash", "hash", unique=True),
         Index("ix_assets_mime_type", "mime_type"),
         CheckConstraint("size_bytes >= 0", name="ck_assets_size_nonneg"),
     )


### PR DESCRIPTION
This PR targets **dev** branch.

Additionally added forgotten `Index("uq_assets_hash", "hash", unique=True),` to `models.py` (found during test of previous PR with `alembic revision --autogenerate -m test` command)