### PR TITLE
Add TemporalScoreRescaling node

### DIFF
--- a/comfy_extras/nodes_eps.py
+++ b/comfy_extras/nodes_eps.py
@@ -90,7 +90,7 @@ class TemporalScoreRescaling(io.ComfyNode):
                     "tsr_k",
                     tooltip=(
                         "Controls the rescaling strength.\n"
-                        "Lower k produces more detailed results; higher k produces smoother results. Setting k = 1 disables rescaling."
+                        "Lower k produces more detailed results; higher k produces smoother results in image generation. Setting k = 1 disables rescaling."
                     ),
                     default=0.95,
                     min=0.01,


### PR DESCRIPTION
Resolve #10214.

TSR’s mechanism can be interpreted as a form of non-uniform Epsilon Scaling (for diffusion), so this PR places it in `nodes_eps.py`. The default parameters are taken from [their t2i demo notebook](https://github.com/temporalscorerescaling/TSR/blob/main/t2img_demo.ipynb).

Since TSR is an SNR-dependent (schedule-dependent) scaling method, it can produce different effect strengths under the same parameter settings with different schedulers.
According to its formulation, TSR gradually converges to the value of k over time.
Therefore, the same scale used in Epsilon Scaling can be used as its constant version for comparison.

#### V-Prediction ztsnr

sampler: er_sde, schedule: simple, cfg: 2.5
<img width="2877" height="1212" alt="tsr_ersde_simple_cfg2_5_resized" src="https://github.com/user-attachments/assets/267d3e6f-a840-465d-8caf-e858d71021ac" />

sampler: er_sde, schedule: beta, cfg: 2.5
<img width="2877" height="1212" alt="tsr_ersde_beta_cfg2_5_resized" src="https://github.com/user-attachments/assets/5c13cc03-7507-44cb-9fbf-fd44133b385f" />

#### SD 3.5 Medium
sampler: euler, schedule: simple, cfg: 5.0
<img width="5558" height="1124" alt="sd3_tsr_euler_simple_cfg5_00001_" src="https://github.com/user-attachments/assets/f093a9ee-e539-46be-9938-f7e215ab268b" />

Using `sigma = 3.0` should have similar effect shown in their SD3 examples.