### PR TITLE
Fix crash on safetensors load for some 3rd party Models

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -82,14 +82,12 @@ _TYPES = {
 def load_safetensors(ckpt):
     f = open(ckpt, "rb")
     mapping = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+    mv = memoryview(mapping)
 
     header_size = struct.unpack("<Q", mapping[:8])[0]
     header = json.loads(mapping[8:8+header_size].decode("utf-8"))
 
-    with warnings.catch_warnings():
-        #We are working with read-only RAM by design
-        warnings.filterwarnings("ignore", message="The given buffer is not writable")
-        data_area = torch.frombuffer(mapping, dtype=torch.uint8)[8 + header_size:]
+    mv = mv[8 + header_size:]
 
     sd = {}
     for name, info in header.items():
@@ -97,7 +95,13 @@ def load_safetensors(ckpt):
             continue
 
         start, end = info["data_offsets"]
-        sd[name] = data_area[start:end].view(_TYPES[info["dtype"]]).view(info["shape"])
+        if start == end:
+            sd[name] = torch.empty(info["shape"], dtype =_TYPES[info["dtype"]])
+        else:
+            with warnings.catch_warnings():
+                #We are working with read-only RAM by design
+                warnings.filterwarnings("ignore", message="The given buffer is not writable")
+                sd[name] = torch.frombuffer(mv[start:end], dtype=_TYPES[info["dtype"]]).view(info["shape"])
 
     return sd, header.get("__metadata__", {}),
 


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/12236

Torch has alignment enforcement when viewing with data type changes but only relative to itself. Do all tensor constructions straight off the memory-view individually so pytorch doesnt see an alignment problem.

The is needed for handling misaligned safetensors weights, which are reasonably common in third party models.

This limits usage of this safetensors loader to GPU compute only as CPUs kernnel are very likely to bus error. But it works for dynamic_vram, where we really dont want to take a deep copy and we always use GPU copy_ which disentangles the misalignment.

Example test conditions:

RTX5090, Linux, pyt2.9, wan 2.2 14B third party misaligned model

Before:

```
!!! Exception during processing !!! self.storage_offset() must be divisible by 4 to view Byte as Float (different element sizes), but got 316294
Traceback (most recent call last):
  File "/home/rattus/ComfyUI/execution.py", line 527, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/execution.py", line 331, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/execution.py", line 305, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "/home/rattus/ComfyUI/execution.py", line 293, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "/home/rattus/ComfyUI/nodes.py", line 969, in load_unet
    model = comfy.sd.load_diffusion_model(unet_path, model_options=model_options)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/sd.py", line 1710, in load_diffusion_model
    sd, metadata = comfy.utils.load_torch_file(unet_path, return_metadata=True)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/utils.py", line 132, in load_torch_file
    raise e
  File "/home/rattus/ComfyUI/comfy/utils.py", line 112, in load_torch_file
    sd, metadata = load_safetensors(ckpt)
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/utils.py", line 100, in load_safetensors
    sd[name] = data_area[start:end].view(_TYPES[info["dtype"]]).view(info["shape"])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: self.storage_offset() must be divisible by 4 to view Byte as Float (different element sizes), but got 316294

Prompt executed in 3.63 seconds
```

After:

<img width="2030" height="857" alt="image" src="https://github.com/user-attachments/assets/6229914f-41b1-4357-ba28-d68457df0cf4" />

```
Prompt executed in 37.45 seconds
```

Regression tests:

flux 2 5090 linux (offloading) :white_check_mark: 
LTX2 FP16, 3060, 32GB, Windows pyt2.8 (high stress) :white_check_mark: 