### PR TITLE
Bump frontend to 1.28.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.28.6
+comfyui-frontend-package==1.28.7
 comfyui-workflow-templates==0.1.95
 comfyui-embedded-docs==0.3.0
 torch


### PR DESCRIPTION
Bump frontend to 1.28.7

```sh
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.28.7
```

- Diff: [v1.28.6...v1.28.7](<https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.28.6...v1.28.7>)
- PyPI: <https://pypi.org/project/comfyui-frontend-package/1.28.7/>
- npm: <https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.28.7>

## Changes

- Allow reordering of linked subgraph widgets
- fix(execution): reset progress state after runs to unfreeze tab title/favicon
- add pricing for new Veo3.1 model
- add additional check when restoring `widgets_values`