### PR TITLE
fix(api-nodes): random issues on Windows by capturing general OSError for retries

### DIFF
--- a/comfy_api_nodes/util/upload_helpers.py
+++ b/comfy_api_nodes/util/upload_helpers.py
@@ -290,7 +290,7 @@ async def upload_file(
                 return
         except asyncio.CancelledError:
             raise ProcessingInterrupted("Task cancelled") from None
-        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        except (aiohttp.ClientError, OSError) as e:
             if attempt <= max_retries:
                 with contextlib.suppress(Exception):
                     request_logger.log_request_response(
@@ -313,7 +313,7 @@ async def upload_file(
                 continue
 
             diag = await _diagnose_connectivity()
-            if diag.get("is_local_issue"):
+            if not diag["internet_accessible"]:
                 raise LocalNetworkError(
                     "Unable to connect to the network. Please check your internet connection and try again."
                 ) from e


### PR DESCRIPTION
Purz reports that both the old and new API clients are unstable with ByteDance nodes when batching around 10 images. The failure is seen during the image download stage and shows:

```
OSError: [WinError 121] The semaphore timeout period has expired
```

I could not reproduce this even on a very slow test connection, which is typical for networking flakiness. However, this is critical because the result may be generated but the workflow will not finish.

This PR makes three changes:

1. Broaden retries to catch `OSError` instead of only `asyncio.TimeoutError` and `socket.gaierror`. This is more correct logically because multiple network related OS errors can occur, and they should all trigger retry.

2. Increase the default `max_retries` in `download_url_to_bytesio` from 3 to 5.

3. Simplify `_diagnose_connectivity`: remove `is_local_issue` and `is_api_issue`. The `internet_accessible` and `api_accessible` flags are sufficient for error messaging. (This is more of a simplification and not a fix)

These changes were tested and situation with them looks better.
