### PR TITLE
utils: fix lanczos grayscale upscaling

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -929,7 +929,9 @@ def bislerp(samples, width, height):
     return result.to(orig_dtype)
 
 def lanczos(samples, width, height):
-    images = [Image.fromarray(np.clip(255. * image.movedim(0, -1).cpu().numpy(), 0, 255).astype(np.uint8)) for image in samples]
+    #the below API is strict and expects grayscale to be squeezed
+    samples = samples.squeeze(1) if samples.shape[1] == 1 else samples.movedim(1, -1)
+    images = [Image.fromarray(np.clip(255. * image.cpu().numpy(), 0, 255).astype(np.uint8)) for image in samples]
     images = [image.resize((width, height), resample=Image.Resampling.LANCZOS) for image in images]
     images = [torch.from_numpy(np.array(image).astype(np.float32) / 255.0).movedim(-1, 0) for image in images]
     result = torch.stack(images)


### PR DESCRIPTION
Fixes: https://github.com/Comfy-Org/ComfyUI/issues/11869

This causes a crash when using lanczos for masks.

Before:

```
  File "/home/rattus/ComfyUI/comfy_extras/nodes_post_processing.py", line 474, in execute
    return io.NodeOutput(scale_dimensions(input, resize_type["width"], resize_type["height"], scale_method, resize_type["crop"]))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy_extras/nodes_post_processing.py", line 299, in scale_dimensions
    input = comfy.utils.common_upscale(input, width, height, scale_method, crop)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/utils.py", line 962, in common_upscale
    out = lanczos(s, width, height)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/utils.py", line 932, in lanczos
    images = [Image.fromarray(np.clip(255. * image.movedim(0, -1).cpu().numpy(), 0, 255).astype(np.uint8)) for image in samples]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/PIL/Image.py", line 3289, in fromarray
    raise TypeError(msg) from e
TypeError: Cannot handle this data type: (1, 1, 1), |u1

```

After:

<img width="1591" height="924" alt="image" src="https://github.com/user-attachments/assets/e386fac5-b309-4945-bb85-594eb2c8bff6" />

Test image:

<img width="1024" height="1024" alt="test_alpha_big" src="https://github.com/user-attachments/assets/65be2782-4636-437e-842b-c4b90b6278c3" />


