### PR TITLE
Lower VAE loading requirements：Create a new branch for GPU memory calculations in qwen-image vae

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -536,7 +536,7 @@ class VAE:
                     self.working_dtypes = [torch.bfloat16, torch.float16, torch.float32]
                     self.memory_used_encode = lambda shape, dtype: 3300 * shape[3] * shape[4] * model_management.dtype_size(dtype)
                     self.memory_used_decode = lambda shape, dtype: 8000 * shape[3] * shape[4] * (16 * 16) * model_management.dtype_size(dtype)
-                else:  # Wan 2.1 VAE 
+                else:  # Wan 2.1 VAE
                     dim = sd["decoder.head.0.gamma"].shape[0]
                     self.upscale_ratio = (lambda a: max(0, a * 4 - 3), 8, 8)
                     self.upscale_index_formula = (4, 8, 8)


### PR DESCRIPTION
# ComfyUI: Improved VAE Memory Estimation for Qwen-Image

Hello ComfyUI developers and maintainers,

I am a long-term user of ComfyUI, and while building a workflow for `qwen-image-edit`, I noticed an issue with VAE memory estimation.

The VAE memory calculation currently inherits from the Wan2.1 branch. On GPUs with less than 32GB (e.g., RTX 5090), VAE decoding for `qwen-image` can take very long—around 4 seconds per inference.

## Memory Measurement

To evaluate the actual memory requirement for `qwen-image` VAE, I created a ComfyUI workflow that loads **only the VAE** and measured encode/decode memory for a 768×1152 image. The results:

| Operation | Formula memory_used (MB) | Measured min memory (MB) | Measured max memory (MB) |
|-----------|-------------------------|-------------------------|-------------------------|
| Encode    | 10125                   | 242.03                  | 2524.85                 |
| Decode    | 11812.5                 | 242.03                  | 3649.99                 |

## Original Memory Formula

```python
self.memory_used_encode = lambda shape, dtype: 6000 * shape[3] * shape[4] * model_management.dtype_size(dtype)
self.memory_used_decode = lambda shape, dtype: 7000 * shape[3] * shape[4] * (8 * 8) * model_management.dtype_size(dtype)
```

## Suggested Constants Based on Measurements

```
K_encode_new = 2000 * 2524.85 / 3375 ≈ 1496
K_decode_new = 2000 * 3649.99 / 3375 ≈ 2164
```

Updated memory formula in `ComfyUI/comfy/sd.py`:

```python
elif "qwen_image" in sd:  # Qwen-Image-Edit / Qwen-Image
    logging.info("qwen-image tag detected, loading VAE with adjusted memory estimation.")
    self.upscale_ratio = (lambda a: max(0, a * 4 - 3), 8, 8)
    self.upscale_index_formula = (4, 8, 8)
    self.downscale_ratio = (lambda a: max(0, math.floor((a + 3) / 4)), 8, 8)
    self.downscale_index_formula = (4, 8, 8)
    self.latent_dim = 3
    self.latent_channels = 16
    ddconfig = {"dim": 96, "z_dim": self.latent_channels, "dim_mult": [1, 2, 4, 4], "num_res_blocks": 2, "attn_scales": [], "temperal_downsample": [False, True, True], "dropout": 0.0}
    self.first_stage_model = comfy.ldm.wan.vae.WanVAE(**ddconfig)
    self.working_dtypes = [torch.bfloat16, torch.float16, torch.float32]
    # Updated memory estimation constants
    self.memory_used_encode = lambda shape, dtype: 1500 * shape[3] * shape[4] * model_management.dtype_size(dtype)
    self.memory_used_decode = lambda shape, dtype: 2200 * shape[3] * shape[4] * (8 * 8) * model_management.dtype_size(dtype)
```

## Marker Key in VAE

To detect `qwen_image`, a marker key is inserted in the VAE safetensors:

```python
from safetensors.torch import safe_open, save_file
import torch

vae_weight_path = "/root/autodl-tmp/ComfyUI/models/vae/qwen_image_vae.safetensors"
new_vae_path = "/root/autodl-tmp/ComfyUI/models/vae/new_qwen_image_vae.safetensors"

state_dict = {}
with safe_open(vae_weight_path, framework="pt") as f:
    keys = list(f.keys())
    first_tensor = f.get_tensor(keys[0])
    dtype = first_tensor.dtype
    for k in keys:
        state_dict[k] = f.get_tensor(k)

# Insert empty key qwen_image with the same dtype
state_dict["qwen_image"] = torch.zeros((0,), dtype=dtype)

# Save the new VAE
save_file(state_dict, new_vae_path)
print(f"Saved new VAE with marker key (dtype={dtype}) to {new_vae_path}")
```

The updated VAE weights are published here: [https://huggingface.co/jiangchengchengNLP/Qwen-Image_VAE](https://huggingface.co/jiangchengchengNLP/Qwen-Image_VAE)

## Results

- For images up to 1024×1536, VAE encode/decode runs entirely on GPU
- Decoding time decreased from ~4.5s to ~1.8s (Or lower, depending on your reasoning size.)for `qwen-image`
- For 1536×1536 images, GPU memory may still be insufficient, causing VAE to fall back to CPU

This change improves memory estimation, reduces decode time, and allows safe GPU inference for most image sizes.