### PR TITLE
Dynamically detect chroma radiance patch size

### DIFF
--- a/comfy/model_detection.py
+++ b/comfy/model_detection.py
@@ -253,7 +253,7 @@ def detect_unet_config(state_dict, key_prefix, metadata=None):
                 dit_config["image_model"] = "chroma_radiance"
                 dit_config["in_channels"] = 3
                 dit_config["out_channels"] = 3
-                dit_config["patch_size"] = 16
+                dit_config["patch_size"] = state_dict.get('{}img_in_patch.weight'.format(key_prefix)).size(dim=-1)
                 dit_config["nerf_hidden_size"] = 64
                 dit_config["nerf_mlp_ratio"] = 4
                 dit_config["nerf_depth"] = 4


### PR DESCRIPTION
This PR adds support for loading chroma radiance x32 models without manually reading x32 flag, x16 chroma radiance models work the same as they did.

Chroma radiance x32: https://huggingface.co/lodestones/Chroma1-Radiance/blob/main/latest_x0_x32_proto.safetensors
(It has a tensor named `__32x32__` however I feel like dynamically detecting by reading `img_in_patch.weight`'s size is a cleaner way to detect it. With this commit model loading works for both the regular (x16) and the x32 chroma radiance models. In theory if an x64 variant was made, it would support loading it as well.)