### PR TITLE
fix: correctly process the Node V1 dict results on V3 node

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -1815,7 +1815,7 @@ class NodeOutput(_NodeOutputInternal):
             ui = data["ui"]
         if "expand" in data:
             expand = data["expand"]
-        return cls(args=args, ui=ui, expand=expand)
+        return cls(*args, ui=ui, expand=expand)
 
     def __getitem__(self, index) -> Any:
         return self.args[index]


### PR DESCRIPTION
Found by chance by a type checker, looks like a typo in the code.

Right now `NodeOutput.from_dict` will always raise an exception, as `NodeOutput` class does not define `args` argument as possible `kwarg`.

Tested on such code in the V3 node:

```python

return {"result": [output_text, "something else"]}
```        

This will lead to such exception during execution:
```
File "/home/shurik/Comfy/ComfyUI-work/comfy_api/latest/_io.py", line 1541, in EXECUTE_NORMALIZED_ASYNC
    to_return = NodeOutput.from_dict(to_return)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shurik/Comfy/ComfyUI-work/comfy_api/latest/_io.py", line 1818, in from_dict
    return cls(args=args, ui=ui, expand=expand)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: NodeOutput.__init__() got an unexpected keyword argument 'args'
```

