### PR TITLE
System prompt "low-quality" for Lumina 2 (CLIPTextEncodeLumina2)

### DIFF
--- a/comfy_extras/nodes_lumina2.py
+++ b/comfy_extras/nodes_lumina2.py
@@ -69,12 +69,16 @@ class CLIPTextEncodeLumina2(io.ComfyNode):
             "degree of image-text alignment based on textual prompts or user prompts.",
         "alignment": "You are an assistant designed to generate high-quality images with the "\
             "highest degree of image-text alignment based on textual prompts."
+        "low-quality": "You are an assistant designed to generate low-quality images "\
+            "based on textual prompts."
     }
-    SYSTEM_PROMPT_TIP = "Lumina2 provide two types of system prompts:" \
+    SYSTEM_PROMPT_TIP = "Lumina2 provide 3 types of system prompts:" \
         "Superior: You are an assistant designed to generate superior images with the superior "\
         "degree of image-text alignment based on textual prompts or user prompts. "\
         "Alignment: You are an assistant designed to generate high-quality images with the highest "\
         "degree of image-text alignment based on textual prompts."
+        "Low Quality: You are an assistant designed to generate low-quality images "\
+        "based on textual prompts or user prompts."
     @classmethod
     def define_schema(cls):
         return io.Schema(


### PR DESCRIPTION
This commit adds the system prompt "low-quality" for negative prompts in Lumina 2.

This system prompt is used in official workflow image (not the JSON) [here](https://cdn-uploads.huggingface.co/production/uploads/655319e00166ff6bd2351948/XPWf7M1OE5DogKwNlnQIk.png), visit [Downloads & Installation](https://huggingface.co/neta-art/Neta-Lumina#downloads--installation) and scroll down.
<img width="3394" height="1384" alt="XPWf7M1OE5DogKwNlnQIk" src="https://github.com/user-attachments/assets/14e69d58-f4e0-4211-a747-16a6d8a7d19d" />

