### PR TITLE
quant ops: Dequantize weight in-place (reduce flux2 VRAM usage)

### DIFF
--- a/comfy/quant_ops.py
+++ b/comfy/quant_ops.py
@@ -425,7 +425,8 @@ class TensorCoreFP8Layout(QuantizedLayout):
     @staticmethod
     def dequantize(qdata, scale, orig_dtype, **kwargs):
         plain_tensor = torch.ops.aten._to_copy.default(qdata, dtype=orig_dtype)
-        return plain_tensor * scale
+        plain_tensor.mul_(scale)
+        return plain_tensor
 
     @classmethod
     def get_plain_tensors(cls, qtensor):


### PR DESCRIPTION
In flux2 these weights are huge (200MB). As plain_tensor is a throw-away deep copy, do this multiplication in-place to save VRAM.

This will at least improve (if not fully fix): https://github.com/comfyanonymous/ComfyUI/issues/10891

Example test conditions:
RTX5090
--reserve-vram 8.9 (to emulate 3090 VRAM ceiling)

Before (peak is 23.3GB):

<img width="2422" height="1163" alt="Screenshot from 2025-11-27 21-18-10" src="https://github.com/user-attachments/assets/33d7fe23-4f6b-4d7a-8c1a-494ba1edf149" />

After (peak is 23.0GB):

<img width="2422" height="1163" alt="Screenshot from 2025-11-27 21-20-05" src="https://github.com/user-attachments/assets/425d1d1f-59d6-4ae5-9734-83c2c3df229d" />
