### PR TITLE
feat: add timestamp to default filename_prefix for cache-busting

### DIFF
--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -162,7 +162,7 @@ class SaveAudio(IO.ComfyNode):
             essentials_category="Audio",
             inputs=[
                 IO.Audio.Input("audio"),
-                IO.String.Input("filename_prefix", default="audio/ComfyUI"),
+                IO.String.Input("filename_prefix", default="audio/ComfyUI_%year%%month%%day%-%hour%%minute%%second%"),
             ],
             hidden=[IO.Hidden.prompt, IO.Hidden.extra_pnginfo],
             is_output_node=True,
@@ -187,7 +187,7 @@ class SaveAudioMP3(IO.ComfyNode):
             category="audio",
             inputs=[
                 IO.Audio.Input("audio"),
-                IO.String.Input("filename_prefix", default="audio/ComfyUI"),
+                IO.String.Input("filename_prefix", default="audio/ComfyUI_%year%%month%%day%-%hour%%minute%%second%"),
                 IO.Combo.Input("quality", options=["V0", "128k", "320k"], default="V0"),
             ],
             hidden=[IO.Hidden.prompt, IO.Hidden.extra_pnginfo],
@@ -215,7 +215,7 @@ class SaveAudioOpus(IO.ComfyNode):
             category="audio",
             inputs=[
                 IO.Audio.Input("audio"),
-                IO.String.Input("filename_prefix", default="audio/ComfyUI"),
+                IO.String.Input("filename_prefix", default="audio/ComfyUI_%year%%month%%day%-%hour%%minute%%second%"),
                 IO.Combo.Input("quality", options=["64k", "96k", "128k", "192k", "320k"], default="128k"),
             ],
             hidden=[IO.Hidden.prompt, IO.Hidden.extra_pnginfo],

--- a/comfy_extras/nodes_hunyuan3d.py
+++ b/comfy_extras/nodes_hunyuan3d.py
@@ -637,7 +637,7 @@ class SaveGLB(IO.ComfyNode):
                     ],
                     tooltip="Mesh or 3D file to save",
                 ),
-                IO.String.Input("filename_prefix", default="mesh/ComfyUI"),
+                IO.String.Input("filename_prefix", default="mesh/ComfyUI_%year%%month%%day%-%hour%%minute%%second%"),
             ],
             hidden=[IO.Hidden.prompt, IO.Hidden.extra_pnginfo]
         )

--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -190,7 +190,7 @@ class SaveAnimatedWEBP(IO.ComfyNode):
             category="image/animation",
             inputs=[
                 IO.Image.Input("images"),
-                IO.String.Input("filename_prefix", default="ComfyUI"),
+                IO.String.Input("filename_prefix", default="ComfyUI_%year%%month%%day%-%hour%%minute%%second%"),
                 IO.Float.Input("fps", default=6.0, min=0.01, max=1000.0, step=0.01),
                 IO.Boolean.Input("lossless", default=True),
                 IO.Int.Input("quality", default=80, min=0, max=100),
@@ -227,7 +227,7 @@ class SaveAnimatedPNG(IO.ComfyNode):
             category="image/animation",
             inputs=[
                 IO.Image.Input("images"),
-                IO.String.Input("filename_prefix", default="ComfyUI"),
+                IO.String.Input("filename_prefix", default="ComfyUI_%year%%month%%day%-%hour%%minute%%second%"),
                 IO.Float.Input("fps", default=6.0, min=0.01, max=1000.0, step=0.01),
                 IO.Int.Input("compress_level", default=4, min=0, max=9, advanced=True),
             ],
@@ -489,7 +489,7 @@ class SaveSVGNode(IO.ComfyNode):
                 IO.SVG.Input("svg"),
                 IO.String.Input(
                     "filename_prefix",
-                    default="svg/ComfyUI",
+                    default="svg/ComfyUI_%year%%month%%day%-%hour%%minute%%second%",
                     tooltip="The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes.",
                 ),
             ],

