### PR TITLE
Add handling for vace_context in context windows

### DIFF
--- a/comfy/context_windows.py
+++ b/comfy/context_windows.py
@@ -188,6 +188,12 @@ class IndexListContextHandler(ContextHandlerABC):
                                 audio_cond = cond_value.cond
                                 if audio_cond.ndim > 1 and audio_cond.size(1) == x_in.size(self.dim):
                                     new_cond_item[cond_key] = cond_value._copy_with(window.get_tensor(audio_cond, device, dim=1))
+                            # Handle vace_context (temporal dim is 3)
+                            elif cond_key == "vace_context" and hasattr(cond_value, "cond") and isinstance(cond_value.cond, torch.Tensor):
+                                vace_cond = cond_value.cond
+                                if vace_cond.ndim >= 4 and vace_cond.size(3) == x_in.size(self.dim):
+                                    sliced_vace = window.get_tensor(vace_cond, device, dim=3, retain_index_list=self.cond_retain_index_list)
+                                    new_cond_item[cond_key] = cond_value._copy_with(sliced_vace)
                             # if has cond that is a Tensor, check if needs to be subset
                             elif hasattr(cond_value, "cond") and isinstance(cond_value.cond, torch.Tensor):
                                 if  (self.dim < cond_value.cond.ndim and cond_value.cond.size(self.dim) == x_in.size(self.dim)) or \


### PR DESCRIPTION
Simply slices up `vace_context` by window to allow the usage of VACE conditioning with Context Windows.
Since the reference image is not separated from the rest of the VACE context, there is no way to know if it includes a reference image. When the `retain_index_list` parameter set to 0 the reference frame will be applied properly to each context window. Consider exposing this option so that users can use VACE with context windows and reference frames.