### PR TITLE
fix img2img operation in Dall2 API node

### DIFF
--- a/comfy_api_nodes/nodes_openai.py
+++ b/comfy_api_nodes/nodes_openai.py
@@ -225,7 +225,7 @@ class OpenAIDalle2(ComfyNodeABC):
             ),
             files=(
                 {
-                    "image": img_binary,
+                    "image": ("image.png", img_binary, "image/png"),
                 }
                 if img_binary
                 else None


### PR DESCRIPTION
Without this fix the error `API Error: Invalid file 'image': unsupported mimetype ('application/octet-stream'). Supported file formats are 'image/png'. (Type: invalid_request_error)` occurs.