### PR TITLE
Support "lite" version of alibaba-pai Z-Image Controlnet

### DIFF
--- a/comfy_extras/nodes_model_patch.py
+++ b/comfy_extras/nodes_model_patch.py
@@ -244,6 +244,10 @@ class ModelPatchLoader:
         elif 'control_all_x_embedder.2-1.weight' in sd: # alipai z image fun controlnet
             sd = z_image_convert(sd)
             config = {}
+            if 'control_layers.4.adaLN_modulation.0.weight' not in sd:
+                config['n_control_layers'] = 3
+                config['additional_in_dim'] = 17
+                config['refiner_control'] = True
             if 'control_layers.14.adaLN_modulation.0.weight' in sd:
                 config['n_control_layers'] = 15
                 config['additional_in_dim'] = 17


### PR DESCRIPTION
alibaba-pai released a new version of their controlnet for Z-image
https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1

It includes a "lite" variant with reduced number of control layers (3 + 2 refiner), which require a small change to run in ComfyUI.

I tested the following models work:
* Z-Image-Turbo-Fun-Controlnet-Tile-2.1-lite-2601-8steps.safetensors
* Z-Image-Turbo-Fun-Controlnet-Union-2.1-2601-8steps.safetensors
* Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors
* Z-Image-Turbo-Fun-Controlnet-Union-2.1-lite-2601-8steps.safetensors
* Z-Image-Turbo-Fun-Controlnet-Union-2.1.safetensors
* Z-Image-Turbo-Fun-Controlnet-Union.safetensors