### PR TITLE
fix(ReCraft-API-node): allow custom multipart parser to return FormData

### DIFF
--- a/comfy_api_nodes/apis/client.py
+++ b/comfy_api_nodes/apis/client.py
@@ -220,13 +220,16 @@ class ApiClient:
         if multipart_parser and data:
             data = multipart_parser(data)
 
-        form = aiohttp.FormData(default_to_multipart=True)
-        if data:  # regular text fields
-            for k, v in data.items():
-                if v is None:
-                    continue  # aiohttp fails to serialize "None" values
-                # aiohttp expects strings or bytes; convert enums etc.
-                form.add_field(k, str(v) if not isinstance(v, (bytes, bytearray)) else v)
+        if isinstance(data, aiohttp.FormData):
+            form = data  # If the parser already returned a FormData, pass it through
+        else:
+            form = aiohttp.FormData(default_to_multipart=True)
+            if data:  # regular text fields
+                for k, v in data.items():
+                    if v is None:
+                        continue  # aiohttp fails to serialize "None" values
+                    # aiohttp expects strings or bytes; convert enums etc.
+                    form.add_field(k, str(v) if not isinstance(v, (bytes, bytearray)) else v)
 
         if files:
             file_iter = files if isinstance(files, list) else files.items()


### PR DESCRIPTION
Follow up the bug found during developing new pylint rules: https://github.com/comfyanonymous/ComfyUI/pull/10213

Currently all ReCraft nodes that accepts at the same time `input file` **and**  `RecRaft Control` broken.

This happened cause `aiohttp` library **does not** expands  list values in `data=` into **repeated form fields**, e.g.:

```
controls[colors][][rgb][]=40
controls[colors][][rgb][]=12
controls[colors][][rgb][]=3
```

The switch to **`aiohttp`** (to make node **async**) broke those nodes, cause `aihttp` serializes them  as strings:

```
controls[colors][][rgb][]= "[40, 12, 3]"
```

---

To prevent the fix from affecting all nodes again, I propose simply extending the current feature of custom `multipart_parser` and allowing it to return `FormData` instead of `dict`.

This way, the fix only touches the custom multipart_parser of ReCraft API nodes and does not affect any other API nodes.


Before this PR:

<img width="1978" height="903" alt="Screenshot From 2025-10-07 09-11-39" src="https://github.com/user-attachments/assets/f5634cf5-f883-4d51-83e7-83c763e0579c" />

After this PR:

<img width="1978" height="903" alt="Screenshot From 2025-10-07 09-12-25" src="https://github.com/user-attachments/assets/a4374596-2c57-41cf-9d03-46891bfc44ce" />