--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -21,7 +21,7 @@ class SaveWEBM(io.ComfyNode):
             is_experimental=True,
             inputs=[
                 io.Image.Input("images"),
-                io.String.Input("filename_prefix", default="ComfyUI"),
+                io.String.Input("filename_prefix", default="ComfyUI_%year%%month%%day%-%hour%%minute%%second%"),
                 io.Combo.Input("codec", options=["vp9", "av1"]),
                 io.Float.Input("fps", default=24.0, min=0.01, max=1000.0, step=0.01),
                 io.Float.Input("crf", default=32.0, min=0, max=63.0, step=1, tooltip="Higher crf means lower quality with a smaller file size, lower crf means higher quality higher filesize."),
@@ -77,7 +77,7 @@ class SaveVideo(io.ComfyNode):
             description="Saves the input images to your ComfyUI output directory.",
             inputs=[
                 io.Video.Input("video", tooltip="The video to save."),
-                io.String.Input("filename_prefix", default="video/ComfyUI", tooltip="The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."),
+                io.String.Input("filename_prefix", default="video/ComfyUI_%year%%month%%day%-%hour%%minute%%second%", tooltip="The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."),
                 io.Combo.Input("format", options=Types.VideoContainer.as_input(), default="auto", tooltip="The format to save the video as."),
                 io.Combo.Input("codec", options=Types.VideoCodec.as_input(), default="auto", tooltip="The codec to use for the video."),
             ],

--- a/nodes.py
+++ b/nodes.py
@@ -1638,7 +1638,7 @@ class SaveImage:
         return {
             "required": {
                 "images": ("IMAGE", {"tooltip": "The images to save."}),
-                "filename_prefix": ("STRING", {"default": "ComfyUI", "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."})
+                "filename_prefix": ("STRING", {"default": "ComfyUI_%year%%month%%day%-%hour%%minute%%second%", "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."})
             },
             "hidden": {
                 "prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"


### PR DESCRIPTION
## Summary

Changes the default `filename_prefix` on all previewable save nodes from `"ComfyUI"` to `"ComfyUI_%year%%month%%day%-%hour%%minute%%second%"`, leveraging the **existing** `compute_vars` template system in `get_save_image_path`.

This solves the browser cache-busting problem (stale previews when output files are overwritten) with **zero new backend code** — just a default value change across 5 files (10 lines changed).

## How it works

The `compute_vars` function in `folder_paths.get_save_image_path` already supports `%year%`, `%month%`, `%day%`, `%hour%`, `%minute%`, `%second%` template variables. When `%` is present in the prefix, these are expanded at save time.

**Before:** `ComfyUI_00001_.png`, `ComfyUI_00002_.png`
**After:** `ComfyUI_20260227-143256_00001_.png`, `ComfyUI_20260227-143256_00002_.png`

## Affected nodes

| Node | Old default | New default |
|------|-------------|-------------|
| SaveImage | `ComfyUI` | `ComfyUI_%year%%month%%day%-%hour%%minute%%second%` |
| SaveWEBM | `ComfyUI` | `ComfyUI_%year%%month%%day%-%hour%%minute%%second%` |
| SaveVideo | `video/ComfyUI` | `video/ComfyUI_%year%%month%%day%-%hour%%minute%%second%` |
| SaveAnimatedWEBP | `ComfyUI` | `ComfyUI_%year%%month%%day%-%hour%%minute%%second%` |
| SaveAnimatedPNG | `ComfyUI` | `ComfyUI_%year%%month%%day%-%hour%%minute%%second%` |
| SaveSVGNode | `svg/ComfyUI` | `svg/ComfyUI_%year%%month%%day%-%hour%%minute%%second%` |
| SaveGLB | `mesh/ComfyUI` | `mesh/ComfyUI_%year%%month%%day%-%hour%%minute%%second%` |
| SaveAudio/MP3/Opus | `audio/ComfyUI` | `audio/ComfyUI_%year%%month%%day%-%hour%%minute%%second%` |

**Not changed:** SaveLatent (`latents/ComfyUI`) — not browser-previewed.

## Why this approach

Per reviewer feedback, this uses the existing template infrastructure instead of adding new `format_output_filename()` / `get_timestamp()` functions. Benefits:

1. **Zero new code** — leverages existing `compute_vars`
2. **User-visible and customizable** — template is in the node widget, users can modify or remove it
3. **Ecosystem-safe** — no filename format changes, no custom node breakage (30+ repos verified)
4. **Existing workflows unaffected** — only newly created nodes get the new default

## ❓ Question for reviewers

**Flat timestamps vs date subfolders?** This PR uses flat timestamps (`ComfyUI_20260227-143256_00001_.png`). An alternative would be date subfolders (`ComfyUI/%year%%month%%day%/ComfyUI_00001_.png`) which organizes outputs by date. Would you prefer subfolder organization instead?