### PR TITLE
Fix Content-Disposition header to comply with RFC 2183

### DIFF
--- a/server.py
+++ b/server.py
@@ -521,7 +521,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -541,7 +541,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -558,7 +558,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
                     else:
                         # Get content type from mimetype, defaulting to 'application/octet-stream'
                         content_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
@@ -570,7 +570,7 @@ class PromptServer():
                         return web.FileResponse(
                             file,
                             headers={
-                                "Content-Disposition": f"filename=\"{filename}\"",
+                                "Content-Disposition": f"attachment; filename=\"{filename}\"",
                                 "Content-Type": content_type
                             }
                         )


### PR DESCRIPTION
Fixes #8914

The view_image function was setting the Content-Disposition header to just 'filename="name.ext"' which doesn't match RFC 2183 specification.

Changed to 'attachment; filename="name.ext"' format which:
- Complies with RFC 2183 specification
- Enables proper filename parsing by HTTP clients
- Fixes issues with third-party downloading libraries (e.g. Go's mime.ParseMediaType)

Modified 4 occurrences in the view_image function for:
- Preview images (webp/jpeg)
- RGB channel extraction (png)
- Alpha channel extraction (png)
- Default file response