### PR TITLE
Propagate Qwen-Image attention mask to image generation.

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -1526,6 +1526,9 @@ class QwenImage(BaseModel):
 
     def extra_conds(self, **kwargs):
         out = super().extra_conds(**kwargs)
+        attention_mask = kwargs.get("attention_mask", None)
+        if attention_mask is not None:
+            out['attention_mask'] = comfy.conds.CONDRegular(attention_mask)
         cross_attn = kwargs.get("cross_attn", None)
         if cross_attn is not None:
             out['c_crossattn'] = comfy.conds.CONDRegular(cross_attn)


### PR DESCRIPTION
### Why?
For optimization purposes, it is sometimes recommended to run model inference with inputs of a fixed size. This can be supported by padding the text tokens to a fixed length, with the padding information propagated to the diffusion model using an attention mask. **This mechanism is implemented in ComfyUI for many models, but not for Qwen-Image**.

### What?
1. **Pass the attention mask from the text encoder to the model's forward function.** This is similar to the implementation of many other models. 
2. **Convert the mask from binary 1/0 format to 0/-∞ format**, to be used as an additive mask where attention is calculated as softmax(scores + mask). This is similar to the implementation in [hunyuan_video](https://github.com/LightricksResearch/ComfyUI/blob/d954b9a7c75fd6ff671a05d4772b738be3c5951f/comfy/ldm/hunyuan_video/model.py#L351), [LTX](https://github.com/LightricksResearch/ComfyUI/blob/d954b9a7c75fd6ff671a05d4772b738be3c5951f/comfy/ldm/lightricks/model.py#L712) and [Cosmos](https://github.com/LightricksResearch/ComfyUI/blob/d954b9a7c75fd6ff671a05d4772b738be3c5951f/comfy/ldm/cosmos/model.py#L390).
3. **Construct a joint attention mask for both text and image tokens**; The text portion is copied from the attention mask passed from the text encoder, while the image portion always attends (mask = 0). This is similar to the implementation in [hunyuan_video](https://github.com/LightricksResearch/ComfyUI/blob/d954b9a7c75fd6ff671a05d4772b738be3c5951f/comfy/ldm/hunyuan_video/model.py#L385).

### Running example
I used the template workflow for Qwen-Image-2512 (its lower part with 4-steps lightning LoRA) and changed only the positive prompt and the seed:
- **prompt:** "_A wintery, cloudy, Christmassy, slightly snowy day in England_"
- **seed:** 89 (fixed)

In order to add text tokens padding, I modified the initialization of `Qwen25_7BVLITokenizer` (the `min_length` argument from 1 to 256) in [text_encoders/qwen_image](https://github.com/LightricksResearch/ComfyUI/blob/d954b9a7c75fd6ff671a05d4772b738be3c5951f/comfy/text_encoders/qwen_image.py#L11).

The following grid presents the results with `min_length=1` and `min_length=256`, without and with this proposed fix; we can see that with the existing implementation, which does not pass the attention mask, the model attends to the padding tokens and the content of the image shifts dramatically, while my fix encourages a much subtler change.


<table align="center">
  <tr>
    <th></th>
    <th><b>without fix</b></th>
    <th><b>with fix</b></th>
  </tr>
  <tr>
    <td align="center"><b><code>min_length = 1</code></b></td>
    <td align="center">
      <img width="250" alt="without_fix_1" src="https://github.com/user-attachments/assets/ddc885bc-add1-45b3-b533-569341e654b8" />
    </td>
    <td align="center">
      <img width="250" alt="with_fix_1" src="https://github.com/user-attachments/assets/5ff28192-f875-4a8f-a142-7ee0745f60b2" />
    </td>
  </tr>
  <tr>
    <td align="center"><b><code>min_length = 256</code></b></td>
    <td align="center">
      <img width="250" alt="without_fix_256" src="https://github.com/user-attachments/assets/89fa3e01-c47f-4ff2-934b-9ffbfac82d08" />
    </td>
    <td align="center">
      <img width="250" alt="with_fix_256" src="https://github.com/user-attachments/assets/42ba3a0f-7bf5-431c-b4d4-f70337e5ea54" />
    </td>
  </tr>
</table>