### PR TITLE
Fix FileNotFoundError when validating cache for deleted directories

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -404,7 +404,11 @@ def cached_filename_list_(folder_name: str) -> tuple[list[str], dict[str, float]
     for x in out[1]:
         time_modified = out[1][x]
         folder = x
-        if os.path.getmtime(folder) != time_modified:
+        try:
+            if os.path.getmtime(folder) != time_modified:
+                return None
+        except Exception as e:
+            logging.warning(f"Warning: Unable to access {folder}. Error: {e}. Skipping this folder.")
             return None
 
     folders = folder_names_and_paths[folder_name]


### PR DESCRIPTION
## Problem

When calling the `/object_info` API endpoint, ComfyUI may crash with a `FileNotFoundError` if a directory that was previously scanned and cached has been manually deleted.

### Error Details

```
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/ComfyUI/models/t5'
  File "folder_paths.py", line 407, in cached_filename_list_
    if os.path.getmtime(folder) != time_modified:
```

### Root Cause

1. The `seed_assets(["models"])` function (introduced in v0.9.2) scans all model directories and caches their structure, including subdirectories like `models/t5`.
2. When a directory is scanned, its path and modification time are stored in the global cache (`filename_list_cache`).
3. If a user manually deletes a directory (e.g., `models/t5`) that was previously cached, the cache still contains a reference to it.
4. When `cached_filename_list_()` validates the cache by checking directory modification times, it calls `os.path.getmtime(folder)` on the deleted directory, causing a `FileNotFoundError`.

## Impact

- **Low risk**: Only adds exception handling, doesn't change core logic
- **Backward compatible**: Existing functionality remains unchanged
- **Improves robustness**: Prevents crashes when directories are manually deleted
- **Performance**: Minimal impact, only adds a try-except check
