### PR TITLE
add svdquant int4 quantization support based on QuantizedLayout

### DIFF
--- a/comfy/svdquant_converter.py
+++ b/comfy/svdquant_converter.py
@@ -1,0 +1,377 @@
+import json
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+# Note: Fused layer splitting is no longer used
+
+
+@dataclass
+class ConvertedState:
+    tensors: Dict[str, torch.Tensor]
+    quant_layers: Dict[str, str]
+
+
+def _is_svd_prefix(keys: set[str], prefix: str) -> bool:
+    return (
+        f"{prefix}.qweight" in keys
+        and f"{prefix}.smooth_factor" in keys
+        and f"{prefix}.proj_down" in keys
+        and f"{prefix}.proj_up" in keys
+    )
+
+
+def _is_awq_prefix(keys: set[str], prefix: str) -> bool:
+    return (
+        f"{prefix}.qweight" in keys
+        and f"{prefix}.wscales" in keys
+        and f"{prefix}.wzeros" in keys
+        and f"{prefix}.smooth_factor" not in keys  # Distinguish from SVDQuant
+    )
+
+
+def _detect_svd_prefixes(state_dict: Dict[str, torch.Tensor]) -> List[str]:
+    prefixes = set()
+    keys = set(state_dict.keys())
+    for key in keys:
+        if not key.endswith(".qweight"):
+            continue
+        prefix = key[: -len(".qweight")]
+        if _is_svd_prefix(keys, prefix):
+            prefixes.add(prefix)
+    return sorted(prefixes)
+
+
+def _detect_awq_prefixes(state_dict: Dict[str, torch.Tensor]) -> List[str]:
+    prefixes = set()
+    keys = set(state_dict.keys())
+    for key in keys:
+        if not key.endswith(".qweight"):
+            continue
+        prefix = key[: -len(".qweight")]
+        if _is_awq_prefix(keys, prefix):
+            prefixes.add(prefix)
+    return sorted(prefixes)
+
+
+def _detect_format(wscales: torch.Tensor) -> str:
+    if wscales.dtype == torch.float8_e4m3fn:
+        return "svdquant_nvfp4"
+    return "svdquant_int4"
+
+
+class _SVDQuantConverter:
+    def __init__(self, state_dict: Dict[str, torch.Tensor]) -> None:
+        self.src = dict(state_dict)
+        self.dst: Dict[str, torch.Tensor] = {}
+        self.quant_layers: Dict[str, str] = {}
+
+    def convert(self) -> ConvertedState:
+        prefixes = _detect_svd_prefixes(self.src)
+        for prefix in prefixes:
+            self._convert_single(prefix)
+
+        for key, tensor in self.src.items():
+            if key not in self.dst:
+                self.dst[key] = tensor
+
+        return ConvertedState(self.dst, self.quant_layers)
+
+    def _pop_tensor(self, key: str) -> torch.Tensor:
+        try:
+            return self.src.pop(key)
+        except KeyError as exc:
+            raise KeyError(f"Missing key '{key}' in SVDQuant checkpoint") from exc
+
+    def _pop_optional(self, key: str) -> torch.Tensor | None:
+        return self.src.pop(key, None)
+
+    def _convert_single(self, prefix: str) -> None:
+        # Ensure all tensors are contiguous to avoid CUDA alignment issues
+        self.dst[f"{prefix}.weight"] = self._pop_tensor(f"{prefix}.qweight").contiguous()
+        wscales = self._pop_tensor(f"{prefix}.wscales").contiguous()
+        self.dst[f"{prefix}.wscales"] = wscales
+        format_name = _detect_format(wscales)
+
+        self.dst[f"{prefix}.smooth_factor"] = self._pop_tensor(f"{prefix}.smooth_factor").contiguous()
+        self.dst[f"{prefix}.smooth_factor_orig"] = self._pop_tensor(
+            f"{prefix}.smooth_factor_orig"
+        ).contiguous()
+        self.dst[f"{prefix}.proj_down"] = self._pop_tensor(f"{prefix}.proj_down").contiguous()
+        self.dst[f"{prefix}.proj_up"] = self._pop_tensor(f"{prefix}.proj_up").contiguous()
+
+        bias = self._pop_optional(f"{prefix}.bias")
+        if bias is not None:
+            self.dst[f"{prefix}.bias"] = bias.contiguous()
+
+        wtscale = self._pop_optional(f"{prefix}.wtscale")
+        if wtscale is not None:
+            self.dst[f"{prefix}.wtscale"] = wtscale.contiguous() if isinstance(wtscale, torch.Tensor) else wtscale
+
+        wcscales = self._pop_optional(f"{prefix}.wcscales")
+        if wcscales is not None:
+            self.dst[f"{prefix}.wcscales"] = wcscales.contiguous()
+
+        self.quant_layers[prefix] = format_name
+
+
+class _AWQConverter:
+    def __init__(self, state_dict: Dict[str, torch.Tensor]) -> None:
+        self.src = dict(state_dict)
+        self.dst: Dict[str, torch.Tensor] = {}
+        self.quant_layers: Dict[str, str] = {}
+
+    def convert(self) -> ConvertedState:
+        prefixes = _detect_awq_prefixes(self.src)
+        for prefix in prefixes:
+            self._convert_single(prefix)
+
+        for key, tensor in self.src.items():
+            if key not in self.dst:
+                self.dst[key] = tensor
+
+        return ConvertedState(self.dst, self.quant_layers)
+
+    def _pop_tensor(self, key: str) -> torch.Tensor:
+        try:
+            return self.src.pop(key)
+        except KeyError as exc:
+            raise KeyError(f"Missing key '{key}' in AWQ checkpoint") from exc
+
+    def _pop_optional(self, key: str) -> torch.Tensor | None:
+        return self.src.pop(key, None)
+
+    def _convert_single(self, prefix: str) -> None:
+        # Ensure all tensors are contiguous to avoid CUDA alignment issues
+        self.dst[f"{prefix}.weight"] = self._pop_tensor(f"{prefix}.qweight").contiguous()
+        self.dst[f"{prefix}.wscales"] = self._pop_tensor(f"{prefix}.wscales").contiguous()
+        self.dst[f"{prefix}.wzeros"] = self._pop_tensor(f"{prefix}.wzeros").contiguous()
+
+        bias = self._pop_optional(f"{prefix}.bias")
+        if bias is not None:
+            self.dst[f"{prefix}.bias"] = bias.contiguous()
+
+        self.quant_layers[prefix] = "awq_int4"
+
+
+def convert_svdquant_state_dict(state_dict: Dict[str, torch.Tensor]) -> ConvertedState:
+    return _SVDQuantConverter(state_dict).convert()
+
+
+def convert_awq_state_dict(state_dict: Dict[str, torch.Tensor]) -> ConvertedState:
+    return _AWQConverter(state_dict).convert()
+
+
+def detect_quantization_formats(state_dict: Dict[str, torch.Tensor]) -> Dict[str, List[str]]:
+    """
+    Detect quantization formats present in a state dict.
+    
+    Parameters
+    ----------
+    state_dict : Dict[str, torch.Tensor]
+        State dictionary to analyze
+    
+    Returns
+    -------
+    Dict[str, List[str]]
+        Dictionary mapping format names to lists of layer prefixes
+        Example: {
+            "svdquant_int4": ["layer1.attn.qkv", "layer2.mlp.up"],
+            "svdquant_nvfp4": ["layer3.attn.qkv"],
+            "awq_int4": ["layer1.mlp.down", "layer4.attn.qkv"]
+        }
+    """
+    result = {}
+    
+    # Detect SVDQuant layers
+    svd_prefixes = _detect_svd_prefixes(state_dict)
+    if svd_prefixes:
+        # Determine if int4 or nvfp4 based on wscales dtype
+        for prefix in svd_prefixes:
+            wscales_key = f"{prefix}.wscales"
+            if wscales_key in state_dict:
+                format_name = _detect_format(state_dict[wscales_key])
+                if format_name not in result:
+                    result[format_name] = []
+                result[format_name].append(prefix)
+    
+    # Detect AWQ layers
+    awq_prefixes = _detect_awq_prefixes(state_dict)
+    if awq_prefixes:
+        result["awq_int4"] = awq_prefixes
+    
+    return result
+
+
+def convert_awq_file(
+    input_path: str,
+    output_path: str,
+    format_version: str = "1.0",
+) -> Tuple[int, Dict[str, str]]:
+    with safe_open(input_path, framework="pt", device="cpu") as f:
+        tensors = {key: f.get_tensor(key) for key in f.keys()}
+        metadata = dict(f.metadata())
+
+    converted = convert_awq_state_dict(tensors)
+    
+    # Convert layer format dict to expected metadata format
+    # From: {"layer": "awq_int4"}
+    # To: {"layer": {"format": "awq_int4"}}
+    layers_metadata = {k: {"format": v} for k, v in converted.quant_layers.items()}
+    
+    metadata["_quantization_metadata"] = json.dumps(
+        {"format_version": format_version, "layers": layers_metadata}, sort_keys=True
+    )
+
+    save_file(converted.tensors, output_path, metadata=metadata)
+    return len(converted.quant_layers), converted.quant_layers
+
+
+def convert_svdquant_file(
+    input_path: str,
+    output_path: str,
+    format_version: str = "1.0",
+) -> Tuple[int, Dict[str, str]]:
+    with safe_open(input_path, framework="pt", device="cpu") as f:
+        tensors = {key: f.get_tensor(key) for key in f.keys()}
+        metadata = dict(f.metadata())
+
+    converted = convert_svdquant_state_dict(tensors)
+    
+    # Convert layer format dict to expected metadata format
+    # From: {"layer": "svdquant_int4"}
+    # To: {"layer": {"format": "svdquant_int4"}}
+    layers_metadata = {k: {"format": v} for k, v in converted.quant_layers.items()}
+    
+    metadata["_quantization_metadata"] = json.dumps(
+        {"format_version": format_version, "layers": layers_metadata}, sort_keys=True
+    )
+    metadata["model_class"] = "QwenImageTransformer2DModel"
+
+    save_file(converted.tensors, output_path, metadata=metadata)
+    return len(converted.quant_layers), converted.quant_layers
+
+
+def convert_quantized_file(
+    input_path: str,
+    output_path: str,
+    format_version: str = "1.0",
+    quant_format: str = "auto",
+) -> Tuple[int, Dict[str, str]]:
+    """
+    Auto-detect and convert quantized checkpoint to ComfyUI format.
+    
+    Supports mixed-format models where some layers are SVDQuant and others are AWQ.
+    Each layer is independently detected and converted to the appropriate format.
+    
+    Parameters
+    ----------
+    input_path : str
+        Path to input checkpoint file
+    output_path : str
+        Path to output checkpoint file
+    format_version : str, optional
+        Quantization metadata format version (default: "1.0")
+    quant_format : str, optional
+        Quantization format: "auto", "svdquant", or "awq" (default: "auto")
+    
+    Returns
+    -------
+    Tuple[int, Dict[str, str]]
+        Number of quantized layers and mapping of layer names to formats
+    """
+    with safe_open(input_path, framework="pt", device="cpu") as f:
+        tensors = {key: f.get_tensor(key) for key in f.keys()}
+        metadata = dict(f.metadata())
+
+    # Auto-detect format if needed
+    if quant_format == "auto":
+        svd_prefixes = _detect_svd_prefixes(tensors)
+        awq_prefixes = _detect_awq_prefixes(tensors)
+        
+        if svd_prefixes and awq_prefixes:
+            # Mixed format - partition tensors by format and convert separately
+            
+            # Build sets of all quantized prefixes
+            all_svd_prefixes = set(svd_prefixes)
+            all_awq_prefixes = set(awq_prefixes)
+            
+            # Helper to check if a key belongs to a specific quantized layer
+            def belongs_to_prefix(key, prefix):
+                """Check if key belongs to a specific layer prefix."""
+                return key == prefix or key.startswith(f"{prefix}.")
+            
+            def is_svd_key(key):
+                """Check if key belongs to any SVDQuant layer."""
+                return any(belongs_to_prefix(key, prefix) for prefix in all_svd_prefixes)
+            
+            def is_awq_key(key):
+                """Check if key belongs to any AWQ layer."""
+                return any(belongs_to_prefix(key, prefix) for prefix in all_awq_prefixes)
+            
+            # Partition tensors by format
+            svd_tensors = {}
+            awq_tensors = {}
+            other_tensors = {}
+            
+            for key, tensor in tensors.items():
+                if is_svd_key(key):
+                    svd_tensors[key] = tensor
+                elif is_awq_key(key):
+                    awq_tensors[key] = tensor
+                else:
+                    other_tensors[key] = tensor
+            
+            # Convert each format separately with only its relevant tensors
+            svd_converted = _SVDQuantConverter(svd_tensors).convert()
+            awq_converted = _AWQConverter(awq_tensors).convert()
+            
+            # Merge results - each converter only has its own layer tensors
+            converted_tensors = {}
+            
+            # Add SVDQuant converted tensors
+            converted_tensors.update(svd_converted.tensors)
+            
+            # Add AWQ converted tensors
+            converted_tensors.update(awq_converted.tensors)
+            
+            # Add non-quantized tensors
+            converted_tensors.update(other_tensors)
+            
+            # Merge quantization layer metadata
+            quant_layers = {}
+            quant_layers.update(svd_converted.quant_layers)
+            quant_layers.update(awq_converted.quant_layers)
+            
+            converted = ConvertedState(converted_tensors, quant_layers)
+        elif svd_prefixes:
+            converted = convert_svdquant_state_dict(tensors)
+        elif awq_prefixes:
+            converted = convert_awq_state_dict(tensors)
+        else:
+            raise ValueError("No quantized layers detected in checkpoint")
+    elif quant_format == "svdquant":
+        converted = convert_svdquant_state_dict(tensors)
+    elif quant_format == "awq":
+        converted = convert_awq_state_dict(tensors)
+    else:
+        raise ValueError(f"Unknown quantization format: {quant_format}")
+
+    # Convert layer format dict to expected metadata format
+    # From: {"layer": "awq_int4"}
+    # To: {"layer": {"format": "awq_int4"}}
+    layers_metadata = {k: {"format": v} for k, v in converted.quant_layers.items()}
+    
+    metadata["_quantization_metadata"] = json.dumps(
+        {"format_version": format_version, "layers": layers_metadata}, sort_keys=True
+    )
+    metadata["model_class"] = "QwenImageTransformer2DModel"
+
+    save_file(converted.tensors, output_path, metadata=metadata)
+    return len(converted.quant_layers), converted.quant_layers
+
+

