### PR TITLE
WanImageToVideo, WanFirstLastFrameToVideo: Add `vae_tile_size` optional arg

### DIFF
--- a/comfy_extras/nodes_wan.py
+++ b/comfy_extras/nodes_wan.py
@@ -27,6 +27,7 @@ class WanImageToVideo(io.ComfyNode):
                 io.Int.Input("height", default=480, min=16, max=nodes.MAX_RESOLUTION, step=16),
                 io.Int.Input("length", default=81, min=1, max=nodes.MAX_RESOLUTION, step=4),
                 io.Int.Input("batch_size", default=1, min=1, max=4096),
+                io.Int.Input("vae_tile_size", default=0, min=0, optional=True, tooltip="VAE encode tile size, 0 means untiled (default)"),
                 io.ClipVisionOutput.Input("clip_vision_output", optional=True),
                 io.Image.Input("start_image", optional=True),
             ],
@@ -38,14 +39,18 @@ class WanImageToVideo(io.ComfyNode):
         )
 
     @classmethod
-    def execute(cls, positive, negative, vae, width, height, length, batch_size, start_image=None, clip_vision_output=None) -> io.NodeOutput:
+    def execute(cls, positive, negative, vae, width, height, length, batch_size, vae_tile_size=0, start_image=None, clip_vision_output=None) -> io.NodeOutput:
         latent = torch.zeros([batch_size, 16, ((length - 1) // 4) + 1, height // 8, width // 8], device=comfy.model_management.intermediate_device())
         if start_image is not None:
             start_image = comfy.utils.common_upscale(start_image[:length].movedim(-1, 1), width, height, "bilinear", "center").movedim(1, -1)
             image = torch.ones((length, height, width, start_image.shape[-1]), device=start_image.device, dtype=start_image.dtype) * 0.5
             image[:start_image.shape[0]] = start_image
 
-            concat_latent_image = vae.encode(image[:, :, :, :3])
+            if vae_tile_size == 0:
+                concat_latent_image = vae.encode(image[:, :, :, :3])
+            else:
+                concat_latent_image = vae.encode_tiled(image[:, :, :, :3], tile_x=vae_tile_size, tile_y=vae_tile_size, overlap=32, tile_t=256, overlap_t=8)
+
             mask = torch.ones((1, 1, latent.shape[2], concat_latent_image.shape[-2], concat_latent_image.shape[-1]), device=start_image.device, dtype=start_image.dtype)
             mask[:, :, :((start_image.shape[0] - 1) // 4) + 1] = 0.0
 
@@ -193,6 +198,7 @@ class WanFirstLastFrameToVideo(io.ComfyNode):
                 io.Int.Input("height", default=480, min=16, max=nodes.MAX_RESOLUTION, step=16),
                 io.Int.Input("length", default=81, min=1, max=nodes.MAX_RESOLUTION, step=4),
                 io.Int.Input("batch_size", default=1, min=1, max=4096),
+                io.Int.Input("vae_tile_size", default=0, min=0, optional=True, tooltip="VAE encode tile size, 0 means untiled (default)"),
                 io.ClipVisionOutput.Input("clip_vision_start_image", optional=True),
                 io.ClipVisionOutput.Input("clip_vision_end_image", optional=True),
                 io.Image.Input("start_image", optional=True),
@@ -206,7 +212,7 @@ class WanFirstLastFrameToVideo(io.ComfyNode):
         )
 
     @classmethod
-    def execute(cls, positive, negative, vae, width, height, length, batch_size, start_image=None, end_image=None, clip_vision_start_image=None, clip_vision_end_image=None) -> io.NodeOutput:
+    def execute(cls, positive, negative, vae, width, height, length, batch_size, vae_tile_size=0, start_image=None, end_image=None, clip_vision_start_image=None, clip_vision_end_image=None) -> io.NodeOutput:
         spacial_scale = vae.spacial_compression_encode()
         latent = torch.zeros([batch_size, vae.latent_channels, ((length - 1) // 4) + 1, height // spacial_scale, width // spacial_scale], device=comfy.model_management.intermediate_device())
         if start_image is not None:
@@ -225,7 +231,11 @@ class WanFirstLastFrameToVideo(io.ComfyNode):
             image[-end_image.shape[0]:] = end_image
             mask[:, :, -end_image.shape[0]:] = 0.0
 
-        concat_latent_image = vae.encode(image[:, :, :, :3])
+        if vae_tile_size == 0:
+            concat_latent_image = vae.encode(image[:, :, :, :3])
+        else:
+            concat_latent_image = vae.encode_tiled(image[:, :, :, :3], tile_x=vae_tile_size, tile_y=vae_tile_size, overlap=32, tile_t=256, overlap_t=8)
+
         mask = mask.view(1, mask.shape[2] // 4, 4, mask.shape[3], mask.shape[4]).transpose(1, 2)
         positive = node_helpers.conditioning_set_values(positive, {"concat_latent_image": concat_latent_image, "concat_mask": mask})
         negative = node_helpers.conditioning_set_values(negative, {"concat_latent_image": concat_latent_image, "concat_mask": mask})


### PR DESCRIPTION
I experience slow VAE performance on my AMD RX 7900 GRE gpu and can usually improve this by opting for the tiled VAE nodes. However, `WanImageToVideo` does VAE encoding and is currently not configurable. This leads to wan workflows being slow for me, see benchmarks.

I propose we add a `vae_tile_size` optional argument to `WanImageToVideo` (and similar). By default this will be `0` to mean untiled, ie acting as it did previously. If set the value will be used as the x & y tile size. This allows users, like me, a way to workaround poor wan VAE untiled encode performance.

As the default behaviour is unchanged this should be backward compatible.

<img width="363" height="403" alt="wan-vae-tile-size-screen" src="https://github.com/user-attachments/assets/89844fb7-ae85-42fa-b49e-db79b7916a2c" />

## Alternatives
* Add new "tiled" variant nodes for wan, e.g. `TiledWanImageToVideo`.
* Automatically pick tiled encoding for certain GPUs, e.g. my gpu -> 256x256 tiled encoding.

## Wan 2.1 VAE benchmarks (480x832 * 81 frames)
<details>
<summary>System info</summary>

`MIOPEN_FIND_MODE=FAST`

```
Total VRAM 16368 MB, total RAM 64217 MB
pytorch version: 2.9.0.dev20250827+rocm6.4
AMD arch: gfx1100
ROCm version: (6, 4)
Set vram state to: NORMAL_VRAM
Device: cuda:0 AMD Radeon RX 7900 GRE : native
Using Flash Attention
Python version: 3.12.11 (main, Jun  4 2025, 10:32:37) [GCC 15.1.1 20250425]
ComfyUI version: 0.3.62
ComfyUI frontend version: 1.27.7
Using split attention in VAE
VAE load device: cuda:0, offload device: cpu, dtype: torch.float16
```

</details>

### VAE Encode
Benches show significant improvement using tiled vae encoding. On my setup 256x256 performed best. **589s -> 25s**.

<details>
<summary>Untiled vs 512 vs 384 vs 256 vs 128</summary>

2 runs each.

#### untiled
Yes really 10 minutes :disappointed: 
```
[WanImageToVideo]: 608.79s
[WanImageToVideo]: 588.72s
```

#### tiled 512,512,32,256,8
```
[WanImageToVideo]: 41.86s
[WanImageToVideo]: 43.68s
```

#### tiled 384,384,32,256,8
```
[WanImageToVideo]: 30.41s
[WanImageToVideo]: 28.89s
```

#### tiled 256,256,32,256,8
```
[WanImageToVideo]: 25.00s
[WanImageToVideo]: 25.35s
```

#### tiled 128,128,32,256,8
```
[WanImageToVideo]: 45.57s
[WanImageToVideo]: 45.31s
```

</details>

### VAE Decode
Benches also show significant improvement using tiled vae decoding. On my setup 256x256 performed best.
_Note: Decoding is already a separate node so no code changes required, this is just kinda related and perhaps interesting._

<details>
<summary>Untiled vs 512 vs 384 vs 256 vs 128</summary>

4 runs each (where possible).

#### untiled
OOM :cry: 

#### tiled 512,512,32,124,8
OOM :cry: 

#### tiled 384,384,32,124,8
```
[VAEDecodeTiled]: 73.94s
[VAEDecodeTiled]: 99.03s
[VAEDecodeTiled]: 62.71s
[VAEDecodeTiled]: 66.34s
```

#### tiled 256,256,32,124,8
```
[VAEDecodeTiled]: 60.79s
[VAEDecodeTiled]: 61.21s
[VAEDecodeTiled]: 54.53s
[VAEDecodeTiled]: 47.72s
```

#### tiled 128,128,32,124,8
```
[VAEDecodeTiled]: 72.18s
[VAEDecodeTiled]: 71.70s
[VAEDecodeTiled]: 71.47s
[VAEDecodeTiled]: 71.29s
```

</details>