### PR TITLE
Option to Skip Symlink Scanning for Network Paths

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -216,6 +216,8 @@ database_default_path = os.path.abspath(
 )
 parser.add_argument("--database-url", type=str, default=f"sqlite:///{database_default_path}", help="Specify the database URL, e.g. for an in-memory database you can use 'sqlite:///:memory:'.")
 
+parser.add_argument("--skip-symlink-scan", action="store_true", help="Skip following symlinks when scanning directories. Useful when symlinks point to network paths with many files. Specifying a filename directly will still work.")
+
 if comfy.options.args_parsing:
     args = parser.parse_args()
 else:

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -240,6 +240,10 @@ def recursive_search(directory: str, excluded_dir_names: list[str] | None=None) 
     if excluded_dir_names is None:
         excluded_dir_names = []
 
+    # Check if we should skip following symlinks
+    skip_symlinks = getattr(args, 'skip_symlink_scan', False)
+    followlinks = not skip_symlinks
+
     result = []
     dirs = {}
 
@@ -254,7 +258,19 @@ def recursive_search(directory: str, excluded_dir_names: list[str] | None=None) 
     subdirs: list[str]
     filenames: list[str]
 
-    for dirpath, subdirs, filenames in os.walk(directory, followlinks=True, topdown=True):
+    for dirpath, subdirs, filenames in os.walk(directory, followlinks=followlinks, topdown=True):
+        # If skipping symlinks, filter out symlinked directories
+        if skip_symlinks:
+            filtered_subdirs = []
+            for d in subdirs:
+                subdir_path = os.path.join(dirpath, d)
+                # Check if it's a symlink
+                if os.path.islink(subdir_path):
+                    logging.debug(f"Skipping symlink: {subdir_path}")
+                    continue
+                filtered_subdirs.append(d)
+            subdirs[:] = filtered_subdirs
+        
         subdirs[:] = [d for d in subdirs if d not in excluded_dir_names]
         for file_name in filenames:
             try:


### PR DESCRIPTION
# Skip Symlink Scanning for Network Paths

## Problem

When a symlink in the lora folder points to a network path containing many LoRA files, ComfyUI experiences severe performance degradation. Workflows that normally take 5-10 seconds can take 11+ minutes because ComfyUI attempts to recursively scan and list all files in the symlinked network directory before executing workflows, even when using the API with direct file paths.

## Solution

Added a `--skip-symlink-scan` command-line flag that prevents ComfyUI from following symlinks during directory scanning operations. This allows:

- **Fast startup/workflow execution**: Symlinked network directories are skipped during scanning
- **Direct file access still works**: When providing file paths directly via a node or API json (e.g., `symlink/SDXL/my_lora.safetensors`), `get_full_path()` can still resolve and access files through symlinks because it uses direct file existence checks rather than directory scanning

## Changes Made

### 1. Added CLI Argument (`comfy/cli_args.py`)
- Added `--skip-symlink-scan` flag to control symlink following behavior during directory scanning

### 2. Modified `recursive_search()` (`folder_paths.py`)
- Checks for `--skip-symlink-scan` flag
- When enabled, filters out symlinked directories during `os.walk()` traversal
- Prevents scanning into network paths accessed via symlinks

### 3. Modified `recursive_search_models_()` (`app/model_manager.py`)
- Applies the same symlink skipping logic for model file listing operations
- Ensures consistency across all directory scanning operations

## Usage

Run ComfyUI with the flag:
```bash
python main.py --skip-symlink-scan
```

This prevents the performance slowdown while still allowing filen paths to work. Note that dropdown lists in the frontend will not show files from symlinked directories when this flag is enabled, but direct API usage is unaffected.

## Technical Details

- `get_full_path()` uses `os.path.isfile()` which automatically resolves symlinks, so direct file access continues to work
- Directory scanning uses `os.walk()` with `followlinks=False` when the flag is set
- Symlinked directories are detected using `os.path.islink()` and filtered out before traversal

