### PR TITLE
Convert mono audio to fake stereo for LTXV VAE encoding

### DIFF
--- a/comfy/ldm/lightricks/vae/audio_vae.py
+++ b/comfy/ldm/lightricks/vae/audio_vae.py
@@ -189,9 +189,12 @@ class AudioVAE(torch.nn.Module):
         waveform = self.device_manager.move_to_load_device(waveform)
         expected_channels = self.autoencoder.encoder.in_channels
         if waveform.shape[1] != expected_channels:
-            raise ValueError(
-                f"Input audio must have {expected_channels} channels, got {waveform.shape[1]}"
-            )
+            if waveform.shape[1] == 1:
+                waveform = waveform.expand(-1, expected_channels, *waveform.shape[2:])
+            else:
+                raise ValueError(
+                    f"Input audio must have {expected_channels} channels, got {waveform.shape[1]}"
+                )
 
         mel_spec = self.preprocessor.waveform_to_mel(
             waveform, waveform_sample_rate, device=self.device_manager.load_device


### PR DESCRIPTION
Some TTS models like Chatterbox or VibeVoice output mono audio and LTXV expects stereo. There's no native node in ComfyUI that could make a two-channel audio (although it has been requested in #10694) and it's really easy to quietly duplicate the channel. In theory, the incoming audio can have 3 or more channels which would also be incompatible with the expected 2, and conversion is not obvious then, so I only handled the most common mono to stereo case.