### PR TITLE
fix(api-nodes): bad indentation in Recraft API node function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ messages_control.disable = [
   "unnecessary-pass",
   "unidiomatic-typecheck",
   "unnecessary-lambda-assignment",
-  "bad-indentation",
   "no-else-return",
   "no-else-raise",
   "invalid-overridden-method",


### PR DESCRIPTION
Enable `bad-indentation` rule and fix found code