### PR TITLE
Implement sliding attention in Gemma3

### DIFF
--- a/comfy/text_encoders/llama.py
+++ b/comfy/text_encoders/llama.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 from dataclasses import dataclass
 from typing import Optional, Any
 import math
-import logging
 
 from comfy.ldm.modules.attention import optimized_attention_for_device
 import comfy.model_management


### PR DESCRIPTION
As the NewBie model uses detailed XML prompts that can be > 1024 tokens, it's time to implement the sliding attention that's previously missing in Gemma3.

I found a mistake in the config that Gemma3 should use 5 sliding + 1 non-sliding, not vice-versa. `rope_theta` and `rope_scale` are also swapped accordingly. (Before sliding attention is implemented, this does not affect the results with < 1024 tokens.)

After this PR, the condition tensor from Gemma3 in ComfyUI is much closer to the one from Gemma3 in Transformers.