### PR TITLE
Ignore all frames except the first one for MPO format.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1663,8 +1663,6 @@ class LoadImage:
         output_masks = []
         w, h = None, None
 
-        excluded_formats = ['MPO']
-
         for i in ImageSequence.Iterator(img):
             i = node_helpers.pillow(ImageOps.exif_transpose, i)
 
@@ -1692,7 +1690,10 @@ class LoadImage:
             output_images.append(image)
             output_masks.append(mask.unsqueeze(0))
 
-        if len(output_images) > 1 and img.format not in excluded_formats:
+            if img.format == "MPO":
+                break  # ignore all frames except the first one for MPO format
+
+        if len(output_images) > 1:
             output_image = torch.cat(output_images, dim=0)
             output_mask = torch.cat(output_masks, dim=0)
         else:


### PR DESCRIPTION
Alternative PR of #11565 with more simpler logic

All logic remains the same as current: we ignore all frames except the first one for MPO.