### PR TITLE
requirements: bump comfy-aimdo to 0.1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ alembic
 SQLAlchemy
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.1.6
+comfy-aimdo>=0.1.7
 requests
 
 #non essential dependencies:


### PR DESCRIPTION
Aimdo 0.1.7

Features:

Implements 256MB VRAM headroom in Linux to avoid VRAM from off-the-pytorch-books incidental usage from kernels.

P.S. I can no longer reproduce the issue on aimdo 0.1.6 however it did make a cuda level (non pytorch aware) async error go away with this. I'm suspicious the issue is very sensitive to incidental VRAM usage on the host and I had everything line up to have aimdo hit 100% exactly. We should have a little headroom on linux for the unexpected anyway.





