### PR TITLE
[V3] API Nodes: convert Tripo API nodes to V3 schema

### DIFF
--- a/comfy_api_nodes/apis/tripo_api.py
+++ b/comfy_api_nodes/apis/tripo_api.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
-from comfy_api_nodes.apis import (
-    TripoModelVersion,
-    TripoTextureQuality,
-)
 from enum import Enum
 from typing import Optional, List, Dict, Any, Union
 
 from pydantic import BaseModel, Field, RootModel
+
+class TripoModelVersion(str, Enum):
+    v2_5_20250123 = 'v2.5-20250123'
+    v2_0_20240919 = 'v2.0-20240919'
+    v1_4_20240625 = 'v1.4-20240625'
+
+
+class TripoTextureQuality(str, Enum):
+    standard = 'standard'
+    detailed = 'detailed'
+
 
 class TripoStyle(str, Enum):
     PERSON_TO_CARTOON = "person:person2cartoon"

--- a/comfy_api_nodes/nodes_tripo.py
+++ b/comfy_api_nodes/nodes_tripo.py
@@ -1,45 +1,38 @@
 import os
-from folder_paths import get_output_directory
-from comfy_api_nodes.mapper_utils import model_field_to_node_input
-from comfy.comfy_types.node_typing import IO
-from comfy_api_nodes.apis import (
-    TripoOrientation,
-    TripoModelVersion,
-)
+from typing import Optional
+
+import torch
+from typing_extensions import override
+
+from comfy_api.latest import IO, ComfyExtension
 from comfy_api_nodes.apis.tripo_api import (
-    TripoTaskType,
-    TripoStyle,
-    TripoFileReference,
+    TripoAnimateRetargetRequest,
+    TripoAnimateRigRequest,
+    TripoConvertModelRequest,
     TripoFileEmptyReference,
-    TripoUrlReference,
+    TripoFileReference,
+    TripoImageToModelRequest,
+    TripoModelVersion,
+    TripoMultiviewToModelRequest,
+    TripoOrientation,
+    TripoRefineModelRequest,
+    TripoStyle,
     TripoTaskResponse,
     TripoTaskStatus,
+    TripoTaskType,
     TripoTextToModelRequest,
-    TripoImageToModelRequest,
-    TripoMultiviewToModelRequest,
     TripoTextureModelRequest,
-    TripoRefineModelRequest,
-    TripoAnimateRigRequest,
-    TripoAnimateRetargetRequest,
-    TripoConvertModelRequest,
+    TripoUrlReference,
 )
-
-from comfy_api_nodes.apis.client import (
+from comfy_api_nodes.util import (
     ApiEndpoint,
-    HttpMethod,
-    SynchronousOperation,
-    PollingOperation,
-    EmptyRequest,
-)
-from comfy_api_nodes.apinode_utils import (
+    download_url_as_bytesio,
+    poll_op,
+    sync_op,
     upload_images_to_comfyapi,
-    download_url_to_bytesio,
 )
+from folder_paths import get_output_directory
 
-
-async def upload_image_to_tripo(image, **kwargs):
-    urls = await upload_images_to_comfyapi(image, max_images=1, auth_kwargs=kwargs)
-    return TripoFileReference(TripoUrlReference(url=urls[0], type="jpeg"))
 
 def get_model_url_from_response(response: TripoTaskResponse) -> str:
     if response.data is not None:
@@ -50,20 +43,18 @@ def get_model_url_from_response(response: TripoTaskResponse) -> str:
 
 
 async def poll_until_finished(
-    kwargs: dict[str, str],
+    node_cls: type[IO.ComfyNode],
     response: TripoTaskResponse,
-) -> tuple[str, str]:
+    average_duration: Optional[int] = None,
+) -> IO.NodeOutput:
     """Polls the Tripo API endpoint until the task reaches a terminal state, then returns the response."""
     if response.code != 0:
         raise RuntimeError(f"Failed to generate mesh: {response.error}")
     task_id = response.data.task_id
