### PR TITLE
fix(user_manager): fix typo in move_userdata dest validation

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -424,7 +424,7 @@ class UserManager():
                 return source
 
             dest = get_user_data_path(request, check_exists=False, param="dest")
-            if not isinstance(source, str):
+            if not isinstance(dest, str):
                 return dest
 
             overwrite = request.query.get("overwrite", 'true') != "false"


### PR DESCRIPTION
Check `dest` instead of `source` when validating destination path in move_userdata endpoint.