### PR TITLE
Fix the issue where subgraph does not work under --cache-none mode (#…

### DIFF
--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -420,6 +420,8 @@ class DependencyAwareCache(BasicCache):
         subcache = await super()._ensure_subcache(node_id, children_ids)
         await self.cache_key_set.add_keys(children_ids)
         for child_id in children_ids:
+            if child_id not in self.descendants:
+                self.descendants[child_id] = set()
             self.descendants[node_id].add(child_id)
             if child_id not in self.ancestors:
                 self.ancestors[child_id] = set()


### PR DESCRIPTION
### Summary
This PR fixes an issue where subgraph execution fails when running with the `--cache-none` mode.

### Root Cause
When running with DependencyAwareCache, the ensure_subcache_for function in comfy_execution/caching.py tries to access self.ancestors[child_id] before it exists, leading to a KeyError.

### Solution
Added a safe initialization for the subcache object under --cache-none mode to ensure ancestors and related mappings are properly created before use.

### Related issue
Fixes #10329
