### PR TITLE
Support LoRA from NewBie LoRA trainer

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -322,6 +322,10 @@ def model_lora_keys_unet(model, key_map={}):
                 key_map["diffusion_model.{}".format(key_lora)] = to
                 key_map["transformer.{}".format(key_lora)] = to
                 key_map["lycoris_{}".format(key_lora.replace(".", "_"))] = to
+        for k in sdk:
+            if k.startswith("diffusion_model.") and k.endswith(".weight"):
+                key_lora = k[len("diffusion_model."):-len(".weight")]
+                key_map["base_model.model.{}".format(key_lora)] = k # NewBie LoRA trainer
 
     if isinstance(model, comfy.model_base.Kandinsky5):
         for k in sdk:


### PR DESCRIPTION
This kind of LoRAs come from [NewBie LoRA trainer](https://github.com/NewBieAI-Lab/NewbieLoraTrainer), and there is the prefix `base_model.model.` in their keys. This may also happen for other training scripts that directly export the LoRA from PEFT. The official NewBie/Lumina2/Z-Image models do not have this prefix, so I implemented the mapping.

An example of the LoRA is https://civitai.com/models/2201563