### PR TITLE
Add support for Flux2 diffusers LoRA format

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -264,6 +264,10 @@ def model_lora_keys_unet(model, key_map={}):
             hidden_size = model.model_config.unet_config.get("hidden_size", 0)
             if k.endswith(".weight") and ".linear1." in k:
                 key_map["{}".format(k.replace(".linear1.weight", ".linear1_qkv"))] = (k, (0, 0, hidden_size * 3))
+            if k.endswith(".linear1.weight") and ".single_blocks." in k: #simpletuner and regular diffusers flux2 lora format
+                key_map[k.replace("diffusion_model.single_blocks.", "transformer.single_transformer_blocks.").replace(".linear1.weight", ".attn.to_qkv_mlp_proj")] = k
+            if k.endswith(".linear2.weight") and ".single_blocks." in k:
+                key_map[k.replace("diffusion_model.single_blocks.", "transformer.single_transformer_blocks.").replace(".linear2.weight", ".attn.to_out")] = k
 
     if isinstance(model, comfy.model_base.GenmoMochi):
         for k in sdk:


### PR DESCRIPTION
Adds mappings for SimpleTuner Flux2 single-stream transformer blocks:
- transformer.single_transformer_blocks.X.attn.to_qkv_mlp_proj -> diffusion_model.single_blocks.X.linear1.weight
- transformer.single_transformer_blocks.X.attn.to_out -> diffusion_model.single_blocks.X.linear2.weight

Tested with Flux2 Klein 9B LoRA trained using SimpleTuner:
- Test LoRA: https://huggingface.co/markury/flux2k9b-simpletuner-lora-loona/blob/main/pytorch_lora_weights.safetensors
- No missing key errors
- Visual output appears correct                                              

Fixes #11926