-    response_poll = await PollingOperation(
-        poll_endpoint=ApiEndpoint(
-            path=f"/proxy/tripo/v2/openapi/task/{task_id}",
-            method=HttpMethod.GET,
-            request_model=EmptyRequest,
-            response_model=TripoTaskResponse,
-        ),
+    response_poll = await poll_op(
+        node_cls,
+        poll_endpoint=ApiEndpoint(path=f"/proxy/tripo/v2/openapi/task/{task_id}"),
+        response_model=TripoTaskResponse,
         completed_statuses=[TripoTaskStatus.SUCCESS],
         failed_statuses=[
             TripoTaskStatus.FAILED,
@@ -73,72 +64,84 @@ async def poll_until_finished(
             TripoTaskStatus.EXPIRED,
         ],
         status_extractor=lambda x: x.data.status,
-        auth_kwargs=kwargs,
-        node_id=kwargs["unique_id"],
-        result_url_extractor=get_model_url_from_response,
         progress_extractor=lambda x: x.data.progress,
-    ).execute()
+        estimated_duration=average_duration,
+    )
     if response_poll.data.status == TripoTaskStatus.SUCCESS:
         url = get_model_url_from_response(response_poll)
-        bytesio = await download_url_to_bytesio(url)
+        bytesio = await download_url_as_bytesio(url)
         # Save the downloaded model file
         model_file = f"tripo_model_{task_id}.glb"
         with open(os.path.join(get_output_directory(), model_file), "wb") as f:
             f.write(bytesio.getvalue())
-        return model_file, task_id
+        return IO.NodeOutput(model_file, task_id)
     raise RuntimeError(f"Failed to generate mesh: {response_poll}")
 
 
-class TripoTextToModelNode:
+class TripoTextToModelNode(IO.ComfyNode):
     """
     Generates 3D models synchronously based on a text prompt using Tripo's API.
     """
-    AVERAGE_DURATION = 80
+
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "prompt": ("STRING", {"multiline": True}),
-            },
-            "optional": {
-                "negative_prompt": ("STRING", {"multiline": True}),
-                "model_version": model_field_to_node_input(IO.COMBO, TripoTextToModelRequest, "model_version", enum_type=TripoModelVersion),
-                "style": model_field_to_node_input(IO.COMBO, TripoTextToModelRequest, "style", enum_type=TripoStyle, default="None"),
-                "texture": ("BOOLEAN", {"default": True}),
-                "pbr": ("BOOLEAN", {"default": True}),
-                "image_seed": ("INT", {"default": 42}),
-                "model_seed": ("INT", {"default": 42}),
-                "texture_seed": ("INT", {"default": 42}),
-                "texture_quality": (["standard", "detailed"], {"default": "standard"}),
-                "face_limit": ("INT", {"min": -1, "max": 500000, "default": -1}),
-                "quad": ("BOOLEAN", {"default": False})
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoTextToModelNode",
+            display_name="Tripo: Text to Model",
+            category="api node/3d/Tripo",
+            inputs=[
+                IO.String.Input("prompt", multiline=True),
+                IO.String.Input("negative_prompt", multiline=True, optional=True),
+                IO.Combo.Input(
+                    "model_version", options=TripoModelVersion, default=TripoModelVersion.v2_5_20250123, optional=True
+                ),
+                IO.Combo.Input("style", options=TripoStyle, default="None", optional=True),
+                IO.Boolean.Input("texture", default=True, optional=True),
+                IO.Boolean.Input("pbr", default=True, optional=True),
+                IO.Int.Input("image_seed", default=42, optional=True),
+                IO.Int.Input("model_seed", default=42, optional=True),
+                IO.Int.Input("texture_seed", default=42, optional=True),
+                IO.Combo.Input("texture_quality", default="standard", options=["standard", "detailed"], optional=True),
+                IO.Int.Input("face_limit", default=-1, min=-1, max=500000, optional=True),
+                IO.Boolean.Input("quad", default=False, optional=True),
+            ],
+            outputs=[
+                IO.String.Output(display_name="model_file"),
+                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+        )
 
-    RETURN_TYPES = ("STRING", "MODEL_TASK_ID",)
-    RETURN_NAMES = ("model_file", "model task_id")
-    FUNCTION = "generate_mesh"
-    CATEGORY = "api node/3d/Tripo"
-    API_NODE = True
-    OUTPUT_NODE = True
-
-    async def generate_mesh(self, prompt, negative_prompt=None, model_version=None, style=None, texture=None, pbr=None, image_seed=None, model_seed=None, texture_seed=None, texture_quality=None, face_limit=None, quad=None, **kwargs):
+    @classmethod
+    async def execute(
+        cls,
+        prompt: str,
+        negative_prompt: Optional[str] = None,
+        model_version=None,
+        style: Optional[str] = None,
+        texture: Optional[bool] = None,
+        pbr: Optional[bool] = None,
+        image_seed: Optional[int] = None,
+        model_seed: Optional[int] = None,
+        texture_seed: Optional[int] = None,
+        texture_quality: Optional[str] = None,
+        face_limit: Optional[int] = None,
+        quad: Optional[bool] = None,
+    ) -> IO.NodeOutput:
         style_enum = None if style == "None" else style
         if not prompt:
             raise RuntimeError("Prompt is required")
-        response = await SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path="/proxy/tripo/v2/openapi/task",
-                method=HttpMethod.POST,
-                request_model=TripoTextToModelRequest,
-                response_model=TripoTaskResponse,
-            ),
-            request=TripoTextToModelRequest(
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            response_model=TripoTaskResponse,
+            data=TripoTextToModelRequest(
                 type=TripoTaskType.TEXT_TO_MODEL,
                 prompt=prompt,
                 negative_prompt=negative_prompt if negative_prompt else None,
@@ -152,64 +155,89 @@ class TripoTextToModelNode:
                 texture_quality=texture_quality,
                 face_limit=face_limit,
                 auto_size=True,
-                quad=quad
+                quad=quad,
             ),
-            auth_kwargs=kwargs,
-        ).execute()
-        return await poll_until_finished(kwargs, response)
+        )
+        return await poll_until_finished(cls, response, average_duration=80)
 
 
-class TripoImageToModelNode:
+class TripoImageToModelNode(IO.ComfyNode):
     """
     Generates 3D models synchronously based on a single image using Tripo's API.
     """
