### PR TITLE
Support ModelScope-Trainer/DiffSynth LoRA format for Z-Image models

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -322,6 +322,7 @@ def model_lora_keys_unet(model, key_map={}):
                 key_map["diffusion_model.{}".format(key_lora)] = to
                 key_map["transformer.{}".format(key_lora)] = to
                 key_map["lycoris_{}".format(key_lora.replace(".", "_"))] = to
+                key_map[key_lora] = to
 
     if isinstance(model, comfy.model_base.Kandinsky5):
         for k in sdk:


### PR DESCRIPTION
Adds support for DiffSynth-trained LoRA format.

<img width="2226" height="988" alt="1" src="https://github.com/user-attachments/assets/10faf99f-7eda-45fe-92fe-df9e822bcda7" />
