### PR TITLE
Bump frontend to 1.27.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.27.7
+comfyui-frontend-package==1.27.10
 comfyui-workflow-templates==0.1.93
 comfyui-embedded-docs==0.2.6
 torch


### PR DESCRIPTION
Bump frontend to 1.27.10

```
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.27.10
```

- Diff: [Comfy-Org/ComfyUI_frontend: v1.27.7...v1.27.10](https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.27.7...v1.27.10)
- PyPI Package: https://pypi.org/project/comfyui-frontend-package/1.27.10/
- npm Types: https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.27.10

## Changes

- Fix: Hotfix release including critical bug fixes from core/1.27 branch