### PR TITLE
fix(api-nodes): enable 2 more pylint rules, removed non needed code

### DIFF
--- a/comfy_api_nodes/nodes_gemini.py
+++ b/comfy_api_nodes/nodes_gemini.py
@@ -39,6 +39,7 @@ from comfy_api_nodes.apinode_utils import (
     tensor_to_base64_string,
     bytesio_to_image_tensor,
 )
+from comfy_api.util import VideoContainer, VideoCodec
 
 
 GEMINI_BASE_ENDPOINT = "/proxy/vertexai/gemini"
@@ -310,7 +311,7 @@ class GeminiNode(ComfyNodeABC):
         Returns:
             List of GeminiPart objects containing the encoded video.
         """
-        from comfy_api.util import VideoContainer, VideoCodec
+
         base_64_string = video_to_base64_string(
             video_input,
             container_format=VideoContainer.MP4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,5 @@ messages_control.disable = [
   "invalid-overridden-method",
   "unused-variable",
   "pointless-string-statement",
-  "inconsistent-return-statements",
-  "import-outside-toplevel",
   "redefined-outer-name",
 ]


### PR DESCRIPTION
1. We can safely enable the `import-outside-toplevel` rule, since there is no reason for API nodes not to import all required modules at the top of the file. If there is ever a strong need to import something elsewhere, we can mark that line with `# noqa`.

2. After enabling the `inconsistent-return-statements` rule, I reviewed the `validate_input_media` function. It sometimes returns `None`, but overall does nothing useful. It can return a string in case of failed validation, but its result is never checked anywhere. When testing the API, I found that rewriting it to `raise` an error on validation would break some existing workflows, because the Moonvalley API successfully processes videos with non-odd dimensions (so the check itself is invalid if we enforce it). I also could not find any cases where `with_frame_conditioning` is required - maybe it was intended for a future video2video implementation that does not yet exist. For now, I suggest removing this unused function completely. If we need this functionality later, we can re-implement it in `validation_utils.py` so it can benefit other nodes and be easy to find/test.

Test that moving import does not break Gemini node:

<img width="1318" height="804" alt="Screenshot From 2025-10-04 07-46-31" src="https://github.com/user-attachments/assets/d5bae1b1-319f-4d76-9b70-a9fb2876bb66" />

Test to prove that dimension check for Moonvalley node is incorrect if we enable it:

https://github.com/user-attachments/assets/590bb380-d75d-4390-acf2-5c0489000f8c

