### PR TITLE
[BlockInfo] Qwen-Image

### DIFF
--- a/comfy/ldm/qwen_image/model.py
+++ b/comfy/ldm/qwen_image/model.py
@@ -439,7 +439,10 @@ class QwenImageTransformer2DModel(nn.Module):
         patches = transformer_options.get("patches", {})
         blocks_replace = patches_replace.get("dit", {})
 
+        transformer_options["total_blocks"] = len(self.transformer_blocks)
+        transformer_options["block_type"] = "double"
         for i, block in enumerate(self.transformer_blocks):
+            transformer_options["block_index"] = i
             if ("double_block", i) in blocks_replace:
                 def block_wrap(args):
                     out = {}


### PR DESCRIPTION
1. Added 3 block informations to the `transformer_options` for **Qwen-Image**:
    - **block_index** - the index of the current block
    - **total_blocks** - the total amount of blocks of that type
    - **block_type** - single / double