### PR TITLE
[API nodes]: adjusted PR template; set min python version for pylint to 3.10

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/api-node.md
+++ b/.github/PULL_REQUEST_TEMPLATE/api-node.md
@@ -18,4 +18,4 @@ If **Need pricing update**:
 - [ ] **QA not required**
 
 ### Comms
-- [ ] Informed **@Kosinkadink**
+- [ ] Informed **Kosinkadink**

--- a/.github/workflows/api-node-template.yml
+++ b/.github/workflows/api-node-template.yml
@@ -2,7 +2,7 @@ name: Append API Node PR template
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'comfy_api_nodes/**'   # only run if these files changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ lint.select = [
 exclude = ["*.ipynb", "**/generated/*.pyi"]
 
 [tool.pylint]
-master.py-version = "3.9"
+master.py-version = "3.10"
 master.extension-pkg-allow-list = [
   "pydantic",
 ]


### PR DESCRIPTION
1. Stop spam of `Kosinkadink` account
2. Do not trigger  PR template action for `edited` event (PR metadata edit).
3. Set minimum python version to 3.10 **for pylint** which is enabled only for API nodes.