### PR TITLE
Add workaround for a hacky nodepack existing

### DIFF
--- a/app/assets/helpers.py
+++ b/app/assets/helpers.py
@@ -81,7 +81,8 @@ def get_comfy_models_folders() -> list[tuple[str, list[str]]]:
     """
     targets: list[tuple[str, list[str]]] = []
     models_root = os.path.abspath(folder_paths.models_dir)
-    for name, (paths, _exts) in folder_paths.folder_names_and_paths.items():
+    for name, values in folder_paths.folder_names_and_paths.items():
+        paths, _exts = values[0], values[1]  # NOTE: this prevents nodepacks that hackily edit folder_... from breaking ComfyUI
         if any(os.path.abspath(p).startswith(models_root + os.sep) for p in paths):
             targets.append((name, paths))
     return targets


### PR DESCRIPTION
It appears there is at least one nodepack that adds a tuple into folder_paths.folder_names_and_paths that has more than 2 values. This is completely unexpected, and I am surprised this didn't break things before; our core code appears to never implicitly assume this after custom nodes are loaded, only before.

The [Assets PR](https://github.com/Comfy-Org/ComfyUI/pull/11315) parsing through folder_paths after custom nodes were loaded, so I guess we only find out now about those nodepacks.

This workaround simply plucks the first and second values from the tuple instead of implicitly expecting two.
