### PR TITLE
caching: Handle None outputs tuple case

### DIFF
--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -399,6 +399,8 @@ class RAMPressureCache(LRUCache):
             ram_usage = RAM_CACHE_DEFAULT_RAM_USAGE
             def scan_list_for_ram_usage(outputs):
                 nonlocal ram_usage
+                if outputs is None:
+                    return
                 for output in outputs:
                     if isinstance(output, list):
                         scan_list_for_ram_usage(output)


### PR DESCRIPTION
This can cause the RAM cache to crash.

https://github.com/comfyanonymous/ComfyUI/issues/10631