### PR TITLE
fix: count non-dict items in outputs_count

### DIFF
--- a/comfy_execution/jobs.py
+++ b/comfy_execution/jobs.py
@@ -171,9 +171,10 @@ def get_outputs_summary(outputs: dict) -> tuple[int, Optional[dict]]:
                 continue
 
             for item in items:
+                count += 1
+
                 if not isinstance(item, dict):
                     continue
-                count += 1
 
                 if preview_output is None and is_previewable(media_type, item):
                     enriched = {


### PR DESCRIPTION
Fix `outputs_count` not counting non-dict output items (e.g., text strings from PreviewAny node).

## Problem

The `get_outputs_summary()` function in `comfy_execution/jobs.py` increments `count` **after** the `isinstance(item, dict)` check, causing non-dict items to be skipped from the count.

Text outputs from nodes like PreviewAny come as inline strings `["test"]` rather than dicts, so they were never counted. This caused `outputs_count: 0` in the jobs API response even when text outputs existed, which prevented the frontend from fetching and displaying them. Example problem:

```
curl "http://localhost:8188/api/jobs/9c1e37e9-7644-4189-a456-88935b629d70" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2243  100  2243    0     0  2589k      0 --:--:-- --:--:-- --:--:-- 2190k
{
  "id": "9c1e37e9-7644-4189-a456-88935b629d70",
  "status": "completed",
  "priority": 0,
  "create_time": 1769675441110,
  "execution_start_time": 1769675441111,
  "execution_end_time": 1769675441129,
  "outputs_count": 0,
  "workflow_id": "d2a78457-e57e-448b-a5dc-b1c4edbf74a0",
  "outputs": {
    "37": {
      "text": [
        "test"
      ]
    }
  },
```

The solution in this PR aligns OSS Python with Cloud's Go implementation which uses len(itemsArray) to count ALL items regardless of type.