### PR TITLE
fix: RFC 2183/5987 compliant Content-Disposition header in /view endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -200,8 +200,8 @@ def create_content_disposition_header(filename: str) -> str:
     """
     # ASCII-safe filename for legacy clients (replace non-ASCII with ?)
     ascii_filename = filename.encode('ascii', 'replace').decode('ascii')
-    # Escape quotes to prevent malformed header (e.g., filename="file"name.png")
-    ascii_filename = ascii_filename.replace('"', "'")
+    # RFC 2183: escape backslashes and quotes within quoted-string
+    ascii_filename = ascii_filename.replace('\\', '\\\\').replace('"', '\\"')
     # RFC 5987 percent-encoded filename for UTF-8 support
     encoded_filename = quote(filename, safe='')
     return f"attachment; filename=\"{ascii_filename}\"; filename*=UTF-8''{encoded_filename}"


### PR DESCRIPTION
## Summary

Fixes the `Content-Disposition` header in the `/view` endpoint to comply with RFC 2183 and RFC 5987.

**Before:** `Content-Disposition: filename="name.ext"`
**After:** `Content-Disposition: attachment; filename="name.ext"; filename*=UTF-8''name.ext`

## Problem

The current header format is missing the required disposition-type (`attachment;`) per RFC 2183. This causes third-party download libraries (e.g., Go's `mime.ParseMediaType`) to fail to parse the filename, resulting in files being saved with incorrect names like "view" instead of the actual filename.

Reported in #8914.

## Changes

- Add `create_content_disposition_header()` helper function that generates RFC-compliant headers
- Update all 4 Content-Disposition headers in the `view_image` endpoint
- Provide ASCII fallback `filename=` for legacy clients (non-ASCII chars replaced with `?`)
- Add RFC 5987 `filename*=UTF-8''` parameter for proper international filename support

## Testing

- Added unit tests covering ASCII, Unicode (Chinese, Japanese), special characters, spaces, and edge cases
- All 9 new tests pass
- Manual testing can be done with: `curl -I "http://localhost:8188/view?filename=test.png"`

## Compatibility

This change is backward compatible:
- Modern browsers/clients will use the `filename*` parameter for UTF-8 support
- Legacy clients will fall back to the ASCII `filename` parameter
- The `attachment;` disposition-type is universally supported

Fixes #8914