### PR TITLE
Fix Z-Image FP16 overflow via downscaling

### DIFF
--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -1001,7 +1001,7 @@ class Lumina2(supported_models_base.BASE):
     unet_extra_config = {}
     latent_format = latent_formats.Flux
 
-    supported_inference_dtypes = [torch.bfloat16, torch.float16, torch.float32]
+    supported_inference_dtypes = [torch.bfloat16, torch.float32]
 
     vae_key_prefix = ["vae."]
     text_encoder_key_prefix = ["text_encoders."]


### PR DESCRIPTION
This PR improves FP16 stability for Z-Image by using scaling instead of clamping.

Because the tensor passes through `Linear` and `RMSNorm`, the fp16 tensor can be scaled down to prevent overflow.
The scale value(2^x) is based on testing.
No noticeable impact on inference speed.
Tested with: Z-Image and Lumina 2.

The `clamp_fp16` function can be safely removed or stay just in case.
[workflow.json](https://github.com/user-attachments/files/24030283/workflow.json)
<img width="4437" height="1530" alt="comparison_result" src="https://github.com/user-attachments/assets/3087e033-665a-40f4-81a9-7b422144bcda" />

