### PR TITLE
Small speed improvements to --async-offload

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -95,20 +95,24 @@ def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None, of
     else:
         wf_context = contextlib.nullcontext()
 
-    bias = None
     non_blocking = comfy.model_management.device_supports_non_blocking(device)
-    if s.bias is not None:
-        has_function = len(s.bias_function) > 0
-        bias = comfy.model_management.cast_to(s.bias, bias_dtype, device, non_blocking=non_blocking, copy=has_function, stream=offload_stream)
 
-        if has_function:
+    weight_has_function = len(s.weight_function) > 0
+    bias_has_function = len(s.bias_function) > 0
+
+    weight = comfy.model_management.cast_to(s.weight, None, device, non_blocking=non_blocking, copy=weight_has_function, stream=offload_stream)
+
+    bias = None
+    if s.bias is not None:
+        bias = comfy.model_management.cast_to(s.bias, bias_dtype, device, non_blocking=non_blocking, copy=bias_has_function, stream=offload_stream)
+
+        if bias_has_function:
             with wf_context:
                 for f in s.bias_function:
                     bias = f(bias)
 
-    has_function = len(s.weight_function) > 0
-    weight = comfy.model_management.cast_to(s.weight, dtype, device, non_blocking=non_blocking, copy=has_function, stream=offload_stream)
-    if has_function:
+    weight = weight.to(dtype=dtype)
+    if weight_has_function:
         with wf_context:
             for f in s.weight_function:
                 weight = f(weight)


### PR DESCRIPTION
These two changes increase speed of bus-bound --async-offload. Tentative speedup is about 7% (although its hard to commit to a number on runpod where transfer speed fluctuates).

This is one of the better speedup measurements (QWEN FP16 512x512 on 5090):

```
Requested to load QwenImage
loaded partially; 22288.75 MB usable, 22278.42 MB loaded, 16689.48 MB offloaded, lowvram patches: 0
100%|███████████████████████████████████████████████| 10/10 [00:15<00:00,  1.59s/it]
Requested to load WanVAE
loaded completely; 267.67 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 25.90 seconds
got prompt
loaded partially; 22250.75 MB usable, 22242.42 MB loaded, 16725.47 MB offloaded, lowvram patches: 0
100%|███████████████████████████████████████████████| 10/10 [00:15<00:00,  1.54s/it]
Requested to load WanVAE
loaded completely; 265.67 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 19.76 seconds
got prompt
loaded partially; 22248.75 MB usable, 22242.42 MB loaded, 16725.47 MB offloaded, lowvram patches: 0
100%|███████████████████████████████████████████████| 10/10 [00:15<00:00,  1.55s/it]
Requested to load WanVAE
loaded completely; 265.67 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 19.71 seconds
```

After

```
Requested to load QwenImage
loaded partially; 22298.75 MB usable, 22293.42 MB loaded, 16674.47 MB offloaded, lowvram patches: 0
100%|███████████████████████████████████████████████| 10/10 [00:14<00:00,  1.40s/it]
Requested to load WanVAE
loaded completely; 267.67 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 119.17 seconds
loaded partially; 22248.75 MB usable, 22242.42 MB loaded, 16725.47 MB offloaded, lowvram patches: 0
100%|███████████████████████████████████████████████| 10/10 [00:13<00:00,  1.32s/it]
Requested to load WanVAE
loaded completely; 265.67 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 17.32 seconds
loaded partially; 22248.75 MB usable, 22242.42 MB loaded, 16725.47 MB offloaded, lowvram patches: 0
100%|███████████████████████████████████████████████| 10/10 [00:13<00:00,  1.32s/it]
Requested to load WanVAE
loaded completely; 265.67 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 17.13 seconds

```
