### PR TITLE
Fix scale_shorter_dimension for portrait inputs

### DIFF
--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -329,7 +329,7 @@ def scale_shorter_dimension(input: torch.Tensor, shorter_size: int, scale_method
     if height < width:
         width = round((width / height) * shorter_size)
         height = shorter_size
-    elif width > height:
+    elif width < height:
         height = round((height / width) * shorter_size)
         width = shorter_size
     else:


### PR DESCRIPTION
<img width="1154" height="971" alt="shorter dimension" src="https://github.com/user-attachments/assets/9d12d17c-c747-43f8-a34a-089fe13fcff0" />

This fixes a conditional typo in `ResizeImageMaskNode` ("scale shorter dimension").

The code used:
- `if height < width`
- `elif width > height`

which duplicates the first condition and causes portrait inputs (width < height) to fall into the `else` branch (square resize), breaking the intended aspect-preserving behavior.

Change:
- `elif width > height` -> `elif width < height`