### PR TITLE
Update readme rdna3 nightly url

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ These have less hardware support than the builds above but they work on windows.
 
 RDNA 3 (RX 7000 series):
 
-```pip install --pre torch torchvision torchaudio --index-url https://rocm.nightlies.amd.com/v2/gfx110X-dgpu/```
+```pip install --pre torch torchvision torchaudio --index-url https://rocm.nightlies.amd.com/v2/gfx110X-all/```
 
 RDNA 3.5 (Strix halo/Ryzen AI Max+ 365):
 


### PR DESCRIPTION
`.../gfx110X-dgpu` no longer seems to be updated. I tested torch `2.11.0a0+rocm7.11.0a20260117` from `.../gfx110X-all` on my rx7900gre and it works fine.