### PR TITLE
mm: wrap the raw stream in context manager

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1052,7 +1052,9 @@ def get_offload_stream(device):
     elif is_device_cuda(device):
         ss = []
         for k in range(NUM_STREAMS):
-            ss.append(torch.cuda.Stream(device=device, priority=0))
+            s1 = torch.cuda.Stream(device=device, priority=0)
+            s1.as_context = torch.cuda.stream
+            ss.append(s1)
         STREAMS[device] = ss
         s = ss[stream_counter]
         stream_counters[device] = stream_counter
@@ -1060,7 +1062,9 @@ def get_offload_stream(device):
     elif is_device_xpu(device):
         ss = []
         for k in range(NUM_STREAMS):
-            ss.append(torch.xpu.Stream(device=device, priority=0))
+            s1 = torch.xpu.Stream(device=device, priority=0)
+            s1.as_context = torch.xpu.stream
+            ss.append(s1)
         STREAMS[device] = ss
         s = ss[stream_counter]
         stream_counters[device] = stream_counter
@@ -1078,12 +1082,19 @@ def cast_to(weight, dtype=None, device=None, non_blocking=False, copy=False, str
             if dtype is None or weight.dtype == dtype:
                 return weight
         if stream is not None:
-            with stream:
+            wf_context = stream
+            if hasattr(wf_context, "as_context"):
+                wf_context = wf_context.as_context(stream)
+            with wf_context:
                 return weight.to(dtype=dtype, copy=copy)
         return weight.to(dtype=dtype, copy=copy)
 
+
     if stream is not None:
-        with stream:
+        wf_context = stream
+        if hasattr(wf_context, "as_context"):
+            wf_context = wf_context.as_context(stream)
+        with wf_context:
             r = torch.empty_like(weight, dtype=dtype, device=device)
             r.copy_(weight, non_blocking=non_blocking)
     else:

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -95,6 +95,8 @@ def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None, of
 
     if offload_stream is not None:
         wf_context = offload_stream
+        if hasattr(wf_context, "as_context"):
+            wf_context = wf_context.as_context(offload_stream)
     else:
         wf_context = contextlib.nullcontext()
 


### PR DESCRIPTION
The documentation of torch.foo.Stream being usable with "with:" suggests it starts at version 2.7. Use the old API for backwards compatibility.

User reported here: https://github.com/comfyanonymous/ComfyUI/issues/10891 (in comments - unrelated to OP issue).

torch 2.6:

https://docs.pytorch.org/docs/2.6/generated/torch.cuda.Stream.html

```
Wrapper around a CUDA stream.

A CUDA stream is a linear sequence of execution that belongs to a specific device, independent from other streams. See [CUDA semantics](https://docs.pytorch.org/docs/2.6/notes/cuda.html#cuda-semantics) for details.

Parameters

        device ([torch.device](https://docs.pytorch.org/docs/2.6/tensor_attributes.html#torch.device) or [int](https://docs.python.org/3/library/functions.html#int), optional) – a device on which to allocate the stream. If [device](https://docs.pytorch.org/docs/2.6/generated/torch.cuda.device.html#torch.cuda.device) is None (default) or a negative integer, this will use the current device.

        priority ([int](https://docs.python.org/3/library/functions.html#int), optional) – priority of the stream, should be 0 or negative, where negative numbers indicate higher priority. By default, streams have priority 0.
```

Torch 2.7:

```
    Wrapper around a CUDA stream.

    A CUDA stream is a linear sequence of execution that belongs to a specific device, independent from other streams. It supports with statement as a context manager to ensure the operators within the with block are running on the corresponding stream. See [CUDA semantics](https://docs.pytorch.org/docs/2.7/notes/cuda.html#cuda-semantics) for details.

    Parameters

            device ([torch.device](https://docs.pytorch.org/docs/2.7/tensor_attributes.html#torch.device) or [int](https://docs.python.org/3/library/functions.html#int), optional) – a device on which to allocate the stream. If [device](https://docs.pytorch.org/docs/2.7/generated/torch.cuda.device.html#torch.cuda.device) is None (default) or a negative integer, this will use the current device.

            priority ([int](https://docs.python.org/3/library/functions.html#int), optional) – priority of the stream, which can be positive, 0, or negative. A lower number indicates a higher priority. By default, the priority is set to 0. If the value falls outside of the allowed priority range, it will automatically be mapped to the nearest valid priority (lowest for large positive numbers or highest for large negative numbers).
 ```