-    AVERAGE_DURATION = 80
+
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "image": ("IMAGE",),
-            },
-            "optional": {
-                "model_version": model_field_to_node_input(IO.COMBO, TripoImageToModelRequest, "model_version", enum_type=TripoModelVersion),
-                "style": model_field_to_node_input(IO.COMBO, TripoTextToModelRequest, "style", enum_type=TripoStyle, default="None"),
-                "texture": ("BOOLEAN", {"default": True}),
-                "pbr": ("BOOLEAN", {"default": True}),
-                "model_seed": ("INT", {"default": 42}),
-                "orientation": model_field_to_node_input(IO.COMBO, TripoImageToModelRequest, "orientation", enum_type=TripoOrientation),
-                "texture_seed": ("INT", {"default": 42}),
-                "texture_quality": (["standard", "detailed"], {"default": "standard"}),
-                "texture_alignment": (["original_image", "geometry"], {"default": "original_image"}),
-                "face_limit": ("INT", {"min": -1, "max": 500000, "default": -1}),
-                "quad": ("BOOLEAN", {"default": False})
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoImageToModelNode",
+            display_name="Tripo: Image to Model",
+            category="api node/3d/Tripo",
+            inputs=[
+                IO.Image.Input("image"),
+                IO.Combo.Input(
+                    "model_version",
+                    options=TripoModelVersion,
+                    tooltip="The model version to use for generation",
+                    optional=True,
+                ),
+                IO.Combo.Input("style", options=TripoStyle, default="None", optional=True),
+                IO.Boolean.Input("texture", default=True, optional=True),
+                IO.Boolean.Input("pbr", default=True, optional=True),
+                IO.Int.Input("model_seed", default=42, optional=True),
+                IO.Combo.Input(
+                    "orientation", options=TripoOrientation, default=TripoOrientation.DEFAULT, optional=True
+                ),
+                IO.Int.Input("texture_seed", default=42, optional=True),
+                IO.Combo.Input("texture_quality", default="standard", options=["standard", "detailed"], optional=True),
+                IO.Combo.Input(
+                    "texture_alignment", default="original_image", options=["original_image", "geometry"], optional=True
+                ),
+                IO.Int.Input("face_limit", default=-1, min=-1, max=500000, optional=True),
+                IO.Boolean.Input("quad", default=False, optional=True),
+            ],
+            outputs=[
+                IO.String.Output(display_name="model_file"),
+                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+        )
 
-    RETURN_TYPES = ("STRING", "MODEL_TASK_ID",)
-    RETURN_NAMES = ("model_file", "model task_id")
-    FUNCTION = "generate_mesh"
-    CATEGORY = "api node/3d/Tripo"
-    API_NODE = True
-    OUTPUT_NODE = True
-
-    async def generate_mesh(self, image, model_version=None, style=None, texture=None, pbr=None, model_seed=None, orientation=None, texture_alignment=None, texture_seed=None, texture_quality=None, face_limit=None, quad=None, **kwargs):
+    @classmethod
+    async def execute(
+        cls,
+        image: torch.Tensor,
+        model_version: Optional[str] = None,
+        style: Optional[str] = None,
+        texture: Optional[bool] = None,
+        pbr: Optional[bool] = None,
+        model_seed: Optional[int] = None,
+        orientation=None,
+        texture_seed: Optional[int] = None,
+        texture_quality: Optional[str] = None,
+        texture_alignment: Optional[str] = None,
+        face_limit: Optional[int] = None,
+        quad: Optional[bool] = None,
+    ) -> IO.NodeOutput:
         style_enum = None if style == "None" else style
         if image is None:
             raise RuntimeError("Image is required")
-        tripo_file = await upload_image_to_tripo(image, **kwargs)
-        response = await SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path="/proxy/tripo/v2/openapi/task",
-                method=HttpMethod.POST,
-                request_model=TripoImageToModelRequest,
-                response_model=TripoTaskResponse,
-            ),
-            request=TripoImageToModelRequest(
+        tripo_file = TripoFileReference(
+            root=TripoUrlReference(
+                url=(await upload_images_to_comfyapi(cls, image, max_images=1))[0],
+                type="jpeg",
+            )
+        )
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            response_model=TripoTaskResponse,
+            data=TripoImageToModelRequest(
                 type=TripoTaskType.IMAGE_TO_MODEL,
                 file=tripo_file,
                 model_version=model_version,
@@ -223,80 +251,105 @@ class TripoImageToModelNode:
                 texture_quality=texture_quality,
                 face_limit=face_limit,
                 auto_size=True,
-                quad=quad
+                quad=quad,
             ),
-            auth_kwargs=kwargs,
-        ).execute()
-        return await poll_until_finished(kwargs, response)
+        )
+        return await poll_until_finished(cls, response, average_duration=80)
 
 
-class TripoMultiviewToModelNode:
+class TripoMultiviewToModelNode(IO.ComfyNode):
     """
     Generates 3D models synchronously based on up to four images (front, left, back, right) using Tripo's API.
     """
