### PR TITLE
feat: add SEARCH_ALIASES for image, mask, and string nodes (2/4)

### DIFF
--- a/comfy_extras/nodes_compositing.py
+++ b/comfy_extras/nodes_compositing.py
@@ -109,6 +109,7 @@ class PorterDuffImageComposite(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="PorterDuffImageComposite",
+            search_aliases=["alpha composite", "blend modes", "layer blend", "transparency blend"],
             display_name="Porter-Duff Image Composite",
             category="mask/compositing",
             inputs=[
@@ -165,6 +166,7 @@ class SplitImageWithAlpha(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="SplitImageWithAlpha",
+            search_aliases=["extract alpha", "separate transparency", "remove alpha"],
             display_name="Split Image with Alpha",
             category="mask/compositing",
             inputs=[
@@ -188,6 +190,7 @@ class JoinImageWithAlpha(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="JoinImageWithAlpha",
+            search_aliases=["add transparency", "apply alpha", "composite alpha", "RGBA"],
             display_name="Join Image with Alpha",
             category="mask/compositing",
             inputs=[

--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -22,6 +22,7 @@ class ImageCrop(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageCrop",
+            search_aliases=["trim"],
             display_name="Image Crop",
             category="image/transform",
             inputs=[
@@ -51,6 +52,7 @@ class RepeatImageBatch(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="RepeatImageBatch",
+            search_aliases=["duplicate image", "clone image"],
             category="image/batch",
             inputs=[
                 IO.Image.Input("image"),
@@ -72,6 +74,7 @@ class ImageFromBatch(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageFromBatch",
+            search_aliases=["select image", "pick from batch", "extract image"],
             category="image/batch",
             inputs=[
                 IO.Image.Input("image"),
@@ -97,6 +100,7 @@ class ImageAddNoise(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageAddNoise",
+            search_aliases=["film grain"],
             category="image",
             inputs=[
                 IO.Image.Input("image"),
@@ -194,11 +198,11 @@ class SaveAnimatedPNG(IO.ComfyNode):
 
 class ImageStitch(IO.ComfyNode):
     """Upstreamed from https://github.com/kijai/ComfyUI-KJNodes"""
-
     @classmethod
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageStitch",
+            search_aliases=["combine images", "join images", "concatenate images", "side by side"],
             display_name="Image Stitch",
             description="Stitches image2 to image1 in the specified direction.\n"
             "If image2 is not provided, returns image1 unchanged.\n"
@@ -369,11 +373,11 @@ class ImageStitch(IO.ComfyNode):
 
 
 class ResizeAndPadImage(IO.ComfyNode):
-
     @classmethod
     def define_schema(cls):
         return IO.Schema(
             node_id="ResizeAndPadImage",
+            search_aliases=["fit to size"],
             category="image/transform",
             inputs=[
                 IO.Image.Input("image"),
@@ -420,11 +424,11 @@ class ResizeAndPadImage(IO.ComfyNode):
 
 
 class SaveSVGNode(IO.ComfyNode):
-
     @classmethod
     def define_schema(cls):
         return IO.Schema(
             node_id="SaveSVGNode",
+            search_aliases=["export vector", "save vector graphics"],
             description="Save SVG files on disk.",
             category="image/save",
             inputs=[
@@ -492,11 +496,11 @@ class SaveSVGNode(IO.ComfyNode):
 
 
 class GetImageSize(IO.ComfyNode):
-
     @classmethod
     def define_schema(cls):
         return IO.Schema(
             node_id="GetImageSize",
+            search_aliases=["dimensions", "resolution", "image info"],
             display_name="Get Image Size",
             description="Returns width and height of the image, and passes it through unchanged.",
             category="image",
@@ -527,11 +531,11 @@ class GetImageSize(IO.ComfyNode):
 
 
 class ImageRotate(IO.ComfyNode):
-
     @classmethod
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageRotate",
+            search_aliases=["turn", "flip orientation"],
             category="image/transform",
             inputs=[
                 IO.Image.Input("image"),
@@ -557,11 +561,11 @@ class ImageRotate(IO.ComfyNode):
 
 
 class ImageFlip(IO.ComfyNode):
-
     @classmethod
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageFlip",
+            search_aliases=["mirror", "reflect"],
             category="image/transform",
             inputs=[
                 IO.Image.Input("image"),

--- a/comfy_extras/nodes_latent.py
+++ b/comfy_extras/nodes_latent.py
@@ -21,6 +21,7 @@ class LatentAdd(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentAdd",
+            search_aliases=["combine latents", "sum latents"],
             category="latent/advanced",
             inputs=[
                 io.Latent.Input("samples1"),
@@ -47,6 +48,7 @@ class LatentSubtract(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentSubtract",
+            search_aliases=["difference latent", "remove features"],
             category="latent/advanced",
             inputs=[
                 io.Latent.Input("samples1"),
@@ -73,6 +75,7 @@ class LatentMultiply(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentMultiply",
+            search_aliases=["scale latent", "amplify latent", "latent gain"],
             category="latent/advanced",
             inputs=[
                 io.Latent.Input("samples"),
@@ -96,6 +99,7 @@ class LatentInterpolate(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentInterpolate",
+            search_aliases=["blend latent", "mix latent", "lerp latent", "transition"],
             category="latent/advanced",
             inputs=[
                 io.Latent.Input("samples1"),
@@ -134,6 +138,7 @@ class LatentConcat(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentConcat",
+            search_aliases=["join latents", "stitch latents"],
             category="latent/advanced",
             inputs=[
                 io.Latent.Input("samples1"),
@@ -173,6 +178,7 @@ class LatentCut(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentCut",
+            search_aliases=["crop latent", "slice latent", "extract region"],
             category="latent/advanced",
             inputs=[
                 io.Latent.Input("samples"),
@@ -213,6 +219,7 @@ class LatentCutToBatch(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentCutToBatch",
+            search_aliases=["slice to batch", "split latent", "tile latent"],
             category="latent/advanced",
             inputs=[
                 io.Latent.Input("samples"),
@@ -254,6 +261,7 @@ class LatentBatch(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentBatch",
+            search_aliases=["combine latents", "merge latents", "join latents"],
             category="latent/batch",
             is_deprecated=True,
             inputs=[
@@ -310,6 +318,7 @@ class LatentApplyOperation(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentApplyOperation",
+            search_aliases=["transform latent"],
             category="latent/advanced/operations",
             is_experimental=True,
             inputs=[
@@ -365,6 +374,7 @@ class LatentOperationTonemapReinhard(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LatentOperationTonemapReinhard",
+            search_aliases=["hdr latent"],
             category="latent/advanced/operations",
             is_experimental=True,
             inputs=[

--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -50,6 +50,7 @@ class LatentCompositeMasked(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="LatentCompositeMasked",
+            search_aliases=["overlay latent", "layer latent", "paste latent", "inpaint latent"],
             category="latent",
             inputs=[
                 IO.Latent.Input("destination"),
@@ -78,6 +79,7 @@ class ImageCompositeMasked(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageCompositeMasked",
+            search_aliases=["paste image", "overlay", "layer"],
             category="image",
             inputs=[
                 IO.Image.Input("destination"),
@@ -105,6 +107,7 @@ class MaskToImage(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="MaskToImage",
+            search_aliases=["convert mask"],
             display_name="Convert Mask to Image",
             category="mask",
             inputs=[
@@ -126,6 +129,7 @@ class ImageToMask(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageToMask",
+            search_aliases=["extract channel", "channel to mask"],
             display_name="Convert Image to Mask",
             category="mask",
             inputs=[
@@ -149,6 +153,7 @@ class ImageColorToMask(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="ImageColorToMask",
+            search_aliases=["color keying", "chroma key"],
             category="mask",
             inputs=[
                 IO.Image.Input("image"),
@@ -194,6 +199,7 @@ class InvertMask(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="InvertMask",
+            search_aliases=["reverse mask", "flip mask"],
             category="mask",
             inputs=[
                 IO.Mask.Input("mask"),
@@ -214,6 +220,7 @@ class CropMask(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="CropMask",
+            search_aliases=["cut mask", "extract mask region", "mask slice"],
             category="mask",
             inputs=[
                 IO.Mask.Input("mask"),
@@ -239,6 +246,7 @@ class MaskComposite(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="MaskComposite",
+            search_aliases=["combine masks", "blend masks", "layer masks"],
             category="mask",
             inputs=[
                 IO.Mask.Input("destination"),
@@ -287,6 +295,7 @@ class FeatherMask(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="FeatherMask",
+            search_aliases=["soft edge mask", "blur mask edges", "gradient mask edge"],
             category="mask",
             inputs=[
                 IO.Mask.Input("mask"),
@@ -333,6 +342,7 @@ class GrowMask(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="GrowMask",
+            search_aliases=["expand mask", "shrink mask"],
             display_name="Grow Mask",
             category="mask",
             inputs=[
@@ -370,6 +380,7 @@ class ThresholdMask(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="ThresholdMask",
+            search_aliases=["binary mask"],
             category="mask",
             inputs=[
                 IO.Mask.Input("mask"),
@@ -394,6 +405,7 @@ class MaskPreview(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="MaskPreview",
+            search_aliases=["show mask", "view mask", "inspect mask", "debug mask"],
             display_name="Preview Mask",
             category="mask",
             description="Saves the input images to your ComfyUI output directory.",

--- a/comfy_extras/nodes_morphology.py
+++ b/comfy_extras/nodes_morphology.py
@@ -12,6 +12,7 @@ class Morphology(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="Morphology",
+            search_aliases=["erode", "dilate"],
             display_name="ImageMorphology",
             category="image/postprocessing",
             inputs=[
@@ -57,6 +58,7 @@ class ImageRGBToYUV(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="ImageRGBToYUV",
+            search_aliases=["color space conversion"],
             category="image/batch",
             inputs=[
                 io.Image.Input("image"),
@@ -78,6 +80,7 @@ class ImageYUVToRGB(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="ImageYUVToRGB",
+            search_aliases=["color space conversion"],
             category="image/batch",
             inputs=[
                 io.Image.Input("Y"),

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -402,7 +402,6 @@ def scale_to_multiple_cover(input: torch.Tensor, multiple: int, scale_method: st
     return input[:, y0:y1, x0:x1]
 
 class ResizeImageMaskNode(io.ComfyNode):
-
     scale_methods = ["nearest-exact", "bilinear", "area", "bicubic", "lanczos"]
     crop_methods = ["disabled", "center"]
 
@@ -424,6 +423,7 @@ class ResizeImageMaskNode(io.ComfyNode):
         crop_combo = io.Combo.Input("crop", options=cls.crop_methods, default="center")
         return io.Schema(
             node_id="ResizeImageMaskNode",
+            search_aliases=["scale image", "scale mask"],
             display_name="Resize Image/Mask",
             category="transform",
             inputs=[
@@ -569,6 +569,7 @@ class BatchMasksNode(io.ComfyNode):
         autogrow_template = io.Autogrow.TemplatePrefix(io.Mask.Input("mask"), prefix="mask", min=2, max=50)
         return io.Schema(
             node_id="BatchMasksNode",
+            search_aliases=["combine masks", "stack masks", "merge masks"],
             display_name="Batch Masks",
             category="mask",
             inputs=[
@@ -589,6 +590,7 @@ class BatchLatentsNode(io.ComfyNode):
         autogrow_template = io.Autogrow.TemplatePrefix(io.Latent.Input("latent"), prefix="latent", min=2, max=50)
         return io.Schema(
             node_id="BatchLatentsNode",
+            search_aliases=["combine latents", "stack latents", "merge latents"],
             display_name="Batch Latents",
             category="latent",
             inputs=[
@@ -612,6 +614,7 @@ class BatchImagesMasksLatentsNode(io.ComfyNode):
                 prefix="input", min=1, max=50)
         return io.Schema(
             node_id="BatchImagesMasksLatentsNode",
+            search_aliases=["combine batch", "merge batch", "stack inputs"],
             display_name="Batch Images/Masks/Latents",
             category="util",
             inputs=[

--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -32,6 +32,7 @@ class StringSubstring(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="StringSubstring",
+            search_aliases=["extract text", "text portion"],
             display_name="Substring",
             category="utils/string",
             inputs=[
@@ -54,6 +55,7 @@ class StringLength(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="StringLength",
+            search_aliases=["character count", "text size"],
             display_name="Length",
             category="utils/string",
             inputs=[
@@ -74,6 +76,7 @@ class CaseConverter(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="CaseConverter",
+            search_aliases=["text case", "uppercase", "lowercase", "capitalize"],
             display_name="Case Converter",
             category="utils/string",
             inputs=[
@@ -106,6 +109,7 @@ class StringTrim(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="StringTrim",
+            search_aliases=["clean whitespace", "remove whitespace"],
             display_name="Trim",
             category="utils/string",
             inputs=[
@@ -136,6 +140,7 @@ class StringReplace(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="StringReplace",
+            search_aliases=["find and replace", "substitute", "swap text"],
             display_name="Replace",
             category="utils/string",
             inputs=[
@@ -158,6 +163,7 @@ class StringContains(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="StringContains",
+            search_aliases=["text includes", "string includes"],
             display_name="Contains",
             category="utils/string",
             inputs=[
@@ -185,6 +191,7 @@ class StringCompare(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="StringCompare",
+            search_aliases=["text match", "string equals", "starts with", "ends with"],
             display_name="Compare",
             category="utils/string",
             inputs=[
@@ -220,6 +227,7 @@ class RegexMatch(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="RegexMatch",
+            search_aliases=["pattern match", "text contains", "string match"],
             display_name="Regex Match",
             category="utils/string",
             inputs=[
@@ -260,6 +268,7 @@ class RegexExtract(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="RegexExtract",
+            search_aliases=["pattern extract", "text parser", "parse text"],
             display_name="Regex Extract",
             category="utils/string",
             inputs=[
@@ -334,6 +343,7 @@ class RegexReplace(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="RegexReplace",
+            search_aliases=["pattern replace", "find and replace", "substitution"],
             display_name="Regex Replace",
             category="utils/string",
             description="Find and replace text using regex patterns.",


### PR DESCRIPTION
## Summary
Add search aliases to image, mask, and string processing nodes in `comfy_extras` to improve node discoverability.

## Files Updated
- `nodes_mask.py` - mask manipulation nodes
- `nodes_images.py` - image processing nodes
- `nodes_post_processing.py` - post-processing effect nodes
- `nodes_string.py` - string manipulation nodes
- `nodes_compositing.py` - compositing nodes
- `nodes_morphology.py` - morphological operation nodes
- `nodes_latent.py` - latent space nodes

## Related

- #12010