### PR TITLE
feat(api-nodes): add Veo3.1 model

### DIFF
--- a/comfy_api_nodes/nodes_veo2.py
+++ b/comfy_api_nodes/nodes_veo2.py
@@ -27,6 +27,13 @@ from comfy_api_nodes.apinode_utils import (
 )
 
 AVERAGE_DURATION_VIDEO_GEN = 32
+MODELS_MAP = {
+    "veo-2.0-generate-001": "veo-2.0-generate-001",
+    "veo-3.1-generate": "veo-3.1-generate-preview",
+    "veo-3.1-fast-generate": "veo-3.1-fast-generate-preview",
+    "veo-3.0-generate-001": "veo-3.0-generate-001",
+    "veo-3.0-fast-generate-001": "veo-3.0-fast-generate-001",
+}
 
 def convert_image_to_base64(image: torch.Tensor):
     if image is None:
@@ -158,6 +165,7 @@ class VeoVideoGenerationNode(IO.ComfyNode):
         model="veo-2.0-generate-001",
         generate_audio=False,
     ):
+        model = MODELS_MAP[model]
         # Prepare the instances for the request
         instances = []
 
@@ -385,7 +393,7 @@ class Veo3VideoGenerationNode(VeoVideoGenerationNode):
                 ),
                 IO.Combo.Input(
                     "model",
-                    options=["veo-3.0-generate-001", "veo-3.0-fast-generate-001"],
+                    options=list(MODELS_MAP.keys()),
                     default="veo-3.0-generate-001",
                     tooltip="Veo 3 model to use for video generation",
                     optional=True,


### PR DESCRIPTION
I propose to use `veo-3.1-fast-generate` and `veo-3.1-generate` as model names, and we will map them internally to the latest `3.1` models to avoid breaking workflows by changing model names.

[frontend pr](https://github.com/Comfy-Org/ComfyUI_frontend/pull/6074)