-    AVERAGE_DURATION = 80
+
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "image": ("IMAGE",),
-            },
-            "optional": {
-                "image_left": ("IMAGE",),
-                "image_back": ("IMAGE",),
-                "image_right": ("IMAGE",),
-                "model_version": model_field_to_node_input(IO.COMBO, TripoMultiviewToModelRequest, "model_version", enum_type=TripoModelVersion),
-                "orientation": model_field_to_node_input(IO.COMBO, TripoImageToModelRequest, "orientation", enum_type=TripoOrientation),
-                "texture": ("BOOLEAN", {"default": True}),
-                "pbr": ("BOOLEAN", {"default": True}),
-                "model_seed": ("INT", {"default": 42}),
-                "texture_seed": ("INT", {"default": 42}),
-                "texture_quality": (["standard", "detailed"], {"default": "standard"}),
-                "texture_alignment": (["original_image", "geometry"], {"default": "original_image"}),
-                "face_limit": ("INT", {"min": -1, "max": 500000, "default": -1}),
-                "quad": ("BOOLEAN", {"default": False})
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoMultiviewToModelNode",
+            display_name="Tripo: Multiview to Model",
+            category="api node/3d/Tripo",
+            inputs=[
+                IO.Image.Input("image"),
+                IO.Image.Input("image_left", optional=True),
+                IO.Image.Input("image_back", optional=True),
+                IO.Image.Input("image_right", optional=True),
+                IO.Combo.Input(
+                    "model_version",
+                    options=TripoModelVersion,
+                    optional=True,
+                    tooltip="The model version to use for generation",
+                ),
+                IO.Combo.Input(
+                    "orientation",
+                    options=TripoOrientation,
+                    default=TripoOrientation.DEFAULT,
+                    optional=True,
+                ),
+                IO.Boolean.Input("texture", default=True, optional=True),
+                IO.Boolean.Input("pbr", default=True, optional=True),
+                IO.Int.Input("model_seed", default=42, optional=True),
+                IO.Int.Input("texture_seed", default=42, optional=True),
+                IO.Combo.Input("texture_quality", default="standard", options=["standard", "detailed"], optional=True),
+                IO.Combo.Input(
+                    "texture_alignment", default="original_image", options=["original_image", "geometry"], optional=True
+                ),
+                IO.Int.Input("face_limit", default=-1, min=-1, max=500000, optional=True),
+                IO.Boolean.Input("quad", default=False, optional=True),
+            ],
+            outputs=[
+                IO.String.Output(display_name="model_file"),
+                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+        )
 
-    RETURN_TYPES = ("STRING", "MODEL_TASK_ID",)
-    RETURN_NAMES = ("model_file", "model task_id")
-    FUNCTION = "generate_mesh"
-    CATEGORY = "api node/3d/Tripo"
-    API_NODE = True
-    OUTPUT_NODE = True
-
-    async def generate_mesh(self, image, image_left=None, image_back=None, image_right=None, model_version=None, orientation=None, texture=None, pbr=None, model_seed=None, texture_seed=None, texture_quality=None, texture_alignment=None, face_limit=None, quad=None, **kwargs):
+    @classmethod
+    async def execute(
+        cls,
+        image: torch.Tensor,
+        image_left: Optional[torch.Tensor] = None,
+        image_back: Optional[torch.Tensor] = None,
+        image_right: Optional[torch.Tensor] = None,
+        model_version: Optional[str] = None,
+        orientation: Optional[str] = None,
+        texture: Optional[bool] = None,
+        pbr: Optional[bool] = None,
+        model_seed: Optional[int] = None,
+        texture_seed: Optional[int] = None,
+        texture_quality: Optional[str] = None,
+        texture_alignment: Optional[str] = None,
+        face_limit: Optional[int] = None,
+        quad: Optional[bool] = None,
+    ) -> IO.NodeOutput:
         if image is None:
             raise RuntimeError("front image for multiview is required")
         images = []
-        image_dict = {
-            "image": image,
-            "image_left": image_left,
-            "image_back": image_back,
-            "image_right": image_right
-        }
+        image_dict = {"image": image, "image_left": image_left, "image_back": image_back, "image_right": image_right}
         if image_left is None and image_back is None and image_right is None:
             raise RuntimeError("At least one of left, back, or right image must be provided for multiview")
         for image_name in ["image", "image_left", "image_back", "image_right"]:
             image_ = image_dict[image_name]
             if image_ is not None:
-                tripo_file = await upload_image_to_tripo(image_, **kwargs)
-                images.append(tripo_file)
+                images.append(
+                    TripoFileReference(
+                        root=TripoUrlReference(
+                            url=(await upload_images_to_comfyapi(cls, image_, max_images=1))[0], type="jpeg"
+                        )
+                    )
+                )
             else:
                 images.append(TripoFileEmptyReference())
-        response = await SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path="/proxy/tripo/v2/openapi/task",
-                method=HttpMethod.POST,
-                request_model=TripoMultiviewToModelRequest,
-                response_model=TripoTaskResponse,
-            ),
-            request=TripoMultiviewToModelRequest(
+        response = await sync_op(
+            cls,
+            ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            response_model=TripoTaskResponse,
+            data=TripoMultiviewToModelRequest(
                 type=TripoTaskType.MULTIVIEW_TO_MODEL,
                 files=images,
                 model_version=model_version,
@@ -310,272 +363,283 @@ class TripoMultiviewToModelNode:
                 face_limit=face_limit,
                 quad=quad,
             ),
-            auth_kwargs=kwargs,
-        ).execute()
-        return await poll_until_finished(kwargs, response)
+        )
+        return await poll_until_finished(cls, response, average_duration=80)
 
 
-class TripoTextureNode:
+class TripoTextureNode(IO.ComfyNode):
+
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "model_task_id": ("MODEL_TASK_ID",),
-            },
-            "optional": {
-                "texture": ("BOOLEAN", {"default": True}),
-                "pbr": ("BOOLEAN", {"default": True}),
-                "texture_seed": ("INT", {"default": 42}),
-                "texture_quality": (["standard", "detailed"], {"default": "standard"}),
-                "texture_alignment": (["original_image", "geometry"], {"default": "original_image"}),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoTextureNode",
+            display_name="Tripo: Texture model",
+            category="api node/3d/Tripo",
+            inputs=[
+                IO.Custom("MODEL_TASK_ID").Input("model_task_id"),
+                IO.Boolean.Input("texture", default=True, optional=True),
+                IO.Boolean.Input("pbr", default=True, optional=True),
+                IO.Int.Input("texture_seed", default=42, optional=True),
+                IO.Combo.Input("texture_quality", default="standard", options=["standard", "detailed"], optional=True),
+                IO.Combo.Input(
+                    "texture_alignment", default="original_image", options=["original_image", "geometry"], optional=True
+                ),
+            ],
+            outputs=[
+                IO.String.Output(display_name="model_file"),
+                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+        )
 
-    RETURN_TYPES = ("STRING", "MODEL_TASK_ID",)
-    RETURN_NAMES = ("model_file", "model task_id")
-    FUNCTION = "generate_mesh"
-    CATEGORY = "api node/3d/Tripo"
-    API_NODE = True
-    OUTPUT_NODE = True
-    AVERAGE_DURATION = 80
-
-    async def generate_mesh(self, model_task_id, texture=None, pbr=None, texture_seed=None, texture_quality=None, texture_alignment=None, **kwargs):
-        response = await SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path="/proxy/tripo/v2/openapi/task",
-                method=HttpMethod.POST,
-                request_model=TripoTextureModelRequest,
-                response_model=TripoTaskResponse,
-            ),
-            request=TripoTextureModelRequest(
+    @classmethod
+    async def execute(
+        cls,
+        model_task_id,
+        texture: Optional[bool] = None,
+        pbr: Optional[bool] = None,
+        texture_seed: Optional[int] = None,
+        texture_quality: Optional[str] = None,
+        texture_alignment: Optional[str] = None,
+    ) -> IO.NodeOutput:
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            response_model=TripoTaskResponse,
+            data=TripoTextureModelRequest(
                 original_model_task_id=model_task_id,
                 texture=texture,
                 pbr=pbr,
                 texture_seed=texture_seed,
                 texture_quality=texture_quality,
-                texture_alignment=texture_alignment
+                texture_alignment=texture_alignment,
             ),
-            auth_kwargs=kwargs,
-        ).execute()
-        return await poll_until_finished(kwargs, response)
+        )
+        return await poll_until_finished(cls, response, average_duration=80)
 
 
-class TripoRefineNode:
+class TripoRefineNode(IO.ComfyNode):
+
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "model_task_id": ("MODEL_TASK_ID", {
-                    "tooltip": "Must be a v1.4 Tripo model"
-                }),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoRefineNode",
+            display_name="Tripo: Refine Draft model",
+            category="api node/3d/Tripo",
+            description="Refine a draft model created by v1.4 Tripo models only.",
+            inputs=[
+                IO.Custom("MODEL_TASK_ID").Input("model_task_id", tooltip="Must be a v1.4 Tripo model"),
+            ],
+            outputs=[
+                IO.String.Output(display_name="model_file"),
+                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+        )
 
