### PR TITLE
Make Autogrow validation work properly

### DIFF
--- a/comfy_extras/nodes_logic.py
+++ b/comfy_extras/nodes_logic.py
@@ -186,7 +186,7 @@ class AutogrowNamesTestNode(io.ComfyNode):
 class AutogrowPrefixTestNode(io.ComfyNode):
     @classmethod
     def define_schema(cls):
-        template = _io.Autogrow.TemplatePrefix(input=io.Float.Input("float", optional=True), prefix="float", min=1, max=10)
+        template = _io.Autogrow.TemplatePrefix(input=io.Float.Input("float"), prefix="float", min=1, max=10)
         return io.Schema(
             node_id="AutogrowPrefixTestNode",
             display_name="AutogrowPrefixTest",
@@ -257,9 +257,9 @@ class LogicExtension(ComfyExtension):
             CustomComboNode,
             # SoftSwitchNode,
             # ConvertStringToComboNode,
-            DCTestNode,
+            # DCTestNode,
             # AutogrowNamesTestNode,
-            AutogrowPrefixTestNode,
+            # AutogrowPrefixTestNode,
             # ComboOutputTestNode,
             # InvertBooleanNode,
         ]


### PR DESCRIPTION
This ensures required and optional Autogrow values work as intended with validation + with the edge case of the template input (and all inputs) being optional.

Currently min=0 will make the frontend act wacky, that will be resolved via frontend.