### PR TITLE
Added try-except around seed_assets call in get_object_info

### DIFF
--- a/server.py
+++ b/server.py
@@ -686,7 +686,10 @@ class PromptServer():
 
         @routes.get("/object_info")
         async def get_object_info(request):
-            seed_assets(["models"])
+            try:
+                seed_assets(["models"])
+            except Exception as e:
+                logging.error(f"Failed to seed assets: {e}")
             with folder_paths.cache_helper:
                 out = {}
                 for x in nodes.NODE_CLASS_MAPPINGS:


### PR DESCRIPTION
People experiencing the error due to the database not being able to get initialized in certain environments (docker, current Mac desktop) due to read/write access shenanigans will no longer have their frontend freeze.

Apparently even though we created the local dbs back in June-ish, we never had anything that tried to write into it before the first assets PR?