-    DESCRIPTION = "Refine a draft model created by v1.4 Tripo models only."
-
-    RETURN_TYPES = ("STRING", "MODEL_TASK_ID",)
-    RETURN_NAMES = ("model_file", "model task_id")
-    FUNCTION = "generate_mesh"
-    CATEGORY = "api node/3d/Tripo"
-    API_NODE = True
-    OUTPUT_NODE = True
-    AVERAGE_DURATION = 240
-
-    async def generate_mesh(self, model_task_id, **kwargs):
-        response = await SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path="/proxy/tripo/v2/openapi/task",
-                method=HttpMethod.POST,
-                request_model=TripoRefineModelRequest,
-                response_model=TripoTaskResponse,
-            ),
-            request=TripoRefineModelRequest(
-                draft_model_task_id=model_task_id
-            ),
-            auth_kwargs=kwargs,
-        ).execute()
-        return await poll_until_finished(kwargs, response)
-
-
-class TripoRigNode:
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "original_model_task_id": ("MODEL_TASK_ID",),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
-
-    RETURN_TYPES = ("STRING", "RIG_TASK_ID")
-    RETURN_NAMES = ("model_file", "rig task_id")
-    FUNCTION = "generate_mesh"
-    CATEGORY = "api node/3d/Tripo"
-    API_NODE = True
-    OUTPUT_NODE = True
-    AVERAGE_DURATION = 180
-
-    async def generate_mesh(self, original_model_task_id, **kwargs):
-        response = await SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path="/proxy/tripo/v2/openapi/task",
-                method=HttpMethod.POST,
-                request_model=TripoAnimateRigRequest,
-                response_model=TripoTaskResponse,
-            ),
-            request=TripoAnimateRigRequest(
-                original_model_task_id=original_model_task_id,
-                out_format="glb",
-                spec="tripo"
-            ),
-            auth_kwargs=kwargs,
-        ).execute()
-        return await poll_until_finished(kwargs, response)
+    async def execute(cls, model_task_id) -> IO.NodeOutput:
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            response_model=TripoTaskResponse,
+            data=TripoRefineModelRequest(draft_model_task_id=model_task_id),
+        )
+        return await poll_until_finished(cls, response, average_duration=240)
 
 
-class TripoRetargetNode:
+class TripoRigNode(IO.ComfyNode):
+
     @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "original_model_task_id": ("RIG_TASK_ID",),
