### PR TITLE
Fix transformer_options getting cleared in Lumina model after z-image PR

### DIFF
--- a/comfy/ldm/lumina/model.py
+++ b/comfy/ldm/lumina/model.py
@@ -586,7 +586,6 @@ class NextDiT(nn.Module):
         cap_feats = self.cap_embedder(cap_feats)  # (N, L, D)  # todo check if able to batchify w.o. redundant compute
 
         patches = transformer_options.get("patches", {})
-        transformer_options = kwargs.get("transformer_options", {})
         x_is_tensor = isinstance(x, torch.Tensor)
         img, mask, img_size, cap_size, freqs_cis = self.patchify_and_embed(x, cap_feats, cap_mask, t, num_tokens, transformer_options=transformer_options)
         freqs_cis = freqs_cis.to(img.device)


### PR DESCRIPTION
The _forward function used to not have transformer_options explicitly defined, so had to be grabbed from kwargs dict.

Since transformer_options is now explicit, this line should be removed. Or alternatively, transformer_options didnt need to be explicitly defined and the patches call could be made under the line being deleted now, but this is 1 line change vs 2 and does not matter.