### PR TITLE
Fix #9141 Ensure “Update” repopulates model lists

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -137,6 +137,15 @@ def set_user_directory(user_dir: str) -> None:
     user_directory = user_dir
 
 
+def clear_filename_list_cache() -> None:
+    """
+    Clear cached filename lists so new files on disk are discovered.
+    """
+    global filename_list_cache
+    filename_list_cache.clear()
+    cache_helper.clear()
+
+
 # System User Protection - Protects system directories from HTTP endpoint access
 # System Users are internal-only users that cannot be accessed via HTTP endpoints.
 # They use the '__' prefix convention (similar to Python's private member convention).

--- a/server.py
+++ b/server.py
@@ -676,6 +676,7 @@ class PromptServer():
 
         @routes.get("/object_info")
         async def get_object_info(request):
+            folder_paths.clear_filename_list_cache()
             with folder_paths.cache_helper:
                 out = {}
                 for x in nodes.NODE_CLASS_MAPPINGS:


### PR DESCRIPTION
### Issue
https://github.com/comfyanonymous/ComfyUI/issues/9141

### Fix
- Add `folder_paths.clear_filename_list_cache()` to invalidate cached model filenames.
- Invoke the cache clear in `/object_info` (triggered by the “r” reload/update) so subsequent `get_filename_list` calls rescan model directories, exposing models added at runtime.
- Keeps discovery logic unchanged; minimal surface-area fix.

### Testing
Tested and works locally on windows. Models can now be reloaded during runtime.