### PR TITLE
Support MThreads (MUSA) GPU

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -138,6 +138,12 @@ try:
 except:
     ixuca_available = False
 
+try:
+    import torchada  # noqa: F401
+    musa_available = hasattr(torch, "musa") and torch.musa.is_available()
+except:
+    musa_available = False
+
 if args.cpu:
     cpu_state = CPUState.CPU
 
@@ -145,27 +151,24 @@ def is_intel_xpu():
     global cpu_state
     global xpu_available
     if cpu_state == CPUState.GPU:
-        if xpu_available:
-            return True
+        return xpu_available
     return False
 
 def is_ascend_npu():
     global npu_available
-    if npu_available:
-        return True
-    return False
+    return npu_available
 
 def is_mlu():
     global mlu_available
-    if mlu_available:
-        return True
-    return False
+    return mlu_available
 
 def is_ixuca():
     global ixuca_available
-    if ixuca_available:
-        return True
-    return False
+    return ixuca_available
+
+def is_musa():
+    global musa_available
+    return musa_available
 
 def get_torch_device():
     global directml_enabled
@@ -310,7 +313,7 @@ def amd_min_version(device=None, min_rdna_version=0):
     return False
 
 MIN_WEIGHT_MEMORY_RATIO = 0.4
-if is_nvidia():
+if is_nvidia() or is_musa():
     MIN_WEIGHT_MEMORY_RATIO = 0.0
 
 ENABLE_PYTORCH_ATTENTION = False
@@ -319,7 +322,7 @@ if args.use_pytorch_cross_attention:
     XFORMERS_IS_AVAILABLE = False
 
 try:
-    if is_nvidia():
+    if is_nvidia() or is_musa():
         if torch_version_numeric[0] >= 2:
             if ENABLE_PYTORCH_ATTENTION == False and args.use_split_cross_attention == False and args.use_quad_cross_attention == False:
                 ENABLE_PYTORCH_ATTENTION = True
@@ -386,7 +389,7 @@ if ENABLE_PYTORCH_ATTENTION:
 
 PRIORITIZE_FP16 = False  # TODO: remove and replace with something that shows exactly which dtype is faster than the other
 try:
-    if (is_nvidia() or is_amd()) and PerformanceFeature.Fp16Accumulation in args.fast:
+    if (is_nvidia() or is_amd() or is_musa()) and PerformanceFeature.Fp16Accumulation in args.fast:
         torch.backends.cuda.matmul.allow_fp16_accumulation = True
         PRIORITIZE_FP16 = True  # TODO: limit to cards where it actually boosts performance
         logging.info("Enabled fp16 accumulation.")
@@ -1031,7 +1034,7 @@ if args.async_offload is not None:
     NUM_STREAMS = args.async_offload
 else:
     #  Enable by default on Nvidia and AMD
-    if is_nvidia() or is_amd():
+    if is_nvidia() or is_amd() or is_musa():
         NUM_STREAMS = 2
 
 if args.disable_async_offload:
@@ -1128,7 +1131,7 @@ PINNED_MEMORY = {}
 TOTAL_PINNED_MEMORY = 0
 MAX_PINNED_MEMORY = -1
 if not args.disable_pinned_memory:
-    if is_nvidia() or is_amd():
+    if is_nvidia() or is_amd() or is_musa():
         if WINDOWS:
             MAX_PINNED_MEMORY = get_total_memory(torch.device("cpu")) * 0.45  # Windows limit is apparently 50%
         else:
@@ -1272,6 +1275,8 @@ def pytorch_attention_flash_attention():
             return True #if you have pytorch attention enabled on AMD it probably supports at least mem efficient attention
         if is_ixuca():
             return True
+        if is_musa():
+            return True
     return False
 
 def force_upcast_attention_dtype():
