### PR TITLE
dynamic_vram: fix pinning with model defined dtype

### DIFF
--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -11,8 +11,7 @@ def pin_memory(module):
     if module.pin_failed or args.disable_pinned_memory or get_pin(module) is not None:
         return
     #FIXME: This is a RAM cache trigger event
-    params = comfy.memory_management.tensors_to_geometries([ module.weight, module.bias ])
-    size = comfy.memory_management.vram_aligned_size(params)
+    size = comfy.memory_management.vram_aligned_size([ module.weight, module.bias ])
     pin = torch.empty((size,), dtype=torch.uint8)
     if comfy.model_management.pin_memory(pin):
         module._pin = pin


### PR DESCRIPTION
pinned memory was converted back to pinning the CPU side weight without any changes. Fix the pinner to use the CPU weight and not the model defined geometry. This will either save RAM or stop buffer overruns when the types mismatch.

Fix the model defined weight caster to use the [ s.weight, s.bias ] interpretation, as xfer_dest might be the flattened pin now. Fix the detection of needing to cast to not be conditional on !pin.

https://github.com/Comfy-Org/ComfyUI/issues/12205

Example Test conditions:

RTX3060, Linux, --fast dynamic_vram

LTX2 VAE decode with on-demand model:

<img width="1913" height="465" alt="image" src="https://github.com/user-attachments/assets/c1ec5e3f-cf4d-40d3-92f2-d21f0d1d7c1c" />

Before:

First crash:

```
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 414, in forward
    return self.forward_comfy_cast_weights(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 406, in forward_comfy_cast_weights
    weight, bias, offload_stream = cast_bias_weight(self, input, offloadable=True)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 207, in cast_bias_weight
    return cast_bias_weight_with_vbar(s, dtype, device, bias_dtype, non_blocking, compute_dtype)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 131, in cast_bias_weight_with_vbar
    comfy.model_management.cast_to_gathered(xfer_source, xfer_dest, non_blocking=non_blocking, stream=offload_stream)
  File "/home/rattus/ComfyUI/comfy/model_management.py", line 1189, in cast_to_gathered
    dest_views = comfy.memory_management.interpret_gathered_like(tensors, r)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/memory_management.py", line 70, in interpret_gathered_like
    raise ValueError(f"Buffer too small: needs {offset + size} bytes, but only has {gathered.numel()}. ")
ValueError: Buffer too small: needs 1770496 bytes, but only has 885760. 
```

Second crash (matches issue OP):

```
  File "/home/rattus/ComfyUI/comfy/ldm/lightricks/vae/causal_conv3d.py", line 72, in forward
    return self.conv(x) if x.shape[2] >= self.time_kernel_size else x[:, :, :0, :, :]
           ^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 414, in forward
    return self.forward_comfy_cast_weights(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 406, in forward_comfy_cast_weights
    weight, bias, offload_stream = cast_bias_weight(self, input, offloadable=True)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 207, in cast_bias_weight
    return cast_bias_weight_with_vbar(s, dtype, device, bias_dtype, non_blocking, compute_dtype)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 138, in cast_bias_weight_with_vbar
    post_cast.copy_(pre_cast)
RuntimeError: The size of tensor a (3) must match the size of tensor b (7078912) at non-singleton dimension 4

Prompt executed in 1.60 seconds
```

After:

```
Model VideoVAE prepared for dynamic VRAM loading. 4663MB Staged. 0 patches attached.
Prompt executed in 17.79 seconds
```
