### PR TITLE
[API Nodes] fix(gemini): use first 10 images as fileData (URLs) and remaining images as inline base64

### DIFF
--- a/comfy_api_nodes/apis/gemini_api.py
+++ b/comfy_api_nodes/apis/gemini_api.py
@@ -58,8 +58,14 @@ class GeminiInlineData(BaseModel):
     mimeType: GeminiMimeType | None = Field(None)
 
 
+class GeminiFileData(BaseModel):
+    fileUri: str | None = Field(None)
+    mimeType: GeminiMimeType | None = Field(None)
+
+
 class GeminiPart(BaseModel):
     inlineData: GeminiInlineData | None = Field(None)
+    fileData: GeminiFileData | None = Field(None)
     text: str | None = Field(None)
 
 


### PR DESCRIPTION
This PR reduces the size of Gemini image requests to Vertex and helps avoid `413 Content Too Large` errors. 

Previously, all input images were always sent as **inline base64 data**, which made large image batches easy to overflow the request size limit.
Now we upload the first ten images (matching Vertex’s current limit of 10 image links) to `GCS`, like we already do in other nodes, and pass them as `fileData.fileUri` links. 

Any remaining images are still sent inline.


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [x] Informed **Kosinkadink**

