### PR TITLE
Fix  model_patcher.py by adding safety check for 'pinned'

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -651,8 +651,12 @@ class ModelPatcher:
             self.pinned.remove(key)
 
     def unpin_all_weights(self):
-        for key in list(self.pinned):
-            self.unpin_weight(key)
+        if hasattr(self, 'pinned'):  # Safety check
+            for key in list(self.pinned):
+                self.unpin_weight(key)
+        else:
+            # Log or skip: self.pinned was not set
+            pass
 
     def _load_list(self):
         loading = []
@@ -1354,6 +1358,12 @@ class ModelPatcher:
         self.clear_cached_hook_weights()
 
     def __del__(self):
-        self.unpin_all_weights()
-        self.detach(unpatch_all=False)
+        try:
+            if hasattr(self, 'pinned'):
+                self.unpin_all_weights()
+            # Existing code...
+        except Exception as e:
+            # Suppress errors in destructor to avoid noise
+            pass
+
 

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1361,7 +1361,7 @@ class ModelPatcher:
         try:
             if hasattr(self, 'pinned'):
                 self.unpin_all_weights()
-            # Existing code...
+                self.detach(unpatch_all=False)
         except Exception as e:
             # Suppress errors in destructor to avoid noise
             pass


### PR DESCRIPTION
After update to v0.6.0 got this error in Nunchaku LoRA Loader:
```
!!! Exception during processing !!! 'NoneType' object is not callable
Traceback (most recent call last):
  File "c:\ComfyUI\execution.py", line 516, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\ComfyUI\execution.py", line 330, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\ComfyUI\execution.py", line 304, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "c:\ComfyUI\execution.py", line 292, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "C:\ComfyUI\custom_nodes\ComfyUI-nunchaku\nodes\lora\flux.py", line 117, in load_lora
    ret_model = copy.deepcopy(model)  # copy everything except the model
                ^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 162, in deepcopy
    y = _reconstruct(x, memo, *rv)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 259, in _reconstruct
    state = deepcopy(state, memo)
            ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 136, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 221, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 162, in deepcopy
    y = _reconstruct(x, memo, *rv)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 259, in _reconstruct
    state = deepcopy(state, memo)
            ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 136, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 221, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 162, in deepcopy
    y = _reconstruct(x, memo, *rv)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 261, in _reconstruct
    y.__setstate__(state)
TypeError: 'NoneType' object is not callable

Prompt executed in 48.54 seconds
Exception ignored in: <function ModelPatcher.__del__ at 0x000002386C4B67A0>
Traceback (most recent call last):
  File "c:\ComfyUI\comfy\model_patcher.py", line 1357, in __del__
    self.unpin_all_weights()
  File "c:\ComfyUI\comfy\model_patcher.py", line 654, in unpin_all_weights
    for key in list(self.pinned):
                    ^^^^^^^^^^^
AttributeError: 'ModelPatcher' object has no attribute 'pinned'
```
This fix AttributeError in ModelPatcher.__del__ by adding safety check for 'pinned'.
***With pull request in ComfyUI-nunchaku - https://github.com/nunchaku-tech/ComfyUI-nunchaku/pull/737