### PR TITLE
Fix VAEEncodeForInpaint to support WAN VAE tuple downscale_ratio

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -374,14 +374,15 @@ class VAEEncodeForInpaint:
     CATEGORY = "latent/inpaint"
 
     def encode(self, vae, pixels, mask, grow_mask_by=6):
-        x = (pixels.shape[1] // vae.downscale_ratio) * vae.downscale_ratio
-        y = (pixels.shape[2] // vae.downscale_ratio) * vae.downscale_ratio
+        downscale_ratio = vae.spacial_compression_encode()
+        x = (pixels.shape[1] // downscale_ratio) * downscale_ratio
+        y = (pixels.shape[2] // downscale_ratio) * downscale_ratio
         mask = torch.nn.functional.interpolate(mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])), size=(pixels.shape[1], pixels.shape[2]), mode="bilinear")
 
         pixels = pixels.clone()
         if pixels.shape[1] != x or pixels.shape[2] != y:
-            x_offset = (pixels.shape[1] % vae.downscale_ratio) // 2
-            y_offset = (pixels.shape[2] % vae.downscale_ratio) // 2
+            x_offset = (pixels.shape[1] % downscale_ratio) // 2
+            y_offset = (pixels.shape[2] % downscale_ratio) // 2
             pixels = pixels[:,x_offset:x + x_offset, y_offset:y + y_offset,:]
             mask = mask[:,:,x_offset:x + x_offset, y_offset:y + y_offset]
 


### PR DESCRIPTION
Resubmit of https://github.com/comfyanonymous/ComfyUI/pull/11259

I've corrected the whitespace issues but kept the OPs git authorship. Content taken from:

```
git remote add cf https://github.com/ChrisFab16/ComfyUI.git
git show -w 01b86f143ec65211435960107fa92efdd71144cd
commit 01b86f143ec65211435960107fa92efdd71144cd (cf/fix/wan-vae-downscale-ratio-inpaint)
Author: ChrisFab16 <christopher@fabritius.dk>
Date:   Fri Dec 19 10:40:50 2025 +0100

    Fix VAEEncodeForInpaint to support WAN VAE tuple downscale_ratio
    
    Use vae.spacial_compression_encode() instead of directly accessing
    downscale_ratio to handle both standard VAEs (int) and WAN VAEs (tuple).
    
    Addresses reviewer feedback on PR #11259.

diff --git a/nodes.py b/nodes.py
index b13ceb57..d413065b 100644
--- a/nodes.py
+++ b/nodes.py
@@ -374,14 +374,15 @@ class VAEEncodeForInpaint:
     CATEGORY = "latent/inpaint"
 
     def encode(self, vae, pixels, mask, grow_mask_by=6):
-        x = (pixels.shape[1] // vae.downscale_ratio) * vae.downscale_ratio
-        y = (pixels.shape[2] // vae.downscale_ratio) * vae.downscale_ratio
+        downscale_ratio = vae.spacial_compression_encode()^M
+        x = (pixels.shape[1] // downscale_ratio) * downscale_ratio^M
+        y = (pixels.shape[2] // downscale_ratio) * downscale_ratio^M
         mask = torch.nn.functional.interpolate(mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])), size=(pixels.shape[1], pixels.shape[2]), mode="bilinear")
 
         pixels = pixels.clone()
         if pixels.shape[1] != x or pixels.shape[2] != y:
-            x_offset = (pixels.shape[1] % vae.downscale_ratio) // 2
-            y_offset = (pixels.shape[2] % vae.downscale_ratio) // 2
+            x_offset = (pixels.shape[1] % downscale_ratio) // 2^M
+            y_offset = (pixels.shape[2] % downscale_ratio) // 2^M
             pixels = pixels[:,x_offset:x + x_offset, y_offset:y + y_offset,:]
             mask = mask[:,:,x_offset:x + x_offset, y_offset:y + y_offset]
```

Use vae.spacial_compression_encode() instead of directly accessing downscale_ratio to handle both standard VAEs (int) and WAN VAEs (tuple).

Test case:

Qwen VAE + VAE Encoding (for Inpaint) Node

<img width="1264" height="608" alt="image" src="https://github.com/user-attachments/assets/e576aae3-1830-40d7-b1d6-c0e577ef955e" />


Before:

```
Using pytorch attention in VAE
Using pytorch attention in VAE
VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
!!! Exception during processing !!! unsupported operand type(s) for //: 'int' and 'tuple'
Traceback (most recent call last):
  File "/home/rattus/ComfyUI/execution.py", line 518, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/execution.py", line 329, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/execution.py", line 303, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "/home/rattus/ComfyUI/execution.py", line 291, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "/home/rattus/ComfyUI/nodes.py", line 377, in encode
    x = (pixels.shape[1] // vae.downscale_ratio) * vae.downscale_ratio
         ~~~~~~~~~~~~~~~~^^~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for //: 'int' and 'tuple'

Prompt executed in 0.10 seconds
```

After:

```
got prompt
Using pytorch attention in VAE
Using pytorch attention in VAE
VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
Requested to load WanVAE
loaded completely; 26934.63 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 0.56 seconds
```