### PR TITLE
fix(logger): handle OSError errno 22 on flush for Windows piped streams

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -48,7 +48,8 @@ class LogInterceptor(io.TextIOWrapper):
                 raise
         if not self._logs_since_flush:
             return
-        logs_to_send = self._logs_since_flush
+        # Copy to prevent callback mutations from affecting retry on failure
+        logs_to_send = list(self._logs_since_flush)
         for cb in self._flush_callbacks:
             cb(logs_to_send)
         # Only clear after all callbacks succeed - if any raises, logs remain for retry


### PR DESCRIPTION
## Summary
- Fixes crash when custom nodes use `print()` in API mode on Windows
- Catches `OSError` with errno 22 (EINVAL) in `LogInterceptor.flush()` that can occur with piped/redirected stdout
- Adds comprehensive unit tests for the logger flush behavior

## Problem
When running ComfyUI in API mode on Windows, print statements from custom nodes crash with:
```
OSError: [Errno 22] Invalid argument
```

This occurs because the log interceptor's `flush()` method fails on piped/redirected streams, even though the `write()` operation succeeded.

## Solution
Wrap the `super().flush()` call in a try-except block that specifically catches errno 22. This error is safe to ignore because:
1. The `write()` already succeeded
2. The flush callbacks still need to execute
3. This is a known Windows issue with piped streams

## Test plan
- [x] Added unit tests in `tests-unit/app_test/test_logger.py`
- [x] All tests pass (`python -m pytest tests-unit/app_test/test_logger.py -v`)
- [x] Existing tests still pass

Fixes #11367