### PR TITLE
Fix OOM by reserving extra VRAM for cached memory from CudaMallocAsync allocator

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -572,6 +572,9 @@ if args.reserve_vram is not None:
     EXTRA_RESERVED_VRAM = args.reserve_vram * 1024 * 1024 * 1024
     logging.debug("Reserving {}MB vram for other applications.".format(EXTRA_RESERVED_VRAM / (1024 * 1024)))
 
+if is_nvidia() and not args.disable_cuda_malloc:
+    EXTRA_RESERVED_VRAM += 32 * 1024 * 1024
+
 def extra_reserved_memory():
     return EXTRA_RESERVED_VRAM
 


### PR DESCRIPTION
This increases `EXTRA_RESERVED_VRAM` by 32MB if CudaMallocAsync is enabled.

The recent OOM issue in FLUX.2 (https://github.com/comfyanonymous/ComfyUI/issues/10891) seems to have mixed reasons from CudaMallocAsync and a VRAM lookahead calculation. For the former, the allocator in CudaMallocAsync can reserve more memory than requested to possibly reduce fragmentation, but the policy is not known so the gap cannot be predicted without actual allocation afaik (if it's wrong please correct it). To find way to stick to the current implementation I have profiled the reserved memory and found a pattern that it usually reserves memory by multiply of 32MB, so here it suggests to reserve it in advance.

Tested on RTX 4090 but the number could be different in other circumstances, so it should be verified by multiples.

It is a temporary solution for sure, a better improvement would be possible. For example, the load function could keep track of this gap on the fly and adjust the offloaded list every time the weight does not fit into the VRAM. Another would be loosening current VRAM calculation with more accurate logic if it's empirical. But at least it seems to resolve some OOM issue for now and it's not a big cost so I leave the quick change possible here.

Trace of reserved and allocated memory on flux 2:

```
[DEBUG 0] reserved: 1280.00 MB (+ 1280.00 MB), allocated: 1280.00 MB, module: 1280.00 MB
[DEBUG 1] reserved: 1600.00 MB (+ 320.00 MB), allocated: 1600.00 MB, module: 320.00 MB
[DEBUG 2] reserved: 1920.00 MB (+ 320.00 MB), allocated: 1920.00 MB, module: 320.00 MB
[DEBUG 3] reserved: 2240.00 MB (+ 320.00 MB), allocated: 2240.00 MB, module: 320.00 MB
...
[DEBUG 62] reserved: 21120.00 MB (+ 320.00 MB), allocated: 21120.00 MB, module: 320.00 MB
[DEBUG 63] reserved: 21440.00 MB (+ 320.00 MB), allocated: 21440.00 MB, module: 320.00 MB
[DEBUG 64] reserved: 21504.00 MB (+ 64.00 MB), allocated: 21480.00 MB, module: 40.00 MB
[DEBUG 65] reserved: 21536.00 MB (+ 32.00 MB), allocated: 21520.00 MB, module: 40.00 MB
[DEBUG 66] reserved: 21568.00 MB (+ 32.00 MB), allocated: 21560.00 MB, module: 40.00 MB
[DEBUG 67] reserved: 21600.00 MB (+ 32.00 MB), allocated: 21600.00 MB, module: 40.00 MB
[DEBUG 68] reserved: 21632.00 MB (+ 32.00 MB), allocated: 21610.00 MB, module: 10.00 MB
[DEBUG 69] reserved: 21632.00 MB (+ 0.00 MB), allocated: 21610.01 MB, module: 0.01 MB
[DEBUG 70] reserved: 21632.00 MB (+ 0.00 MB), allocated: 21610.02 MB, module: 0.01 MB
[DEBUG 71] reserved: 21632.00 MB (+ 0.00 MB), allocated: 21610.03 MB, module: 0.01 MB
...
```