### PR TITLE
fix(api-nodes): reimport of base64 in Gemini node

### DIFF
--- a/comfy_api_nodes/nodes_gemini.py
+++ b/comfy_api_nodes/nodes_gemini.py
@@ -490,7 +490,6 @@ class GeminiInputFiles(ComfyNodeABC):
         # Use base64 string directly, not the data URI
         with open(file_path, "rb") as f:
             file_content = f.read()
-        import base64
         base64_str = base64.b64encode(file_content).decode("utf-8")
 
         return GeminiPart(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,5 @@ messages_control.disable = [
   "pointless-string-statement",
   "inconsistent-return-statements",
   "import-outside-toplevel",
-  "reimported",
   "redefined-outer-name",
 ]


### PR DESCRIPTION
Removing import does not affect the node:

<img width="1304" height="735" alt="Screenshot From 2025-10-03 18-38-45" src="https://github.com/user-attachments/assets/8af4655f-f8b6-402e-82cc-057ce99f119a" />
