### PR TITLE
sd: revise hy VAE VRAM

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -483,8 +483,10 @@ class VAE:
                 self.latent_dim = 3
                 self.latent_channels = ddconfig['z_channels'] = sd["decoder.conv_in.conv.weight"].shape[1]
                 self.first_stage_model = AutoencoderKL(ddconfig=ddconfig, embed_dim=sd['post_quant_conv.weight'].shape[1])
-                self.memory_used_decode = lambda shape, dtype: (1500 * shape[2] * shape[3] * shape[4] * (4 * 8 * 8)) * model_management.dtype_size(dtype)
-                self.memory_used_encode = lambda shape, dtype: (900 * max(shape[2], 2) * shape[3] * shape[4]) * model_management.dtype_size(dtype)
+                #This is likely to significantly over-estimate with single image or low frame counts as the
+                #implementation is able to completely skip caching. Rework if used as an image only VAE
+                self.memory_used_decode = lambda shape, dtype: (2800 * min(8, ((shape[2] - 1) * 4) + 1) * shape[3] * shape[4] * (8 * 8)) * model_management.dtype_size(dtype)
+                self.memory_used_encode = lambda shape, dtype: (1400 * min(9, shape[2]) * shape[3] * shape[4]) * model_management.dtype_size(dtype)
                 self.working_dtypes = [torch.bfloat16, torch.float16, torch.float32]
             elif "decoder.unpatcher3d.wavelets" in sd:
                 self.upscale_ratio = (lambda a: max(0, a * 8 - 7), 8, 8)


### PR DESCRIPTION
This was recently collapsed down to rolling VAE through temporal. Clamp The time dimension.

calibrated on RTX5090 with the below cases.

As a general rule, it's innacurate on the side of overestimating for low frame counts due to no-cache fast path in the implementation, so those are still a bit inaccurate.

Its hard to perfectly fix the various cases as a simple expression. I've gone slightly cautious on the estimates as we are coming from a long history of low expectations on this VAEs VRAM usage so better to play a little safe than push the perf.

<img width="1241" height="1227" alt="image" src="https://github.com/user-attachments/assets/c62b1ff0-3d4b-4bbf-a744-48edd3e9d5ab" />
