### PR TITLE
Fix: utils package shadowed by comfy/utils.py

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -19,7 +19,7 @@ from PIL.PngImagePlugin import PngInfo
 import numpy as np
 import safetensors.torch
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy"))
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), "comfy"))
 
 import comfy.diffusers_load
 import comfy.samplers


### PR DESCRIPTION
## Summary
  - Fix `ModuleNotFoundError: No module named 'utils.install_util'; 'utils' is not a package` error

  ## Problem
  `sys.path.insert(0, ...)` in `nodes.py` line 22 places the `comfy/` directory at the front of `sys.path`. When code later imports `from utils.install_util import ...`, Python finds `comfy/utils.py` (a module file) instead of the top-level `utils/` package.

  This breaks imports in:
  - `app/frontend_management.py`
  - `app/database/db.py`

  ## Fix
  Change `sys.path.insert(0, ...)` to `sys.path.append(...)` so the `comfy/` directory is added at the end of `sys.path`, preserving normal import resolution order.

  ## Test plan
  - [x] Verified `python main.py` starts without import errors
  - [x] Verified `from utils.install_util import get_missing_requirements_message` works after importing `nodes`