### PR TITLE
feat(api-nodes): add price extractor feature; small fixes to Kling/Pika

### DIFF
--- a/comfy_api_nodes/apis/client.py
+++ b/comfy_api_nodes/apis/client.py
@@ -782,9 +782,11 @@ class PollingOperation(Generic[T, R]):
         poll_endpoint: ApiEndpoint[EmptyRequest, R],
         completed_statuses: list[str],
         failed_statuses: list[str],
+        *,
         status_extractor: Callable[[R], Optional[str]],
         progress_extractor: Callable[[R], Optional[float]] | None = None,
         result_url_extractor: Callable[[R], Optional[str]] | None = None,
+        price_extractor: Callable[[R], Optional[float]] | None = None,
         request: Optional[T] = None,
         api_base: str | None = None,
         auth_token: Optional[str] = None,
@@ -815,10 +817,12 @@ class PollingOperation(Generic[T, R]):
         self.status_extractor = status_extractor or (lambda x: getattr(x, "status", None))
         self.progress_extractor = progress_extractor
         self.result_url_extractor = result_url_extractor
+        self.price_extractor = price_extractor
         self.node_id = node_id
         self.completed_statuses = completed_statuses
         self.failed_statuses = failed_statuses
         self.final_response: Optional[R] = None
+        self.extracted_price: Optional[float] = None
 
     async def execute(self, client: Optional[ApiClient] = None) -> R:
         owns_client = client is None
@@ -840,6 +844,8 @@ class PollingOperation(Generic[T, R]):
     def _display_text_on_node(self, text: str):
         if not self.node_id:
             return
+        if self.extracted_price is not None:
+            text = f"Price: {self.extracted_price}$\n{text}"
         PromptServer.instance.send_progress_text(text, self.node_id)
 
     def _display_time_progress_on_node(self, time_completed: int | float):
@@ -877,9 +883,7 @@ class PollingOperation(Generic[T, R]):
             try:
                 logging.debug("[DEBUG] Polling attempt #%s", poll_count)
 
-                request_dict = (
-                    None if self.request is None else self.request.model_dump(exclude_none=True)
-                )
+                request_dict = None if self.request is None else self.request.model_dump(exclude_none=True)
 
                 if poll_count == 1:
                     logging.debug(
@@ -911,6 +915,11 @@ class PollingOperation(Generic[T, R]):
                     new_progress = self.progress_extractor(response_obj)
                     if new_progress is not None:
                         progress.update_absolute(new_progress, total=PROGRESS_BAR_MAX)
+
+                if self.price_extractor:
+                    price = self.price_extractor(response_obj)
+                    if price is not None:
+                        self.extracted_price = price
 
                 if status == TaskStatus.COMPLETED:
                     message = "Task completed successfully"

--- a/comfy_api_nodes/nodes_pika.py
+++ b/comfy_api_nodes/nodes_pika.py
@@ -17,6 +17,7 @@ from comfy_api.input_impl.video_types import VideoCodec, VideoContainer, VideoIn
 from comfy_api_nodes.apinode_utils import (
     download_url_to_video_output,
     tensor_to_bytesio,
+    validate_string,
 )
 from comfy_api_nodes.apis import pika_defs
 from comfy_api_nodes.apis.client import (
@@ -590,6 +591,7 @@ class PikaStartEndFrameNode(comfy_io.ComfyNode):
         resolution: str,
         duration: int,
     ) -> comfy_io.NodeOutput:
+        validate_string(prompt_text, field_name="prompt_text", min_length=1)
         pika_files = [
             ("keyFrames", ("image_start.png", tensor_to_bytesio(image_start), "image/png")),
             ("keyFrames", ("image_end.png", tensor_to_bytesio(image_end), "image/png")),


### PR DESCRIPTION
1. Add `price_extractor` for the API nodes where we can not calculate price in advance. Currently it is displayed in the "status" text - in future we can make minor changes and perhaps allow updating Price Badge from the Node.
2. Change most of `PollingOperation` args to be `kwargs` as new changes will be made in upcoming PR(we already use everywhere only kwargs when using it) - just to be safe.
3. Add check for `PikaStartEndFrameNode` node to disallow empty prompts(error 422 from their API).
4. Fixed a single output bug (`video_id` was output instead of `duration`) in the `KlingDualCharacterVideoEffectNode` node, which was detected by the (now working) type checker.


<img width="405" height="380" alt="Screenshot From 2025-10-10 09-52-37" src="https://github.com/user-attachments/assets/068bd08b-e680-4d54-87d1-019cda7f5425" />
