### PR TITLE
fix: use float32 for Qwen image rotary embeddings

### DIFF
--- a/comfy/ldm/qwen_image/model.py
+++ b/comfy/ldm/qwen_image/model.py
@@ -473,7 +473,7 @@ class QwenImageTransformer2DModel(nn.Module):
         txt_start = round(max(((x.shape[-1] + (self.patch_size // 2)) // self.patch_size) // 2, ((x.shape[-2] + (self.patch_size // 2)) // self.patch_size) // 2))
         txt_ids = torch.arange(txt_start, txt_start + context.shape[1], device=x.device).reshape(1, -1, 1).repeat(x.shape[0], 1, 3)
         ids = torch.cat((txt_ids, img_ids), dim=1)
-        image_rotary_emb = self.pe_embedder(ids).to(x.dtype).contiguous()
+        image_rotary_emb = self.pe_embedder(ids).to(torch.float32).contiguous()
         del ids, txt_ids, img_ids
 
         hidden_states = self.img_in(hidden_states)


### PR DESCRIPTION
## Problem

When using torch.compile with bfloat16 inference, Qwen image models fail with:

```
No backend can handle 'apply_rope1': eager: freqs_cis: dtype torch.bfloat16 not in {torch.float32}
```

## Root Cause

1. Commit `4cd88186` ('Use single apply_rope function across models') refactored all models to use a shared `apply_rope1` function and correctly set Qwen's `image_rotary_emb` to `.to(torch.float32)`

2. Commit `c4a6b389` ('Lower ltxv mem usage') inadvertently reverted Qwen back to `.to(x.dtype)` (bfloat16), breaking compatibility with the shared `apply_rope1` function

3. The `apply_rope1` function uses `addcmul_` in-place operations that fail under `torch.compile` when `freqs_cis` is bfloat16

## Fix

This restores the correct behavior by ensuring `image_rotary_emb` is always `float32` for the Qwen model, matching the expected dtype for `apply_rope1`.

## Testing

Tested with Qwen Image Edit workflows on cloud deployment.