### PR TITLE
Support "transformer." LoRA prefix for Z-Image

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -320,6 +320,7 @@ def model_lora_keys_unet(model, key_map={}):
                 to = diffusers_keys[k]
                 key_lora = k[:-len(".weight")]
                 key_map["diffusion_model.{}".format(key_lora)] = to
+                key_map["transformer.{}".format(key_lora)] = to
                 key_map["lycoris_{}".format(key_lora.replace(".", "_"))] = to
 
     return key_map


### PR DESCRIPTION
This PR adds it to Z-Image the "transformer." LoRA prefix that is supported for other models like Qwen.
For some reason the code for Lumina2 is used for Z-Image.

Please try to be consistent in your LoRA loading code. Thank you.