-                "animation": ([
-                    "preset:idle",
-                    "preset:walk",
-                    "preset:climb",
-                    "preset:jump",
-                    "preset:slash",
-                    "preset:shoot",
-                    "preset:hurt",
-                    "preset:fall",
-                    "preset:turn",
-                ],),
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoRigNode",
+            display_name="Tripo: Rig model",
+            category="api node/3d/Tripo",
+            inputs=[IO.Custom("MODEL_TASK_ID").Input("original_model_task_id")],
+            outputs=[
+                IO.String.Output(display_name="model_file"),
+                IO.Custom("RIG_TASK_ID").Output(display_name="rig task_id"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+        )
 
-    RETURN_TYPES = ("STRING", "RETARGET_TASK_ID")
-    RETURN_NAMES = ("model_file", "retarget task_id")
-    FUNCTION = "generate_mesh"
-    CATEGORY = "api node/3d/Tripo"
-    API_NODE = True
-    OUTPUT_NODE = True
-    AVERAGE_DURATION = 30
+    @classmethod
+    async def execute(cls, original_model_task_id) -> IO.NodeOutput:
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            response_model=TripoTaskResponse,
+            data=TripoAnimateRigRequest(original_model_task_id=original_model_task_id, out_format="glb", spec="tripo"),
+        )
+        return await poll_until_finished(cls, response, average_duration=180)
 
