### PR TITLE
Reduce LTX2 VRAM use by more efficient timestep embed handling

### DIFF
--- a/comfy/ldm/lightricks/av_model.py
+++ b/comfy/ldm/lightricks/av_model.py
@@ -15,7 +15,7 @@ class CompressedTimestep:
     """Store video timestep embeddings in compressed form using per-frame indexing."""
     __slots__ = ('data', 'batch_size', 'num_frames', 'patches_per_frame', 'feature_dim')
 
-    def __init__(self, tensor, patches_per_frame):
+    def __init__(self, tensor: torch.Tensor, patches_per_frame: int):
         """
         tensor: [batch_size, num_tokens, feature_dim] tensor where num_tokens = num_frames * patches_per_frame
         patches_per_frame: Number of spatial patches per frame (height * width in latent space)
@@ -46,7 +46,7 @@ class CompressedTimestep:
         expanded = self.data.unsqueeze(2).expand(self.batch_size, self.num_frames, self.patches_per_frame, self.feature_dim)
         return expanded.reshape(self.batch_size, -1, self.feature_dim)
 
-    def expand_for_computation(self, scale_shift_table, batch_size, indices):
+    def expand_for_computation(self, scale_shift_table: torch.Tensor, batch_size: int, indices: slice = slice(None, None)):
         """Compute ada values on compressed per-frame data, then expand spatially."""
         num_ada_params = scale_shift_table.shape[0]
 
@@ -180,7 +180,7 @@ class BasicAVTransformerBlock(nn.Module):
         )
 
     def get_ada_values(
-        self, scale_shift_table: torch.Tensor, batch_size: int, timestep, indices: slice = slice(None, None)
+        self, scale_shift_table: torch.Tensor, batch_size: int, timestep: torch.Tensor, indices: slice = slice(None, None)
     ):
         if isinstance(timestep, CompressedTimestep):
             return timestep.expand_for_computation(scale_shift_table, batch_size, indices)


### PR DESCRIPTION
This should be one way to solve the problem with LTX2 VRAM usage when denoise_mask is used, so every I2V workflow is affected. The whole per token timesteps are kept in memory, which especially in higher input sizes end up growing to multiple gigabytes, similar/same(?) issue than I recall Wan 2.2 5B initially having.

I tried couple of approaches and latest is both faster then original code, and uses far less VRAM. Previously I had to always use --reserve-vram 4-7 with I2V, now I don't have to use it at all. Model outputs remain identical to what they were before based on testing by couple of people including myself.

There is probably other, better ways to achieve this, but this at least works as proof of concept.

One example of before/after, note the huge timestep tensor blocks gone and peak VRAM usage being lower:

<img width="2185" height="528" alt="chrome_7VIbqPXLZ6" src="https://github.com/user-attachments/assets/7b855f0b-f1b1-41eb-9b3b-70d42078a3e8" />

It is also possible to cut the feed forward activation spike visible in the memory graph, however I did not figure out a way to do that without affecting the model output, that is still available currently for testing as a model patch node in KJNodes, and can further reduce VRAM peak.

