### PR TITLE
Update the rocm.nightlies.amd.com link for the 7000 series

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ These have less hardware support than the builds above but they work on windows.
 
 RDNA 3 (RX 7000 series):
 
-```pip install --pre torch torchvision torchaudio --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/```
+```pip install --pre torch torchvision torchaudio --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/```
 
 RDNA 3.5 (Strix halo/Ryzen AI Max+ 365):
 


### PR DESCRIPTION
As far as I know, they stopped using the gfx110X-dgpu directory and instead, use the gfx110X-all directory now. You can verify this by looking at the builds dates +rocmX.X.Xa2025___ between the two directories