-    async def generate_mesh(self, animation, original_model_task_id, **kwargs):
-        response = await SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path="/proxy/tripo/v2/openapi/task",
-                method=HttpMethod.POST,
-                request_model=TripoAnimateRetargetRequest,
-                response_model=TripoTaskResponse,
-            ),
-            request=TripoAnimateRetargetRequest(
+
+class TripoRetargetNode(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoRetargetNode",
+            display_name="Tripo: Retarget rigged model",
+            category="api node/3d/Tripo",
+            inputs=[
+                IO.Custom("RIG_TASK_ID").Input("original_model_task_id"),
+                IO.Combo.Input(
+                    "animation",
+                    options=[
+                        "preset:idle",
+                        "preset:walk",
+                        "preset:climb",
+                        "preset:jump",
+                        "preset:slash",
+                        "preset:shoot",
+                        "preset:hurt",
+                        "preset:fall",
+                        "preset:turn",
+                    ],
+                ),
+            ],
+            outputs=[
+                IO.String.Output(display_name="model_file"),
+                IO.Custom("RETARGET_TASK_ID").Output(display_name="retarget task_id"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+        )
+
+    @classmethod
+    async def execute(cls, original_model_task_id, animation: str) -> IO.NodeOutput:
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            response_model=TripoTaskResponse,
+            data=TripoAnimateRetargetRequest(
                 original_model_task_id=original_model_task_id,
                 animation=animation,
                 out_format="glb",
-                bake_animation=True
+                bake_animation=True,
             ),
-            auth_kwargs=kwargs,
-        ).execute()
-        return await poll_until_finished(kwargs, response)
+        )
+        return await poll_until_finished(cls, response, average_duration=30)
 
 
-class TripoConversionNode:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "original_model_task_id": ("MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID",),
-                "format": (["GLTF", "USDZ", "FBX", "OBJ", "STL", "3MF"],),
-            },
-            "optional": {
-                "quad": ("BOOLEAN", {"default": False}),
-                "face_limit": ("INT", {"min": -1, "max": 500000, "default": -1}),
-                "texture_size": ("INT", {"min": 128, "max": 4096, "default": 4096}),
-                "texture_format": (["BMP", "DPX", "HDR", "JPEG", "OPEN_EXR", "PNG", "TARGA", "TIFF", "WEBP"], {"default": "JPEG"})
-            },
-            "hidden": {
-                "auth_token": "AUTH_TOKEN_COMFY_ORG",
-                "comfy_api_key": "API_KEY_COMFY_ORG",
-                "unique_id": "UNIQUE_ID",
-            },
-        }
+class TripoConversionNode(IO.ComfyNode):
 
     @classmethod
-    def VALIDATE_INPUTS(cls, input_types):
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoConversionNode",
+            display_name="Tripo: Convert model",
+            category="api node/3d/Tripo",
+            inputs=[
+                IO.Custom("MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID").Input("original_model_task_id"),
+                IO.Combo.Input("format", options=["GLTF", "USDZ", "FBX", "OBJ", "STL", "3MF"]),
+                IO.Boolean.Input("quad", default=False, optional=True),
+                IO.Int.Input(
+                    "face_limit",
+                    default=-1,
+                    min=-1,
+                    max=500000,
+                    optional=True,
+                ),
+                IO.Int.Input(
+                    "texture_size",
+                    default=4096,
+                    min=128,
+                    max=4096,
+                    optional=True,
+                ),
+                IO.Combo.Input(
+                    "texture_format",
+                    options=["BMP", "DPX", "HDR", "JPEG", "OPEN_EXR", "PNG", "TARGA", "TIFF", "WEBP"],
+                    default="JPEG",
+                    optional=True,
+                ),
+            ],
+            outputs=[],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+        )
+
+    @classmethod
+    def validate_inputs(cls, input_types):
         # The min and max of input1 and input2 are still validated because
         # we didn't take `input1` or `input2` as arguments
         if input_types["original_model_task_id"] not in ("MODEL_TASK_ID", "RIG_TASK_ID", "RETARGET_TASK_ID"):
             return "original_model_task_id must be MODEL_TASK_ID, RIG_TASK_ID or RETARGET_TASK_ID type"
         return True
 
-    RETURN_TYPES = ()
-    FUNCTION = "generate_mesh"
-    CATEGORY = "api node/3d/Tripo"
-    API_NODE = True
-    OUTPUT_NODE = True
-    AVERAGE_DURATION = 30
-
-    async def generate_mesh(self, original_model_task_id, format, quad, face_limit, texture_size, texture_format, **kwargs):
+    @classmethod
+    async def execute(
+        cls,
+        original_model_task_id,
+        format: str,
+        quad: bool,
+        face_limit: int,
+        texture_size: int,
+        texture_format: str,
+    ) -> IO.NodeOutput:
         if not original_model_task_id:
             raise RuntimeError("original_model_task_id is required")
