### PR TITLE
sd: bump HY1.5 VAE estimate

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -471,7 +471,7 @@ class VAE:
                                                             decoder_config={'target': "comfy.ldm.hunyuan_video.vae_refiner.Decoder", 'params': ddconfig})
 
                 self.memory_used_encode = lambda shape, dtype: (1400 * 9 * shape[-2] * shape[-1]) * model_management.dtype_size(dtype)
-                self.memory_used_decode = lambda shape, dtype: (2800 * 4 * shape[-2] * shape[-1] * 16 * 16) * model_management.dtype_size(dtype)
+                self.memory_used_decode = lambda shape, dtype: (3600 * 4 * shape[-2] * shape[-1] * 16 * 16) * model_management.dtype_size(dtype)
             elif "decoder.conv_in.conv.weight" in sd:
                 ddconfig = {'double_z': True, 'z_channels': 4, 'resolution': 256, 'in_channels': 3, 'out_ch': 3, 'ch': 128, 'ch_mult': [1, 2, 4, 4], 'num_res_blocks': 2, 'attn_resolutions': [], 'dropout': 0.0}
                 ddconfig["conv3d"] = True


### PR DESCRIPTION
I'm able to push vram above estimate on partial unload. Bump the estimate. This is experimentally determined with a 720P and 480P datapoint calibrating for 24GB VRAM total.

https://github.com/comfyanonymous/ComfyUI/issues/11072

Example test conditions:
RTX5090 --reserve-vram 8.9 (emulate 4090)

HY1.5 480P (with ksampler before decode)

before (24.4 GB - Just Over Limit - matches windows 4090 user who reported issue):

<img width="2369" height="1185" alt="image" src="https://github.com/user-attachments/assets/262eccf6-ab4e-4e69-9f1e-60db1a541856" />


after (21.8GB):

<img width="2369" height="1185" alt="image" src="https://github.com/user-attachments/assets/db52b68b-29c6-4d8d-b088-f8985b3704cf" />


