### PR TITLE
Fix error from logging line in Context Windows

### DIFF
--- a/comfy/context_windows.py
+++ b/comfy/context_windows.py
@@ -143,7 +143,7 @@ class IndexListContextHandler(ContextHandlerABC):
         # if multiple conds, split based on primary region
         if self.split_conds_to_windows and len(cond_in) > 1:
             region = window.get_region_index(len(cond_in))
-            logging.info(f"Splitting conds to windows; using region {region} for window {window[0]}-{window[-1]} with center ratio {window.center_ratio:.3f}")
+            logging.info(f"Splitting conds to windows; using region {region} for window {window.index_list[0]}-{window.index_list[-1]} with center ratio {window.center_ratio:.3f}")
             cond_in = [cond_in[region]]
         # cond object is a list containing a dict - outer list is irrelevant, so just loop through it
         for actual_cond in cond_in:


### PR DESCRIPTION
Even though this feature is not fully exposed yet in the nodes, there is still a bug in the logging line when splitting conds to windows.
`window[0]` should instead be `window.index_list[0]`