-        response = await SynchronousOperation(
-            endpoint=ApiEndpoint(
-                path="/proxy/tripo/v2/openapi/task",
-                method=HttpMethod.POST,
-                request_model=TripoConvertModelRequest,
-                response_model=TripoTaskResponse,
-            ),
-            request=TripoConvertModelRequest(
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            response_model=TripoTaskResponse,
+            data=TripoConvertModelRequest(
                 original_model_task_id=original_model_task_id,
                 format=format,
                 quad=quad if quad else None,
                 face_limit=face_limit if face_limit != -1 else None,
                 texture_size=texture_size if texture_size != 4096 else None,
-                texture_format=texture_format if texture_format != "JPEG" else None
+                texture_format=texture_format if texture_format != "JPEG" else None,
             ),
-            auth_kwargs=kwargs,
-        ).execute()
-        return await poll_until_finished(kwargs, response)
+        )
+        return await poll_until_finished(cls, response, average_duration=30)
 
 
-NODE_CLASS_MAPPINGS = {
-    "TripoTextToModelNode": TripoTextToModelNode,
-    "TripoImageToModelNode": TripoImageToModelNode,
-    "TripoMultiviewToModelNode": TripoMultiviewToModelNode,
-    "TripoTextureNode": TripoTextureNode,
-    "TripoRefineNode": TripoRefineNode,
-    "TripoRigNode": TripoRigNode,
-    "TripoRetargetNode": TripoRetargetNode,
-    "TripoConversionNode": TripoConversionNode,
-}
+class TripoExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[IO.ComfyNode]]:
+        return [
+            TripoTextToModelNode,
+            TripoImageToModelNode,
+            TripoMultiviewToModelNode,
+            TripoTextureNode,
+            TripoRefineNode,
+            TripoRigNode,
+            TripoRetargetNode,
+            TripoConversionNode,
+        ]
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    "TripoTextToModelNode": "Tripo: Text to Model",
-    "TripoImageToModelNode": "Tripo: Image to Model",
-    "TripoMultiviewToModelNode": "Tripo: Multiview to Model",
-    "TripoTextureNode": "Tripo: Texture model",
-    "TripoRefineNode": "Tripo: Refine Draft model",
-    "TripoRigNode": "Tripo: Rig model",
-    "TripoRetargetNode": "Tripo: Retarget rigged model",
-    "TripoConversionNode": "Tripo: Convert model",
-}
+
+async def comfy_entrypoint() -> TripoExtension:
+    return TripoExtension()

--- a/comfy_api_nodes/util/__init__.py
+++ b/comfy_api_nodes/util/__init__.py
@@ -20,6 +20,7 @@ from .conversions import (
     trim_video,
 )
 from .download_helpers import (
+    download_url_as_bytesio,
     download_url_to_bytesio,
     download_url_to_image_tensor,
     download_url_to_video_output,
@@ -56,6 +57,7 @@ __all__ = [
     "upload_images_to_comfyapi",
     "upload_video_to_comfyapi",
     # Download helpers
+    "download_url_as_bytesio",
     "download_url_to_bytesio",
     "download_url_to_image_tensor",
     "download_url_to_video_output",

--- a/comfy_api_nodes/util/download_helpers.py
+++ b/comfy_api_nodes/util/download_helpers.py
@@ -240,6 +240,18 @@ async def download_url_to_video_output(
     return VideoFromFile(result)
 
 
+async def download_url_as_bytesio(
+    url: str,
+    *,
+    timeout: float = None,
+    cls: type[COMFY_IO.ComfyNode] = None,
+) -> BytesIO:
+    """Downloads content from a URL and returns a new BytesIO (rewound to 0)."""
+    result = BytesIO()
+    await download_url_to_bytesio(url, result, timeout=timeout, cls=cls)
+    return result
+
+
 def _generate_operation_id(method: str, url: str, attempt: int) -> str:
     try:
         parsed = urlparse(url)


### PR DESCRIPTION
The nodes have been migrated to the V3 scheme and also to the new API client.

All nodes were tested after conversion:

<img width="1353" height="1139" alt="Screenshot From 2025-10-24 20-38-51" src="https://github.com/user-attachments/assets/e55244a3-6a00-4336-b60c-7f13aa577d0a" />

Objects git diff: 
[object_info_difference.zip](https://github.com/user-attachments/files/23130123/object_info_difference.zip)

note: for the `model_version` there is slight difference, as `Combo` in V3 schema does not support `None` as `default`. This change in `git diff` should not affect backward compatibility for node.