@@ -1403,6 +1408,9 @@ def should_use_fp16(device=None, model_params=0, prioritize_performance=True, ma
     if torch.version.hip:
         return True
 
+    if is_musa():
+        return True
+
     props = torch.cuda.get_device_properties(device)
     if props.major >= 8:
         return True
@@ -1473,6 +1481,9 @@ def should_use_bf16(device=None, model_params=0, prioritize_performance=True, ma
                 return True
             return False
 
+    if is_musa():
+        return True
+
     props = torch.cuda.get_device_properties(device)
 
     if is_mlu():
@@ -1495,25 +1506,27 @@ def supports_fp8_compute(device=None):
     if SUPPORT_FP8_OPS:
         return True
 
-    if not is_nvidia():
-        return False
-
     props = torch.cuda.get_device_properties(device)
-    if props.major >= 9:
-        return True
-    if props.major < 8:
-        return False
-    if props.minor < 9:
-        return False
-
-    if torch_version_numeric < (2, 3):
-        return False
-
-    if WINDOWS:
-        if torch_version_numeric < (2, 4):
+    if is_nvidia():
+        if props.major >= 9:
+            return True
+        if props.major < 8:
+            return False
+        if props.minor < 9:
             return False
 
-    return True
+        if torch_version_numeric < (2, 3):
+            return False
+
+        if WINDOWS:
+            if torch_version_numeric < (2, 4):
+                return False
+
+    elif is_musa():
+        if props.major >= 3:
+            return True
+
+    return False
 
 def supports_nvfp4_compute(device=None):
     if not is_nvidia():
@@ -1564,7 +1577,7 @@ def unload_all_models():
     free_memory(1e30, get_torch_device())
 
 def debug_memory_summary():
-    if is_amd() or is_nvidia():
+    if is_amd() or is_nvidia() or is_musa():
         return torch.cuda.memory.memory_summary()
     return ""
 

--- a/main.py
+++ b/main.py
@@ -37,11 +37,13 @@ if __name__ == "__main__":
         devices = ','.join(map(str, devices))
         os.environ['CUDA_VISIBLE_DEVICES'] = str(devices)
         os.environ['HIP_VISIBLE_DEVICES'] = str(devices)
+        os.environ['MUSA_VISIBLE_DEVICES'] = str(devices)
 
     if args.cuda_device is not None:
         os.environ['CUDA_VISIBLE_DEVICES'] = str(args.cuda_device)
         os.environ['HIP_VISIBLE_DEVICES'] = str(args.cuda_device)
         os.environ["ASCEND_RT_VISIBLE_DEVICES"] = str(args.cuda_device)
+        os.environ['MUSA_VISIBLE_DEVICES'] = str(args.cuda_device)
         logging.info("Set cuda device to: {}".format(args.cuda_device))
 
     if args.oneapi_device_selector is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ kornia>=0.7.1
 spandrel
 pydantic~=2.0
 pydantic-settings~=2.0
+torchada>=0.1.22


### PR DESCRIPTION
This PR adds support for Moore Threads (MUSA) GPU platform, expanding ComfyUI's hardware compatibility.

#### Testing Done

1. Tested `flux1_krea_dev` template to generate an image from the given prompt:
<img width="1353" height="801" alt="flux" src="https://github.com/user-attachments/assets/509e228d-605c-4f6c-8172-164f1dc60e30" />

2. Followed https://comfyanonymous.github.io/ComfyUI_examples/wan/ to run a Text to Video workflow (umt5_xxl_fp8_e4m3fn_scaled.safetensors+wan_2.1_vae.safetensors+wan2.1_t2v_1.3B_fp16.safetensors):

<img width="1392" height="801" alt="screenshot" src="https://github.com/user-attachments/assets/f3c878e4-872a-49e0-b9f8-ebf8f87bb70c" />

Server logs:
```bash
root@worker3218:/ws# python main.py --enable-manager
[START] Security scan
[ComfyUI-Manager] Using uv as Python module for pip operations.
Using Python 3.10.12 environment at: /usr
[DONE] Security scan
** ComfyUI startup time: 2026-01-04 17:49:31.633
** Platform: Linux
** Python version: 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
** Python executable: /usr/bin/python
** ComfyUI Path: /ws
** ComfyUI Base Folder Path: /ws
** User directory: /ws/user
** ComfyUI-Manager config path: /ws/user/__manager/config.ini
** Log path: /ws/user/comfyui.log
Using Python 3.10.12 environment at: /usr
Using Python 3.10.12 environment at: /usr
[PRE] ComfyUI-Manager
Checkpoint files will always be loaded safely.
Total VRAM 81838 MB, total RAM 2063756 MB
2026-01-04 17:49:35 | model_management | 140030750700672 | INFO : Total VRAM 81838 MB, total RAM 2063756 MB
pytorch version: 2.7.1
2026-01-04 17:49:35 | model_management | 140030750700672 | INFO : pytorch version: 2.7.1
Set vram state to: NORMAL_VRAM
2026-01-04 17:49:35 | model_management | 140030750700672 | INFO : Set vram state to: NORMAL_VRAM
Device: musa
2026-01-04 17:49:35 | model_management | 140030750700672 | INFO : Device: musa
Using async weight offloading with 2 streams
2026-01-04 17:49:35 | model_management | 140030750700672 | INFO : Using async weight offloading with 2 streams
Enabled pinned memory 1960568.0
2026-01-04 17:49:35 | model_management | 140030750700672 | INFO : Enabled pinned memory 1960568.0
Using pytorch attention
2026-01-04 17:49:36 | attention | 140030750700672 | INFO : Using pytorch attention
Python version: 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
2026-01-04 17:49:37 | main | 140030750700672 | INFO : Python version: 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
ComfyUI version: 0.7.0
2026-01-04 17:49:37 | main | 140030750700672 | INFO : ComfyUI version: 0.7.0
ComfyUI frontend version: 1.35.9
2026-01-04 17:49:37 | frontend_management | 140030750700672 | INFO : ComfyUI frontend version: 1.35.9
[Prompt Server] web root: /usr/local/lib/python3.10/dist-packages/comfyui_frontend_package/static
2026-01-04 17:49:37 | server | 140030750700672 | INFO : [Prompt Server] web root: /usr/local/lib/python3.10/dist-packages/comfyui_frontend_package/static
[START] ComfyUI-Manager
2026-01-04 17:49:37 | __init__ | 140030750700672 | INFO : [START] ComfyUI-Manager
[ComfyUI-Manager] network_mode: public
2026-01-04 17:49:37 | manager_server | 140030750700672 | INFO : [ComfyUI-Manager] network_mode: public
Total VRAM 81838 MB, total RAM 2063756 MB
2026-01-04 17:49:37 | model_management | 140030750700672 | INFO : Total VRAM 81838 MB, total RAM 2063756 MB
pytorch version: 2.7.1
2026-01-04 17:49:37 | model_management | 140030750700672 | INFO : pytorch version: 2.7.1
Set vram state to: NORMAL_VRAM
2026-01-04 17:49:37 | model_management | 140030750700672 | INFO : Set vram state to: NORMAL_VRAM
Device: musa
2026-01-04 17:49:37 | model_management | 140030750700672 | INFO : Device: musa
Using async weight offloading with 2 streams
2026-01-04 17:49:37 | model_management | 140030750700672 | INFO : Using async weight offloading with 2 streams
Enabled pinned memory 1960568.0
2026-01-04 17:49:37 | model_management | 140030750700672 | INFO : Enabled pinned memory 1960568.0

Import times for custom nodes:
2026-01-04 17:49:38 | nodes | 140030750700672 | INFO : 
Import times for custom nodes:
   0.0 seconds: /ws/custom_nodes/websocket_image_save.py
2026-01-04 17:49:38 | nodes | 140030750700672 | INFO :    0.0 seconds: /ws/custom_nodes/websocket_image_save.py

2026-01-04 17:49:38 | nodes | 140030750700672 | INFO : 
Context impl SQLiteImpl.
2026-01-04 17:49:38 | migration | 140030750700672 | INFO : Context impl SQLiteImpl.
Will assume non-transactional DDL.
2026-01-04 17:49:38 | migration | 140030750700672 | INFO : Will assume non-transactional DDL.
No target revision found.
2026-01-04 17:49:38 | db | 140030750700672 | WARNING : No target revision found.
Starting server

2026-01-04 17:49:38 | server | 140030750700672 | INFO : Starting server

To see the GUI go to: http://127.0.0.1:8188
2026-01-04 17:49:38 | server | 140030750700672 | INFO : To see the GUI go to: http://127.0.0.1:8188
got prompt
2026-01-04 17:49:45 | server | 140030750700672 | INFO : got prompt
Using pytorch attention in VAE
2026-01-04 17:49:45 | model | 139999219230272 | INFO : Using pytorch attention in VAE
Using pytorch attention in VAE
2026-01-04 17:49:45 | model | 139999219230272 | INFO : Using pytorch attention in VAE
VAE load device: musa:0, offload device: cpu, dtype: torch.bfloat16
2026-01-04 17:49:45 | sd | 139999219230272 | INFO : VAE load device: musa:0, offload device: cpu, dtype: torch.bfloat16
Found quantization metadata version 1
2026-01-04 17:49:45 | utils | 139999219230272 | INFO : Found quantization metadata version 1
Using MixedPrecisionOps for text encoder
2026-01-04 17:49:45 | sd1_clip | 139999219230272 | INFO : Using MixedPrecisionOps for text encoder
CLIP/text encoder model load device: musa:0, offload device: cpu, current: cpu, dtype: torch.float16
2026-01-04 17:49:46 | sd | 139999219230272 | INFO : CLIP/text encoder model load device: musa:0, offload device: cpu, current: cpu, dtype: torch.float16
Requested to load WanTEModel
2026-01-04 17:49:46 | model_management | 139999219230272 | INFO : Requested to load WanTEModel
loaded completely; 80024.92 MB usable, 6419.49 MB loaded, full load: True
2026-01-04 17:49:51 | model_patcher | 139999219230272 | INFO : loaded completely; 80024.92 MB usable, 6419.49 MB loaded, full load: True
/ws/comfy/ops.py:34: UserWarning: Expected query, key and value to all be of dtype: {Half, BFloat16}. Got Query dtype: float, Key dtype: float, and Value dtype: float instead. (Triggered internally at /home/torch_musa/build/generated_cuda_compatible/include/ATen/native/transformers/sdp_utils_cpp.h:90.)
  return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)

2026-01-04 17:50:07 | warnings | 139999219230272 | WARNING : /ws/comfy/ops.py:34: UserWarning: Expected query, key and value to all be of dtype: {Half, BFloat16}. Got Query dtype: float, Key dtype: float, and Value dtype: float instead. (Triggered internally at /home/torch_musa/build/generated_cuda_compatible/include/ATen/native/transformers/sdp_utils_cpp.h:90.)
  return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)

model weight dtype torch.float16, manual cast: None
2026-01-04 17:50:07 | model_base | 139999219230272 | INFO : model weight dtype torch.float16, manual cast: None
model_type FLOW
2026-01-04 17:50:07 | model_base | 139999219230272 | INFO : model_type FLOW
Requested to load WAN21
2026-01-04 17:50:07 | model_management | 139999219230272 | INFO : Requested to load WAN21
loaded completely; 71799.64 MB usable, 2706.18 MB loaded, full load: True
2026-01-04 17:50:08 | model_patcher | 139999219230272 | INFO : loaded completely; 71799.64 MB usable, 2706.18 MB loaded, full load: True
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:28<00:00,  1.07it/s]
Requested to load WanVAE
2026-01-04 17:50:36 | model_management | 139999219230272 | INFO : Requested to load WanVAE
loaded completely; 64455.93 MB usable, 242.03 MB loaded, full load: True
2026-01-04 17:50:36 | model_patcher | 139999219230272 | INFO : loaded completely; 64455.93 MB usable, 242.03 MB loaded, full load: True
/ws/comfy/ops.py:34: UserWarning: Unsupported qk_head_dim: 384 v_head_dim: 384 for FlashAttention in MUSA backend (Triggered internally at /home/torch_musa/torch_musa/csrc/aten/ops/attention/mudnn/SDPUtils.h:129.)
  return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)

2026-01-04 17:50:36 | warnings | 139999219230272 | WARNING : /ws/comfy/ops.py:34: UserWarning: Unsupported qk_head_dim: 384 v_head_dim: 384 for FlashAttention in MUSA backend (Triggered internally at /home/torch_musa/torch_musa/csrc/aten/ops/attention/mudnn/SDPUtils.h:129.)
  return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)

Prompt executed in 55.36 seconds
2026-01-04 17:50:40 | main | 139999219230272 | INFO : Prompt executed in 55.36 seconds
FETCH ComfyRegistry Data [DONE]
2026-01-04 17:52:01 | cnr_utils | 139999742518848 | INFO : FETCH ComfyRegistry Data [DONE]
[ComfyUI-Manager] default cache updated: https://api.comfy.org/nodes
2026-01-04 17:52:01 | manager_util | 139999742518848 | INFO : [ComfyUI-Manager] default cache updated: https://api.comfy.org/nodes
FETCH DATA from: /ws/user/__manager/cache/1514988643_custom-node-list.json [DONE]
[ComfyUI-Manager] All startup tasks have been completed.
2026-01-04 17:52:02 | manager_server | 139999742518848 | INFO : [ComfyUI-Manager] All startup tasks have been completed.
got prompt
2026-01-04 17:52:27 | server | 140030750700672 | INFO : got prompt
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:27<00:00,  1.10it/s]
Prompt executed in 31.36 seconds
2026-01-04 17:52:58 | main | 139999219230272 | INFO : Prompt executed in 31.36 seconds
```