### PR TITLE
Make Batch Images node add alpha channel when one of the inputs has it

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1854,9 +1854,9 @@ class ImageBatch:
     def batch(self, image1, image2):
         if image1.shape[-1] != image2.shape[-1]:
             if image1.shape[-1] > image2.shape[-1]:
-                image2 = torch.cat((image2, torch.ones((image2.shape[0], image2.shape[1], image2.shape[2], 1))), dim=-1)
+                image2 = torch.nn.functional.pad(image2, (0,1), mode='constant', value=1.0)
             else:
-                image1 = torch.cat((image1, torch.ones((image1.shape[0], image1.shape[1], image1.shape[2], 1))), dim=-1)
+                image1 = torch.nn.functional.pad(image1, (0,1), mode='constant', value=1.0)
         if image1.shape[1:] != image2.shape[1:]:
             image2 = comfy.utils.common_upscale(image2.movedim(-1,1), image1.shape[2], image1.shape[1], "bilinear", "center").movedim(1,-1)
         s = torch.cat((image1, image2), dim=0)


### PR DESCRIPTION
The alpha channel gets 1.0 values to mean fully opaque, which is what we want.

Discovered that 'Join Image with Alpha' node flips the mask values when adding alpha, so that things that aren't 'masked' by white become fully opaque. Confused me a bit during testing.