### PR TITLE
[API Nodes] mark OpenAIDalle2 and OpenAIDalle3 nodes as deprecated

### DIFF
--- a/comfy_api_nodes/nodes_openai.py
+++ b/comfy_api_nodes/nodes_openai.py
@@ -169,6 +169,7 @@ class OpenAIDalle2(IO.ComfyNode):
                 IO.Hidden.unique_id,
             ],
             is_api_node=True,
+            is_deprecated=True,
         )
 
     @classmethod
@@ -299,6 +300,7 @@ class OpenAIDalle3(IO.ComfyNode):
                 IO.Hidden.unique_id,
             ],
             is_api_node=True,
+            is_deprecated=True,
         )
 
     @classmethod


### PR DESCRIPTION
This PR marks `OpenAIDalle2` and `OpenAIDalle3` nodes as deprecated.
OpenAI will remove those models on May 12, 2026.


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [x] Informed **@Kosinkadink**

