### PR TITLE
Disable torch compiler for cast_bias_weight function

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -25,6 +25,9 @@ import comfy.rmsnorm
 import contextlib
 
 def run_every_op():
+    if torch.compiler.is_compiling():
+        return
+
     comfy.model_management.throw_exception_if_processing_interrupted()
 
 def scaled_dot_product_attention(q, k, v, *args, **kwargs):


### PR DESCRIPTION
This also removes support for pytorch 2.2, 2.3 will probably still work.