### PR TITLE
Bump frontend to 1.33

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.32.10
+comfyui-frontend-package==1.33.10
 comfyui-workflow-templates==0.7.25
 comfyui-embedded-docs==0.3.1
 torch


### PR DESCRIPTION
Test:

```bash
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.33.10
```

- Diff: [v1.32.10...v1.33.10](https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.32.10...v1.33.10)
- PyPI: https://pypi.org/project/comfyui-frontend-package/1.33.10/
- npm: https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.33.10

**Changes**

- Add back settings button (gear/cog) to the sidebar
- Improve frontend load/startup time significantly
- Update the node search result algorithm with 2025 usage data (old was 2024)
- GPU accelerated maskeditor rendering
- Support `display_name` Python Node class property on frontend
- Support renaming widgets and unsetting widget labels
- Change multiline text widget to use browser context menu
- Allow updating position and mode on missing nodes
- When filtering by IO type, put wildcards last
- Improve widget spacing and Markdown padding
- Add missing translations/localizations
- Improve asset cards and queue progress panel designs
- Add missing nodes warning UI to queue button and breadcrumb
- Remove queue sidebar tab
- Clear/evict API key on failed auth
- Mobile fixes, various bug fixes
