### PR TITLE
Dynamic_vram: Remove Aimdo exemption for empty_cache (fixes VRAM leak)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1724,11 +1724,9 @@ def soft_empty_cache(force=False):
     elif is_mlu():
         torch.mlu.empty_cache()
     elif torch.cuda.is_available():
-        if comfy.memory_management.aimdo_allocator is None:
-            #Pytorch 2.7 and earlier crashes if you try and empty_cache when mempools exist
-            torch.cuda.synchronize()
-            torch.cuda.empty_cache()
-            torch.cuda.ipc_collect()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.cuda.ipc_collect()
 
 def unload_all_models():
     free_memory(1e30, get_torch_device())

--- a/main.py
+++ b/main.py
@@ -192,7 +192,10 @@ import comfy_aimdo.control
 import comfy_aimdo.torch
 
 if enables_dynamic_vram():
-    if comfy_aimdo.control.init_device(comfy.model_management.get_torch_device().index):
+    if comfy.model_management.torch_version_numeric < (2, 8):
+        logging.warning("Unsupported Pytorch detected. DynamicVRAM support requires Pytorch version 2.8 or later. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
+        comfy.memory_management.aimdo_allocator = None
+    elif comfy_aimdo.control.init_device(comfy.model_management.get_torch_device().index):
         if args.verbose == 'DEBUG':
             comfy_aimdo.control.set_log_debug()
         elif args.verbose == 'CRITICAL':
@@ -208,7 +211,7 @@ if enables_dynamic_vram():
         comfy.memory_management.aimdo_allocator = comfy_aimdo.torch.get_torch_allocator()
         logging.info("DynamicVRAM support detected and enabled")
     else:
-        logging.info("No working comfy-aimdo install detected. DynamicVRAM support disabled. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
+        logging.warning("No working comfy-aimdo install detected. DynamicVRAM support disabled. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
         comfy.memory_management.aimdo_allocator = None
 
 


### PR DESCRIPTION
It's more important to get the torch caching allocator GC up and running than supporting the pyt2.7 bug. Switch it on.

Defeature dynamic_vram + pyt2.7.

Example test conditions:

RTX3060, 32GB RAM, Windows, pyt 2.8, --fast dynamic_vram
LTX tiled decode then clear the cache in the GUI

Before (2.4GB VRAM after clear):

<img width="2198" height="719" alt="before" src="https://github.com/user-attachments/assets/278c12fe-0387-4093-929e-fa57578d00fd" />

After (0.7 VRAM after clear):

<img width="2288" height="730" alt="after" src="https://github.com/user-attachments/assets/c05f1bf0-0d05-45e6-a693-3f0a62bb9b0c" />
