### PR TITLE
Add env TORCH_AMD_CUDNN_ENABLED (third try)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -343,7 +343,7 @@ try:
                 "0", "off", "false", "disable", "disabled", "no"}
             if not torch.backends.cudnn.enabled:
                 logging.info(
-                    "ComfyUI has set torch.backends.cudnn.enabled to False for better AMD performance. Set environment var TORCH_AMD_CUDDNN_ENABLED=1 to enable it again.")
+                    "ComfyUI has set torch.backends.cudnn.enabled to False for better AMD performance. Set environment var TORCH_AMD_CUDNN_ENABLED=1 to enable it again.")
 
         try:
             rocm_version = tuple(map(int, str(torch.version.hip).split(".")[:2]))


### PR DESCRIPTION
To offset the substantial effects of https://github.com/comfyanonymous/ComfyUI/pull/10302, this PR provides (and informs the user of) an environment variable that can be set to nullify the unilateral decision made in https://github.com/comfyanonymous/ComfyUI/pull/10302 to disable cudNN for all AMD users.

> nothing else in comfy uses env vars to enable/disable stuff 

@comfyanonymous

You keep insisting that because cudnn=False runs faster for you, it must therefore be forced on everyone. That is not engineering. That is theology.

Let us review what you have done. Your pull request simply hard-codes torch.backends.cudnn.enabled = False for all RDNA3 and RDNA4 users. You wrote that you "have no idea why it helps but it does" on your system. That may be true for your test box, your driver, your kernel. But issue #10447 shows another user whose performance collapsed the moment cudnn was disabled. Issue #10460 shows the same pattern. For them, your patch breaks what once worked. That alone should end this argument: if a change helps some and harms others, the correct path is configurability, not decree.

Then you said "nothing else in Comfy uses env vars to enable or disable stuff." False. Comfy already reads them: COMFYUI_DIR, proxies, path expansions, HTTP settings. Users have asked for .env support and config overrides repeatedly. Pretending this tool never touches environment variables is historical revision, not justification. The absence of a precedent is not a reason to block a useful one.

ComfyUI runs on wildly different hardware and software combinations: Linux, Windows, ROCm 6.x, Torch 2.x, FlashAttention, tuned kernels, patched builds. The very nature of this ecosystem demands flexibility. A developer who locks a single behavior across such diversity is courting regression. Hardware changes. Drivers update. A fix today becomes a bottleneck tomorrow. Your forced flag will age like milk.

The purpose of an env var is precisely this: to give users an escape hatch when automatic detection fails or when blanket assumptions crumble. A flag such as COMFYUI_CUDNN_ENABLED=1 or 0 would let everyone test, measure, and choose without touching the source. It adds no maintenance cost. It adds resilience. It adds honesty.

If you truly believe in your optimization, you can keep it as the default, as this PR allows.  It simply adds a message and the required fuctionality to support it: 

"cudnn disabled for AMD; set COMFYUI_CUDNN_ENABLED=1 to re-enable." 

That informs without coercing. That is how grown-up software behaves.

Right now, your stance is that your environment defines truth. It does not. It defines your truth. And until you allow others to define theirs, what you are enforcing is not a performance improvement, but a constraint masquerading as genius.