### PR TITLE
Fix: downgrade torch to 2.8.0 for GPUs based on the Pascal architecture.

### DIFF
--- a/.github/workflows/windows_release_dependencies_manual.yml
+++ b/.github/workflows/windows_release_dependencies_manual.yml
@@ -7,7 +7,7 @@ on:
         description: 'torch dependencies'
         required: false
         type: string
-        default: "torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu128"
+        default: "torch==2.8.0 torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu128"
       cache_tag:
         description: 'Cached dependencies tag'
         required: true


### PR DESCRIPTION
This PR aims to address an issue caused by PyTorch version 2.9+cu128.  
This version appears to be poorly supported on Pascal architecture, causing problems for GTX 1000 series GPUs (see Pull #9929).
