### PR TITLE
change display name of PreviewAny node to "Preview as Text"

### DIFF
--- a/comfy_extras/nodes_preview_any.py
+++ b/comfy_extras/nodes_preview_any.py
@@ -39,5 +39,5 @@ NODE_CLASS_MAPPINGS = {
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "PreviewAny": "Preview Any",
+    "PreviewAny": "Preview as Text",
 }


### PR DESCRIPTION
Change `Preview Any` to be `Preview as Text`

The effect of this will not be immediately apparent, as Frontend [use the display name](https://github.com/Comfy-Org/ComfyUI_frontend/blob/e42715086ef2175eb02ee3f9a9f60efd353a5211/src/locales/en/nodeDefs.json#L8843-L8851) from translations strings.