--- a/convert_svdquant_checkpoint.py
+++ b/convert_svdquant_checkpoint.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Convert quantized checkpoints (SVDQuant, AWQ, or mixed) into the ComfyUI quantization format.
+"""
+
+import argparse
+from pathlib import Path
+from safetensors import safe_open
+
+from comfy.svdquant_converter import (
+    convert_quantized_file,
+    convert_svdquant_file,
+    convert_awq_file,
+    detect_quantization_formats,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Convert quantized .safetensors files (SVDQuant, AWQ, or mixed) "
+        "into the ComfyUI format with per-layer metadata for MixedPrecisionOps."
+    )
+    parser.add_argument("input", type=Path, help="Path to the source quantized .safetensors file.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Destination path for the converted checkpoint. "
+        "Defaults to <input_name>_comfy.safetensors in the same directory.",
+    )
+    parser.add_argument(
+        "--format-version",
+        default="1.0",
+        help="Format version to store inside _quantization_metadata (default: 1.0).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["auto", "svdquant", "awq"],
+        default="auto",
+        help="Quantization format (default: auto-detect).",
+    )
+    parser.add_argument(
+        "--detect-only",
+        action="store_true",
+        help="Only detect and report quantization formats without converting.",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    input_path = args.input.expanduser().resolve()
+    
+    # Detect formats if requested
+    if args.detect_only:
+        print(f"[Quantization Detector] Analyzing: {input_path}")
+        with safe_open(str(input_path), framework="pt", device="cpu") as f:
+            tensors = {key: f.get_tensor(key) for key in f.keys()}
+        
+        formats = detect_quantization_formats(tensors)
+        
+        if not formats:
+            print("[Quantization Detector] No quantized layers detected.")
+            return
+        
+        print(f"[Quantization Detector] Detected formats:")
+        total_layers = 0
+        for format_name, layer_prefixes in sorted(formats.items()):
+            print(f"\n  {format_name}: {len(layer_prefixes)} layers")
+            for prefix in sorted(layer_prefixes)[:5]:  # Show first 5
+                print(f"    - {prefix}")
+            if len(layer_prefixes) > 5:
+                print(f"    ... and {len(layer_prefixes) - 5} more")
+            total_layers += len(layer_prefixes)
+        
+        print(f"\n[Quantization Detector] Total: {total_layers} quantized layers")
+        print(f"[Quantization Detector] Use without --detect-only to convert.")
+        return
+    
+    # Convert checkpoint
+    if args.output is None:
+        output_path = input_path.with_name(f"{input_path.stem}_comfy.safetensors")
+    else:
+        output_path = args.output.expanduser().resolve()
+
+    layer_count, quant_layers = convert_quantized_file(
+        str(input_path),
+        str(output_path),
+        format_version=args.format_version,
+        quant_format=args.format,
+    )
+    
+    # Group layers by format for display
+    format_groups = {}
+    for layer_name, fmt in quant_layers.items():
+        if fmt not in format_groups:
+            format_groups[fmt] = []
+        format_groups[fmt].append(layer_name)
+    
+    print(f"[Quantization Converter] Converted {layer_count} layers.")
+    print(f"[Quantization Converter] Output saved to: {output_path}")
+    print(f"\n[Quantization Converter] Quantized layers by format:")
+    
+    for fmt, layers in sorted(format_groups.items()):
+        print(f"\n  {fmt}: {len(layers)} layers")
+        for layer_name in sorted(layers)[:5]:  # Show first 5
+            print(f"    - {layer_name}")
+        if len(layers) > 5:
+            print(f"    ... and {len(layers) - 5} more")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests-unit/comfy_quant/test_quant_registry.py
+++ b/tests-unit/comfy_quant/test_quant_registry.py
@@ -1,7 +1,10 @@
-import unittest
-import torch
-import sys
 import os
+import sys
+import unittest
+from pathlib import Path
+
+import torch
+from safetensors.torch import load_file
 
 # Add comfy to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -13,7 +16,9 @@ from comfy.cli_args import args
 if not has_gpu():
     args.cpu = True
 
-from comfy.quant_ops import QuantizedTensor, TensorCoreFP8Layout
+from comfy.quant_ops import QuantizedTensor, TensorCoreFP8Layout, AWQQuantLayout, SVDQuantLayout
+from comfy.ops import mixed_precision_ops
+from comfy.svdquant_converter import convert_svdquant_state_dict, convert_awq_state_dict
 
 
 class TestQuantizedTensor(unittest.TestCase):
@@ -156,6 +161,199 @@ class TestTensorCoreFP8Layout(unittest.TestCase):
         self.assertTrue(torch.allclose(dequantized, float_tensor, rtol=0.1, atol=0.1))
 
 
+class TestAWQQuantLayout(unittest.TestCase):
+    """Test the AWQQuantLayout implementation"""
+
+    def test_awq_layout_creation(self):
+        """Test creating an AWQ quantized tensor"""
+        # AWQ uses pre-quantized weights loaded from checkpoints
+        # Create dummy AWQ quantized weights
+        out_features, in_features = 256, 128
+        group_size = 64
+        
+        qweight = torch.randint(0, 255, (out_features // 4, in_features // 2), dtype=torch.int32)
+        wscales = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16)
+        wzeros = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16)
+        
+        layout_params = {
+            'wscales': wscales,
+            'wzeros': wzeros,
+            'group_size': group_size,
+            'orig_dtype': torch.bfloat16,
+            'is_weight': True,
+        }
+        
+        qt = QuantizedTensor(qweight, "AWQQuantLayout", layout_params)
+        
+        self.assertIsInstance(qt, QuantizedTensor)
+        self.assertEqual(qt.shape, qweight.shape)
+        self.assertEqual(qt.dtype, torch.int32)
+        self.assertEqual(qt._layout_type, "AWQQuantLayout")
+        self.assertEqual(qt._layout_params['group_size'], group_size)
+
+    def test_awq_quantize_not_supported(self):
+        """Test that online quantization raises NotImplementedError for AWQ"""
+        # AWQ doesn't support online quantization - weights must be pre-quantized
+        float_tensor = torch.randn(32, 64, dtype=torch.float32)
+        
+        with self.assertRaises(NotImplementedError):
+            AWQQuantLayout.quantize(float_tensor, is_weight=True)
+
+    def test_awq_get_plain_tensors(self):
+        """Test extracting plain tensors from AWQ quantized tensor"""
+        out_features, in_features = 256, 128
+        group_size = 64
+        
+        qweight = torch.randint(0, 255, (out_features // 4, in_features // 2), dtype=torch.int32)
+        wscales = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16)
+        wzeros = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16)
+        
+        layout_params = {
+            'wscales': wscales,
+            'wzeros': wzeros,
+            'group_size': group_size,
+            'orig_dtype': torch.bfloat16,
+            'is_weight': True,
+        }
+        
+        qt = QuantizedTensor(qweight, "AWQQuantLayout", layout_params)
+        plain_tensors = AWQQuantLayout.get_plain_tensors(qt)
+        
+        # Verify we can extract all necessary components
+        self.assertIsInstance(plain_tensors, dict)
+        self.assertIn('qweight', plain_tensors)
+        self.assertIn('wscales', plain_tensors)
+        self.assertIn('wzeros', plain_tensors)
+        self.assertIn('group_size', plain_tensors)
+        self.assertTrue(torch.equal(plain_tensors['qweight'], qweight))
+        self.assertTrue(torch.equal(plain_tensors['wscales'], wscales))
+        self.assertTrue(torch.equal(plain_tensors['wzeros'], wzeros))
+
+
+class TestSVDQuantLayout(unittest.TestCase):
+    """Test the SVDQuantLayout implementation"""
+
+    def test_svdquant_layout_creation(self):
+        """Test creating an SVDQuant quantized tensor"""
+        # SVDQuant uses pre-quantized weights loaded from checkpoints
+        out_features, in_features = 256, 128
+        rank = 32
+        group_size = 64
+        precision = "int4"
+        
+        # Create dummy SVDQuant quantized weights (int8 range is -128 to 127)
+        qweight = torch.randint(-128, 127, (out_features, in_features // 2), dtype=torch.int8)
+        wscales = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16)
+        smooth_factor = torch.randn(in_features, dtype=torch.bfloat16)
+        smooth_factor_orig = torch.randn(in_features, dtype=torch.bfloat16)
+        proj_down = torch.randn(in_features, rank, dtype=torch.bfloat16)
+        proj_up = torch.randn(out_features, rank, dtype=torch.bfloat16)
+        
+        layout_params = {
+            'wscales': wscales,
+            'smooth_factor': smooth_factor,
+            'smooth_factor_orig': smooth_factor_orig,
+            'proj_down': proj_down,
+            'proj_up': proj_up,
+            'group_size': group_size,
+            'precision': precision,
+            'orig_dtype': torch.bfloat16,
+            'is_weight': True,
+            'act_unsigned': False,
+            'wtscale': None,
+            'wcscales': None,
+        }
+        
+        qt = QuantizedTensor(qweight, "SVDQuantLayout", layout_params)
+        
+        self.assertIsInstance(qt, QuantizedTensor)
+        self.assertEqual(qt.shape, qweight.shape)
+        self.assertEqual(qt.dtype, torch.int8)
+        self.assertEqual(qt._layout_type, "SVDQuantLayout")
+        self.assertEqual(qt._layout_params['group_size'], group_size)
+        self.assertEqual(qt._layout_params['precision'], precision)
+
+    def test_svdquant_quantize_not_supported(self):
+        """Test that online quantization raises NotImplementedError for SVDQuant"""
+        # SVDQuant doesn't support online quantization - weights must be pre-quantized
+        float_tensor = torch.randn(32, 64, dtype=torch.float32)
+        
+        with self.assertRaises(NotImplementedError):
+            SVDQuantLayout.quantize(float_tensor, is_weight=True)
+
+    def test_svdquant_dequantize_not_supported(self):
+        """Test that weight dequantization raises NotImplementedError for SVDQuant"""
+        # Full weight dequantization is not supported (complex operation)
+        out_features, in_features = 256, 128
+        rank = 32
+        group_size = 64
+        
+        qweight = torch.randint(-128, 127, (out_features, in_features // 2), dtype=torch.int8)
+        wscales = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16)
+        smooth_factor = torch.randn(in_features, dtype=torch.bfloat16)
+        proj_down = torch.randn(in_features, rank, dtype=torch.bfloat16)
+        proj_up = torch.randn(out_features, rank, dtype=torch.bfloat16)
+        
+        with self.assertRaises(NotImplementedError):
+            SVDQuantLayout.dequantize(
+                qweight,
+                is_weight=True,
+                wscales=wscales,
+                smooth_factor=smooth_factor,
+                proj_down=proj_down,
+                proj_up=proj_up,
+                group_size=group_size,
+                precision="int4",
+                orig_dtype=torch.bfloat16
+            )
+
+    def test_svdquant_get_plain_tensors(self):
+        """Test extracting plain tensors from SVDQuant quantized tensor"""
+        out_features, in_features = 256, 128
+        rank = 32
+        group_size = 64
+        
+        qweight = torch.randint(-128, 127, (out_features, in_features // 2), dtype=torch.int8)
+        wscales = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16)
+        smooth_factor = torch.randn(in_features, dtype=torch.bfloat16)
+        smooth_factor_orig = torch.randn(in_features, dtype=torch.bfloat16)
+        proj_down = torch.randn(in_features, rank, dtype=torch.bfloat16)
+        proj_up = torch.randn(out_features, rank, dtype=torch.bfloat16)
+        
+        layout_params = {
+            'wscales': wscales,
+            'smooth_factor': smooth_factor,
+            'smooth_factor_orig': smooth_factor_orig,
+            'proj_down': proj_down,
+            'proj_up': proj_up,
+            'group_size': group_size,
+            'precision': "int4",
+            'orig_dtype': torch.bfloat16,
+            'is_weight': True,
+            'act_unsigned': False,
+            'wtscale': None,
+            'wcscales': None,
+        }
+        
+        qt = QuantizedTensor(qweight, "SVDQuantLayout", layout_params)
+        plain_tensors = SVDQuantLayout.get_plain_tensors(qt)
+        
+        # Verify we can extract all necessary components
+        self.assertIsInstance(plain_tensors, dict)
+        self.assertIn('qweight', plain_tensors)
+        self.assertIn('wscales', plain_tensors)
+        self.assertIn('smooth_factor', plain_tensors)
+        self.assertIn('proj_down', plain_tensors)
+        self.assertIn('proj_up', plain_tensors)
+        self.assertIn('group_size', plain_tensors)
+        self.assertIn('precision', plain_tensors)
+        self.assertTrue(torch.equal(plain_tensors['qweight'], qweight))
+        self.assertTrue(torch.equal(plain_tensors['wscales'], wscales))
+        self.assertTrue(torch.equal(plain_tensors['smooth_factor'], smooth_factor))
+        self.assertTrue(torch.equal(plain_tensors['proj_down'], proj_down))
+        self.assertTrue(torch.equal(plain_tensors['proj_up'], proj_up))
+
+
 class TestFallbackMechanism(unittest.TestCase):
     """Test fallback for unsupported operations"""
 
@@ -184,6 +382,159 @@ class TestFallbackMechanism(unittest.TestCase):
         # FP8 introduces quantization error, so use loose tolerance
         mean_error = (result - expected).abs().mean()
         self.assertLess(mean_error, 0.05, f"Mean error {mean_error:.4f} is too large")
+
+
+class TestAWQConversion(unittest.TestCase):
+    """Test AWQ checkpoint conversion"""
+    
+    def test_awq_single_layer_conversion(self):
+        """Test converting a single AWQ layer"""
+        in_features, out_features = 128, 256
+        group_size = 64
+        
+        # Create AWQ checkpoint format
+        state_dict = {
+            "layer.qweight": torch.randint(0, 255, (out_features // 4, in_features // 2), dtype=torch.int32),
+            "layer.wscales": torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16),
+            "layer.wzeros": torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16),
+            "layer.bias": torch.randn(out_features, dtype=torch.bfloat16),
+        }
+        
+        converted = convert_awq_state_dict(state_dict)
+        
+        # Check that qweight was renamed to weight
+        self.assertIn("layer.weight", converted.tensors)
+        self.assertNotIn("layer.qweight", converted.tensors)
+        
+        # Check other parameters preserved
+        self.assertIn("layer.wscales", converted.tensors)
+        self.assertIn("layer.wzeros", converted.tensors)
+        self.assertIn("layer.bias", converted.tensors)
+        
+        # Check quantization metadata
+        self.assertIn("layer", converted.quant_layers)
+        self.assertEqual(converted.quant_layers["layer"], "awq_int4")
+    
+    def test_awq_tensor_shapes(self):
+        """Test that converted AWQ tensors have correct shapes"""
+        in_features, out_features = 3072, 18432
+        group_size = 64
+        
+        state_dict = {
+            "layer.qweight": torch.randint(0, 255, (out_features // 4, in_features // 2), dtype=torch.int32),
+            "layer.wscales": torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16),
+            "layer.wzeros": torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16),
+        }
+        
+        converted = convert_awq_state_dict(state_dict)
+        
+        # Check qweight shape (packed 4-bit)
+        qweight = converted.tensors["layer.weight"]
+        self.assertEqual(qweight.shape, (out_features // 4, in_features // 2))
+        self.assertEqual(qweight.dtype, torch.int32)
+        
+        # Check wscales shape
+        wscales = converted.tensors["layer.wscales"]
+        self.assertEqual(wscales.shape, (in_features // group_size, out_features))
+        self.assertEqual(wscales.dtype, torch.bfloat16)
+        
+        # Check wzeros shape
+        wzeros = converted.tensors["layer.wzeros"]
+        self.assertEqual(wzeros.shape, (in_features // group_size, out_features))
+        self.assertEqual(wzeros.dtype, torch.bfloat16)
+
+
+class TestAWQLinearOperation(unittest.TestCase):
+    """Test AWQ linear operations with actual nunchaku kernels"""
+    
+    @unittest.skipUnless(has_gpu(), "GPU required for AWQ operations")
+    def test_awq_linear_basic(self):
+        """Test basic AWQ linear operation by calling kernel directly"""
+        try:
+            from nunchaku.ops.gemv import awq_gemv_w4a16_cuda
+        except ImportError:
+            self.skipTest("nunchaku package not available")
+        
+        device = torch.device("cuda")
+        in_features, out_features = 128, 256
+        group_size = 64
+        batch_size = 4
+        
+        # Create AWQ quantized weight tensors
+        qweight = torch.randint(0, 255, (out_features // 4, in_features // 2), dtype=torch.int32, device=device)
+        wscales = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16, device=device)
+        wzeros = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16, device=device)
+        bias = torch.randn(out_features, dtype=torch.bfloat16, device=device)
+        
+        # Create layout params
+        layout_params = {
+            'wscales': wscales,
+            'wzeros': wzeros,
+            'group_size': group_size,
+            'orig_dtype': torch.bfloat16,
+            'is_weight': True,
+        }
+        
+        weight = QuantizedTensor(qweight, "AWQQuantLayout", layout_params)
+        
+        # Check that weight is a QuantizedTensor
+        self.assertIsInstance(weight, QuantizedTensor)
+        self.assertEqual(weight._layout_type, "AWQQuantLayout")
+        
+        # Create input
+        x = torch.randn(batch_size, in_features, dtype=torch.bfloat16, device=device)
+        
+        # Call AWQ linear handler directly
+        from comfy.quant_ops import awq_linear
+        output = awq_linear(torch.ops.aten.linear.default, (x, weight, bias), {})
+        
+        # Check output shape and dtype
+        self.assertEqual(output.shape, (batch_size, out_features))
+        self.assertEqual(output.dtype, torch.bfloat16)
+    
+    @unittest.skipUnless(has_gpu(), "GPU required for AWQ operations")
+    def test_awq_linear_2d_input(self):
+        """Test AWQ linear with 2D input (batch, features) by calling kernel directly"""
+        try:
+            from nunchaku.ops.gemv import awq_gemv_w4a16_cuda
+        except ImportError:
+            self.skipTest("nunchaku package not available")
+        
+        device = torch.device("cuda")
+        in_features, out_features = 128, 256
+        group_size = 64
+        batch_size = 4
+        
+        # Create AWQ quantized weight tensors
+        qweight = torch.randint(0, 255, (out_features // 4, in_features // 2), dtype=torch.int32, device=device)
+        wscales = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16, device=device)
+        wzeros = torch.randn(in_features // group_size, out_features, dtype=torch.bfloat16, device=device)
+        
+        # Create layout params
+        layout_params = {
+            'wscales': wscales,
+            'wzeros': wzeros,
+            'group_size': group_size,
+            'orig_dtype': torch.bfloat16,
+            'is_weight': True,
+        }
+        
+        weight = QuantizedTensor(qweight, "AWQQuantLayout", layout_params)
+        
+        # Check that weight is a QuantizedTensor
+        self.assertIsInstance(weight, QuantizedTensor)
+        self.assertEqual(weight._layout_type, "AWQQuantLayout")
+        
+        # Create 2D input
+        x = torch.randn(batch_size, in_features, dtype=torch.bfloat16, device=device)
+        
+        # Call AWQ linear handler directly
+        from comfy.quant_ops import awq_linear
+        output = awq_linear(torch.ops.aten.linear.default, (x, weight, None), {})
+        
+        # Check output shape
+        self.assertEqual(output.shape, (batch_size, out_features))
+        self.assertEqual(output.dtype, torch.bfloat16)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds support for **SVDQuant INT4 quantization** as a new `QuantizedLayout` in ComfyUI, enabling faster inference and reduced VRAM usage.

## Key Changes

### 1. New Quantization Layouts (`comfy/quant_ops.py`)

Added two new layout types to support SVDQuant and AWQ quantization formats:

- **`SVDQuantLayout`**: Implements W4A4 quantization using SVD decomposition
  - Decomposes linear operations as: `X*W = X * proj_up * proj_down + quantize(X) * quantize(R)`
  - Supports both `int4` and `nvfp4` precision modes
  - Integrates with nunchaku CUDA kernels for optimized inference

- **`AWQQuantLayout`**: Implements W4A16 quantization (Activation-aware Weight Quantization)
  - Keeps activations in 16-bit precision while quantizing weights to 4-bit
  - Uses nunchaku's `awq_gemv_w4a16_cuda` for efficient GEMM operations

### 2. Support Nunchaku-style QKV Merging (`comfy/ldm/qwen_image/model.py`)

In `Nunchaku's SVDQuant` quantization for `QWen` model they merged k_proj, q_proj and v_proj into one tensor `qkv_proj`. So we have to modify QWen model a little bit to support that.

Why we can't keep the q, k, v separated to keep it compatible as our previous code and model format: 
* 1. nunchaku SVDQuant needs data driven calibration, they prepared datasets to calibrate to generate this quantization model. And all the intermediate scales, smooth factors etc are mixed together, can't be simply splitted into q, k, v. 
* 2. there might be performance gain to merge q, k, v.

### 3. Extended Quantization Parameter Support (`comfy/ops.py`)

- Extended `mixed_precision_ops` to handle additional quantization parameters:
  -  added `custom_layer_params_keys` to support more complicated quantization format for SVDQuant-specific tensors (wscales, smooth_factor, proj_down, proj_up, etc.)
  - Proper handling of `QuantizedTensor` in `cast_bias_weight` for dtype detection

### 4. Model Converter (`comfy/svdquant_converter.py`)

Added converter to transform nunchaku-style checkpoints to ComfyUI's `QuantizedLayout` format.

## Performance Comparison

Tested with this workflow: [svdq_qwen_test_workflow.json](https://github.com/user-attachments/files/23885517/svdq_qwen_test_workflow.json)


Tested on **NVIDIA RTX 4090 (24GB VRAM)** with Qwen-Image model:

| Model | Runtime (1st / 2nd+) | Max VRAM |
|-------|---------------------|----------|
| `qwen_image_fp8_e4m3fn.safetensors` | 75.68s / 56.52s | 21,333 MB |
| `qwen_image_int4_svdq.safetensors` | **42s / 31s** | **13,205 MB** |

**Improvements:**
- ⚡ **~45% faster** inference (31s vs 56.52s)
- 💾 **~38% less VRAM** (13.2GB vs 21.3GB)

Generated image:

By qwen_image_fp8_e4m3fn:
<img width="1328" height="1328" alt="ComfyUI_00106_" src="https://github.com/user-attachments/assets/ca10def0-236b-42af-84fe-cc034aa18fd9" />

By qwen_image_int4_svdq:

<img width="1328" height="1328" alt="ComfyUI_00105_" src="https://github.com/user-attachments/assets/4540e72a-69e6-449a-ad7c-2e6a68d7dca1" />

## Pre-converted Model

A converted model is available on Hugging Face:

🤗 **[lyogavin/QWen-Image_ComfyUI_SVDQ](https://huggingface.co/lyogavin/QWen-Image_ComfyUI_SVDQ)**

## Testing

- Unit tests included for converter functions
- Tested with ComfyUI workflow to verify end-to-end functionality

## Dependencies

 **nunchaku** library [installation instruction here](https://nunchaku.tech/docs/nunchaku/installation/installation.html).

