### PR TITLE
Added PATCH method to CORS headers

### DIFF
--- a/server.py
+++ b/server.py
@@ -98,7 +98,7 @@ def create_cors_middleware(allowed_origin: str):
             response = await handler(request)
 
         response.headers['Access-Control-Allow-Origin'] = allowed_origin
-        response.headers['Access-Control-Allow-Methods'] = 'POST, GET, DELETE, PUT, OPTIONS'
+        response.headers['Access-Control-Allow-Methods'] = 'POST, GET, DELETE, PUT, OPTIONS, PATCH'
         response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
         response.headers['Access-Control-Allow-Credentials'] = 'true'
         return response


### PR DESCRIPTION
Added PATCH http method to access-control-allow-methods header because there are now PATCH endpoints exposed in the API.

See https://github.com/comfyanonymous/ComfyUI/blob/277237ccc1499bac7fcd221a666dfe7a32ac4206/api_server/routes/internal/internal_routes.py#L34 for an example of an API endpoint that uses the PATCH method.

Why this is important: some endpoints are not available when using the --enable-cors-header option because the Access-Control-Allow-Methods doesn't include the PATCH method. We might consider also using a `*` instead (I think it's HTTP standards compliant) for future compatibility, but this route conforms to current repo standards.