### PR TITLE
Fix: filter hidden files from /internal/files endpoint

### DIFF
--- a/api_server/routes/internal/internal_routes.py
+++ b/api_server/routes/internal/internal_routes.py
@@ -58,8 +58,13 @@ class InternalRoutes:
                 return web.json_response({"error": "Invalid directory type"}, status=400)
 
             directory = get_directory_by_type(directory_type)
+
+            def is_visible_file(entry: os.DirEntry) -> bool:
+                """Filter out hidden files (e.g., .DS_Store on macOS)."""
+                return entry.is_file() and not entry.name.startswith('.')
+
             sorted_files = sorted(
-                (entry for entry in os.scandir(directory) if entry.is_file()),
+                (entry for entry in os.scandir(directory) if is_visible_file(entry)),
                 key=lambda entry: -entry.stat().st_mtime
             )
             return web.json_response([entry.name for entry in sorted_files], status=200)


### PR DESCRIPTION
## Summary

Filter out hidden files (e.g., `.DS_Store` on macOS) from the `/internal/files/{directory_type}` endpoint response.

This fixes an issue where the `LoadImageOutput` node would fail to load an image on macOS because `.DS_Store` was returned as the first file in the output directory.

## Background

This fix was originally attempted in the frontend repo (https://github.com/Comfy-Org/ComfyUI_frontend/pull/7200), but filtering at the API level is the cleaner solution since it prevents invalid files from being returned to any client.

## Test plan

- On macOS with `.DS_Store` in the output folder, verify the file is no longer returned by `/internal/files/output`
- Verify normal image/video files are still returned correctly