### PR TITLE
fix: improve path checking logic in main.py to handle module paths more reliably

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ def execute_prestartup_script():
 
         for possible_module in possible_modules:
             module_path = os.path.join(custom_node_path, possible_module)
-            if os.path.isfile(module_path) or module_path.endswith(".disabled") or module_path == "__pycache__":
+            if os.path.isfile(module_path) or possible_module.endswith(".disabled") or possible_module == "__pycache__":
                 continue
 
             script_path = os.path.join(module_path, "prestartup_script.py")


### PR DESCRIPTION
This PR refines the path-checking logic in `main.py`. 

The conditional that checks whether `module_path` is “__pycache__” or `module_path` is a disabled module has been improved to ensure more reliable directory filtering during startup.

Because module_path is a path, and possible_module is just a filename, using module_path does not make some check effective.

So I change module_path to possible_module.
