### PR TITLE
Implement asynchronous module prefetching (QWEN+WAN so far)

### DIFF
--- a/comfy/ldm/qwen_image/model.py
+++ b/comfy/ldm/qwen_image/model.py
@@ -387,6 +387,9 @@ class QwenImageTransformer2DModel(nn.Module):
         hidden_states, img_ids, orig_shape = self.process_img(x)
         num_embeds = hidden_states.shape[1]
 
+        prefetch_queue = comfy.ops.make_prefetch_queue(list(self.transformer_blocks))
+        comfy.ops.prefetch_queue_pop(prefetch_queue, x.device, None)
+
         if ref_latents is not None:
             h = 0
             w = 0
@@ -436,6 +439,7 @@ class QwenImageTransformer2DModel(nn.Module):
         blocks_replace = patches_replace.get("dit", {})
 
         for i, block in enumerate(self.transformer_blocks):
+            comfy.ops.prefetch_queue_pop(prefetch_queue, x.device, block)
             if ("double_block", i) in blocks_replace:
                 def block_wrap(args):
                     out = {}
@@ -466,6 +470,8 @@ class QwenImageTransformer2DModel(nn.Module):
                     add = control_i[i]
                     if add is not None:
                         hidden_states[:, :add.shape[1]] += add
+
+        comfy.ops.prefetch_queue_pop(prefetch_queue, x.device, block)
 
         hidden_states = self.norm_out(hidden_states, temb)
         hidden_states = self.proj_out(hidden_states)


### PR DESCRIPTION
Draft of a generic module prefetcher. Implement the core feature and give one example of how to use it with QWEN.

This is able to get very close to compute saturation whereas --async-offload as-is still has a few compute stalls.

Leaving as a draft for now, as I am still trying to find a better way.

Start comfy use QWEN to try it out. You need the following startup args:

```
--async-offload --fast pinned_memory --reserve-vram 3 
```

It consumes a bit extra VRAM so you need to --reserve-vram to avoid OOMing.