### PR TITLE
Fix: Treat bytes data as primitive type in cache signature hashing

### DIFF
--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -53,7 +53,7 @@ class Unhashable:
 def to_hashable(obj):
     # So that we don't infinitely recurse since frozenset and tuples
     # are Sequences.
-    if isinstance(obj, (int, float, str, bool, type(None))):
+    if isinstance(obj, (int, float, str, bool, bytes, type(None))):
         return obj
     elif isinstance(obj, Mapping):
         return frozenset([(to_hashable(k), to_hashable(v)) for k, v in sorted(obj.items())])


### PR DESCRIPTION
`bytes` data is now treated as a **Sequence** in cache signature hashing, which leads to redundant recursion.
Since `bytes` are a primitive and hashable type, it would be better to return the object directly.
