### PR TITLE
fix(api-nodes): use a unique name for uploading audio files

### DIFF
--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -567,7 +567,7 @@ async def execute_lipsync(
     # Upload the audio file to Comfy API and get download URL
     if audio:
         audio_url = await upload_audio_to_comfyapi(
-            cls, audio, container_format="mp3", codec_name="libmp3lame", mime_type="audio/mpeg", filename="output.mp3"
+            cls, audio, container_format="mp3", codec_name="libmp3lame", mime_type="audio/mpeg"
         )
         logging.info("Uploaded audio to Comfy API. URL: %s", audio_url)
     else:

--- a/comfy_api_nodes/util/conversions.py
+++ b/comfy_api_nodes/util/conversions.py
@@ -55,7 +55,7 @@ def image_tensor_pair_to_batch(image1: torch.Tensor, image2: torch.Tensor) -> to
 
 def tensor_to_bytesio(
     image: torch.Tensor,
-    name: str | None = None,
+    *,
     total_pixels: int = 2048 * 2048,
     mime_type: str = "image/png",
 ) -> BytesIO:
@@ -75,7 +75,7 @@ def tensor_to_bytesio(
 
     pil_image = tensor_to_pil(image, total_pixels=total_pixels)
     img_binary = pil_to_bytesio(pil_image, mime_type=mime_type)
-    img_binary.name = f"{name if name else uuid.uuid4()}.{mimetype_to_extension(mime_type)}"
+    img_binary.name = f"{uuid.uuid4()}.{mimetype_to_extension(mime_type)}"
     return img_binary
 
 

--- a/comfy_api_nodes/util/upload_helpers.py
+++ b/comfy_api_nodes/util/upload_helpers.py
@@ -82,7 +82,6 @@ async def upload_audio_to_comfyapi(
     container_format: str = "mp4",
     codec_name: str = "aac",
     mime_type: str = "audio/mp4",
-    filename: str = "uploaded_audio.mp4",
 ) -> str:
     """
     Uploads a single audio input to ComfyUI API and returns its download URL.
@@ -92,7 +91,7 @@ async def upload_audio_to_comfyapi(
     waveform: torch.Tensor = audio["waveform"]
     audio_data_np = audio_tensor_to_contiguous_ndarray(waveform)
     audio_bytes_io = audio_ndarray_to_bytesio(audio_data_np, sample_rate, container_format, codec_name)
-    return await upload_file_to_comfyapi(cls, audio_bytes_io, filename, mime_type)
+    return await upload_file_to_comfyapi(cls, audio_bytes_io, f"{uuid.uuid4()}.{container_format}", mime_type)
 
 
 async def upload_video_to_comfyapi(


### PR DESCRIPTION
1. Removed the `filename` parameter in the `upload_audio_to_comfyapi` function, so now it always uploads a file with a unique name. This **fixes** the situation when two nodes in one workflow can upload audio file to the same object.

2. Removed the `name` parameter in the `tensor_to_bytesio` function used for uploading images. It is not used anywhere and should not be used for the same reason as above.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [x] Informed **Kosinkadink**

