### PR TITLE
ops: Put weight cast on the offload stream - Fixes --async-offload black screen

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -110,9 +110,9 @@ def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None, of
                 for f in s.bias_function:
                     bias = f(bias)
 
-    weight = weight.to(dtype=dtype)
-    if weight_has_function:
+    if weight_has_function or weight.dtype != dtype:
         with wf_context:
+            weight = weight.to(dtype=dtype)
             for f in s.weight_function:
                 weight = f(weight)
 


### PR DESCRIPTION
This needs to be on the offload stream. This reproduced a black screen with low resolution images on a slow bus when using FP8.

Example Test conditions:
python main.py --async-offload --novram
QWEN FP8 512x512, RTX5090 with PCIE downgraded by BIOS to generation 2.

Before: black screen
After: image as expected

This probably broke in https://github.com/comfyanonymous/ComfyUI/pull/10593/files, and slipped through my regression tests that didn't go extreme enough with the slow-bus test case.