### PR TITLE
fix: prevent symlink-based path traversal in /view endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -495,7 +495,10 @@ class PromptServer():
 
                 if "subfolder" in request.rel_url.query:
                     full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
-                    if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
+                    # Resolve symlinks BEFORE validation to prevent symlink-based path traversal
+                    real_output_dir = os.path.realpath(full_output_dir)
+                    real_base_dir = os.path.realpath(output_dir)
+                    if not real_output_dir.startswith(real_base_dir + os.sep) and real_output_dir != real_base_dir:
                         return web.Response(status=403)
                     output_dir = full_output_dir
 


### PR DESCRIPTION
## Summary
This PR fixes a symlink-based path traversal vulnerability in the `/view` endpoint that could allow attackers to read arbitrary files from the server filesystem.

## Problem
The path validation using `os.path.commonpath()` occurred **before** symlink resolution. An attacker could:
1. Create a symlink in an allowed directory (input/output/temp) pointing to any location
2. Access files through that symlink, bypassing the path check

Example attack:
```bash
ln -s /etc input/etc_link
curl "http://localhost:8188/view?filename=passwd&subfolder=etc_link&type=input"
# Returns contents of /etc/passwd
```

## Solution
Resolve symlinks using `os.path.realpath()` **before** validating that the path is within allowed directories.

## Changes
- Added symlink resolution before path validation in `/view` endpoint
- Uses `os.path.realpath()` to get the canonical path
- Validates resolved path starts with the allowed base directory

## Testing
- Verified legitimate subfolder access still works
- Verified symlink attacks are now blocked with 403 response
- No breaking changes to existing functionality

Fixes #12285

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)