### PR TITLE
Hunyuan Video 1.5 manual FLF implementation

### DIFF
--- a/comfy_extras/nodes_hunyuan.py
+++ b/comfy_extras/nodes_hunyuan.py
@@ -154,35 +154,35 @@ class HunyuanVideo15FirstLastFrameToVideo(io.ComfyNode):
     @classmethod
     def execute(cls, positive, negative, vae, width, height, length, batch_size, start_image=None, end_image=None, clip_vision_start_image=None, clip_vision_end_image=None) -> io.NodeOutput:
 
-        latent = torch.zeros([batch_size, 32, ((length - 1) // 4) + 1, height // 16, width // 16], 
+        latent = torch.zeros([batch_size, 32, ((length - 1) // 4) + 1, height // 16, width // 16],
                             device=comfy.model_management.intermediate_device())
-        
-        concat_latent_image = torch.zeros((batch_size, 32, latent.shape[2], latent.shape[3], latent.shape[4]), 
+
+        concat_latent_image = torch.zeros((batch_size, 32, latent.shape[2], latent.shape[3], latent.shape[4]),
                                          device=comfy.model_management.intermediate_device())
-        
-        mask = torch.ones((1, 1, latent.shape[2], latent.shape[3], latent.shape[4]), 
+
+        mask = torch.ones((1, 1, latent.shape[2], latent.shape[3], latent.shape[4]),
                          device=comfy.model_management.intermediate_device())
-        
+
         if start_image is not None:
             start_image = comfy.utils.common_upscale(start_image[:length].movedim(-1, 1), width, height, "bilinear", "center").movedim(1, -1)
-            
+
             encoded_start = vae.encode(start_image[:, :, :, :3])
-            
+
             concat_latent_image[:, :, :encoded_start.shape[2], :, :] = encoded_start
-            
+
             start_frames_in_latent = ((start_image.shape[0] - 1) // 4) + 1
             mask[:, :, :start_frames_in_latent] = 0.0
-        
+
         if end_image is not None:
             end_image = comfy.utils.common_upscale(end_image[-length:].movedim(-1, 1), width, height, "bilinear", "center").movedim(1, -1)
-            
+
             encoded_end = vae.encode(end_image[:, :, :, :3])
-            
+
             end_frames_in_latent = ((end_image.shape[0] - 1) // 4) + 1
             concat_latent_image[:, :, -end_frames_in_latent:, :, :] = encoded_end[:, :, -end_frames_in_latent:, :, :]
-            
+
             mask[:, :, -end_frames_in_latent:] = 0.0
-        
+
         positive = node_helpers.conditioning_set_values(positive, {"concat_latent_image": concat_latent_image, "concat_mask": mask})
         negative = node_helpers.conditioning_set_values(negative, {"concat_latent_image": concat_latent_image, "concat_mask": mask})
 


### PR DESCRIPTION
This pull request adds "manual" first-last frame support for Hunyuan1.5 video generation via latent concatenation.

The code is very simple and based on the first-last-frame implementation for Wan.

Because Hunyuan uses CLIP vision embeddings as input, without the dedicated model only one of them is used as provided.

One thing I would like to have help with is the last frame often "flickering" without direct soft transition. I also observed this problem for Wan2.2/VACE, but there it was less noticeable.

Otherwise, it looks good and it indeed takes the last frame's subject in consideration.

https://github.com/user-attachments/assets/b0bd5b68-1691-4707-8e7a-5dfbe69e5df8

<img width="256" height="256" alt="ComfyUI_temp_rqlky_00011_" src="https://github.com/user-attachments/assets/a649af34-a637-4cb4-a27c-742032f3fddc" />

<img width="256" height="256" alt="ComfyUI_temp_rqlky_00002_" src="https://github.com/user-attachments/assets/39e5eebc-7092-4e5a-abaf-d4e942f9fd25" />

Closes #11020.
