### PR TITLE
feat: add CI container version bump automation

### DIFF
--- a/.github/workflows/update-ci-container.yml
+++ b/.github/workflows/update-ci-container.yml
@@ -55,8 +55,5 @@ jobs:
 
             **Triggered by:** ${{ github.event_name == 'release' && format('[Release {0}]({1})', github.event.release.tag_name, github.event.release.html_url) || 'Manual workflow dispatch' }}
 
-            **After merging:**
-            1. Create a new release tag to publish the updated container
-            2. Update frontend's `ci-tests-e2e.yaml` container reference if needed
           labels: automation
           commit-message: "chore: bump ComfyUI to ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary
- Adds a workflow that triggers on releases to create PRs in the comfyui-ci-container repo
- Updates the ComfyUI version in the Dockerfile automatically
- Supports both release events and manual workflow dispatch

## Prerequisites
- `CI_CONTAINER_PAT` secret with repo scope for `comfy-org/comfyui-ci-container`

## Test plan
- [x] Add secret to repository
- [x] Test with manual workflow dispatch
- [x] Verify PR is created in comfyui-ci-container