### PR TITLE
feat: add SEARCH_ALIASES for model and misc nodes (4/4)

### DIFF
--- a/comfy_extras/nodes_align_your_steps.py
+++ b/comfy_extras/nodes_align_your_steps.py
@@ -28,6 +28,7 @@ class AlignYourStepsScheduler(io.ComfyNode):
     def define_schema(cls) -> io.Schema:
         return io.Schema(
             node_id="AlignYourStepsScheduler",
+            search_aliases=["AYS scheduler"],
             category="sampling/custom_sampling/schedulers",
             inputs=[
                 io.Combo.Input("model_type", options=["SD1", "SDXL", "SVD"]),

--- a/comfy_extras/nodes_attention_multiply.py
+++ b/comfy_extras/nodes_attention_multiply.py
@@ -71,6 +71,7 @@ class CLIPAttentionMultiply(io.ComfyNode):
     def define_schema(cls) -> io.Schema:
         return io.Schema(
             node_id="CLIPAttentionMultiply",
+            search_aliases=["clip attention scale", "text encoder attention"],
             category="_for_testing/attention_experiments",
             inputs=[
                 io.Clip.Input("clip"),

--- a/comfy_extras/nodes_canny.py
+++ b/comfy_extras/nodes_canny.py
@@ -10,6 +10,7 @@ class Canny(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="Canny",
+            search_aliases=["edge detection", "outline", "contour detection", "line art"],
             category="image/preprocessors",
             inputs=[
                 io.Image.Input("image"),

--- a/comfy_extras/nodes_controlnet.py
+++ b/comfy_extras/nodes_controlnet.py
@@ -38,6 +38,7 @@ class ControlNetInpaintingAliMamaApply(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="ControlNetInpaintingAliMamaApply",
+            search_aliases=["masked controlnet"],
             category="conditioning/controlnet",
             inputs=[
                 io.Conditioning.Input("positive"),

--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -297,6 +297,7 @@ class ExtendIntermediateSigmas(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="ExtendIntermediateSigmas",
+            search_aliases=["interpolate sigmas"],
             category="sampling/custom_sampling/sigmas",
             inputs=[
                 io.Sigmas.Input("sigmas"),
@@ -856,6 +857,7 @@ class DualCFGGuider(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="DualCFGGuider",
+            search_aliases=["dual prompt guidance"],
             category="sampling/custom_sampling/guiders",
             inputs=[
                 io.Model.Input("model"),
@@ -883,6 +885,7 @@ class DisableNoise(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="DisableNoise",
+            search_aliases=["zero noise"],
             category="sampling/custom_sampling/noise",
             inputs=[],
             outputs=[io.Noise.Output()]
@@ -1019,6 +1022,7 @@ class ManualSigmas(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="ManualSigmas",
+            search_aliases=["custom noise schedule", "define sigmas"],
             category="_for_testing/custom_sampling",
             is_experimental=True,
             inputs=[

--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -1223,11 +1223,11 @@ class ResolutionBucket(io.ComfyNode):
 
 class MakeTrainingDataset(io.ComfyNode):
     """Encode images with VAE and texts with CLIP to create a training dataset."""
-
     @classmethod
     def define_schema(cls):
         return io.Schema(
             node_id="MakeTrainingDataset",
+            search_aliases=["encode dataset"],
             display_name="Make Training Dataset",
             category="dataset",
             is_experimental=True,
@@ -1309,11 +1309,11 @@ class MakeTrainingDataset(io.ComfyNode):
 
 class SaveTrainingDataset(io.ComfyNode):
     """Save encoded training dataset (latents + conditioning) to disk."""
-
     @classmethod
     def define_schema(cls):
         return io.Schema(
             node_id="SaveTrainingDataset",
+            search_aliases=["export training data"],
             display_name="Save Training Dataset",
             category="dataset",
             is_experimental=True,
@@ -1410,11 +1410,11 @@ class SaveTrainingDataset(io.ComfyNode):
 
 class LoadTrainingDataset(io.ComfyNode):
     """Load encoded training dataset from disk."""
-
     @classmethod
     def define_schema(cls):
         return io.Schema(
             node_id="LoadTrainingDataset",
+            search_aliases=["import dataset", "training data"],
             display_name="Load Training Dataset",
             category="dataset",
             is_experimental=True,

--- a/comfy_extras/nodes_differential_diffusion.py
+++ b/comfy_extras/nodes_differential_diffusion.py
@@ -11,6 +11,7 @@ class DifferentialDiffusion(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="DifferentialDiffusion",
+            search_aliases=["inpaint gradient", "variable denoise strength"],
             display_name="Differential Diffusion",
             category="_for_testing",
             inputs=[

--- a/comfy_extras/nodes_fresca.py
+++ b/comfy_extras/nodes_fresca.py
@@ -58,6 +58,7 @@ class FreSca(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="FreSca",
+            search_aliases=["frequency guidance"],
             display_name="FreSca",
             category="_for_testing",
             description="Applies frequency-dependent scaling to the guidance",

--- a/comfy_extras/nodes_hidream.py
+++ b/comfy_extras/nodes_hidream.py
@@ -38,6 +38,7 @@ class CLIPTextEncodeHiDream(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="CLIPTextEncodeHiDream",
+            search_aliases=["hidream prompt"],
             category="advanced/conditioning",
             inputs=[
                 io.Clip.Input("clip"),

--- a/comfy_extras/nodes_hooks.py
+++ b/comfy_extras/nodes_hooks.py
@@ -259,6 +259,7 @@ class SetClipHooks:
         return (clip,)
 
 class ConditioningTimestepsRange:
+    SEARCH_ALIASES = ["prompt scheduling", "timestep segments", "conditioning phases"]
     NodeId = 'ConditioningTimestepsRange'
     NodeName = 'Timesteps Range'
     @classmethod
@@ -468,6 +469,7 @@ class SetHookKeyframes:
         return (hooks,)
 
 class CreateHookKeyframe:
+    SEARCH_ALIASES = ["hook scheduling", "strength animation", "timed hook"]
     NodeId = 'CreateHookKeyframe'
     NodeName = 'Create Hook Keyframe'
     @classmethod
@@ -497,6 +499,7 @@ class CreateHookKeyframe:
         return (prev_hook_kf,)
 
 class CreateHookKeyframesInterpolated:
+    SEARCH_ALIASES = ["ease hook strength", "smooth hook transition", "interpolate keyframes"]
     NodeId = 'CreateHookKeyframesInterpolated'
     NodeName = 'Create Hook Keyframes Interp.'
     @classmethod
@@ -544,6 +547,7 @@ class CreateHookKeyframesInterpolated:
         return (prev_hook_kf,)
 
 class CreateHookKeyframesFromFloats:
+    SEARCH_ALIASES = ["batch keyframes", "strength list to keyframes"]
     NodeId = 'CreateHookKeyframesFromFloats'
     NodeName = 'Create Hook Keyframes From Floats'
     @classmethod
@@ -618,6 +622,7 @@ class SetModelHooksOnCond:
 # Combine Hooks
 #------------------------------------------
 class CombineHooks:
+    SEARCH_ALIASES = ["merge hooks"]
     NodeId = 'CombineHooks2'
     NodeName = 'Combine Hooks [2]'
     @classmethod

--- a/comfy_extras/nodes_hunyuan3d.py
+++ b/comfy_extras/nodes_hunyuan3d.py
@@ -618,6 +618,7 @@ class SaveGLB(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="SaveGLB",
+            search_aliases=["export 3d model", "save mesh"],
             category="3d",
             is_output_node=True,
             inputs=[

--- a/comfy_extras/nodes_kandinsky5.py
+++ b/comfy_extras/nodes_kandinsky5.py
@@ -104,6 +104,7 @@ class CLIPTextEncodeKandinsky5(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="CLIPTextEncodeKandinsky5",
+            search_aliases=["kandinsky prompt"],
             category="advanced/conditioning/kandinsky5",
             inputs=[
                 io.Clip.Input("clip"),

--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -75,6 +75,7 @@ class Preview3D(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="Preview3D",
+            search_aliases=["view mesh", "3d viewer"],
             display_name="Preview 3D & Animation",
             category="3d",
             is_experimental=True,

--- a/comfy_extras/nodes_logic.py
+++ b/comfy_extras/nodes_logic.py
@@ -224,6 +224,7 @@ class ConvertStringToComboNode(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="ConvertStringToComboNode",
+            search_aliases=["string to dropdown", "text to combo"],
             display_name="Convert String to Combo",
             category="logic",
             inputs=[io.String.Input("string")],
@@ -239,6 +240,7 @@ class InvertBooleanNode(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="InvertBooleanNode",
+            search_aliases=["not", "toggle", "negate", "flip boolean"],
             display_name="Invert Boolean",
             category="logic",
             inputs=[io.Boolean.Input("boolean")],

--- a/comfy_extras/nodes_lora_extract.py
+++ b/comfy_extras/nodes_lora_extract.py
@@ -78,6 +78,7 @@ class LoraSave(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LoraSave",
+            search_aliases=["export lora"],
             display_name="Extract and Save Lora",
             category="_for_testing",
             inputs=[

--- a/comfy_extras/nodes_lumina2.py
+++ b/comfy_extras/nodes_lumina2.py
@@ -79,6 +79,7 @@ class CLIPTextEncodeLumina2(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="CLIPTextEncodeLumina2",
+            search_aliases=["lumina prompt"],
             display_name="CLIP Text Encode for Lumina2",
             category="conditioning",
             description="Encodes a system prompt and a user prompt using a CLIP model into an embedding "

--- a/comfy_extras/nodes_model_advanced.py
+++ b/comfy_extras/nodes_model_advanced.py
@@ -299,6 +299,7 @@ class RescaleCFG:
         return (m, )
 
 class ModelComputeDtype:
+    SEARCH_ALIASES = ["model precision", "change dtype"]
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "model": ("MODEL",),

--- a/comfy_extras/nodes_model_merging.py
+++ b/comfy_extras/nodes_model_merging.py
@@ -91,6 +91,7 @@ class CLIPMergeSimple:
 
 
 class CLIPSubtract:
+    SEARCH_ALIASES = ["clip difference", "text encoder subtract"]
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "clip1": ("CLIP",),
@@ -113,6 +114,7 @@ class CLIPSubtract:
 
 
 class CLIPAdd:
+    SEARCH_ALIASES = ["combine clip"]
     @classmethod
     def INPUT_TYPES(s):
         return {"required": { "clip1": ("CLIP",),
@@ -225,6 +227,7 @@ def save_checkpoint(model, clip=None, vae=None, clip_vision=None, filename_prefi
     comfy.sd.save_checkpoint(output_checkpoint, model, clip, vae, clip_vision, metadata=metadata, extra_keys=extra_keys)
 
 class CheckpointSave:
+    SEARCH_ALIASES = ["save model", "export checkpoint", "merge save"]
     def __init__(self):
         self.output_dir = folder_paths.get_output_directory()
 
@@ -337,6 +340,7 @@ class VAESave:
         return {}
 
 class ModelSave:
+    SEARCH_ALIASES = ["export model", "checkpoint save"]
     def __init__(self):
         self.output_dir = folder_paths.get_output_directory()
 

--- a/comfy_extras/nodes_pixart.py
+++ b/comfy_extras/nodes_pixart.py
@@ -7,6 +7,7 @@ class CLIPTextEncodePixArtAlpha(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="CLIPTextEncodePixArtAlpha",
+            search_aliases=["pixart prompt"],
             category="advanced/conditioning",
             description="Encodes text and sets the resolution conditioning for PixArt Alpha. Does not apply to PixArt Sigma.",
             inputs=[

--- a/comfy_extras/nodes_preview_any.py
+++ b/comfy_extras/nodes_preview_any.py
@@ -16,7 +16,7 @@ class PreviewAny():
     OUTPUT_NODE = True
 
     CATEGORY = "utils"
-    SEARCH_ALIASES = ["preview", "show", "display", "view", "show text", "display text", "preview text", "show output", "inspect", "debug"]
+    SEARCH_ALIASES = ["show output", "inspect", "debug", "print value", "show text"]
 
     def main(self, source=None):
         value = 'None'

--- a/comfy_extras/nodes_sd3.py
+++ b/comfy_extras/nodes_sd3.py
@@ -65,6 +65,7 @@ class CLIPTextEncodeSD3(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="CLIPTextEncodeSD3",
+            search_aliases=["sd3 prompt"],
             category="advanced/conditioning",
             inputs=[
                 io.Clip.Input("clip"),

--- a/comfy_extras/nodes_train.py
+++ b/comfy_extras/nodes_train.py
@@ -1101,6 +1101,7 @@ class SaveLoRA(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="SaveLoRA",
+            search_aliases=["export lora"],
             display_name="Save LoRA Weights",
             category="loaders",
             is_experimental=True,
@@ -1144,6 +1145,7 @@ class LossGraphNode(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LossGraphNode",
+            search_aliases=["training chart", "training visualization", "plot loss"],
             display_name="Plot Loss Graph",
             category="training",
             is_experimental=True,

--- a/comfy_extras/nodes_wanmove.py
+++ b/comfy_extras/nodes_wanmove.py
@@ -324,6 +324,7 @@ class GenerateTracks(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="GenerateTracks",
+            search_aliases=["motion paths", "camera movement", "trajectory"],
             category="conditioning/video_models",
             inputs=[
                 io.Int.Input("width", default=832, min=16, max=4096, step=16),

--- a/comfy_extras/nodes_webcam.py
+++ b/comfy_extras/nodes_webcam.py
@@ -5,6 +5,7 @@ MAX_RESOLUTION = nodes.MAX_RESOLUTION
 
 
 class WebcamCapture(nodes.LoadImage):
+    SEARCH_ALIASES = ["camera input", "live capture", "camera feed", "snapshot"]
     @classmethod
     def INPUT_TYPES(s):
         return {


### PR DESCRIPTION
## Summary
Add search aliases to model-related and miscellaneous nodes in `comfy_extras` to improve node discoverability.

## Files Updated
- **Model nodes**: `nodes_model_merging.py`, `nodes_model_advanced.py`, `nodes_lora_extract.py`
- **Sampler nodes**: `nodes_custom_sampler.py`, `nodes_align_your_steps.py`
- **Control nodes**: `nodes_controlnet.py`, `nodes_attention_multiply.py`, `nodes_hooks.py`
- **Training nodes**: `nodes_train.py`, `nodes_dataset.py`
- **Utility nodes**: `nodes_logic.py`, `nodes_canny.py`, `nodes_differential_diffusion.py`
- **Architecture-specific**: `nodes_sd3.py`, `nodes_pixart.py`, `nodes_lumina2.py`, `nodes_kandinsky5.py`, `nodes_hidream.py`, `nodes_fresca.py`, `nodes_hunyuan3d.py`
- **Media nodes**: `nodes_load_3d.py`, `nodes_webcam.py`, `nodes_preview_any.py`, `nodes_wanmove.py`

## Related

- #12010