### PR TITLE
Load metadata on VAELoader

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -798,8 +798,8 @@ class VAELoader:
                 vae_path = folder_paths.get_full_path_or_raise("vae_approx", vae_name)
             else:
                 vae_path = folder_paths.get_full_path_or_raise("vae", vae_name)
-            sd = comfy.utils.load_torch_file(vae_path)
-        vae = comfy.sd.VAE(sd=sd)
+            sd, metadata = comfy.utils.load_torch_file(vae_path, return_metadata=True)
+        vae = comfy.sd.VAE(sd=sd, metadata=metadata)
         vae.throw_exception_if_invalid()
         return (vae,)
 


### PR DESCRIPTION
Needed to load the proper LTX2 VAE if separated from checkpoint, for example when using GGUF.

It turns out the VAE in the initial distilled checkpoints is an old one, and the proper VAE requires metadata to function normally.