### PR TITLE
add indent=4 kwarg to json.dumps() in "Preview Any" node

### DIFF
--- a/comfy_extras/nodes_preview_any.py
+++ b/comfy_extras/nodes_preview_any.py
@@ -25,7 +25,7 @@ class PreviewAny():
             value = str(source)
         elif source is not None:
             try:
-                value = json.dumps(source)
+                value = json.dumps(source, indent=4)
             except Exception:
                 try:
                     value = str(source)


### PR DESCRIPTION
Added pretty print the json dump in Preview Any node, so that it is slightly easier to read.

#### Without this code change (before):
<img width="1042" height="904" alt="Screenshot From 2025-10-12 12-28-50" src="https://github.com/user-attachments/assets/81db30b8-8ba1-4438-952f-692110c6aa41" />

#### With this code change (after):
<img width="1042" height="904" alt="Screenshot From 2025-10-12 12-28-55" src="https://github.com/user-attachments/assets/1b7926c4-6889-4618-9043-11648fd2afda" />
