### PR TITLE
Add support for custom hidden node inputs

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -1344,7 +1344,8 @@ class Schema:
     """The category of the node, as per the "Add Node" menu."""
     inputs: list[Input] = field(default_factory=list)
     outputs: list[Output] = field(default_factory=list)
-    hidden: list[Hidden] = field(default_factory=list)
+    hidden: list[Hidden | str] = field(default_factory=list)
+    """Hidden inputs. Use Hidden enum for system values (PROMPT, UNIQUE_ID, etc.) or plain strings for custom frontend-provided values."""
     description: str=""
     """Node description, shown as a tooltip when hovering over the node."""
     search_aliases: list[str] = field(default_factory=list)
@@ -1443,7 +1444,10 @@ class Schema:
         input = create_input_dict_v1(self.inputs)
         if self.hidden:
             for hidden in self.hidden:
-                input.setdefault("hidden", {})[hidden.name] = (hidden.value,)
+                if isinstance(hidden, str):
+                    input.setdefault("hidden", {})[hidden] = (hidden,)
+                else:
+                    input.setdefault("hidden", {})[hidden.name] = (hidden.value,)
         # create separate lists from output fields
         output = []
         output_is_list = []
@@ -1504,7 +1508,10 @@ class Schema:
                 add_to_dict_v3(output, output_dict)
         if self.hidden:
             for hidden in self.hidden:
-                hidden_list.append(hidden.value)
+                if isinstance(hidden, str):
+                    hidden_list.append(hidden)
+                else:
+                    hidden_list.append(hidden.value)
 
         info = NodeInfoV3(
             input=input_dict,

--- a/comfy_extras/nodes_logic.py
+++ b/comfy_extras/nodes_logic.py
@@ -104,7 +104,11 @@ class CustomComboNode(io.ComfyNode):
             category="utils",
             is_experimental=True,
             inputs=[io.Combo.Input("choice", options=[])],
-            outputs=[io.String.Output()]
+            outputs=[
+                io.String.Output(display_name="STRING"),
+                io.Int.Output(display_name="INDEX"),
+            ],
+            hidden=["index"],
         )
 
     @classmethod
@@ -115,8 +119,8 @@ class CustomComboNode(io.ComfyNode):
         return True
 
     @classmethod
-    def execute(cls, choice: io.Combo.Type) -> io.NodeOutput:
-        return io.NodeOutput(choice)
+    def execute(cls, choice: io.Combo.Type, index: int = 0) -> io.NodeOutput:
+        return io.NodeOutput(choice, index)
 
 
 class DCTestNode(io.ComfyNode):

--- a/execution.py
+++ b/execution.py
@@ -192,6 +192,11 @@ def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=
                 hidden_inputs_v3[io.Hidden.auth_token_comfy_org] = extra_data.get("auth_token_comfy_org", None)
             if io.Hidden.api_key_comfy_org.name in hidden:
                 hidden_inputs_v3[io.Hidden.api_key_comfy_org] = extra_data.get("api_key_comfy_org", None)
+            # Handle custom hidden inputs from prompt data
+            system_hidden_names = {h.name for h in io.Hidden}
+            for hidden_name in hidden:
+                if hidden_name not in system_hidden_names and hidden_name in inputs:
+                    input_data_all[hidden_name] = [inputs[hidden_name]]
     else:
         if "hidden" in valid_inputs:
             h = valid_inputs["hidden"]


### PR DESCRIPTION
This was supported in the v1 schema, but doesn't look to be supported for V3.
Allows nodes to specify a list of "hidden" inputs that do not cause any input/widget to be rendered on frontend, but still passed to the node during execution.

This is then implemented for returning the selected index on the Custom Combo node (frontend already sends this)