### PR TITLE
Separate Int node without control_after_generate

### DIFF
--- a/comfy_extras/nodes_primitive.py
+++ b/comfy_extras/nodes_primitive.py
@@ -40,6 +40,24 @@ class StringMultiline(io.ComfyNode):
         return io.NodeOutput(value)
 
 
+class RandInt(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="PrimitiveRandomInt",
+            display_name="RandomInt",
+            category="utils/primitive",
+            inputs=[
+                io.Int.Input("value", min=-sys.maxsize, max=sys.maxsize, control_after_generate=True),
+            ],
+            outputs=[io.Int.Output()],
+        )
+
+    @classmethod
+    def execute(cls, value: int) -> io.NodeOutput:
+        return io.NodeOutput(value)
+
+
 class Int(io.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -48,7 +66,7 @@ class Int(io.ComfyNode):
             display_name="Int",
             category="utils/primitive",
             inputs=[
-                io.Int.Input("value", min=-sys.maxsize, max=sys.maxsize, control_after_generate=True),
+                io.Int.Input("value", min=-sys.maxsize, max=sys.maxsize),
             ],
             outputs=[io.Int.Output()],
         )
@@ -100,6 +118,7 @@ class PrimitivesExtension(ComfyExtension):
         return [
             String,
             StringMultiline,
+            RandInt,
             Int,
             Float,
             Boolean,


### PR DESCRIPTION
Separate integer primitive that does not contain randomizing function which will act as primary integer primitive and for integers with randomizing, a new primitive named RandInt instead. 

This will greatly reduce canvas clutter when using primitive integer for purposes like steps, resolution and other use cases that does not need randomization nor are related to seed.

Having the randomizing element always present also runs the risk of the user accidentally leaving node at random on a primitive that then passes that value to a node that causes server to hang because of it. Possibly even worse.