### PR TITLE
docs: Add Linux Python build requirements for bzip2 and lzma

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,22 @@ Install the dependencies by opening your terminal inside the ComfyUI folder and:
 
 After this you should have everything installed and can proceed to running ComfyUI.
 
+#### Linux: Python Build Requirements
+
+If you are building Python from source on Linux (e.g., using pyenv, asdf, or compiling manually), ensure the following development libraries are installed **before** building Python. These are required for the `_bz2` and `_lzma` standard library modules:
+
+**Debian/Ubuntu:**
+```bash
+sudo apt install libbz2-dev liblzma-dev
+```
+
+**RHEL/Fedora/CentOS:**
+```bash
+sudo dnf install bzip2-devel xz-devel
+```
+
+After installing these packages, rebuild Python to include the `_bz2` and `_lzma` modules.
+
 ### Others:
 
 #### Apple Mac silicon


### PR DESCRIPTION
Fixes #3219

Documents that Linux users building Python from source need to install `libbz2-dev` and `liblzma-dev` (Debian/Ubuntu) or `bzip2-devel` and `xz-devel` (RHEL/Fedora/CentOS) before building Python to ensure the `_bz2` and `_lzma` standard library modules are available.

This helps users who install Python via pyenv, asdf, or compile from source avoid cryptic import errors when running ComfyUI.

---

### Test Evidence

**N/A** - This is a documentation-only change. No code behavior is modified, so no testing is required.

### Visual Documentation

**N/A** - This PR does not change any user-facing behavior or UI. It only adds installation instructions to the README.md for Linux users building Python from source.

---

### Summary of Changes

| File | Change |
|------|--------|
| `README.md` | Added a note about required system packages for Linux users who build Python from source |

### Why This Change?

Linux users who compile Python (via `pyenv`, `asdf`, or manual build) may encounter:
```
ModuleNotFoundError: No module named '_bz2'
ModuleNotFoundError: No module named '_lzma'
```

This happens because Python's build process silently skips these modules if the development libraries aren't installed beforehand. This documentation helps users avoid hours of debugging.