### PR TITLE
use empty list defaults for Schema.inputs/outputs/hidden to avoid None issues

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -5,7 +5,7 @@ import inspect
 from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Iterable
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Callable, Literal, TypedDict, TypeVar, TYPE_CHECKING
 from typing_extensions import NotRequired, final
@@ -1199,9 +1199,9 @@ class Schema:
     """Display name of node."""
     category: str = "sd"
     """The category of the node, as per the "Add Node" menu."""
-    inputs: list[Input]=None
-    outputs: list[Output]=None
-    hidden: list[Hidden]=None
+    inputs: list[Input] = field(default_factory=list)
+    outputs: list[Output] = field(default_factory=list)
+    hidden: list[Hidden] = field(default_factory=list)
     description: str=""
     """Node description, shown as a tooltip when hovering over the node."""
     is_input_list: bool = False


### PR DESCRIPTION
Fixes #11080

Normalize `Schema.inputs` / `outputs` / `hidden` to empty lists so custom nodes that omit inputs stay iterable without **extra** `None` checks. 

Existing checks against `None` are left unchanged, since some custom nodes may still assign `inputs = None`, but this is low risk and will show up as type warnings once typings are fully fixed. 
This keeps conditions like `if self.inputs:` behaving the same while allowing simple loops like `for i in self.inputs:` without additional guards.
