### PR TITLE
[V3] convert nodes_kling.py to V3 schema

### DIFF
--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -10,6 +10,8 @@ from collections.abc import Callable
 import math
 import logging
 
+from typing_extensions import override
+
 import torch
 
 from comfy_api_nodes.apis import (
@@ -63,8 +65,8 @@ from comfy_api_nodes.apinode_utils import (
     upload_video_to_comfyapi,
     upload_audio_to_comfyapi,
     download_url_to_image_tensor,
+    validate_string,
 )
-from comfy_api_nodes.mapper_utils import model_field_to_node_input
 from comfy_api_nodes.util.validation_utils import (
     validate_image_dimensions,
     validate_image_aspect_ratio,
@@ -73,8 +75,7 @@ from comfy_api_nodes.util.validation_utils import (
 )
 from comfy_api.input.basic_types import AudioInput
 from comfy_api.input.video_types import VideoInput
-from comfy_api.input_impl import VideoFromFile
-from comfy.comfy_types.node_typing import IO, InputTypeOptions, ComfyNodeABC
+from comfy_api.latest import ComfyExtension, io as comfy_io
 
 KLING_API_VERSION = "v1"
 PATH_TEXT_TO_VIDEO = f"/proxy/kling/{KLING_API_VERSION}/videos/text2video"
@@ -103,10 +104,113 @@ AVERAGE_DURATION_VIDEO_EXTEND = 320
 R = TypeVar("R")
 
 
-class KlingApiError(Exception):
-    """Base exception for Kling API errors."""
+MODE_TEXT2VIDEO = {
+    "standard mode / 5s duration / kling-v1": ("std", "5", "kling-v1"),
+    "standard mode / 10s duration / kling-v1": ("std", "10", "kling-v1"),
+    "pro mode / 5s duration / kling-v1": ("pro", "5", "kling-v1"),
+    "pro mode / 10s duration / kling-v1": ("pro", "10", "kling-v1"),
+    "standard mode / 5s duration / kling-v1-6": ("std", "5", "kling-v1-6"),
+    "standard mode / 10s duration / kling-v1-6": ("std", "10", "kling-v1-6"),
+    "pro mode / 5s duration / kling-v2-master": ("pro", "5", "kling-v2-master"),
+    "pro mode / 10s duration / kling-v2-master": ("pro", "10", "kling-v2-master"),
+    "standard mode / 5s duration / kling-v2-master": ("std", "5", "kling-v2-master"),
+    "standard mode / 10s duration / kling-v2-master": ("std", "10", "kling-v2-master"),
+    "pro mode / 5s duration / kling-v2-1-master": ("pro", "5", "kling-v2-1-master"),
+    "pro mode / 10s duration / kling-v2-1-master": ("pro", "10", "kling-v2-1-master"),
+    "pro mode / 5s duration / kling-v2-5-turbo": ("pro", "5", "kling-v2-5-turbo"),
+    "pro mode / 10s duration / kling-v2-5-turbo": ("pro", "10", "kling-v2-5-turbo"),
+}
+"""
+Mapping of mode strings to their corresponding (mode, duration, model_name) tuples.
+Only includes config combos that support the `image_tail` request field.
 
-    pass
+See: [Kling API Docs Capability Map](https://app.klingai.com/global/dev/document-api/apiReference/model/skillsMap)
+"""
+
+
+MODE_START_END_FRAME = {
+    "standard mode / 5s duration / kling-v1": ("std", "5", "kling-v1"),
+    "pro mode / 5s duration / kling-v1": ("pro", "5", "kling-v1"),
+    "pro mode / 5s duration / kling-v1-5": ("pro", "5", "kling-v1-5"),
+    "pro mode / 10s duration / kling-v1-5": ("pro", "10", "kling-v1-5"),
+    "pro mode / 5s duration / kling-v1-6": ("pro", "5", "kling-v1-6"),
+    "pro mode / 10s duration / kling-v1-6": ("pro", "10", "kling-v1-6"),
+    "pro mode / 5s duration / kling-v2-1": ("pro", "5", "kling-v2-1"),
+    "pro mode / 10s duration / kling-v2-1": ("pro", "10", "kling-v2-1"),
+}
+"""
+Returns a mapping of mode strings to their corresponding (mode, duration, model_name) tuples.
+Only includes config combos that support the `image_tail` request field.
+
+See: [Kling API Docs Capability Map](https://app.klingai.com/global/dev/document-api/apiReference/model/skillsMap)
+"""
+
+
+VOICES_CONFIG = {
+    # English voices
+    "Melody": ("girlfriend_4_speech02", "en"),
+    "Sunny": ("genshin_vindi2", "en"),
+    "Sage": ("zhinen_xuesheng", "en"),
+    "Ace": ("AOT", "en"),
+    "Blossom": ("ai_shatang", "en"),
+    "Peppy": ("genshin_klee2", "en"),
+    "Dove": ("genshin_kirara", "en"),
+    "Shine": ("ai_kaiya", "en"),
+    "Anchor": ("oversea_male1", "en"),
+    "Lyric": ("ai_chenjiahao_712", "en"),
+    "Tender": ("chat1_female_new-3", "en"),
+    "Siren": ("chat_0407_5-1", "en"),
+    "Zippy": ("cartoon-boy-07", "en"),
+    "Bud": ("uk_boy1", "en"),
+    "Sprite": ("cartoon-girl-01", "en"),
+    "Candy": ("PeppaPig_platform", "en"),
+    "Beacon": ("ai_huangzhong_712", "en"),
+    "Rock": ("ai_huangyaoshi_712", "en"),
+    "Titan": ("ai_laoguowang_712", "en"),
+    "Grace": ("chengshu_jiejie", "en"),
+    "Helen": ("you_pingjing", "en"),
+    "Lore": ("calm_story1", "en"),
+    "Crag": ("uk_man2", "en"),
+    "Prattle": ("laopopo_speech02", "en"),
+    "Hearth": ("heainainai_speech02", "en"),
+    "The Reader": ("reader_en_m-v1", "en"),
+    "Commercial Lady": ("commercial_lady_en_f-v1", "en"),
+    # Chinese voices
+    "阳光少年": ("genshin_vindi2", "zh"),
+    "懂事小弟": ("zhinen_xuesheng", "zh"),
+    "运动少年": ("tiyuxi_xuedi", "zh"),
+    "青春少女": ("ai_shatang", "zh"),
+    "温柔小妹": ("genshin_klee2", "zh"),
+    "元气少女": ("genshin_kirara", "zh"),
+    "阳光男生": ("ai_kaiya", "zh"),
+    "幽默小哥": ("tiexin_nanyou", "zh"),
+    "文艺小哥": ("ai_chenjiahao_712", "zh"),
+    "甜美邻家": ("girlfriend_1_speech02", "zh"),
+    "温柔姐姐": ("chat1_female_new-3", "zh"),
+    "职场女青": ("girlfriend_2_speech02", "zh"),
+    "活泼男童": ("cartoon-boy-07", "zh"),
+    "俏皮女童": ("cartoon-girl-01", "zh"),
+    "稳重老爸": ("ai_huangyaoshi_712", "zh"),
+    "温柔妈妈": ("you_pingjing", "zh"),
+    "严肃上司": ("ai_laoguowang_712", "zh"),
+    "优雅贵妇": ("chengshu_jiejie", "zh"),
+    "慈祥爷爷": ("zhuxi_speech02", "zh"),
+    "唠叨爷爷": ("uk_oldman3", "zh"),
+    "唠叨奶奶": ("laopopo_speech02", "zh"),
+    "和蔼奶奶": ("heainainai_speech02", "zh"),
+    "东北老铁": ("dongbeilaotie_speech02", "zh"),
+    "重庆小伙": ("chongqingxiaohuo_speech02", "zh"),
+    "四川妹子": ("chuanmeizi_speech02", "zh"),
+    "潮汕大叔": ("chaoshandashu_speech02", "zh"),
+    "台湾男生": ("ai_taiwan_man2_speech02", "zh"),
+    "西安掌柜": ("xianzhanggui_speech02", "zh"),
+    "天津姐姐": ("tianjinjiejie_speech02", "zh"),
+    "新闻播报男": ("diyinnansang_DB_CN_M_04-v2", "zh"),
+    "译制片男": ("yizhipiannan-v1", "zh"),
+    "撒娇女友": ("tianmeixuemei-v1", "zh"),
+    "刀片烟嗓": ("daopianyansang-v1", "zh"),
+    "乖巧正太": ("mengwa-v1", "zh"),
+}
 
 
 async def poll_until_finished(
@@ -140,11 +244,6 @@ async def poll_until_finished(
 def is_valid_camera_control_configs(configs: list[float]) -> bool:
     """Verifies that at least one camera control configuration is non-zero."""
     return any(not math.isclose(value, 0.0) for value in configs)
-
-
-def is_valid_prompt(prompt: str) -> bool:
-    """Verifies that the prompt is not empty."""
-    return bool(prompt)
 
 
 def is_valid_task_creation_response(response: KlingText2VideoResponse) -> bool:
@@ -190,7 +289,7 @@ def validate_task_creation_response(response) -> None:
     if not is_valid_task_creation_response(response):
         error_msg = f"Kling initial request failed. Code: {response.code}, Message: {response.message}, Data: {response.data}"
         logging.error(error_msg)
-        raise KlingApiError(error_msg)
+        raise Exception(error_msg)
 
 
 def validate_video_result_response(response) -> None:
@@ -198,7 +297,7 @@ def validate_video_result_response(response) -> None:
     if not is_valid_video_response(response):
         error_msg = f"Kling task {response.data.task_id} succeeded but no video data found in response."
         logging.error(f"Error: {error_msg}.\nResponse: {response}")
-        raise KlingApiError(error_msg)
+        raise Exception(error_msg)
 
 
 def validate_image_result_response(response) -> None:
@@ -206,7 +305,7 @@ def validate_image_result_response(response) -> None:
     if not is_valid_image_response(response):
         error_msg = f"Kling task {response.data.task_id} succeeded but no image data found in response."
         logging.error(f"Error: {error_msg}.\nResponse: {response}")
-        raise KlingApiError(error_msg)
+        raise Exception(error_msg)
 
 
 def validate_input_image(image: torch.Tensor) -> None:
@@ -219,21 +318,6 @@ def validate_input_image(image: torch.Tensor) -> None:
     """
     validate_image_dimensions(image, min_width=300, min_height=300)
     validate_image_aspect_ratio(image, min_aspect_ratio=1 / 2.5, max_aspect_ratio=2.5)
-
-
-def get_camera_control_input_config(
-    tooltip: str, default: float = 0.0
-) -> tuple[IO, InputTypeOptions]:
-    """Returns common InputTypeOptions for Kling camera control configurations."""
-    input_config = {
-        "default": default,
-        "min": -10.0,
-        "max": 10.0,
-        "step": 0.25,
-        "display": "slider",
-        "tooltip": tooltip,
-    }
-    return IO.FLOAT, input_config
 
 
 def get_video_from_response(response) -> KlingVideoResult:
@@ -278,17 +362,6 @@ def get_images_urls_from_response(response) -> Optional[str]:
         return None
 
 
-async def video_result_to_node_output(
-    video: KlingVideoResult,
-) -> tuple[VideoFromFile, str, str]:
-    """Converts a KlingVideoResult to a tuple of (VideoFromFile, str, str) to be used as a ComfyUI node output."""
-    return (
-        await download_url_to_video_output(str(video.url)),
-        str(video.id),
-        str(video.duration),
-    )
-
-
 async def image_result_to_node_output(
     images: list[KlingImageResult],
 ) -> torch.Tensor:
@@ -302,57 +375,339 @@ async def image_result_to_node_output(
         return torch.cat([await download_url_to_image_tensor(str(image.url)) for image in images])
 
 
-class KlingNodeBase(ComfyNodeABC):
-    """Base class for Kling nodes."""
+async def execute_text2video(
+    auth_kwargs: dict[str, str],
+    node_id: str,
+    prompt: str,
+    negative_prompt: str,
+    cfg_scale: float,
+    model_name: str,
+    model_mode: str,
+    duration: str,
+    aspect_ratio: str,
+    camera_control: Optional[KlingCameraControl] = None,
+) -> comfy_io.NodeOutput:
+    validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_T2V)
+    initial_operation = SynchronousOperation(
+        endpoint=ApiEndpoint(
+            path=PATH_TEXT_TO_VIDEO,
+            method=HttpMethod.POST,
+            request_model=KlingText2VideoRequest,
+            response_model=KlingText2VideoResponse,
+        ),
+        request=KlingText2VideoRequest(
+            prompt=prompt if prompt else None,
+            negative_prompt=negative_prompt if negative_prompt else None,
+            duration=KlingVideoGenDuration(duration),
+            mode=KlingVideoGenMode(model_mode),
+            model_name=KlingVideoGenModelName(model_name),
+            cfg_scale=cfg_scale,
+            aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
+            camera_control=camera_control,
+        ),
+        auth_kwargs=auth_kwargs,
+    )
 
-    FUNCTION = "api_call"
-    CATEGORY = "api node/video/Kling"
-    API_NODE = True
+    task_creation_response = await initial_operation.execute()
+    validate_task_creation_response(task_creation_response)
+
+    task_id = task_creation_response.data.task_id
+    final_response = await poll_until_finished(
+        auth_kwargs,
+        ApiEndpoint(
+            path=f"{PATH_TEXT_TO_VIDEO}/{task_id}",
+            method=HttpMethod.GET,
+            request_model=EmptyRequest,
+            response_model=KlingText2VideoResponse,
+        ),
+        result_url_extractor=get_video_url_from_response,
+        estimated_duration=AVERAGE_DURATION_T2V,
+        node_id=node_id,
+    )
+    validate_video_result_response(final_response)
+
+    video = get_video_from_response(final_response)
+    return comfy_io.NodeOutput(await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration))
 
 
-class KlingCameraControls(KlingNodeBase):
+async def execute_image2video(
+    auth_kwargs: dict[str, str],
+    node_id: str,
+    start_frame: torch.Tensor,
+    prompt: str,
+    negative_prompt: str,
+    model_name: str,
+    cfg_scale: float,
+    model_mode: str,
+    aspect_ratio: str,
+    duration: str,
+    camera_control: Optional[KlingCameraControl] = None,
+    end_frame: Optional[torch.Tensor] = None,
+) -> comfy_io.NodeOutput:
+    validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_I2V)
+    validate_input_image(start_frame)
+
+    if camera_control is not None:
+        # Camera control type for image 2 video is always `simple`
+        camera_control.type = KlingCameraControlType.simple
+
+    if model_mode == "std" and model_name == KlingVideoGenModelName.kling_v2_5_turbo.value:
+        model_mode = "pro"  # October 5: currently "std" mode is not supported for this model
+
+    initial_operation = SynchronousOperation(
+        endpoint=ApiEndpoint(
+            path=PATH_IMAGE_TO_VIDEO,
+            method=HttpMethod.POST,
+            request_model=KlingImage2VideoRequest,
+            response_model=KlingImage2VideoResponse,
+        ),
+        request=KlingImage2VideoRequest(
+            model_name=KlingVideoGenModelName(model_name),
+            image=tensor_to_base64_string(start_frame),
+            image_tail=(
+                tensor_to_base64_string(end_frame)
+                if end_frame is not None
+                else None
+            ),
+            prompt=prompt,
+            negative_prompt=negative_prompt if negative_prompt else None,
+            cfg_scale=cfg_scale,
+            mode=KlingVideoGenMode(model_mode),
+            duration=KlingVideoGenDuration(duration),
+            camera_control=camera_control,
+        ),
+        auth_kwargs=auth_kwargs,
+    )
+
+    task_creation_response = await initial_operation.execute()
+    validate_task_creation_response(task_creation_response)
+    task_id = task_creation_response.data.task_id
+
+    final_response = await poll_until_finished(
+            auth_kwargs,
+            ApiEndpoint(
+                path=f"{PATH_IMAGE_TO_VIDEO}/{task_id}",
+                method=HttpMethod.GET,
+                request_model=KlingImage2VideoRequest,
+                response_model=KlingImage2VideoResponse,
+            ),
+            result_url_extractor=get_video_url_from_response,
+            estimated_duration=AVERAGE_DURATION_I2V,
+            node_id=node_id,
+        )
+    validate_video_result_response(final_response)
+
+    video = get_video_from_response(final_response)
+    return comfy_io.NodeOutput(await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration))
+
+
+async def execute_video_effect(
+    auth_kwargs: dict[str, str],
+    node_id: str,
+    dual_character: bool,
+    effect_scene: KlingDualCharacterEffectsScene | KlingSingleImageEffectsScene,
+    model_name: str,
+    duration: KlingVideoGenDuration,
+    image_1: torch.Tensor,
+    image_2: Optional[torch.Tensor] = None,
+    model_mode: Optional[KlingVideoGenMode] = None,
+) -> comfy_io.NodeOutput:
+    if dual_character:
+        request_input_field = KlingDualCharacterEffectInput(
+            model_name=model_name,
+            mode=model_mode,
+            images=[
+                tensor_to_base64_string(image_1),
+                tensor_to_base64_string(image_2),
+            ],
+            duration=duration,
+        )
+    else:
+        request_input_field = KlingSingleImageEffectInput(
+            model_name=model_name,
+            image=tensor_to_base64_string(image_1),
+            duration=duration,
+        )
+
+    initial_operation = SynchronousOperation(
+        endpoint=ApiEndpoint(
+            path=PATH_VIDEO_EFFECTS,
+            method=HttpMethod.POST,
+            request_model=KlingVideoEffectsRequest,
+            response_model=KlingVideoEffectsResponse,
+        ),
+        request=KlingVideoEffectsRequest(
+            effect_scene=effect_scene,
+            input=request_input_field,
+        ),
+        auth_kwargs=auth_kwargs,
+    )
+
+    task_creation_response = await initial_operation.execute()
+    validate_task_creation_response(task_creation_response)
+    task_id = task_creation_response.data.task_id
+
+    final_response = await poll_until_finished(
+        auth_kwargs,
+        ApiEndpoint(
+            path=f"{PATH_VIDEO_EFFECTS}/{task_id}",
+            method=HttpMethod.GET,
+            request_model=EmptyRequest,
+            response_model=KlingVideoEffectsResponse,
+        ),
+        result_url_extractor=get_video_url_from_response,
+        estimated_duration=AVERAGE_DURATION_VIDEO_EFFECTS,
+        node_id=node_id,
+    )
+    validate_video_result_response(final_response)
+
+    video = get_video_from_response(final_response)
+    return comfy_io.NodeOutput(await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration))
+
+
+async def execute_lipsync(
+    auth_kwargs: dict[str, str],
+    node_id: str,
+    video: VideoInput,
+    audio: Optional[AudioInput] = None,
+    voice_language: Optional[str] = None,
+    model_mode: Optional[str] = None,
+    text: Optional[str] = None,
+    voice_speed: Optional[float] = None,
+    voice_id: Optional[str] = None,
+) -> comfy_io.NodeOutput:
+    if text:
+        validate_string(text, field_name="Text", max_length=MAX_PROMPT_LENGTH_LIP_SYNC)
+    validate_video_dimensions(video, 720, 1920)
+    validate_video_duration(video, 2, 10)
+
+    # Upload video to Comfy API and get download URL
+    video_url = await upload_video_to_comfyapi(video, auth_kwargs=auth_kwargs)
+    logging.info("Uploaded video to Comfy API. URL: %s", video_url)
+
+    # Upload the audio file to Comfy API and get download URL
+    if audio:
+        audio_url = await upload_audio_to_comfyapi(audio, auth_kwargs=auth_kwargs)
+        logging.info("Uploaded audio to Comfy API. URL: %s", audio_url)
+    else:
+        audio_url = None
+
+    initial_operation = SynchronousOperation(
+        endpoint=ApiEndpoint(
+            path=PATH_LIP_SYNC,
+            method=HttpMethod.POST,
+            request_model=KlingLipSyncRequest,
+            response_model=KlingLipSyncResponse,
+        ),
+        request=KlingLipSyncRequest(
+            input=KlingLipSyncInputObject(
+                video_url=video_url,
+                mode=model_mode,
+                text=text,
+                voice_language=voice_language,
+                voice_speed=voice_speed,
+                audio_type="url",
+                audio_url=audio_url,
+                voice_id=voice_id,
+            ),
+        ),
+        auth_kwargs=auth_kwargs,
+    )
+
+    task_creation_response = await initial_operation.execute()
+    validate_task_creation_response(task_creation_response)
+    task_id = task_creation_response.data.task_id
+
+    final_response = await poll_until_finished(
+        auth_kwargs,
+        ApiEndpoint(
+            path=f"{PATH_LIP_SYNC}/{task_id}",
+            method=HttpMethod.GET,
+            request_model=EmptyRequest,
+            response_model=KlingLipSyncResponse,
+        ),
+        result_url_extractor=get_video_url_from_response,
+        estimated_duration=AVERAGE_DURATION_LIP_SYNC,
+        node_id=node_id,
+    )
+    validate_video_result_response(final_response)
+
+    video = get_video_from_response(final_response)
+    return comfy_io.NodeOutput(await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration))
+
+
+class KlingCameraControls(comfy_io.ComfyNode):
     """Kling Camera Controls Node"""
 
     @classmethod
-    def INPUT_TYPES(cls):
-        return {
-            "required": {
-                "camera_control_type": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingCameraControl,
-                    "type",
-                    enum_type=KlingCameraControlType,
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingCameraControls",
+            display_name="Kling Camera Controls",
+            category="api node/video/Kling",
+            description="Allows specifying configuration options for Kling Camera Controls and motion control effects.",
+            inputs=[
+                comfy_io.Combo.Input("camera_control_type", options=[i.value for i in KlingCameraControlType]),
+                comfy_io.Float.Input(
+                    "horizontal_movement",
+                    default=0.0,
+                    min=-10.0,
+                    max=10.0,
+                    step=0.25,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Controls camera's movement along horizontal axis (x-axis). Negative indicates left, positive indicates right",
                 ),
-                "horizontal_movement": get_camera_control_input_config(
-                    "Controls camera's movement along horizontal axis (x-axis). Negative indicates left, positive indicates right"
+                comfy_io.Float.Input(
+                    "vertical_movement",
+                    default=0.0,
+                    min=-10.0,
+                    max=10.0,
+                    step=0.25,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Controls camera's movement along vertical axis (y-axis). Negative indicates downward, positive indicates upward.",
                 ),
-                "vertical_movement": get_camera_control_input_config(
-                    "Controls camera's movement along vertical axis (y-axis). Negative indicates downward, positive indicates upward."
-                ),
-                "pan": get_camera_control_input_config(
-                    "Controls camera's rotation in vertical plane (x-axis). Negative indicates downward rotation, positive indicates upward rotation.",
+                comfy_io.Float.Input(
+                    "pan",
                     default=0.5,
+                    min=-10.0,
+                    max=10.0,
+                    step=0.25,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Controls camera's rotation in vertical plane (x-axis). Negative indicates downward rotation, positive indicates upward rotation.",
                 ),
-                "tilt": get_camera_control_input_config(
-                    "Controls camera's rotation in horizontal plane (y-axis). Negative indicates left rotation, positive indicates right rotation.",
+                comfy_io.Float.Input(
+                    "tilt",
+                    default=0.0,
+                    min=-10.0,
+                    max=10.0,
+                    step=0.25,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Controls camera's rotation in horizontal plane (y-axis). Negative indicates left rotation, positive indicates right rotation.",
                 ),
-                "roll": get_camera_control_input_config(
-                    "Controls camera's rolling amount (z-axis). Negative indicates counterclockwise, positive indicates clockwise.",
+                comfy_io.Float.Input(
+                    "roll",
+                    default=0.0,
+                    min=-10.0,
+                    max=10.0,
+                    step=0.25,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Controls camera's rolling amount (z-axis). Negative indicates counterclockwise, positive indicates clockwise.",
                 ),
-                "zoom": get_camera_control_input_config(
-                    "Controls change in camera's focal length. Negative indicates narrower field of view, positive indicates wider field of view.",
+                comfy_io.Float.Input(
+                    "zoom",
+                    default=0.0,
+                    min=-10.0,
+                    max=10.0,
+                    step=0.25,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Controls change in camera's focal length. Negative indicates narrower field of view, positive indicates wider field of view.",
                 ),
-            }
-        }
-
-    DESCRIPTION = "Allows specifying configuration options for Kling Camera Controls and motion control effects."
-    RETURN_TYPES = ("CAMERA_CONTROL",)
-    RETURN_NAMES = ("camera_control",)
-    FUNCTION = "main"
-    API_NODE = False  # This is just a helper node, it doesn't make an API call
+            ],
+            outputs=[comfy_io.Custom("CAMERA_CONTROL").Output(display_name="camera_control")],
+        )
 
     @classmethod
-    def VALIDATE_INPUTS(
+    def validate_inputs(
         cls,
         horizontal_movement: float,
         vertical_movement: float,
@@ -374,8 +729,9 @@ class KlingCameraControls(KlingNodeBase):
             return "Invalid camera control configs: at least one of the values must be non-zero"
         return True
 
-    def main(
-        self,
+    @classmethod
+    def execute(
+        cls,
         camera_control_type: str,
         horizontal_movement: float,
         vertical_movement: float,
@@ -383,8 +739,8 @@ class KlingCameraControls(KlingNodeBase):
         tilt: float,
         roll: float,
         zoom: float,
-    ) -> tuple[KlingCameraControl]:
-        return (
+    ) -> comfy_io.NodeOutput:
+        return comfy_io.NodeOutput(
             KlingCameraControl(
                 type=KlingCameraControlType(camera_control_type),
                 config=KlingCameraConfig(
@@ -395,303 +751,186 @@ class KlingCameraControls(KlingNodeBase):
                     tilt=tilt,
                     zoom=zoom,
                 ),
-            ),
+            )
         )
 
 
-class KlingTextToVideoNode(KlingNodeBase):
+class KlingTextToVideoNode(comfy_io.ComfyNode):
     """Kling Text to Video Node"""
 
-    @staticmethod
-    def get_mode_string_mapping() -> dict[str, tuple[str, str, str]]:
-        """
-        Returns a mapping of mode strings to their corresponding (mode, duration, model_name) tuples.
-        Only includes config combos that support the `image_tail` request field.
-
-        See: [Kling API Docs Capability Map](https://app.klingai.com/global/dev/document-api/apiReference/model/skillsMap)
-        """
-        return {
-            "standard mode / 5s duration / kling-v1": ("std", "5", "kling-v1"),
-            "standard mode / 10s duration / kling-v1": ("std", "10", "kling-v1"),
-            "pro mode / 5s duration / kling-v1": ("pro", "5", "kling-v1"),
-            "pro mode / 10s duration / kling-v1": ("pro", "10", "kling-v1"),
-            "standard mode / 5s duration / kling-v1-6": ("std", "5", "kling-v1-6"),
-            "standard mode / 10s duration / kling-v1-6": ("std", "10", "kling-v1-6"),
-            "pro mode / 5s duration / kling-v2-master": ("pro", "5", "kling-v2-master"),
-            "pro mode / 10s duration / kling-v2-master": ("pro", "10", "kling-v2-master"),
-            "standard mode / 5s duration / kling-v2-master": ("std", "5", "kling-v2-master"),
-            "standard mode / 10s duration / kling-v2-master": ("std", "10", "kling-v2-master"),
-            "pro mode / 5s duration / kling-v2-1-master": ("pro", "5", "kling-v2-1-master"),
-            "pro mode / 10s duration / kling-v2-1-master": ("pro", "10", "kling-v2-1-master"),
-            "pro mode / 5s duration / kling-v2-5-turbo": ("pro", "5", "kling-v2-5-turbo"),
-            "pro mode / 10s duration / kling-v2-5-turbo": ("pro", "10", "kling-v2-5-turbo"),
-        }
-
     @classmethod
-    def INPUT_TYPES(s):
-        modes = list(KlingTextToVideoNode.get_mode_string_mapping().keys())
-        return {
-            "required": {
-                "prompt": model_field_to_node_input(
-                    IO.STRING, KlingText2VideoRequest, "prompt", multiline=True
-                ),
-                "negative_prompt": model_field_to_node_input(
-                    IO.STRING, KlingText2VideoRequest, "negative_prompt", multiline=True
-                ),
-                "cfg_scale": model_field_to_node_input(
-                    IO.FLOAT,
-                    KlingText2VideoRequest,
-                    "cfg_scale",
-                    default=1.0,
-                    min=0.0,
-                    max=1.0,
-                ),
-                "aspect_ratio": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingText2VideoRequest,
+    def define_schema(cls) -> comfy_io.Schema:
+        modes = list(MODE_TEXT2VIDEO.keys())
+        return comfy_io.Schema(
+            node_id="KlingTextToVideoNode",
+            display_name="Kling Text to Video",
+            category="api node/video/Kling",
+            description="Kling Text to Video Node",
+            inputs=[
+                comfy_io.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
+                comfy_io.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
+                comfy_io.Float.Input("cfg_scale", default=1.0, min=0.0, max=1.0),
+                comfy_io.Combo.Input(
                     "aspect_ratio",
-                    enum_type=KlingVideoGenAspectRatio,
+                    options=[i.value for i in KlingVideoGenAspectRatio],
+                    default="16:9",
                 ),
-                "mode": (
-                    modes,
-                    {
-                        "default": modes[4],
-                        "tooltip": "The configuration to use for the video generation following the format: mode / duration / model_name.",
-                    },
+                comfy_io.Combo.Input(
+                    "mode",
+                    options=modes,
+                    default=modes[4],
+                    tooltip="The configuration to use for the video generation following the format: mode / duration / model_name.",
                 ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    RETURN_TYPES = ("VIDEO", "STRING", "STRING")
-    RETURN_NAMES = ("VIDEO", "video_id", "duration")
-    DESCRIPTION = "Kling Text to Video Node"
-
-    async def get_response(
-        self, task_id: str, auth_kwargs: dict[str, str], node_id: Optional[str] = None
-    ) -> KlingText2VideoResponse:
-        return await poll_until_finished(
-            auth_kwargs,
-            ApiEndpoint(
-                path=f"{PATH_TEXT_TO_VIDEO}/{task_id}",
-                method=HttpMethod.GET,
-                request_model=EmptyRequest,
-                response_model=KlingText2VideoResponse,
-            ),
-            result_url_extractor=get_video_url_from_response,
-            estimated_duration=AVERAGE_DURATION_T2V,
-            node_id=node_id,
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
         )
 
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         prompt: str,
         negative_prompt: str,
         cfg_scale: float,
         mode: str,
         aspect_ratio: str,
-        camera_control: Optional[KlingCameraControl] = None,
-        model_name: Optional[str] = None,
-        duration: Optional[str] = None,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ) -> tuple[VideoFromFile, str, str]:
-        validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_T2V)
-        if model_name is None:
-            mode, duration, model_name = self.get_mode_string_mapping()[mode]
-        initial_operation = SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path=PATH_TEXT_TO_VIDEO,
-                method=HttpMethod.POST,
-                request_model=KlingText2VideoRequest,
-                response_model=KlingText2VideoResponse,
-            ),
-            request=KlingText2VideoRequest(
-                prompt=prompt if prompt else None,
-                negative_prompt=negative_prompt if negative_prompt else None,
-                duration=KlingVideoGenDuration(duration),
-                mode=KlingVideoGenMode(mode),
-                model_name=KlingVideoGenModelName(model_name),
-                cfg_scale=cfg_scale,
-                aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
-                camera_control=camera_control,
-            ),
-            auth_kwargs=kwargs,
+    ) -> comfy_io.NodeOutput:
+        model_mode, duration, model_name = MODE_TEXT2VIDEO[mode]
+        return await execute_text2video(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            cfg_scale=cfg_scale,
+            model_mode=model_mode,
+            aspect_ratio=aspect_ratio,
+            model_name=model_name,
+            duration=duration,
         )
 
-        task_creation_response = await initial_operation.execute()
-        validate_task_creation_response(task_creation_response)
 
-        task_id = task_creation_response.data.task_id
-        final_response = await self.get_response(
-            task_id, auth_kwargs=kwargs, node_id=unique_id
-        )
-        validate_video_result_response(final_response)
-
-        video = get_video_from_response(final_response)
-        return await video_result_to_node_output(video)
-
-
-class KlingCameraControlT2VNode(KlingTextToVideoNode):
+class KlingCameraControlT2VNode(comfy_io.ComfyNode):
     """
     Kling Text to Video Camera Control Node. This node is a text to video node, but it supports controlling the camera.
     Duration, mode, and model_name request fields are hard-coded because camera control is only supported in pro mode with the kling-v1-5 model at 5s duration as of 2025-05-02.
     """
 
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "prompt": model_field_to_node_input(
-                    IO.STRING, KlingText2VideoRequest, "prompt", multiline=True
-                ),
-                "negative_prompt": model_field_to_node_input(
-                    IO.STRING,
-                    KlingText2VideoRequest,
-                    "negative_prompt",
-                    multiline=True,
-                ),
-                "cfg_scale": model_field_to_node_input(
-                    IO.FLOAT,
-                    KlingText2VideoRequest,
-                    "cfg_scale",
-                    default=0.75,
-                    min=0.0,
-                    max=1.0,
-                ),
-                "aspect_ratio": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingText2VideoRequest,
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingCameraControlT2VNode",
+            display_name="Kling Text to Video (Camera Control)",
+            category="api node/video/Kling",
+            description="Transform text into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original text.",
+            inputs=[
+                comfy_io.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
+                comfy_io.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
+                comfy_io.Float.Input("cfg_scale", default=0.75, min=0.0, max=1.0),
+                comfy_io.Combo.Input(
                     "aspect_ratio",
-                    enum_type=KlingVideoGenAspectRatio,
+                    options=[i.value for i in KlingVideoGenAspectRatio],
+                    default="16:9",
                 ),
-                "camera_control": (
-                    "CAMERA_CONTROL",
-                    {
-                        "tooltip": "Can be created using the Kling Camera Controls node. Controls the camera movement and motion during the video generation.",
-                    },
+                comfy_io.Custom("CAMERA_CONTROL").Input(
+                    "camera_control",
+                    tooltip="Can be created using the Kling Camera Controls node. Controls the camera movement and motion during the video generation.",
                 ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
+        )
 
-    DESCRIPTION = "Transform text into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original text."
-
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         prompt: str,
         negative_prompt: str,
         cfg_scale: float,
         aspect_ratio: str,
         camera_control: Optional[KlingCameraControl] = None,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        return await super().api_call(
+    ) -> comfy_io.NodeOutput:
+        return await execute_text2video(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
             model_name=KlingVideoGenModelName.kling_v1,
             cfg_scale=cfg_scale,
-            mode=KlingVideoGenMode.std,
+            model_mode=KlingVideoGenMode.std,
             aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
             duration=KlingVideoGenDuration.field_5,
             prompt=prompt,
             negative_prompt=negative_prompt,
             camera_control=camera_control,
-            **kwargs,
         )
 
 
-class KlingImage2VideoNode(KlingNodeBase):
+class KlingImage2VideoNode(comfy_io.ComfyNode):
     """Kling Image to Video Node"""
 
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "start_frame": model_field_to_node_input(
-                    IO.IMAGE,
-                    KlingImage2VideoRequest,
-                    "image",
-                    tooltip="The reference image used to generate the video.",
-                ),
-                "prompt": model_field_to_node_input(
-                    IO.STRING, KlingImage2VideoRequest, "prompt", multiline=True
-                ),
-                "negative_prompt": model_field_to_node_input(
-                    IO.STRING,
-                    KlingImage2VideoRequest,
-                    "negative_prompt",
-                    multiline=True,
-                ),
-                "model_name": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImage2VideoRequest,
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingImage2VideoNode",
+            display_name="Kling Image to Video",
+            category="api node/video/Kling",
+            description="Kling Image to Video Node",
+            inputs=[
+                comfy_io.Image.Input("start_frame", tooltip="The reference image used to generate the video."),
+                comfy_io.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
+                comfy_io.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
+                comfy_io.Combo.Input(
                     "model_name",
-                    enum_type=KlingVideoGenModelName,
+                    options=[i.value for i in KlingVideoGenModelName],
+                    default="kling-v2-master",
                 ),
-                "cfg_scale": model_field_to_node_input(
-                    IO.FLOAT,
-                    KlingImage2VideoRequest,
-                    "cfg_scale",
-                    default=0.8,
-                    min=0.0,
-                    max=1.0,
-                ),
-                "mode": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImage2VideoRequest,
-                    "mode",
-                    enum_type=KlingVideoGenMode,
-                ),
-                "aspect_ratio": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImage2VideoRequest,
+                comfy_io.Float.Input("cfg_scale", default=0.8, min=0.0, max=1.0),
+                comfy_io.Combo.Input("mode", options=[i.value for i in KlingVideoGenMode], default="std"),
+                comfy_io.Combo.Input(
                     "aspect_ratio",
-                    enum_type=KlingVideoGenAspectRatio,
+                    options=[i.value for i in KlingVideoGenAspectRatio],
+                    default="16:9",
                 ),
-                "duration": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImage2VideoRequest,
-                    "duration",
-                    enum_type=KlingVideoGenDuration,
-                ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    RETURN_TYPES = ("VIDEO", "STRING", "STRING")
-    RETURN_NAMES = ("VIDEO", "video_id", "duration")
-    DESCRIPTION = "Kling Image to Video Node"
-
-    async def get_response(
-        self, task_id: str, auth_kwargs: dict[str, str], node_id: Optional[str] = None
-    ) -> KlingImage2VideoResponse:
-        return await poll_until_finished(
-            auth_kwargs,
-            ApiEndpoint(
-                path=f"{PATH_IMAGE_TO_VIDEO}/{task_id}",
-                method=HttpMethod.GET,
-                request_model=KlingImage2VideoRequest,
-                response_model=KlingImage2VideoResponse,
-            ),
-            result_url_extractor=get_video_url_from_response,
-            estimated_duration=AVERAGE_DURATION_I2V,
-            node_id=node_id,
+                comfy_io.Combo.Input("duration", options=[i.value for i in KlingVideoGenDuration], default="5"),
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
         )
 
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         start_frame: torch.Tensor,
         prompt: str,
         negative_prompt: str,
@@ -702,212 +941,151 @@ class KlingImage2VideoNode(KlingNodeBase):
         duration: str,
         camera_control: Optional[KlingCameraControl] = None,
         end_frame: Optional[torch.Tensor] = None,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ) -> tuple[VideoFromFile]:
-        validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_I2V)
-        validate_input_image(start_frame)
-
-        if camera_control is not None:
-            # Camera control type for image 2 video is always `simple`
-            camera_control.type = KlingCameraControlType.simple
-
-        if mode == "std" and model_name == KlingVideoGenModelName.kling_v2_5_turbo.value:
-            mode = "pro"  # October 5: currently "std" mode is not supported for this model
-
-        initial_operation = SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path=PATH_IMAGE_TO_VIDEO,
-                method=HttpMethod.POST,
-                request_model=KlingImage2VideoRequest,
-                response_model=KlingImage2VideoResponse,
-            ),
-            request=KlingImage2VideoRequest(
-                model_name=KlingVideoGenModelName(model_name),
-                image=tensor_to_base64_string(start_frame),
-                image_tail=(
-                    tensor_to_base64_string(end_frame)
-                    if end_frame is not None
-                    else None
-                ),
-                prompt=prompt,
-                negative_prompt=negative_prompt if negative_prompt else None,
-                cfg_scale=cfg_scale,
-                mode=KlingVideoGenMode(mode),
-                duration=KlingVideoGenDuration(duration),
-                camera_control=camera_control,
-            ),
-            auth_kwargs=kwargs,
+    ) -> comfy_io.NodeOutput:
+        return await execute_image2video(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
+            start_frame=start_frame,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            cfg_scale=cfg_scale,
+            model_name=model_name,
+            aspect_ratio=aspect_ratio,
+            model_mode=mode,
+            duration=duration,
+            camera_control=camera_control,
+            end_frame=end_frame,
         )
 
-        task_creation_response = await initial_operation.execute()
-        validate_task_creation_response(task_creation_response)
-        task_id = task_creation_response.data.task_id
 
-        final_response = await self.get_response(
-            task_id, auth_kwargs=kwargs, node_id=unique_id
-        )
-        validate_video_result_response(final_response)
-
-        video = get_video_from_response(final_response)
-        return await video_result_to_node_output(video)
-
-
-class KlingCameraControlI2VNode(KlingImage2VideoNode):
+class KlingCameraControlI2VNode(comfy_io.ComfyNode):
     """
     Kling Image to Video Camera Control Node. This node is a image to video node, but it supports controlling the camera.
     Duration, mode, and model_name request fields are hard-coded because camera control is only supported in pro mode with the kling-v1-5 model at 5s duration as of 2025-05-02.
     """
 
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "start_frame": model_field_to_node_input(
-                    IO.IMAGE, KlingImage2VideoRequest, "image"
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingCameraControlI2VNode",
+            display_name="Kling Image to Video (Camera Control)",
+            category="api node/video/Kling",
+            description="Transform still images into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original image.",
+            inputs=[
+                comfy_io.Image.Input(
+                    "start_frame",
+                    tooltip="Reference Image - URL or Base64 encoded string, cannot exceed 10MB, resolution not less than 300*300px, aspect ratio between 1:2.5 ~ 2.5:1. Base64 should not include data:image prefix.",
                 ),
-                "prompt": model_field_to_node_input(
-                    IO.STRING, KlingImage2VideoRequest, "prompt", multiline=True
-                ),
-                "negative_prompt": model_field_to_node_input(
-                    IO.STRING,
-                    KlingImage2VideoRequest,
-                    "negative_prompt",
-                    multiline=True,
-                ),
-                "cfg_scale": model_field_to_node_input(
-                    IO.FLOAT,
-                    KlingImage2VideoRequest,
-                    "cfg_scale",
-                    default=0.75,
-                    min=0.0,
-                    max=1.0,
-                ),
-                "aspect_ratio": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImage2VideoRequest,
+                comfy_io.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
+                comfy_io.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
+                comfy_io.Float.Input("cfg_scale", default=0.75, min=0.0, max=1.0),
+                comfy_io.Combo.Input(
                     "aspect_ratio",
-                    enum_type=KlingVideoGenAspectRatio,
+                    options=[i.value for i in KlingVideoGenAspectRatio],
+                    default="16:9",
                 ),
-                "camera_control": (
-                    "CAMERA_CONTROL",
-                    {
-                        "tooltip": "Can be created using the Kling Camera Controls node. Controls the camera movement and motion during the video generation.",
-                    },
+                comfy_io.Custom("CAMERA_CONTROL").Input(
+                    "camera_control",
+                    tooltip="Can be created using the Kling Camera Controls node. Controls the camera movement and motion during the video generation.",
                 ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
+        )
 
-    DESCRIPTION = "Transform still images into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original image."
-
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         start_frame: torch.Tensor,
         prompt: str,
         negative_prompt: str,
         cfg_scale: float,
         aspect_ratio: str,
         camera_control: KlingCameraControl,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        return await super().api_call(
+    ) -> comfy_io.NodeOutput:
+        return await execute_image2video(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
             model_name=KlingVideoGenModelName.kling_v1_5,
             start_frame=start_frame,
             cfg_scale=cfg_scale,
-            mode=KlingVideoGenMode.pro,
+            model_mode=KlingVideoGenMode.pro,
             aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
             duration=KlingVideoGenDuration.field_5,
             prompt=prompt,
             negative_prompt=negative_prompt,
             camera_control=camera_control,
-            unique_id=unique_id,
-            **kwargs,
         )
 
 
-class KlingStartEndFrameNode(KlingImage2VideoNode):
+class KlingStartEndFrameNode(comfy_io.ComfyNode):
     """
     Kling First Last Frame Node. This node allows creation of a video from a first and last frame. It calls the normal image to video endpoint, but only allows the subset of input options that support the `image_tail` request field.
     """
 
-    @staticmethod
-    def get_mode_string_mapping() -> dict[str, tuple[str, str, str]]:
-        """
-        Returns a mapping of mode strings to their corresponding (mode, duration, model_name) tuples.
-        Only includes config combos that support the `image_tail` request field.
-
-        See: [Kling API Docs Capability Map](https://app.klingai.com/global/dev/document-api/apiReference/model/skillsMap)
-        """
-        return {
-            "standard mode / 5s duration / kling-v1": ("std", "5", "kling-v1"),
-            "pro mode / 5s duration / kling-v1": ("pro", "5", "kling-v1"),
-            "pro mode / 5s duration / kling-v1-5": ("pro", "5", "kling-v1-5"),
-            "pro mode / 10s duration / kling-v1-5": ("pro", "10", "kling-v1-5"),
-            "pro mode / 5s duration / kling-v1-6": ("pro", "5", "kling-v1-6"),
-            "pro mode / 10s duration / kling-v1-6": ("pro", "10", "kling-v1-6"),
-            "pro mode / 5s duration / kling-v2-1": ("pro", "5", "kling-v2-1"),
-            "pro mode / 10s duration / kling-v2-1": ("pro", "10", "kling-v2-1"),
-        }
+    @classmethod
+    def define_schema(cls) -> comfy_io.Schema:
+        modes = list(MODE_START_END_FRAME.keys())
+        return comfy_io.Schema(
+            node_id="KlingStartEndFrameNode",
+            display_name="Kling Start-End Frame to Video",
+            category="api node/video/Kling",
+            description="Generate a video sequence that transitions between your provided start and end images. The node creates all frames in between, producing a smooth transformation from the first frame to the last.",
+            inputs=[
+                comfy_io.Image.Input(
+                    "start_frame",
+                    tooltip="Reference Image - URL or Base64 encoded string, cannot exceed 10MB, resolution not less than 300*300px, aspect ratio between 1:2.5 ~ 2.5:1. Base64 should not include data:image prefix.",
+                ),
+                comfy_io.Image.Input(
+                    "end_frame",
+                    tooltip="Reference Image - End frame control. URL or Base64 encoded string, cannot exceed 10MB, resolution not less than 300*300px. Base64 should not include data:image prefix.",
+                ),
+                comfy_io.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
+                comfy_io.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
+                comfy_io.Float.Input("cfg_scale", default=0.5, min=0.0, max=1.0),
+                comfy_io.Combo.Input(
+                    "aspect_ratio",
+                    options=[i.value for i in KlingVideoGenAspectRatio],
+                    default="16:9",
+                ),
+                comfy_io.Combo.Input(
+                    "mode",
+                    options=modes,
+                    default=modes[2],
+                    tooltip="The configuration to use for the video generation following the format: mode / duration / model_name.",
+                ),
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
+        )
 
     @classmethod
-    def INPUT_TYPES(s):
-        modes = list(KlingStartEndFrameNode.get_mode_string_mapping().keys())
-        return {
-            "required": {
-                "start_frame": model_field_to_node_input(
-                    IO.IMAGE, KlingImage2VideoRequest, "image"
-                ),
-                "end_frame": model_field_to_node_input(
-                    IO.IMAGE, KlingImage2VideoRequest, "image_tail"
-                ),
-                "prompt": model_field_to_node_input(
-                    IO.STRING, KlingImage2VideoRequest, "prompt", multiline=True
-                ),
-                "negative_prompt": model_field_to_node_input(
-                    IO.STRING,
-                    KlingImage2VideoRequest,
-                    "negative_prompt",
-                    multiline=True,
-                ),
-                "cfg_scale": model_field_to_node_input(
-                    IO.FLOAT,
-                    KlingImage2VideoRequest,
-                    "cfg_scale",
-                    default=0.5,
-                    min=0.0,
-                    max=1.0,
-                ),
-                "aspect_ratio": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImage2VideoRequest,
-                    "aspect_ratio",
-                    enum_type=KlingVideoGenAspectRatio,
-                ),
-                "mode": (
-                    modes,
-                    {
-                        "default": modes[2],
-                        "tooltip": "The configuration to use for the video generation following the format: mode / duration / model_name.",
-                    },
-                ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    DESCRIPTION = "Generate a video sequence that transitions between your provided start and end images. The node creates all frames in between, producing a smooth transformation from the first frame to the last."
-
-    async def api_call(
-        self,
+    async def execute(
+        cls,
         start_frame: torch.Tensor,
         end_frame: torch.Tensor,
         prompt: str,
@@ -915,90 +1093,78 @@ class KlingStartEndFrameNode(KlingImage2VideoNode):
         cfg_scale: float,
         aspect_ratio: str,
         mode: str,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        mode, duration, model_name = KlingStartEndFrameNode.get_mode_string_mapping()[
-            mode
-        ]
-        return await super().api_call(
+    ) -> comfy_io.NodeOutput:
+        mode, duration, model_name = MODE_START_END_FRAME[mode]
+        return await execute_image2video(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
             prompt=prompt,
             negative_prompt=negative_prompt,
             model_name=model_name,
             start_frame=start_frame,
             cfg_scale=cfg_scale,
-            mode=mode,
+            model_mode=mode,
             aspect_ratio=aspect_ratio,
             duration=duration,
             end_frame=end_frame,
-            unique_id=unique_id,
-            **kwargs,
         )
 
 
-class KlingVideoExtendNode(KlingNodeBase):
+class KlingVideoExtendNode(comfy_io.ComfyNode):
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "prompt": model_field_to_node_input(
-                    IO.STRING, KlingVideoExtendRequest, "prompt", multiline=True
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingVideoExtendNode",
+            display_name="Kling Video Extend",
+            category="api node/video/Kling",
+            description="Kling Video Extend Node. Extend videos made by other Kling nodes. The video_id is created by using other Kling Nodes.",
+            inputs=[
+                comfy_io.String.Input(
+                    "prompt",
+                    multiline=True,
+                    tooltip="Positive text prompt for guiding the video extension",
                 ),
-                "negative_prompt": model_field_to_node_input(
-                    IO.STRING,
-                    KlingVideoExtendRequest,
+                comfy_io.String.Input(
                     "negative_prompt",
                     multiline=True,
+                    tooltip="Negative text prompt for elements to avoid in the extended video",
                 ),
-                "cfg_scale": model_field_to_node_input(
-                    IO.FLOAT,
-                    KlingVideoExtendRequest,
-                    "cfg_scale",
-                    default=0.5,
-                    min=0.0,
-                    max=1.0,
+                comfy_io.Float.Input("cfg_scale", default=0.5, min=0.0, max=1.0),
+                comfy_io.String.Input(
+                    "video_id",
+                    force_input=True,
+                    tooltip="The ID of the video to be extended. Supports videos generated by text-to-video, image-to-video, and previous video extension operations. Cannot exceed 3 minutes total duration after extension.",
                 ),
-                "video_id": model_field_to_node_input(
-                    IO.STRING, KlingVideoExtendRequest, "video_id", forceInput=True
-                ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    RETURN_TYPES = ("VIDEO", "STRING", "STRING")
-    RETURN_NAMES = ("VIDEO", "video_id", "duration")
-    DESCRIPTION = "Kling Video Extend Node. Extend videos made by other Kling nodes. The video_id is created by using other Kling Nodes."
-
-    async def get_response(
-        self, task_id: str, auth_kwargs: dict[str, str], node_id: Optional[str] = None
-    ) -> KlingVideoExtendResponse:
-        return await poll_until_finished(
-            auth_kwargs,
-            ApiEndpoint(
-                path=f"{PATH_VIDEO_EXTEND}/{task_id}",
-                method=HttpMethod.GET,
-                request_model=EmptyRequest,
-                response_model=KlingVideoExtendResponse,
-            ),
-            result_url_extractor=get_video_url_from_response,
-            estimated_duration=AVERAGE_DURATION_VIDEO_EXTEND,
-            node_id=node_id,
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
         )
 
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         prompt: str,
         negative_prompt: str,
         cfg_scale: float,
         video_id: str,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ) -> tuple[VideoFromFile, str, str]:
+    ) -> comfy_io.NodeOutput:
         validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_T2V)
+        auth = {
+            "auth_token": cls.hidden.auth_token_comfy_org,
+            "comfy_api_key": cls.hidden.api_key_comfy_org,
+        }
         initial_operation = SynchronousOperation(
             endpoint=ApiEndpoint(
                 path=PATH_VIDEO_EXTEND,
@@ -1012,560 +1178,323 @@ class KlingVideoExtendNode(KlingNodeBase):
                 cfg_scale=cfg_scale,
                 video_id=video_id,
             ),
-            auth_kwargs=kwargs,
+            auth_kwargs=auth,
         )
 
         task_creation_response = await initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = await self.get_response(
-            task_id, auth_kwargs=kwargs, node_id=unique_id
-        )
-        validate_video_result_response(final_response)
-
-        video = get_video_from_response(final_response)
-        return await video_result_to_node_output(video)
-
-
-class KlingVideoEffectsBase(KlingNodeBase):
-    """Kling Video Effects Base"""
-
-    RETURN_TYPES = ("VIDEO", "STRING", "STRING")
-    RETURN_NAMES = ("VIDEO", "video_id", "duration")
-
-    async def get_response(
-        self, task_id: str, auth_kwargs: dict[str, str], node_id: Optional[str] = None
-    ) -> KlingVideoEffectsResponse:
-        return await poll_until_finished(
-            auth_kwargs,
+        final_response = await poll_until_finished(
+            auth,
             ApiEndpoint(
-                path=f"{PATH_VIDEO_EFFECTS}/{task_id}",
+                path=f"{PATH_VIDEO_EXTEND}/{task_id}",
                 method=HttpMethod.GET,
                 request_model=EmptyRequest,
-                response_model=KlingVideoEffectsResponse,
+                response_model=KlingVideoExtendResponse,
             ),
             result_url_extractor=get_video_url_from_response,
-            estimated_duration=AVERAGE_DURATION_VIDEO_EFFECTS,
-            node_id=node_id,
-        )
-
-    async def api_call(
-        self,
-        dual_character: bool,
-        effect_scene: KlingDualCharacterEffectsScene | KlingSingleImageEffectsScene,
-        model_name: str,
-        duration: KlingVideoGenDuration,
-        image_1: torch.Tensor,
-        image_2: Optional[torch.Tensor] = None,
-        mode: Optional[KlingVideoGenMode] = None,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        if dual_character:
-            request_input_field = KlingDualCharacterEffectInput(
-                model_name=model_name,
-                mode=mode,
-                images=[
-                    tensor_to_base64_string(image_1),
-                    tensor_to_base64_string(image_2),
-                ],
-                duration=duration,
-            )
-        else:
-            request_input_field = KlingSingleImageEffectInput(
-                model_name=model_name,
-                image=tensor_to_base64_string(image_1),
-                duration=duration,
-            )
-
-        initial_operation = SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path=PATH_VIDEO_EFFECTS,
-                method=HttpMethod.POST,
-                request_model=KlingVideoEffectsRequest,
-                response_model=KlingVideoEffectsResponse,
-            ),
-            request=KlingVideoEffectsRequest(
-                effect_scene=effect_scene,
-                input=request_input_field,
-            ),
-            auth_kwargs=kwargs,
-        )
-
-        task_creation_response = await initial_operation.execute()
-        validate_task_creation_response(task_creation_response)
-        task_id = task_creation_response.data.task_id
-
-        final_response = await self.get_response(
-            task_id, auth_kwargs=kwargs, node_id=unique_id
+            estimated_duration=AVERAGE_DURATION_VIDEO_EXTEND,
+            node_id=cls.hidden.unique_id,
         )
         validate_video_result_response(final_response)
 
         video = get_video_from_response(final_response)
-        return await video_result_to_node_output(video)
+        return comfy_io.NodeOutput(await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration))
 
 
-class KlingDualCharacterVideoEffectNode(KlingVideoEffectsBase):
+class KlingDualCharacterVideoEffectNode(comfy_io.ComfyNode):
     """Kling Dual Character Video Effect Node"""
 
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "image_left": (IO.IMAGE, {"tooltip": "Left side image"}),
-                "image_right": (IO.IMAGE, {"tooltip": "Right side image"}),
-                "effect_scene": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingVideoEffectsRequest,
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingDualCharacterVideoEffectNode",
+            display_name="Kling Dual Character Video Effects",
+            category="api node/video/Kling",
+            description="Achieve different special effects when generating a video based on the effect_scene. First image will be positioned on left side, second on right side of the composite.",
+            inputs=[
+                comfy_io.Image.Input("image_left", tooltip="Left side image"),
+                comfy_io.Image.Input("image_right", tooltip="Right side image"),
+                comfy_io.Combo.Input(
                     "effect_scene",
-                    enum_type=KlingDualCharacterEffectsScene,
+                    options=[i.value for i in KlingDualCharacterEffectsScene],
                 ),
-                "model_name": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingDualCharacterEffectInput,
+                comfy_io.Combo.Input(
                     "model_name",
-                    enum_type=KlingCharacterEffectModelName,
+                    options=[i.value for i in KlingCharacterEffectModelName],
+                    default="kling-v1",
                 ),
-                "mode": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingDualCharacterEffectInput,
+                comfy_io.Combo.Input(
                     "mode",
-                    enum_type=KlingVideoGenMode,
+                    options=[i.value for i in KlingVideoGenMode],
+                    default="std",
                 ),
-                "duration": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingDualCharacterEffectInput,
+                comfy_io.Combo.Input(
                     "duration",
-                    enum_type=KlingVideoGenDuration,
+                    options=[i.value for i in KlingVideoGenDuration],
                 ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
+        )
 
-    DESCRIPTION = "Achieve different special effects when generating a video based on the effect_scene. First image will be positioned on left side, second on right side of the composite."
-    RETURN_TYPES = ("VIDEO", "STRING")
-    RETURN_NAMES = ("VIDEO", "duration")
-
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         image_left: torch.Tensor,
         image_right: torch.Tensor,
         effect_scene: KlingDualCharacterEffectsScene,
         model_name: KlingCharacterEffectModelName,
         mode: KlingVideoGenMode,
         duration: KlingVideoGenDuration,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        video, _, duration = await super().api_call(
+    ) -> comfy_io.NodeOutput:
+        video, _, duration = await execute_video_effect(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
             dual_character=True,
             effect_scene=effect_scene,
             model_name=model_name,
-            mode=mode,
+            model_mode=mode,
             duration=duration,
             image_1=image_left,
             image_2=image_right,
-            unique_id=unique_id,
-            **kwargs,
         )
         return video, duration
 
 
-class KlingSingleImageVideoEffectNode(KlingVideoEffectsBase):
+class KlingSingleImageVideoEffectNode(comfy_io.ComfyNode):
     """Kling Single Image Video Effect Node"""
 
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "image": (
-                    IO.IMAGE,
-                    {
-                        "tooltip": " Reference Image. URL or Base64 encoded string (without data:image prefix). File size cannot exceed 10MB, resolution not less than 300*300px, aspect ratio between 1:2.5 ~ 2.5:1"
-                    },
-                ),
-                "effect_scene": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingVideoEffectsRequest,
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingSingleImageVideoEffectNode",
+            display_name="Kling Video Effects",
+            category="api node/video/Kling",
+            description="Achieve different special effects when generating a video based on the effect_scene.",
+            inputs=[
+                comfy_io.Image.Input("image", tooltip=" Reference Image. URL or Base64 encoded string (without data:image prefix). File size cannot exceed 10MB, resolution not less than 300*300px, aspect ratio between 1:2.5 ~ 2.5:1"),
+                comfy_io.Combo.Input(
                     "effect_scene",
-                    enum_type=KlingSingleImageEffectsScene,
+                    options=[i.value for i in KlingSingleImageEffectsScene],
                 ),
-                "model_name": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingSingleImageEffectInput,
+                comfy_io.Combo.Input(
                     "model_name",
-                    enum_type=KlingSingleImageEffectModelName,
+                    options=[i.value for i in KlingSingleImageEffectModelName],
                 ),
-                "duration": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingSingleImageEffectInput,
+                comfy_io.Combo.Input(
                     "duration",
-                    enum_type=KlingVideoGenDuration,
+                    options=[i.value for i in KlingVideoGenDuration],
                 ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
+        )
 
-    DESCRIPTION = "Achieve different special effects when generating a video based on the effect_scene."
-
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         image: torch.Tensor,
         effect_scene: KlingSingleImageEffectsScene,
         model_name: KlingSingleImageEffectModelName,
         duration: KlingVideoGenDuration,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        return await super().api_call(
+    ) -> comfy_io.NodeOutput:
+        return await execute_video_effect(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
             dual_character=False,
             effect_scene=effect_scene,
             model_name=model_name,
             duration=duration,
             image_1=image,
-            unique_id=unique_id,
-            **kwargs,
         )
 
 
-class KlingLipSyncBase(KlingNodeBase):
-    """Kling Lip Sync Base"""
-
-    RETURN_TYPES = ("VIDEO", "STRING", "STRING")
-    RETURN_NAMES = ("VIDEO", "video_id", "duration")
-
-    def validate_lip_sync_video(self, video: VideoInput):
-        """
-        Validates the input video adheres to the expectations of the Kling Lip Sync API:
-        - Video length does not exceed 10s and is not shorter than 2s
-        - Length and width dimensions should both be between 720px and 1920px
-
-        See: https://app.klingai.com/global/dev/document-api/apiReference/model/videoTolip
-        """
-        validate_video_dimensions(video, 720, 1920)
-        validate_video_duration(video, 2, 10)
-
-    def validate_text(self, text: str):
-        if not text:
-            raise ValueError("Text is required")
-        if len(text) > MAX_PROMPT_LENGTH_LIP_SYNC:
-            raise ValueError(
-                f"Text is too long. Maximum length is {MAX_PROMPT_LENGTH_LIP_SYNC} characters."
-            )
-
-    async def get_response(
-        self, task_id: str, auth_kwargs: dict[str, str], node_id: Optional[str] = None
-    ) -> KlingLipSyncResponse:
-        """Polls the Kling API endpoint until the task reaches a terminal state."""
-        return await poll_until_finished(
-            auth_kwargs,
-            ApiEndpoint(
-                path=f"{PATH_LIP_SYNC}/{task_id}",
-                method=HttpMethod.GET,
-                request_model=EmptyRequest,
-                response_model=KlingLipSyncResponse,
-            ),
-            result_url_extractor=get_video_url_from_response,
-            estimated_duration=AVERAGE_DURATION_LIP_SYNC,
-            node_id=node_id,
-        )
-
-    async def api_call(
-        self,
-        video: VideoInput,
-        audio: Optional[AudioInput] = None,
-        voice_language: Optional[str] = None,
-        mode: Optional[str] = None,
-        text: Optional[str] = None,
-        voice_speed: Optional[float] = None,
-        voice_id: Optional[str] = None,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ) -> tuple[VideoFromFile, str, str]:
-        if text:
-            self.validate_text(text)
-        self.validate_lip_sync_video(video)
-
-        # Upload video to Comfy API and get download URL
-        video_url = await upload_video_to_comfyapi(video, auth_kwargs=kwargs)
-        logging.info("Uploaded video to Comfy API. URL: %s", video_url)
-
-        # Upload the audio file to Comfy API and get download URL
-        if audio:
-            audio_url = await upload_audio_to_comfyapi(audio, auth_kwargs=kwargs)
-            logging.info("Uploaded audio to Comfy API. URL: %s", audio_url)
-        else:
-            audio_url = None
-
-        initial_operation = SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path=PATH_LIP_SYNC,
-                method=HttpMethod.POST,
-                request_model=KlingLipSyncRequest,
-                response_model=KlingLipSyncResponse,
-            ),
-            request=KlingLipSyncRequest(
-                input=KlingLipSyncInputObject(
-                    video_url=video_url,
-                    mode=mode,
-                    text=text,
-                    voice_language=voice_language,
-                    voice_speed=voice_speed,
-                    audio_type="url",
-                    audio_url=audio_url,
-                    voice_id=voice_id,
-                ),
-            ),
-            auth_kwargs=kwargs,
-        )
-
-        task_creation_response = await initial_operation.execute()
-        validate_task_creation_response(task_creation_response)
-        task_id = task_creation_response.data.task_id
-
-        final_response = await self.get_response(
-            task_id, auth_kwargs=kwargs, node_id=unique_id
-        )
-        validate_video_result_response(final_response)
-
-        video = get_video_from_response(final_response)
-        return await video_result_to_node_output(video)
-
-
-class KlingLipSyncAudioToVideoNode(KlingLipSyncBase):
+class KlingLipSyncAudioToVideoNode(comfy_io.ComfyNode):
     """Kling Lip Sync Audio to Video Node. Syncs mouth movements in a video file to the audio content of an audio file."""
 
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "video": (IO.VIDEO, {}),
-                "audio": (IO.AUDIO, {}),
-                "voice_language": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingLipSyncInputObject,
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingLipSyncAudioToVideoNode",
+            display_name="Kling Lip Sync Video with Audio",
+            category="api node/video/Kling",
+            description="Kling Lip Sync Audio to Video Node. Syncs mouth movements in a video file to the audio content of an audio file. When using, ensure that the audio contains clearly distinguishable vocals and that the video contains a distinct face. The audio file should not be larger than 5MB. The video file should not be larger than 100MB, should have height/width between 720px and 1920px, and should be between 2s and 10s in length.",
+            inputs=[
+                comfy_io.Video.Input("video"),
+                comfy_io.Audio.Input("audio"),
+                comfy_io.Combo.Input(
                     "voice_language",
-                    enum_type=KlingLipSyncVoiceLanguage,
+                    options=[i.value for i in KlingLipSyncVoiceLanguage],
+                    default="en",
                 ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
+        )
 
-    DESCRIPTION = "Kling Lip Sync Audio to Video Node. Syncs mouth movements in a video file to the audio content of an audio file. When using, ensure that the audio contains clearly distinguishable vocals and that the video contains a distinct face. The audio file should not be larger than 5MB. The video file should not be larger than 100MB, should have height/width between 720px and 1920px, and should be between 2s and 10s in length."
-
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         video: VideoInput,
         audio: AudioInput,
         voice_language: str,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        return await super().api_call(
+    ) -> comfy_io.NodeOutput:
+        return await execute_lipsync(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
             video=video,
             audio=audio,
             voice_language=voice_language,
-            mode="audio2video",
-            unique_id=unique_id,
-            **kwargs,
+            model_mode="audio2video",
         )
 
 
-class KlingLipSyncTextToVideoNode(KlingLipSyncBase):
+class KlingLipSyncTextToVideoNode(comfy_io.ComfyNode):
     """Kling Lip Sync Text to Video Node. Syncs mouth movements in a video file to a text prompt."""
 
-    @staticmethod
-    def get_voice_config() -> dict[str, tuple[str, str]]:
-        return {
-            # English voices
-            "Melody": ("girlfriend_4_speech02", "en"),
-            "Sunny": ("genshin_vindi2", "en"),
-            "Sage": ("zhinen_xuesheng", "en"),
-            "Ace": ("AOT", "en"),
-            "Blossom": ("ai_shatang", "en"),
-            "Peppy": ("genshin_klee2", "en"),
-            "Dove": ("genshin_kirara", "en"),
-            "Shine": ("ai_kaiya", "en"),
-            "Anchor": ("oversea_male1", "en"),
-            "Lyric": ("ai_chenjiahao_712", "en"),
-            "Tender": ("chat1_female_new-3", "en"),
-            "Siren": ("chat_0407_5-1", "en"),
-            "Zippy": ("cartoon-boy-07", "en"),
-            "Bud": ("uk_boy1", "en"),
-            "Sprite": ("cartoon-girl-01", "en"),
-            "Candy": ("PeppaPig_platform", "en"),
-            "Beacon": ("ai_huangzhong_712", "en"),
-            "Rock": ("ai_huangyaoshi_712", "en"),
-            "Titan": ("ai_laoguowang_712", "en"),
-            "Grace": ("chengshu_jiejie", "en"),
-            "Helen": ("you_pingjing", "en"),
-            "Lore": ("calm_story1", "en"),
-            "Crag": ("uk_man2", "en"),
-            "Prattle": ("laopopo_speech02", "en"),
-            "Hearth": ("heainainai_speech02", "en"),
-            "The Reader": ("reader_en_m-v1", "en"),
-            "Commercial Lady": ("commercial_lady_en_f-v1", "en"),
-            # Chinese voices
-            "阳光少年": ("genshin_vindi2", "zh"),
-            "懂事小弟": ("zhinen_xuesheng", "zh"),
-            "运动少年": ("tiyuxi_xuedi", "zh"),
-            "青春少女": ("ai_shatang", "zh"),
-            "温柔小妹": ("genshin_klee2", "zh"),
-            "元气少女": ("genshin_kirara", "zh"),
-            "阳光男生": ("ai_kaiya", "zh"),
-            "幽默小哥": ("tiexin_nanyou", "zh"),
-            "文艺小哥": ("ai_chenjiahao_712", "zh"),
-            "甜美邻家": ("girlfriend_1_speech02", "zh"),
-            "温柔姐姐": ("chat1_female_new-3", "zh"),
-            "职场女青": ("girlfriend_2_speech02", "zh"),
-            "活泼男童": ("cartoon-boy-07", "zh"),
-            "俏皮女童": ("cartoon-girl-01", "zh"),
-            "稳重老爸": ("ai_huangyaoshi_712", "zh"),
-            "温柔妈妈": ("you_pingjing", "zh"),
-            "严肃上司": ("ai_laoguowang_712", "zh"),
-            "优雅贵妇": ("chengshu_jiejie", "zh"),
-            "慈祥爷爷": ("zhuxi_speech02", "zh"),
-            "唠叨爷爷": ("uk_oldman3", "zh"),
-            "唠叨奶奶": ("laopopo_speech02", "zh"),
-            "和蔼奶奶": ("heainainai_speech02", "zh"),
-            "东北老铁": ("dongbeilaotie_speech02", "zh"),
-            "重庆小伙": ("chongqingxiaohuo_speech02", "zh"),
-            "四川妹子": ("chuanmeizi_speech02", "zh"),
-            "潮汕大叔": ("chaoshandashu_speech02", "zh"),
-            "台湾男生": ("ai_taiwan_man2_speech02", "zh"),
-            "西安掌柜": ("xianzhanggui_speech02", "zh"),
-            "天津姐姐": ("tianjinjiejie_speech02", "zh"),
-            "新闻播报男": ("diyinnansang_DB_CN_M_04-v2", "zh"),
-            "译制片男": ("yizhipiannan-v1", "zh"),
-            "撒娇女友": ("tianmeixuemei-v1", "zh"),
-            "刀片烟嗓": ("daopianyansang-v1", "zh"),
-            "乖巧正太": ("mengwa-v1", "zh"),
-        }
+    @classmethod
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingLipSyncTextToVideoNode",
+            display_name="Kling Lip Sync Video with Text",
+            category="api node/video/Kling",
+            description="Kling Lip Sync Text to Video Node. Syncs mouth movements in a video file to a text prompt. The video file should not be larger than 100MB, should have height/width between 720px and 1920px, and should be between 2s and 10s in length.",
+            inputs=[
+                comfy_io.Video.Input("video"),
+                comfy_io.String.Input(
+                    "text",
+                    multiline=True,
+                    tooltip="Text Content for Lip-Sync Video Generation. Required when mode is text2video. Maximum length is 120 characters.",
+                ),
+                comfy_io.Combo.Input(
+                    "voice",
+                    options=list(VOICES_CONFIG.keys()),
+                    default="Melody",
+                ),
+                comfy_io.Float.Input(
+                    "voice_speed",
+                    default=1,
+                    min=0.8,
+                    max=2.0,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Speech Rate. Valid range: 0.8~2.0, accurate to one decimal place.",
+                ),
+            ],
+            outputs=[
+                comfy_io.Video.Output(),
+                comfy_io.String.Output(display_name="video_id"),
+                comfy_io.String.Output(display_name="duration"),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
+        )
 
     @classmethod
-    def INPUT_TYPES(s):
-        voice_options = list(s.get_voice_config().keys())
-        return {
-            "required": {
-                "video": (IO.VIDEO, {}),
-                "text": model_field_to_node_input(
-                    IO.STRING, KlingLipSyncInputObject, "text", multiline=True
-                ),
-                "voice": (voice_options, {"default": voice_options[0]}),
-                "voice_speed": model_field_to_node_input(
-                    IO.FLOAT, KlingLipSyncInputObject, "voice_speed", slider=True
-                ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    DESCRIPTION = "Kling Lip Sync Text to Video Node. Syncs mouth movements in a video file to a text prompt. The video file should not be larger than 100MB, should have height/width between 720px and 1920px, and should be between 2s and 10s in length."
-
-    async def api_call(
-        self,
+    async def execute(
+        cls,
         video: VideoInput,
         text: str,
         voice: str,
         voice_speed: float,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        voice_id, voice_language = KlingLipSyncTextToVideoNode.get_voice_config()[voice]
-        return await super().api_call(
+    ) -> comfy_io.NodeOutput:
+        voice_id, voice_language = VOICES_CONFIG[voice]
+        return await execute_lipsync(
+            auth_kwargs={
+                "auth_token": cls.hidden.auth_token_comfy_org,
+                "comfy_api_key": cls.hidden.api_key_comfy_org,
+            },
+            node_id=cls.hidden.unique_id,
             video=video,
             text=text,
             voice_language=voice_language,
             voice_id=voice_id,
             voice_speed=voice_speed,
-            mode="text2video",
-            unique_id=unique_id,
-            **kwargs,
+            model_mode="text2video",
         )
 
 
-class KlingImageGenerationBase(KlingNodeBase):
-    """Kling Image Generation Base Node."""
-
-    RETURN_TYPES = ("IMAGE",)
-    CATEGORY = "api node/image/Kling"
-
-    def validate_prompt(self, prompt: str, negative_prompt: Optional[str] = None):
-        if not prompt or len(prompt) > MAX_PROMPT_LENGTH_IMAGE_GEN:
-            raise ValueError(
-                f"Prompt must be less than {MAX_PROMPT_LENGTH_IMAGE_GEN} characters"
-            )
-        if negative_prompt and len(negative_prompt) > MAX_PROMPT_LENGTH_IMAGE_GEN:
-            raise ValueError(
-                f"Negative prompt must be less than {MAX_PROMPT_LENGTH_IMAGE_GEN} characters"
-            )
-
-
-class KlingVirtualTryOnNode(KlingImageGenerationBase):
+class KlingVirtualTryOnNode(comfy_io.ComfyNode):
     """Kling Virtual Try On Node."""
 
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "human_image": (IO.IMAGE, {}),
-                "cloth_image": (IO.IMAGE, {}),
-                "model_name": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingVirtualTryOnRequest,
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingVirtualTryOnNode",
+            display_name="Kling Virtual Try On",
+            category="api node/image/Kling",
+            description="Kling Virtual Try On Node. Input a human image and a cloth image to try on the cloth on the human. You can merge multiple clothing item pictures into one image with a white background.",
+            inputs=[
+                comfy_io.Image.Input("human_image"),
+                comfy_io.Image.Input("cloth_image"),
+                comfy_io.Combo.Input(
                     "model_name",
-                    enum_type=KlingVirtualTryOnModelName,
+                    options=[i.value for i in KlingVirtualTryOnModelName],
+                    default="kolors-virtual-try-on-v1",
                 ),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    DESCRIPTION = "Kling Virtual Try On Node. Input a human image and a cloth image to try on the cloth on the human. You can merge multiple clothing item pictures into one image with a white background."
-
-    async def get_response(
-        self, task_id: str, auth_kwargs: dict[str, str], node_id: Optional[str] = None
-    ) -> KlingVirtualTryOnResponse:
-        return await poll_until_finished(
-            auth_kwargs,
-            ApiEndpoint(
-                path=f"{PATH_VIRTUAL_TRY_ON}/{task_id}",
-                method=HttpMethod.GET,
-                request_model=EmptyRequest,
-                response_model=KlingVirtualTryOnResponse,
-            ),
-            result_url_extractor=get_images_urls_from_response,
-            estimated_duration=AVERAGE_DURATION_VIRTUAL_TRY_ON,
-            node_id=node_id,
+            ],
+            outputs=[
+                comfy_io.Image.Output(),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
         )
 
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         human_image: torch.Tensor,
         cloth_image: torch.Tensor,
         model_name: KlingVirtualTryOnModelName,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
+    ) -> comfy_io.NodeOutput:
+        auth = {
+            "auth_token": cls.hidden.auth_token_comfy_org,
+            "comfy_api_key": cls.hidden.api_key_comfy_org,
+        }
         initial_operation = SynchronousOperation(
             endpoint=ApiEndpoint(
                 path=PATH_VIRTUAL_TRY_ON,
@@ -1578,113 +1507,99 @@ class KlingVirtualTryOnNode(KlingImageGenerationBase):
                 cloth_image=tensor_to_base64_string(cloth_image),
                 model_name=model_name,
             ),
-            auth_kwargs=kwargs,
+            auth_kwargs=auth,
         )
 
         task_creation_response = await initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = await self.get_response(
-            task_id, auth_kwargs=kwargs, node_id=unique_id
+        final_response = await poll_until_finished(
+            auth,
+            ApiEndpoint(
+                path=f"{PATH_VIRTUAL_TRY_ON}/{task_id}",
+                method=HttpMethod.GET,
+                request_model=EmptyRequest,
+                response_model=KlingVirtualTryOnResponse,
+            ),
+            result_url_extractor=get_images_urls_from_response,
+            estimated_duration=AVERAGE_DURATION_VIRTUAL_TRY_ON,
+            node_id=cls.hidden.unique_id,
         )
         validate_image_result_response(final_response)
 
         images = get_images_from_response(final_response)
-        return (await image_result_to_node_output(images),)
+        return comfy_io.NodeOutput(await image_result_to_node_output(images))
 
 
-class KlingImageGenerationNode(KlingImageGenerationBase):
+class KlingImageGenerationNode(comfy_io.ComfyNode):
     """Kling Image Generation Node. Generate an image from a text prompt with an optional reference image."""
 
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "prompt": model_field_to_node_input(
-                    IO.STRING,
-                    KlingImageGenerationsRequest,
-                    "prompt",
-                    multiline=True,
-                    max_length=MAX_PROMPT_LENGTH_IMAGE_GEN,
+    def define_schema(cls) -> comfy_io.Schema:
+        return comfy_io.Schema(
+            node_id="KlingImageGenerationNode",
+            display_name="Kling Image Generation",
+            category="api node/image/Kling",
+            description="Kling Image Generation Node. Generate an image from a text prompt with an optional reference image.",
+            inputs=[
+                comfy_io.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
+                comfy_io.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
+                comfy_io.Combo.Input(
+                    "image_type",
+                    options=[i.value for i in KlingImageGenImageReferenceType],
                 ),
-                "negative_prompt": model_field_to_node_input(
-                    IO.STRING,
-                    KlingImageGenerationsRequest,
-                    "negative_prompt",
-                    multiline=True,
-                ),
-                "image_type": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImageGenerationsRequest,
-                    "image_reference",
-                    enum_type=KlingImageGenImageReferenceType,
-                ),
-                "image_fidelity": model_field_to_node_input(
-                    IO.FLOAT,
-                    KlingImageGenerationsRequest,
+                comfy_io.Float.Input(
                     "image_fidelity",
-                    slider=True,
+                    default=0.5,
+                    min=0.0,
+                    max=1.0,
                     step=0.01,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Reference intensity for user-uploaded images",
                 ),
-                "human_fidelity": model_field_to_node_input(
-                    IO.FLOAT,
-                    KlingImageGenerationsRequest,
+                comfy_io.Float.Input(
                     "human_fidelity",
-                    slider=True,
+                    default=0.45,
+                    min=0.0,
+                    max=1.0,
                     step=0.01,
+                    display_mode=comfy_io.NumberDisplay.slider,
+                    tooltip="Subject reference similarity",
                 ),
-                "model_name": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImageGenerationsRequest,
+                comfy_io.Combo.Input(
                     "model_name",
-                    enum_type=KlingImageGenModelName,
+                    options=[i.value for i in KlingImageGenModelName],
+                    default="kling-v1",
                 ),
-                "aspect_ratio": model_field_to_node_input(
-                    IO.COMBO,
-                    KlingImageGenerationsRequest,
+                comfy_io.Combo.Input(
                     "aspect_ratio",
-                    enum_type=KlingImageGenAspectRatio,
+                    options=[i.value for i in KlingImageGenAspectRatio],
+                    default="16:9",
                 ),
-                "n": model_field_to_node_input(
-                    IO.INT,
-                    KlingImageGenerationsRequest,
+                comfy_io.Int.Input(
                     "n",
+                    default=1,
+                    min=1,
+                    max=9,
+                    tooltip="Number of generated images",
                 ),
-            },
-            "optional": {
-                "image": (IO.IMAGE, {}),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    DESCRIPTION = "Kling Image Generation Node. Generate an image from a text prompt with an optional reference image."
-
-    async def get_response(
-        self,
-        task_id: str,
-        auth_kwargs: Optional[dict[str, str]],
-        node_id: Optional[str] = None,
-    ) -> KlingImageGenerationsResponse:
-        return await poll_until_finished(
-            auth_kwargs,
-            ApiEndpoint(
-                path=f"{PATH_IMAGE_GENERATIONS}/{task_id}",
-                method=HttpMethod.GET,
-                request_model=EmptyRequest,
-                response_model=KlingImageGenerationsResponse,
-            ),
-            result_url_extractor=get_images_urls_from_response,
-            estimated_duration=AVERAGE_DURATION_IMAGE_GEN,
-            node_id=node_id,
+                comfy_io.Image.Input("image", optional=True),
+            ],
+            outputs=[
+                comfy_io.Image.Output(),
+            ],
+            hidden=[
+                comfy_io.Hidden.auth_token_comfy_org,
+                comfy_io.Hidden.api_key_comfy_org,
+                comfy_io.Hidden.unique_id,
+            ],
+            is_api_node=True,
         )
 
-    async def api_call(
-        self,
+    @classmethod
+    async def execute(
+        cls,
         model_name: KlingImageGenModelName,
         prompt: str,
         negative_prompt: str,
@@ -1694,10 +1609,9 @@ class KlingImageGenerationNode(KlingImageGenerationBase):
         n: int,
         aspect_ratio: KlingImageGenAspectRatio,
         image: Optional[torch.Tensor] = None,
-        unique_id: Optional[str] = None,
-        **kwargs,
-    ):
-        self.validate_prompt(prompt, negative_prompt)
+    ) -> comfy_io.NodeOutput:
+        validate_string(prompt, field_name="prompt", min_length=1, max_length=MAX_PROMPT_LENGTH_IMAGE_GEN)
+        validate_string(negative_prompt, field_name="negative_prompt", max_length=MAX_PROMPT_LENGTH_IMAGE_GEN)
 
         if image is None:
             image_type = None
@@ -1706,6 +1620,10 @@ class KlingImageGenerationNode(KlingImageGenerationBase):
         else:
             image = tensor_to_base64_string(image)
 
+        auth = {
+            "auth_token": cls.hidden.auth_token_comfy_org,
+            "comfy_api_key": cls.hidden.api_key_comfy_org,
+        }
         initial_operation = SynchronousOperation(
             endpoint=ApiEndpoint(
                 path=PATH_IMAGE_GENERATIONS,
@@ -1724,50 +1642,50 @@ class KlingImageGenerationNode(KlingImageGenerationBase):
                 n=n,
                 aspect_ratio=aspect_ratio,
             ),
-            auth_kwargs=kwargs,
+            auth_kwargs=auth,
         )
 
         task_creation_response = await initial_operation.execute()
         validate_task_creation_response(task_creation_response)
         task_id = task_creation_response.data.task_id
 
-        final_response = await self.get_response(
-            task_id, auth_kwargs=kwargs, node_id=unique_id
+        final_response = await poll_until_finished(
+            auth,
+            ApiEndpoint(
+                path=f"{PATH_IMAGE_GENERATIONS}/{task_id}",
+                method=HttpMethod.GET,
+                request_model=EmptyRequest,
+                response_model=KlingImageGenerationsResponse,
+            ),
+            result_url_extractor=get_images_urls_from_response,
+            estimated_duration=AVERAGE_DURATION_IMAGE_GEN,
+            node_id=cls.hidden.unique_id,
         )
         validate_image_result_response(final_response)
 
         images = get_images_from_response(final_response)
-        return (await image_result_to_node_output(images),)
+        return comfy_io.NodeOutput(await image_result_to_node_output(images))
 
 
-NODE_CLASS_MAPPINGS = {
-    "KlingCameraControls": KlingCameraControls,
-    "KlingTextToVideoNode": KlingTextToVideoNode,
-    "KlingImage2VideoNode": KlingImage2VideoNode,
-    "KlingCameraControlI2VNode": KlingCameraControlI2VNode,
-    "KlingCameraControlT2VNode": KlingCameraControlT2VNode,
-    "KlingStartEndFrameNode": KlingStartEndFrameNode,
-    "KlingVideoExtendNode": KlingVideoExtendNode,
-    "KlingLipSyncAudioToVideoNode": KlingLipSyncAudioToVideoNode,
-    "KlingLipSyncTextToVideoNode": KlingLipSyncTextToVideoNode,
-    "KlingVirtualTryOnNode": KlingVirtualTryOnNode,
-    "KlingImageGenerationNode": KlingImageGenerationNode,
-    "KlingSingleImageVideoEffectNode": KlingSingleImageVideoEffectNode,
-    "KlingDualCharacterVideoEffectNode": KlingDualCharacterVideoEffectNode,
-}
+class KlingExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[comfy_io.ComfyNode]]:
+        return [
+            KlingCameraControls,
+            KlingTextToVideoNode,
+            KlingImage2VideoNode,
+            KlingCameraControlI2VNode,
+            KlingCameraControlT2VNode,
+            KlingStartEndFrameNode,
+            KlingVideoExtendNode,
+            KlingLipSyncAudioToVideoNode,
+            KlingLipSyncTextToVideoNode,
+            KlingVirtualTryOnNode,
+            KlingImageGenerationNode,
+            KlingSingleImageVideoEffectNode,
+            KlingDualCharacterVideoEffectNode,
+        ]
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "KlingCameraControls": "Kling Camera Controls",
-    "KlingTextToVideoNode": "Kling Text to Video",
-    "KlingImage2VideoNode": "Kling Image to Video",
-    "KlingCameraControlI2VNode": "Kling Image to Video (Camera Control)",
-    "KlingCameraControlT2VNode": "Kling Text to Video (Camera Control)",
-    "KlingStartEndFrameNode": "Kling Start-End Frame to Video",
-    "KlingVideoExtendNode": "Kling Video Extend",
-    "KlingLipSyncAudioToVideoNode": "Kling Lip Sync Video with Audio",
-    "KlingLipSyncTextToVideoNode": "Kling Lip Sync Video with Text",
-    "KlingVirtualTryOnNode": "Kling Virtual Try On",
-    "KlingImageGenerationNode": "Kling Image Generation",
-    "KlingSingleImageVideoEffectNode": "Kling Video Effects",
-    "KlingDualCharacterVideoEffectNode": "Kling Dual Character Video Effects",
-}
+
+async def comfy_entrypoint() -> KlingExtension:
+    return KlingExtension()


### PR DESCRIPTION
The test workflow was saved in V1 nodes and loaded and tested in V3:

https://github.com/user-attachments/assets/e3660efb-64c7-4e5e-b2e8-43f8b574eaee

Note:
1. I was not able to get Camera Control working with most parameters in the V1 Nodes version. Error: `camera_control.config is not allowed for this type: right_turn_forward`.
2. Lip Sync Audio wasn’t tested either because it rejects MP3 and WAV inputs. Error: `"Audio format is invalid"`.

We can investigate these in a separate PR if needed, since this conversion PR does not change behavior or include fixes.

Objects git diff:

[object_info_difference.zip](https://github.com/user-attachments/files/22725544/object_info_difference.zip)

