### PR TITLE
[BlockInfo] Index to Tensor

### DIFF
--- a/comfy/ldm/chroma/model.py
+++ b/comfy/ldm/chroma/model.py
@@ -183,7 +183,7 @@ class Chroma(nn.Module):
         transformer_options["total_blocks"] = len(self.double_blocks)
         transformer_options["block_type"] = "double"
         for i, block in enumerate(self.double_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=img.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             if i not in self.skip_mmdit:
                 double_mod = (
                     self.get_modulations(mod_vectors, "double_img", idx=i),
@@ -229,7 +229,7 @@ class Chroma(nn.Module):
         transformer_options["total_blocks"] = len(self.single_blocks)
         transformer_options["block_type"] = "single"
         for i, block in enumerate(self.single_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=img.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             if i not in self.skip_dit:
                 single_mod = self.get_modulations(mod_vectors, "single", idx=i)
                 if ("single_block", i) in blocks_replace:

--- a/comfy/ldm/flux/model.py
+++ b/comfy/ldm/flux/model.py
@@ -186,7 +186,7 @@ class Flux(nn.Module):
         transformer_options["total_blocks"] = len(self.double_blocks)
         transformer_options["block_type"] = "double"
         for i, block in enumerate(self.double_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=img.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             if ("double_block", i) in blocks_replace:
                 def block_wrap(args):
                     out = {}
@@ -233,7 +233,7 @@ class Flux(nn.Module):
         transformer_options["total_blocks"] = len(self.single_blocks)
         transformer_options["block_type"] = "single"
         for i, block in enumerate(self.single_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=img.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             if ("single_block", i) in blocks_replace:
                 def block_wrap(args):
                     out = {}

--- a/comfy/ldm/hunyuan_video/model.py
+++ b/comfy/ldm/hunyuan_video/model.py
@@ -392,7 +392,7 @@ class HunyuanVideo(nn.Module):
         transformer_options["total_blocks"] = len(self.double_blocks)
         transformer_options["block_type"] = "double"
         for i, block in enumerate(self.double_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=img.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             if ("double_block", i) in blocks_replace:
                 def block_wrap(args):
                     out = {}
@@ -417,7 +417,7 @@ class HunyuanVideo(nn.Module):
         transformer_options["total_blocks"] = len(self.single_blocks)
         transformer_options["block_type"] = "single"
         for i, block in enumerate(self.single_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=img.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             if ("single_block", i) in blocks_replace:
                 def block_wrap(args):
                     out = {}

--- a/comfy/ldm/kandinsky5/model.py
+++ b/comfy/ldm/kandinsky5/model.py
@@ -375,7 +375,7 @@ class Kandinsky5(nn.Module):
         transformer_options["total_blocks"] = len(self.visual_transformer_blocks)
         transformer_options["block_type"] = "double"
         for i, block in enumerate(self.visual_transformer_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=visual_embed.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             if ("double_block", i) in blocks_replace:
                 def block_wrap(args):
                     return block(x=args["x"], context=args["context"], time_embed=args["time_embed"], freqs=args["freqs"], transformer_options=args.get("transformer_options"))

--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -921,7 +921,7 @@ class SpatialTransformer(nn.Module):
         if self.use_linear:
             x = self.proj_in(x)
         for i, block in enumerate(self.transformer_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=x.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             x = block(x, context=context[i], transformer_options=transformer_options)
         if self.use_linear:
             x = self.proj_out(x)
@@ -1067,7 +1067,7 @@ class SpatialVideoTransformer(SpatialTransformer):
         for it_, (block, mix_block) in enumerate(
             zip(self.transformer_blocks, self.time_stack)
         ):
-            transformer_options["block_index"] = torch.tensor(it_, dtype=torch.uint8, device=x.device)
+            transformer_options["block_index"] = torch.tensor(it_, dtype=torch.uint8, device="cpu")
             x = block(
                 x,
                 context=spatial_context,

--- a/comfy/ldm/qwen_image/model.py
+++ b/comfy/ldm/qwen_image/model.py
@@ -442,7 +442,7 @@ class QwenImageTransformer2DModel(nn.Module):
         transformer_options["total_blocks"] = len(self.transformer_blocks)
         transformer_options["block_type"] = "double"
         for i, block in enumerate(self.transformer_blocks):
-            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device=hidden_states.device)
+            transformer_options["block_index"] = torch.tensor(i, dtype=torch.uint8, device="cpu")
             if ("double_block", i) in blocks_replace:
                 def block_wrap(args):
                     out = {}


### PR DESCRIPTION
- Convert the `block_index` from `int` to a `torch.Tensor`, to support `torch.compile`
    - **dtype:** `torch.uint8`
    - **device:** ~~input's device~~ `cpu`