### PR TITLE
execution: Allow subgraph nodes to execute multiple times

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -445,6 +445,7 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                     resolved_outputs.append(tuple(resolved_output))
             output_data = merge_result_data(resolved_outputs, class_def)
             output_ui = []
+            del pending_subgraph_results[unique_id]
             has_subgraph = False
         else:
             get_progress_state().start_progress(unique_id)
@@ -527,10 +528,6 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 if new_graph is None:
                     cached_outputs.append((False, node_outputs))
                 else:
-                    # Check for conflicts
-                    for node_id in new_graph.keys():
-                        if dynprompt.has_node(node_id):
-                            raise DuplicateNodeError(f"Attempt to add duplicate node {node_id}. Ensure node ids are unique and deterministic or use graph_utils.GraphBuilder.")
                     for node_id, node_info in new_graph.items():
                         new_node_ids.append(node_id)
                         display_id = node_info.get("override_display_id", unique_id)


### PR DESCRIPTION
In the case of --cache-none lazy and subgraph execution can cause anything to be run multiple times per workflow. If that rerun nodes is in itself a subgraph generator, this will crash for two reasons.

pending_subgraph_results[] does not cleanup entries after their use. So when a pending_subgraph_result is consumed, remove it from the list so that if the corresponding node is fully re-executed this misses lookup and it fall through to execute the node as it should.

Secondly, theres is an explicit enforcement against dups in the addition of subgraphs nodes as ephemerals to the dymprompt. Remove this enforcement as the use case is now valid.

---

This was discovered by @asagi4 in testing of https://github.com/comfyanonymous/ComfyUI/pull/10454 however the issue is generic to --cache-none and --cache-ram.

Here is the test case before:

```
!!! Exception during processing !!! 'NoneType' object is not subscriptable
Traceback (most recent call last):
  File "/home/rattus/ComfyUI/execution.py", line 439, in execute
    node_output = execution_list.get_output_cache(source_node, unique_id)[source_output]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

<img width="1513" height="878" alt="subgraph-of-subgraph-fail" src="https://github.com/user-attachments/assets/2d0e19e5-9575-4ab8-9c1e-e7d475daa4bd" />


After fix:

<img width="1513" height="878" alt="subgraph-of-subgraph-fixed" src="https://github.com/user-attachments/assets/754d2286-d62b-4346-98b4-645d65d4b545" />
