### PR TITLE
fix(KlingLipSyncAudioToVideoNode): convert audio to mp3 format

### DIFF
--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -518,7 +518,9 @@ async def execute_lipsync(
 
     # Upload the audio file to Comfy API and get download URL
     if audio:
-        audio_url = await upload_audio_to_comfyapi(cls, audio)
+        audio_url = await upload_audio_to_comfyapi(
+            cls, audio, container_format="mp3", codec_name="libmp3lame", mime_type="audio/mpeg", filename="output.mp3"
+        )
         logging.info("Uploaded audio to Comfy API. URL: %s", audio_url)
     else:
         audio_url = None


### PR DESCRIPTION
Kling does not support `mp4` audio format

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [x] **QA done**
- [ ] **QA not required**

### Comms
- [x] Informed **Kosinkadink**

