### PR TITLE
Fix LoRA patching for scaled fp8 with low VRAM

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -415,6 +415,13 @@ def scaled_fp8_ops(fp8_matrix_mult=False, scale_input=False, override_dtype=None
                     return weight
                 else:
                     return weight * self.scale_weight.to(device=weight.device, dtype=weight.dtype)
+                
+            def revert_weight(self, weight, inplace=False, **kwargs):
+                if inplace:
+                    weight /= self.scale_weight.to(device=weight.device, dtype=weight.dtype)
+                    return weight
+                else:
+                    return weight / self.scale_weight.to(device=weight.device, dtype=weight.dtype)
 
             def set_weight(self, weight, inplace_update=False, seed=None, **kwargs):
                 weight = comfy.float.stochastic_rounding(weight / self.scale_weight.to(device=weight.device, dtype=weight.dtype), self.weight.dtype, seed=seed)


### PR DESCRIPTION
## Summary

This PR updates `LowVramPatch` to properly handle scaled fp8 models. 

## Issue

Currently, in low VRAM situations, LoRA's are applied to the unscaled weights instead first applying the scaling factor. This can lead to quality issues when the scale parameter differs significantly from 1. In particular, the Wan 2.1 / 2.2 14B scaled fp8 models require offloading for 16GB GPU's, which can lead to significant issues when applying various LoRA's.

## Details

This PR updates `LowVramPatch` to retrieve the `convert_weight` function from the layer if it exists, and apply it to the weights before merging the LoRA. In addition, this PR introduces a `revert_weight` function (an analog to the existing `set_weight` function) to unscale the weights after merging the LoRA.