### PR TITLE
always unload re-used but modified models - Fixed bad outputs in some Upscaler / Lora flows

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -503,10 +503,7 @@ class LoadedModel:
         use_more_vram = lowvram_model_memory
         if use_more_vram == 0:
             use_more_vram = 1e32
-        if use_more_vram > 0:
-            self.model_use_more_vram(use_more_vram, force_patch_weights=force_patch_weights)
-        else:
-            self.model.partially_unload(self.model.offload_device, -use_more_vram, force_patch_weights=force_patch_weights)
+        self.model_use_more_vram(use_more_vram, force_patch_weights=force_patch_weights)
 
         real_model = self.model.model
 

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -928,6 +928,9 @@ class ModelPatcher:
                 extra_memory += (used - self.model.model_loaded_weight_memory)
 
             self.patch_model(load_weights=False)
+            if extra_memory < 0 and not unpatch_weights:
+                self.partially_unload(self.offload_device, -extra_memory, force_patch_weights=force_patch_weights)
+                return 0
             full_load = False
             if self.model.model_lowvram == False and self.model.model_loaded_weight_memory > 0:
                 self.apply_hooks(self.forced_hooks, force_apply=True)


### PR DESCRIPTION
The partial unloader path in model re-use flow skips straight to the actual unload without any check of the patching UUID. This means that if you do an upscale flow with a model patch on an existing model, it will not apply your patchings.

Fix by delaying the partial_unload until after the uuid checks. This is done by making partial_unload a mode of partial_load where extra_mem is -ve.

Example test case:
RTX5090, 96GB RAM
python main.py
This workflow - QWEN FP16 small batch, and then same model with Lora + big batch (quality output is reliant on the Lora being applied):

[reproducer.json](https://github.com/user-attachments/files/23499217/reproducer.json)

<img width="2375" height="791" alt="workflow" src="https://github.com/user-attachments/assets/a3db8148-7ebe-473c-937e-2d75b4715345" />

Prompt:

"
a full chessboard on a dark timber table with a pair of circular semi-focal glasses, pocket watch, chess timer. The chess pieces are gold for one side, and silver for the other. A candle is burning in an ornate candlestick. All depths of the image are fully in focus.
"

without this fix:

<img width="1328" height="1328" alt="bad" src="https://github.com/user-attachments/assets/cba85120-8d83-4603-a75c-324171eb6c89" />

with this fix:

<img width="1328" height="1328" alt="good" src="https://github.com/user-attachments/assets/33c3c83f-a293-40ec-85df-701013e0f14c" />
