### PR TITLE
fix(api-nodes): allow negative_prompt in PixVerse API nodes to be multiline

### DIFF
--- a/comfy_api_nodes/nodes_pixverse.py
+++ b/comfy_api_nodes/nodes_pixverse.py
@@ -146,7 +146,7 @@ class PixverseTextToVideoNode(comfy_io.ComfyNode):
                 comfy_io.String.Input(
                     "negative_prompt",
                     default="",
-                    force_input=True,
+                    multiline=True,
                     tooltip="An optional text description of undesired elements on an image.",
                     optional=True,
                 ),
@@ -284,7 +284,7 @@ class PixverseImageToVideoNode(comfy_io.ComfyNode):
                 comfy_io.String.Input(
                     "negative_prompt",
                     default="",
-                    force_input=True,
+                    multiline=True,
                     tooltip="An optional text description of undesired elements on an image.",
                     optional=True,
                 ),
@@ -425,7 +425,7 @@ class PixverseTransitionVideoNode(comfy_io.ComfyNode):
                 comfy_io.String.Input(
                     "negative_prompt",
                     default="",
-                    force_input=True,
+                    multiline=True,
                     tooltip="An optional text description of undesired elements on an image.",
                     optional=True,
                 ),


### PR DESCRIPTION
Following up with the bug found during the development of this PR: https://github.com/comfyanonymous/ComfyUI/pull/10177

Video with bug(after generation I press F5 and my workflow is a little bit broken as Frontend assigns the "Results" to the `negative_prompt` field which have `force_input=True` - _my assumption_):

https://github.com/user-attachments/assets/fef9a21f-7f92-4684-a587-73e5093c55dc


To quickly and easy fix it I suggest to remove `force_input=True` from the negative_prompt definition and additionally to allow it to be `multiline`.

To verify that this change wasn't breaking, I created a test workflow, and export it as usual and additionally in API format.

After that I switched to this PR and run both versions:


https://github.com/user-attachments/assets/d9bd30fd-2741-4af1-b00c-30371e6b7c83

https://github.com/user-attachments/assets/0d303eef-362e-4df3-8eed-8cf18ae2a47e


