### PR TITLE
Fix duplicate model_management initialization in hunyuan_video upsampler.py

### DIFF
--- a/comfy/ldm/hunyuan_video/upsampler.py
+++ b/comfy/ldm/hunyuan_video/upsampler.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from comfy.ldm.modules.diffusionmodules.model import ResnetBlock, VideoConv3d
 from comfy.ldm.hunyuan_video.vae_refiner import RMS_norm
-import model_management, model_patcher
+from comfy import model_management, model_patcher
 
 class SRResidualCausalBlock3D(nn.Module):
     def __init__(self, channels: int):


### PR DESCRIPTION
Current behavior:
comfy/ldm/hunyuan_video/upsampler.py imports model_management directly as top-level modules. Double initialization and log spamming.

Fix:
Changed imports to absolute imports (from comfy import ...) to align with the rest of the codebase and ensure the singleton instances are used correctly.