### PR TITLE
add get_frame_count and get_frame_rate methods to `VideoInput` class

### DIFF
--- a/comfy_api/latest/_input/video_types.py
+++ b/comfy_api/latest/_input/video_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from fractions import Fraction
 from typing import Optional, Union, IO
 import io
 import av
@@ -71,6 +72,33 @@ class VideoInput(ABC):
         components = self.get_components()
         frame_count = components.images.shape[0]
         return float(frame_count / components.frame_rate)
+
+    def get_frame_count(self) -> int:
+        """
+        Returns the number of frames in the video.
+
+        Default implementation uses :meth:`get_components`, which may require
+        loading all frames into memory. File-based implementations should
+        override this method and use container/stream metadata instead.
+
+        Returns:
+            Total number of frames as an integer.
+        """
+        return int(self.get_components().images.shape[0])
+
+    def get_frame_rate(self) -> Fraction:
+        """
+        Returns the frame rate of the video.
+
+        Default implementation materializes the video into memory via
+        `get_components()`. Subclasses that can inspect the underlying
+        container (e.g. `VideoFromFile`) should override this with a more
+        efficient implementation.
+
+        Returns:
+            Frame rate as a Fraction.
+        """
+        return self.get_components().frame_rate
 
     def get_container_format(self) -> str:
         """


### PR DESCRIPTION
1. Add lightweight `get_frame_count` and `get_frame_rate` helpers to `VideoInput` and implement metadata‑based versions for `VideoFromFile`. 
2. Update the Topaz Upscaler API node to use these helpers instead of `get_components()`, so we no longer materialize all video frames into memory just to compute frame count / fps. 

This removes the huge RAM overhead (e.g. >45 GB usage for a 44‑second video on my machine,) when sending longer clips to Topaz for upscaling.

<img width="770" height="227" alt="Screenshot From 2025-11-23 15-27-14" src="https://github.com/user-attachments/assets/47cce673-6c8c-409f-81b7-f1d888b5b0c5" />

