### PR TITLE
Ignore Windows stderr flush errors

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -32,7 +32,10 @@ class LogInterceptor(io.TextIOWrapper):
         super().write(data)
 
     def flush(self):
-        super().flush()
+        try:
+            super().flush()
+        except (OSError, ValueError):
+            pass
         for cb in self._flush_callbacks:
             cb(self._logs_since_flush)
             self._logs_since_flush = []


### PR DESCRIPTION
While running SDXL turbo API from web (comfyui workflow api [Windows]) I encountered below error - 

`"Execution error: {\"prompt_id\":\"a7ecfdc4-57a0-42eb-a397-2b4e09923ff5\",\"node_id\":\"9\",\"node_type\":\"KSampler\",\"executed\":[\"2\",\"4\",\"3\",\"6\"],\"exception_message\":\"[Errno 22] Invalid argument\\n\",\"exception_type\":\"OSError\",\"traceback\":[\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\execution.py\\\", line 516, in execute\\n    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)\\n                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\execution.py\\\", line 330, in get_output_data\\n    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)\\n                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\execution.py\\\", line 304, in _async_map_node_over_list\\n    await process_inputs(input_dict, i)\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\execution.py\\\", line 292, in process_inputs\\n    result = f(**inputs)\\n             ^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\nodes.py\\\", line 1538, in sample\\n    return common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise=denoise)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\nodes.py\\\", line 1505, in common_ksampler\\n    samples = comfy.sample.sample(model, noise, steps, cfg, sampler_name, scheduler, positive, negative, latent_image,\\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\sample.py\\\", line 60, in sample\\n    samples = sampler.sample(noise, positive, negative, cfg=cfg, latent_image=latent_image, start_step=start_step, last_step=last_step, force_full_denoise=force_full_denoise, denoise_mask=noise_mask, sigmas=sigmas, callback=callback, disable_pbar=disable_pbar, seed=seed)\\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\samplers.py\\\", line 1178, in sample\\n    return sample(self.model, noise, positive, negative, cfg, self.device, sampler, sigmas, self.model_options, latent_image=latent_image, denoise_mask=denoise_mask, callback=callback, disable_pbar=disable_pbar, seed=seed)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\samplers.py\\\", line 1068, in sample\\n    return cfg_guider.sample(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\samplers.py\\\", line 1050, in sample\\n    output = executor.execute(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=latent_shapes)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\patcher_extension.py\\\", line 112, in execute\\n    return self.original(*args, **kwargs)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\samplers.py\\\", line 994, in outer_sample\\n    output = self.inner_sample(noise, latent_image, device, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=latent_shapes)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\samplers.py\\\", line 980, in inner_sample\\n    samples = executor.execute(self, sigmas, extra_args, callback, noise, latent_image, denoise_mask, disable_pbar)\\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\patcher_extension.py\\\", line 112, in execute\\n    return self.original(*args, **kwargs)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\samplers.py\\\", line 752, in sample\\n    samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)\\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\mywork\\\\ai\\\\ComfyUI\\\\.venv\\\\Lib\\\\site-packages\\\\torch\\\\utils\\\\_contextlib.py\\\", line 120, in decorate_context\\n    return func(*args, **kwargs)\\n           ^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\comfy\\\\k_diffusion\\\\sampling.py\\\", line 188, in sample_euler\\n    for i in trange(len(sigmas) - 1, disable=disable):\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\mywork\\\\ai\\\\ComfyUI\\\\.venv\\\\Lib\\\\site-packages\\\\tqdm\\\\auto.py\\\", line 37, in trange\\n    return tqdm(range(*args), **kwargs)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\mywork\\\\ai\\\\ComfyUI\\\\.venv\\\\Lib\\\\site-packages\\\\tqdm\\\\asyncio.py\\\", line 24, in __init__\\n    super().__init__(iterable, *args, **kwargs)\\n\",\"  File \\\"C:\\\\mywork\\\\ai\\\\ComfyUI\\\\.venv\\\\Lib\\\\site-packages\\\\tqdm\\\\std.py\\\", line 1096, in __init__\\n    self.sp = self.status_printer(self.fp)\\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\",\"  File \\\"C:\\\\mywork\\\\ai\\\\ComfyUI\\\\.venv\\\\Lib\\\\site-packages\\\\tqdm\\\\std.py\\\", line 448, in status_printer\\n    getattr(sys.stderr, 'flush', lambda: None)()\\n\",\"  File \\\"C:\\\\mywork\\\\ai\\\\ComfyUI\\\\.venv\\\\Lib\\\\site-packages\\\\comfyui_manager\\\\prestartup_script.py\\\", line 346, in flush\\n    else:\\n\",\"  File \\\"C:\\\\Users\\\\akdesk\\\\AppData\\\\Local\\\\Programs\\\\ComfyUI\\\\resources\\\\ComfyUI\\\\app\\\\logger.py\\\", line 35, in flush\\n    try:\\n\"],\"current_inputs\":{\"seed\":[9493899430947],\"steps\":[1],\"cfg\":[1],\"sampler_name\":[\"euler\"],\"scheduler\":[\"simple\"],\"denoise\":[0.51],\"model\":[\"<comfy.model_patcher.ModelPatcher object at 0x000001A106DB4800>\"],\"positive\":[\"[[tensor([[[-3.8917, -2.5113,  4.7167,  ...,  0.1904,  0.4180, -0.2969],\\n         [ 0.0893, -0.6197, -0.4877,  ...,  0.5010, -0.0373, -0.1578],\\n         [-0.8100,  0.7784, -0.6064,  ...,  0.7569, -0.0574,  0.0363],\\n         ...,\\n         [ 0.1699,  0.4243, -1.4070,  ..., -0.4261,  0.3274,  0.1695],\\n         [ 0.1648,  0.4260, -1.4104,  ..., -0.4884,  0.2035,  0.0875],\\n         [ 0.1954,  0.4995, -1.3730,  ..., -0.5655,  0.1199, -0.0789]]]), {'pooled_output': tensor([[-0.7455,  0.1107, -0.6369,  ..., -1.5046, -0.4919,  1.4990]])}]]\"],\"negative\":[\"[[tensor([[[0., 0., 0.,  ..., 0., 0., 0.],\\n         [0., 0., 0.,  ..., 0., 0., 0.],\\n         [0., 0., 0.,  ..., 0., 0., 0.],\\n         ...,\\n         [0., 0., 0.,  ..., 0., 0., 0.],\\n         [0., 0., 0.,  ..., 0., 0., 0.],\\n         [0., 0., 0.,  ..., 0., 0., 0.]]]), {'pooled_output': tensor([[0., 0., 0.,  ..., 0., 0., 0.]])}]]\"],\"latent_image\":[\"{'samples': tensor([[[[ 21.5000,  20.3750,  19.3750,  ...,  21.3750,  21.3750,  22.1250],\\n          [ 18.3750,  20.1250,  17.6250,  ...,  17.5000,  18.1250,  18.0000],\\n          [ 19.5000,  19.3750,  18.0000,  ...,  19.3750,  17.7500,  20.2500],\\n          ...,\\n          [ 18.7500,  19.6250,  17.8750,  ...,  18.1250,  18.0000,  20.1250],\\n          [ 16.3750,  19.0000,  17.8750,  ...,  17.8750,  18.1250,  21.1250],\\n          [ 21.6250,  22.0000,  21.3750,  ...,  21.2500,  21.7500,  20.6250]],\\n\\n         [[ -4.2500,  -1.0469,  -2.9844,  ...,  -2.3594,  -0.1367,   4.0312],\\n          [ -0.1123,   6.5625,   0.3242,  ...,   2.4375,   2.5469,   2.9375],\\n          [  1.4609,   4.3750,   0.6953,  ...,   7.5000,   1.6719,   5.4062],\\n          ...,\\n          [  0.2539,   4.7812,   0.6953,  ...,   1.3359,   2.4219,   5.4375],\\n          [ -2.0469,   3.5469,   1.5156,  ...,   1.2969,   2.2656,   5.2812],\\n          [  4.0625,   3.9375,   4.4375,  ...,   4.3125,   4.2188,   4.4062]],\\n\\n         [[  9.6250,  -0.4023,   3.1094,  ...,  -0.4258,  -0.7266,   8.7500],\\n          [ -1.2031,   7.0312,   9.2500,  ...,   9.1250,   8.6250,   1.1406],\\n          [  9.6875,   7.6250,   9.0625,  ...,   5.8125,   8.9375,   8.8125],\\n          ...,\\n          [  9.0625,   7.0938,   8.8750,  ...,   9.2500,   9.1250,   9.0625],\\n          [  2.4062,   2.3438,   8.6250,  ...,   9.6250,  10.1250,   9.0000],\\n          [  6.5312,   5.8125,   5.7812,  ...,   6.0312,   6.1875,   6.7500]],\\n\\n         [[ -1.6094,  -5.4375,  -9.2500,  ...,  -4.8438,  -5.1875,  -4.4688],\\n          [ -6.0312, -10.1875,  -8.0625,  ...,  -9.0625,  -8.9375, -11.5000],\\n          [ -4.9062,  -8.2500,  -8.1250,  ...,  -9.1250,  -7.9062,  -6.3750],\\n          ...,\\n          [ -5.2500,  -8.6250,  -8.1250,  ...,  -8.3125,  -8.0000,  -6.2812],\\n          [-10.2500, -11.3750,  -8.3750,  ...,  -7.9688,  -8.2500,  -6.1250],\\n          [ -3.0469,  -5.2188,  -5.9062,  ...,  -5.8750,  -5.5938,  -3.2500]]]])}\"]},\"current_outputs\":[\"9\",\"2\",\"4\",\"12\",\"15\",\"3\",\"6\",\"16\",\"5\",\"10\",\"11\"],\"timestamp\":1767539402262}"`


This is the fix for the above error