### PR TITLE
ops: Fix offloading with FP8MM performance

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -718,6 +718,7 @@ class ModelPatcher:
                             continue
 
                 cast_weight = self.force_cast_weights
+                m.comfy_force_cast_weights = self.force_cast_weights
                 if lowvram_weight:
                     if hasattr(m, "comfy_cast_weights"):
                         m.weight_function = []


### PR DESCRIPTION
This logic was checking comfy_cast_weights, and going straight to to the forward_comfy_cast_weights implementation without attempting to downscale input to fp8 in the event comfy_cast_weights is set.

The main reason comfy_cast_weights would be set would be for async offload, which is not a good reason to nix FP8MM.

So instead, and together the underlying exclusions for FP8MM which are:

* having a weight_function (usually LowVramPatch)
* force_cast_weights (compute dtype override)
* the weight is not Quantized
* the input is already quantized
* the model or layer has MM explictily disabled.

If you get past all of those exclusions, quantize the input tensor. Then hand the new input, quantized or not off to
forward_comfy_cast_weights to handle it. If the weight is offloaded but input is quantized you will get an offloaded MM8.

Example test conditions:

rtx5090, --novram

Wan workflow:

<img width="2437" height="1072" alt="image" src="https://github.com/user-attachments/assets/e1b5b912-7057-4d93-ae3c-7c8095676563" />


Before:

```
Requested to load WAN21
loaded partially; 0.00 MB usable, 0.00 MB loaded, 13631.42 MB offloaded, 585.11 MB buffer reserved, lowvram patches: 0
100%|██████████| 2/2 [00:19<00:00,  9.72s/it]
Found quantization metadata version 1
Detected mixed precision quantization
Using mixed precision operations
model weight dtype torch.float16, manual cast: torch.float16
model_type FLOW
Requested to load WAN21
loaded partially; 0.00 MB usable, 0.00 MB loaded, 13631.42 MB offloaded, 585.11 MB buffer reserved, lowvram patches: 0
100%|██████████| 2/2 [00:19<00:00,  9.71s/it]

```

After:

```
Requested to load WAN21
loaded partially; 0.00 MB usable, 0.00 MB loaded, 13631.42 MB offloaded, 585.11 MB buffer reserved, lowvram patches: 0
100%|██████████| 2/2 [00:14<00:00,  7.14s/it]
Found quantization metadata version 1
Detected mixed precision quantization
Using mixed precision operations
model weight dtype torch.float16, manual cast: torch.float16
model_type FLOW
Requested to load WAN21
loaded partially; 0.00 MB usable, 0.00 MB loaded, 13631.42 MB offloaded, 585.11 MB buffer reserved, lowvram patches: 0
100%|██████████| 2/2 [00:14<00:00,  7.16s/it]
```

Flux 2 workflow:

<img width="2132" height="947" alt="image" src="https://github.com/user-attachments/assets/efffd5cc-c3b4-4388-bff7-c8289fe005de" />

Before:

```
Requested to load Flux2
loaded partially; 0.00 MB usable, 0.00 MB loaded, 33813.00 MB offloaded, 1620.00 MB buffer reserved, lowvram patches: 0
100%|██████████| 25/25 [00:43<00:00,  1.72s/it]
```

After:

```
Requested to load Flux2
loaded partially; 0.00 MB usable, 0.00 MB loaded, 33813.00 MB offloaded, 1620.00 MB buffer reserved, lowvram patches: 0
100%|██████████| 25/25 [00:31<00:00,  1.26s/it]
```

The could be a big speedup for heavy offloaders with less powerful cards as at least wan is usually compute bottlnecked as this is cutting significant compute load.