### PR TITLE
feat: add create_time dict to prompt field in /history and /queue

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@ import os
 import sys
 import asyncio
 import traceback
+import time
 
 import nodes
 import folder_paths
@@ -733,6 +734,7 @@ class PromptServer():
                     for sensitive_val in execution.SENSITIVE_EXTRA_DATA_KEYS:
                         if sensitive_val in extra_data:
                             sensitive[sensitive_val] = extra_data.pop(sensitive_val)
+                    extra_data["create_time"] = int(time.time() * 1000)  # timestamp in milliseconds
                     self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute, sensitive))
                     response = {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}
                     return web.json_response(response)


### PR DESCRIPTION
## Context

In order to support queue status, we added `create_time` to the API response in comfy cloud. Adding it to core as well so that it is supported in base ComfyUI

### This PR

Adds `{"create_time": <timestamp_ms>}` as a field in the prompt list.

_Why a dict and not just another field?_

We can add other metadata to this dict later instead of expanding this list to infinity

### Test plan

`queue_running`:
<img width="426" height="201" alt="image" src="https://github.com/user-attachments/assets/d9437889-02ae-411b-bb44-ed1f42495d6b" />

`queue_pending`: 
<img width="712" height="178" alt="image" src="https://github.com/user-attachments/assets/6aa28b35-3568-4477-b214-b725731b97c6" />

`history`:
<img width="723" height="110" alt="image" src="https://github.com/user-attachments/assets/5a6021b1-b974-46d1-ba41-14e3c54695a4" />
