### PR TITLE
fix(api-nodes): edge cases in responses for Gemini models

### DIFF
--- a/comfy_api_nodes/apis/gemini_api.py
+++ b/comfy_api_nodes/apis/gemini_api.py
@@ -113,9 +113,9 @@ class GeminiGenerationConfig(BaseModel):
     maxOutputTokens: int | None = Field(None, ge=16, le=8192)
     seed: int | None = Field(None)
     stopSequences: list[str] | None = Field(None)
-    temperature: float | None = Field(1, ge=0.0, le=2.0)
-    topK: int | None = Field(40, ge=1)
-    topP: float | None = Field(0.95, ge=0.0, le=1.0)
+    temperature: float | None = Field(None, ge=0.0, le=2.0)
+    topK: int | None = Field(None, ge=1)
+    topP: float | None = Field(None, ge=0.0, le=1.0)
 
 
 class GeminiImageConfig(BaseModel):


### PR DESCRIPTION
1. **Gemini-3-Pro-Image:** When the user enters a help-style prompt (e.g., `help`, `help me`) with response modality set to `IMAGE`, the API may return `promptFeedback=None`. This fix detects that case and surfaces the appropriate error message instead of failing silently.

2. **Gemini-2.5-flash-image:** With `modality=IMAGE` and a help-style prompt, the response can contain `usageMetadata.candidatesTokensDetails=None`. Add a null guard so we don’t attempt to enumerate a `NoneType` and spam the logs.

3. **Docs:** Update the `aspect_ratio` description for **Gemini-3-Pro** to be more accurate.

4. **Sampling defaults:** Stop hard-coding model parameters (e.g., `temperature`, `topK`) in the Pydantic model. Recent Google docs recommend leaving `temperature` unset and note that defaults vary by model. We were also sending `topK=40` while the `Gemini-3-Pro-Image` model default is `64`; rely on backend defaults instead. Reference: [https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image)



<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

