### PR TITLE
Support ModelScope-Trainer/DiffSynth LoRA format for Flux.2 Klein models

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -260,6 +260,7 @@ def model_lora_keys_unet(model, key_map={}):
                 key_map["transformer.{}".format(k[:-len(".weight")])] = to #simpletrainer and probably regular diffusers flux lora format
                 key_map["lycoris_{}".format(k[:-len(".weight")].replace(".", "_"))] = to #simpletrainer lycoris
                 key_map["lora_transformer_{}".format(k[:-len(".weight")].replace(".", "_"))] = to #onetrainer
+                key_map[k[:-len(".weight")]] = to #DiffSynth lora format
         for k in sdk:
             hidden_size = model.model_config.unet_config.get("hidden_size", 0)
             if k.endswith(".weight") and ".linear1." in k:


### PR DESCRIPTION
LoRA trained by DiffSynth Studio seems not to be supported in ComfyUI

LoRA for testing: https://www.modelscope.cn/models/atimea/Transient_as_an_April_Day_Klein/summary

## Before
LoRA key not loaded
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/9b0d6c5d-7a15-459d-8f1f-376d080218ad" />
<img width="3072" height="1024" alt="ComfyUI_00830_" src="https://github.com/user-attachments/assets/7731ca00-a134-46f8-b3ce-9310572da082" />



## After
<img width="3454" height="1910" alt="image" src="https://github.com/user-attachments/assets/ede30409-dc18-4586-8f3a-c388681dc192" />

<img width="3414" height="1034" alt="image" src="https://github.com/user-attachments/assets/e8f80e99-139d-4b0f-9ecf-c5300ef1d07d" />

<img width="3072" height="1024" alt="ComfyUI_00828_" src="https://github.com/user-attachments/assets/0f8f9b84-583e-4b61-8920-2561367fd28f" />