### PR TITLE
fix(api-nodes): use correct PikaSwaps endpoint and request model

### DIFF
--- a/comfy_api_nodes/nodes_pika.py
+++ b/comfy_api_nodes/nodes_pika.py
@@ -590,9 +590,9 @@ class PikaSwapsNode(comfy_io.ComfyNode):
         }
         initial_operation = SynchronousOperation(
             endpoint=ApiEndpoint(
-                path=PATH_PIKADDITIONS,
+                path=PATH_PIKASWAPS,
                 method=HttpMethod.POST,
-                request_model=PikaBodyGeneratePikadditionsGeneratePikadditionsPost,
+                request_model=PikaBodyGeneratePikaswapsGeneratePikaswapsPost,
                 response_model=PikaGenerateResponse,
             ),
             request=pika_request_data,


### PR DESCRIPTION
The PikaSwapsNode was using PATH_PIKADDITIONS instead of PATH_PIKASWAPS.
Updated to match the official Pika API endpoint `/generate/pikaswaps`.
