### PR TITLE
Handle the None case for the model_dtype (Fixes GGUF + Lora crash)

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -139,6 +139,8 @@ def low_vram_patch_estimate_vram(model, key):
     if weight is None:
         return 0
     model_dtype = getattr(model, "manual_cast_dtype", torch.float32)
+    if model_dtype is None:
+        model_dtype = torch.float32
     return weight.numel() * model_dtype.itemsize * LOWVRAM_PATCH_ESTIMATE_MATH_FACTOR
 
 def get_key_weight(model, key):


### PR DESCRIPTION
There are paths where this can be None. Default to fp32 in that case.

https://discordapp.com/channels/1218270712402415686/1243610878314807337/1447705628758904832