### PR TITLE
Add support for sage attention 3 in comfyui, enable via new cli arg

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -34,7 +34,7 @@ SAGE_ATTENTION3_IS_AVAILABLE = False
 try:
     from sageattn3 import sageattn3_blackwell
     SAGE_ATTENTION3_IS_AVAILABLE = True
-except ImportError as e:
+except ImportError:
     pass
 
 FLASH_ATTENTION_IS_AVAILABLE = False


### PR DESCRIPTION
This is basic Sage Attention 3 support. Because it is still unstable and differs significantly from previous versions of Sage Attention, a separate switch --use-sage-attiention3 is provided to enable or disable it. You need to install Sage Attention 3 in your environment before enabling it.