### PR TITLE
feat: add SEARCH_ALIASES for audio and video nodes (3/4)

### DIFF
--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -69,6 +69,7 @@ class VAEEncodeAudio(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="VAEEncodeAudio",
+            search_aliases=["audio to latent"],
             display_name="VAE Encode Audio",
             category="latent/audio",
             inputs=[
@@ -97,6 +98,7 @@ class VAEDecodeAudio(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="VAEDecodeAudio",
+            search_aliases=["latent to audio"],
             display_name="VAE Decode Audio",
             category="latent/audio",
             inputs=[
@@ -122,6 +124,7 @@ class SaveAudio(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="SaveAudio",
+            search_aliases=["export flac"],
             display_name="Save Audio (FLAC)",
             category="audio",
             inputs=[
@@ -146,6 +149,7 @@ class SaveAudioMP3(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="SaveAudioMP3",
+            search_aliases=["export mp3"],
             display_name="Save Audio (MP3)",
             category="audio",
             inputs=[
@@ -173,6 +177,7 @@ class SaveAudioOpus(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="SaveAudioOpus",
+            search_aliases=["export opus"],
             display_name="Save Audio (Opus)",
             category="audio",
             inputs=[
@@ -200,6 +205,7 @@ class PreviewAudio(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="PreviewAudio",
+            search_aliases=["play audio"],
             display_name="Preview Audio",
             category="audio",
             inputs=[
@@ -259,6 +265,7 @@ class LoadAudio(IO.ComfyNode):
         files = folder_paths.filter_files_content_types(os.listdir(input_dir), ["audio", "video"])
         return IO.Schema(
             node_id="LoadAudio",
+            search_aliases=["import audio", "open audio", "audio file"],
             display_name="Load Audio",
             category="audio",
             inputs=[
@@ -296,6 +303,7 @@ class RecordAudio(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="RecordAudio",
+            search_aliases=["microphone input", "audio capture", "voice input"],
             display_name="Record Audio",
             category="audio",
             inputs=[
@@ -320,6 +328,7 @@ class TrimAudioDuration(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="TrimAudioDuration",
+            search_aliases=["cut audio", "audio clip", "shorten audio"],
             display_name="Trim Audio Duration",
             description="Trim audio tensor into chosen time range.",
             category="audio",
@@ -372,6 +381,7 @@ class SplitAudioChannels(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="SplitAudioChannels",
+            search_aliases=["stereo to mono"],
             display_name="Split Audio Channels",
             description="Separates the audio into left and right channels.",
             category="audio",
@@ -472,6 +482,7 @@ class AudioConcat(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="AudioConcat",
+            search_aliases=["join audio", "combine audio", "append audio"],
             display_name="Audio Concat",
             description="Concatenates the audio1 to audio2 in the specified direction.",
             category="audio",
@@ -519,6 +530,7 @@ class AudioMerge(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="AudioMerge",
+            search_aliases=["mix audio", "overlay audio", "layer audio"],
             display_name="Audio Merge",
             description="Combine two audio tracks by overlaying their waveforms.",
             category="audio",
@@ -579,6 +591,7 @@ class AudioAdjustVolume(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="AudioAdjustVolume",
+            search_aliases=["audio gain", "loudness", "audio level"],
             display_name="Audio Adjust Volume",
             category="audio",
             inputs=[
@@ -614,6 +627,7 @@ class EmptyAudio(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="EmptyAudio",
+            search_aliases=["blank audio"],
             display_name="Empty Audio",
             category="audio",
             inputs=[

--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -16,6 +16,7 @@ class SaveWEBM(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="SaveWEBM",
+            search_aliases=["export webm"],
             category="image/video",
             is_experimental=True,
             inputs=[
@@ -69,6 +70,7 @@ class SaveVideo(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="SaveVideo",
+            search_aliases=["export video"],
             display_name="Save Video",
             category="image/video",
             description="Saves the input images to your ComfyUI output directory.",
@@ -116,6 +118,7 @@ class CreateVideo(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="CreateVideo",
+            search_aliases=["images to video"],
             display_name="Create Video",
             category="image/video",
             description="Create a video from images.",
@@ -140,6 +143,7 @@ class GetVideoComponents(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="GetVideoComponents",
+            search_aliases=["extract frames", "split video", "video to images", "demux"],
             display_name="Get Video Components",
             category="image/video",
             description="Extracts all components from a video: frames, audio, and framerate.",
@@ -167,6 +171,7 @@ class LoadVideo(io.ComfyNode):
         files = folder_paths.filter_files_content_types(files, ["video"])
         return io.Schema(
             node_id="LoadVideo",
+            search_aliases=["import video", "open video", "video file"],
             display_name="Load Video",
             category="image/video",
             inputs=[

--- a/comfy_extras/nodes_wan.py
+++ b/comfy_extras/nodes_wan.py
@@ -286,6 +286,7 @@ class WanVaceToVideo(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="WanVaceToVideo",
+            search_aliases=["video conditioning", "video control"],
             category="conditioning/video_models",
             inputs=[
                 io.Conditioning.Input("positive"),
@@ -704,6 +705,7 @@ class WanTrackToVideo(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="WanTrackToVideo",
+            search_aliases=["motion tracking", "trajectory video", "point tracking", "keypoint animation"],
             category="conditioning/video_models",
             inputs=[
                 io.Conditioning.Input("positive"),


### PR DESCRIPTION
## Summary
Add search aliases to audio and video nodes in `comfy_extras` to improve node discoverability.

## Files Updated
- `nodes_audio.py` - audio loading, saving, and processing nodes
- `nodes_video.py` - video loading and processing nodes
- `nodes_wan.py` - WAN model nodes

## Related

- #12010