### PR TITLE
Set Flux models to eval mode to restore FP8 performance

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -834,6 +834,7 @@ class PixArt(BaseModel):
 class Flux(BaseModel):
     def __init__(self, model_config, model_type=ModelType.FLUX, device=None, unet_model=comfy.ldm.flux.model.Flux):
         super().__init__(model_config, model_type, device=device, unet_model=unet_model)
+        self.diffusion_model.eval().requires_grad_(False)
         self.memory_usage_factor_conds = ("ref_latents",)
 
     def concat_cond(self, **kwargs):


### PR DESCRIPTION
Fixes performance regression introduced in #9854 where the fp8_linear optimization path was being skipped during inference because Flux models were not explicitly set to eval mode.

This increased my Flux workflow's it/s on a 5090 back to 2.75 it/s, up from 1.85 it/s which I was getting on latest master.

Specifically, 7be2b49b6b3430783555bc6bc8fcb3f46d5392e7 was the first commit chronologically where my it/s dropped.