### PR TITLE
Add workaround in validation.py for V3 Combo outputs (only merge after stable)

### DIFF
--- a/comfy_execution/validation.py
+++ b/comfy_execution/validation.py
@@ -23,6 +23,13 @@ def validate_node_input(
     if not received_type != input_type:
         return True
 
+    # If input_type is a Combo, frontend permits a Combo output to be connected,
+    # but it is defined as a tuple of values with V3 schema.
+    # This probably should be dealt with sending one thing to the frontend and another to the backend,
+    # but this will do for now.
+    if input_type == "COMBO" and isinstance(received_type, tuple):
+        return True
+
     # Not equal, and not strings
     if not isinstance(received_type, str) or not isinstance(input_type, str):
         return False


### PR DESCRIPTION
To make V3 Combo work as outputs in the frontend, we provide the list of options as the output io_type. This does not jive well with the current logic of validation and makes me question how it worked for V1, so I added code to treat a tuple of values as COMBO.