### PR TITLE
Pytorch is stupid.

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -58,7 +58,7 @@ except (ModuleNotFoundError, TypeError):
 NVIDIA_MEMORY_CONV_BUG_WORKAROUND = False
 try:
     if comfy.model_management.is_nvidia():
-        if torch.backends.cudnn.version() >= 91200 and comfy.model_management.torch_version_numeric >= (2, 9) and comfy.model_management.torch_version_numeric <= (2, 10):
+        if torch.backends.cudnn.version() >= 91002 and comfy.model_management.torch_version_numeric >= (2, 9) and comfy.model_management.torch_version_numeric <= (2, 10):
             #TODO: change upper bound version once it's fixed'
             NVIDIA_MEMORY_CONV_BUG_WORKAROUND = True
             logging.info("working around nvidia conv3d memory bug.")


### PR DESCRIPTION
This cudnn version is supposed to be affected by a bug that makes the conv3d output be broken on large outputs but it doesn't seem to be actually broken on the consumer GPUs I tried (ada and blackwell). This is why pytorch made it take another path that takes 3x the memory.

Instead of limiting their cudnn conv3d "fix" to the single GPU that was affected they just went and broke everything.

I had originally limited my workaround to 9.12 and up because I thought 9.10 was broken.

