### PR TITLE
Fix custom nodes import error.

### DIFF
--- a/comfy/ldm/chroma/layers.py
+++ b/comfy/ldm/chroma/layers.py
@@ -7,6 +7,9 @@ from comfy.ldm.flux.layers import (
     ModulationOut,
 )
 
+# TODO: remove this in a few months
+SingleStreamBlock = None
+DoubleStreamBlock = None
 
 
 class ChromaModulationOut(ModulationOut):


### PR DESCRIPTION
This should fix the import errors but will break if the custom nodes actually try to use the class.