### PR TITLE
mm: guard against double pin and unpin explicitly

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1103,6 +1103,12 @@ def pin_memory(tensor):
     if not is_device_cpu(tensor.device):
         return False
 
+    if tensor.is_pinned():
+        #NOTE: Cuda does detect when a tensor is already pinned and would
+        #error below, but there are proven cases where this also queues an error
+        #on the GPU async. So dont trust the CUDA API and guard here
+        return False
+
     size = tensor.numel() * tensor.element_size()
     if (TOTAL_PINNED_MEMORY + size) > MAX_PINNED_MEMORY:
         return False
@@ -1121,6 +1127,12 @@ def unpin_memory(tensor):
         return False
 
     if not is_device_cpu(tensor.device):
+        return False
+
+    if not tensor.is_pinned():
+        #NOTE: Cuda does detect when a tensor is already pinned and would
+        #error below, but there are proven cases where this also queues an error
+        #on the GPU async. So dont trust the CUDA API and guard here
         return False
 
     ptr = tensor.data_ptr()


### PR DESCRIPTION
If you let cuda be the one to detect double pin/unpinning it actually creates an async GPU error.

I was never able to reproduce any of the issues in:

https://github.com/comfyanonymous/ComfyUI/issues/10662

but this is an attempted fix in the dark.

I did mock up a test program that at least gives one of the users error messages about double pinning and confirmed I can stop the async error by pre-guarding the Cuda API.

Given the test result its probably safest to add this guard. If we are lucky it fixes all the async reports in #10662.

Here is the test program:

```
import torch
import ctypes
import os
import sys

device = torch.device('cuda')
print(f"Using GPU: {torch.cuda.get_device_name()[0]}")

NUM_ELEMENTS = 500
DTYPE = torch.float32

host_tensor = torch.empty(NUM_ELEMENTS, dtype=DTYPE, device='cpu')

half_size_elements = NUM_ELEMENTS // 2
half_size_bytes = half_size_elements * DTYPE.itemsize

half1 = host_tensor[:half_size_elements]
half2 = host_tensor[half_size_elements:]

ptr1 = half1.data_ptr()
ptr2 = half2.data_ptr()

print(f"pointers {hex(ptr1)} {hex(ptr2)}") 

print(f"{torch.cuda.cudart().cudaHostRegister(ptr1, half_size_bytes, 1) == 0}")
#comment out this duplicate to move on
print(f"{torch.cuda.cudart().cudaHostRegister(ptr1, half_size_bytes, 1) == 0}")
print(f"{torch.cuda.cudart().cudaHostRegister(ptr2, half_size_bytes, 1) == 0}")

print(half1.to(device=device) * half2.to(device=device))

print(f"{torch.cuda.cudart().cudaHostUnregister(ptr1)}")
print(f"{torch.cuda.cudart().cudaHostUnregister(ptr1)}")
print(f"{torch.cuda.cudart().cudaHostUnregister(ptr2)}")

print(half1.to(device=device) * half2.to(device=device))
```

output:

```
Using GPU: N
pointers 0x2f994940 0x2f994d28
True
False
True
Traceback (most recent call last):
  File "/media/rattus/qwe/foo.py", line 29, in <module>
    print(half1.to(device=device) * half2.to(device=device))
          ^^^^^^^^^^^^^^^^^^^^^^^
torch.AcceleratorError: CUDA error: part or all of the requested memory range is already mapped
Search for `cudaErrorHostMemoryAlreadyRegistered' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```