### PR TITLE
bugFix: make sure CLIP is running on gpu when `gpu-only` is set.

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -125,8 +125,6 @@ class CLIP:
         self.patcher.hook_mode = comfy.hooks.EnumHookMode.MinVram
         self.patcher.is_clip = True
         self.apply_hooks_to_conds = None
-        if params['device'] == load_device:
-            model_management.load_models_gpu([self.patcher], force_full_load=True)
         self.layer_idx = None
         self.use_clip_schedule = False
         logging.info("CLIP/text encoder model load device: {}, offload device: {}, current: {}, dtype: {}".format(load_device, offload_device, params['device'], dtype))


### PR DESCRIPTION
### What:
There's currently a bug that causes text encoding (The node name is `CLIP Text Encode (Prompt)`) to be executed on the cpu when `gpu-only` flag is set. Ironically when `gpu-only` is not set, the node is executing on the gpu. The bug is affecting workflows that use `Load Checkpoint` node together with sd1.5 and sdxl models. 

### Why it solves the issue:
[Here](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/sd.py#L1252-L1253) we initialize the CLIP, and in the init  we already load the model when gpu-only is set. Immediately after the init, we call `clip.load_sd()`, and this puts the weights back to cpu.

The actual code that encodes the prompt [is this](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/sd1_clip.py#L252), which uses the device of the weight, which will be cpu.

If we don't call to `model_management.load_models_gpu`, it will be called anyway later, and then will move the weight to gpu for us.

### How to reproduce the bug:
1. Run ComfyUI with `--gpu-only`, and execute a simple workflow with the node `Load Checkpoint`, and select any sdxl or sd1.5 model.
2. Inspect the value of the `device` [here](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/sd1_clip.py#L252), which will be cpu instead of cuda.