### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/api-node-template.yml
+++ b/.github/workflows/api-node-template.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Ensure template exists and append to PR body
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history to compare changes
 

--- a/.github/workflows/pullrequest-ci-run.yml
+++ b/.github/workflows/pullrequest-ci-run.yml
@@ -42,7 +42,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
 
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -83,7 +83,7 @@ jobs:
       pull-requests: "read"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.git_tag }}
           fetch-depth: 150

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: "This issue is being marked stale because it has not had any activity for 30 days. Reply below within 7 days if your issue still isn't solved, and it will be left open. Otherwise, the issue will be closed automatically."
           days-before-stale: 30

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/test-execution.yml
+++ b/.github/workflows/test-execution.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python      
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install requirements

--- a/.github/workflows/test-launch.yml
+++ b/.github/workflows/test-launch.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout ComfyUI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: "Comfy-Org/ComfyUI"
         path: "ComfyUI"
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     - name: Install requirements
@@ -39,7 +39,7 @@ jobs:
           exit 1
         fi
       working-directory: ComfyUI
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: always()
       with:
         name: console-output

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python      
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install requirements

--- a/.github/workflows/update-api-stubs.yml
+++ b/.github/workflows/update-api-stubs.yml
@@ -11,10 +11,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       
@@ -43,7 +43,7 @@ jobs:
       
       - name: Create Pull Request
         if: steps.git-check.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'chore: update API models from OpenAPI spec'
           title: 'Update API models from api.comfy.org'

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/windows_release_dependencies.yml
+++ b/.github/workflows/windows_release_dependencies.yml
@@ -38,8 +38,8 @@ jobs:
   build_dependencies:
     runs-on: windows-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-python@v5
+        - uses: actions/checkout@v6
+        - uses: actions/setup-python@v6
           with:
             python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
 

--- a/.github/workflows/windows_release_dependencies_manual.yml
+++ b/.github/workflows/windows_release_dependencies_manual.yml
@@ -30,8 +30,8 @@ jobs:
   build_dependencies:
     runs-on: windows-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-python@v5
+        - uses: actions/checkout@v6
+        - uses: actions/setup-python@v6
           with:
             python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
 

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -32,11 +32,11 @@ jobs:
         pull-requests: "read"
     runs-on: windows-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             fetch-depth: 30
             persist-credentials: false
-        - uses: actions/setup-python@v5
+        - uses: actions/setup-python@v6
           with:
             python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
         - shell: bash

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -48,7 +48,7 @@ jobs:
             pwd
             ls
 
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             fetch-depth: 150
             persist-credentials: false


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/test-launch.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/test-execution.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test-build.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/windows_release_package.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test-execution.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/update-version.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/update-version.yml`
- Updated `actions/github-script` from `v6` to `v8` in `.github/workflows/pullrequest-ci-run.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/update-api-stubs.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test-unit.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/windows_release_dependencies_manual.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/api-node-template.yml`
- Updated `peter-evans/create-pull-request` from `v5` to `v8` in `.github/workflows/update-api-stubs.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test-launch.yml`
- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/ruff.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ruff.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/check-line-endings.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/test-unit.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test-launch.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/windows_release_nightly_pytorch.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/stable-release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/windows_release_dependencies.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/windows_release_dependencies.yml`
- Updated `actions/stale` from `v9` to `v10` in `.github/workflows/stale-issues.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/windows_release_nightly_pytorch.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/update-api-stubs.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/test-build.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/windows_release_dependencies_manual.yml`
