### PR TITLE
feat: add essentials_category field to node schema

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -1309,7 +1309,7 @@ class NodeInfoV1:
     api_node: bool=None
     price_badge: dict | None = None
     search_aliases: list[str]=None
-    essentials_category: str=None
+    main_category: str=None
 
 
 @dataclass
@@ -1431,8 +1431,8 @@ class Schema:
     """Flags a node as expandable, allowing NodeOutput to include 'expand' property."""
     accept_all_inputs: bool=False
     """When True, all inputs from the prompt will be passed to the node as kwargs, even if not defined in the schema."""
-    essentials_category: str | None = None
-    """Optional category for the Essentials tab. Path-based like category field (e.g., 'Basic', 'Image Tools/Editing')."""
+    main_category: str | None = None
+    """Optional main category for top-level tabs in the node library (e.g., 'Basic', 'Image Tools', 'Partner Nodes')."""
 
     def validate(self):
         '''Validate the schema:
@@ -1539,7 +1539,7 @@ class Schema:
             python_module=getattr(cls, "RELATIVE_PYTHON_MODULE", "nodes"),
             price_badge=self.price_badge.as_dict(self.inputs) if self.price_badge is not None else None,
             search_aliases=self.search_aliases if self.search_aliases else None,
-            essentials_category=self.essentials_category,
+            main_category=self.main_category,
         )
         return info
 

--- a/comfy_api_nodes/nodes_hunyuan3d.py
+++ b/comfy_api_nodes/nodes_hunyuan3d.py
@@ -37,7 +37,7 @@ class TencentTextToModelNode(IO.ComfyNode):
             node_id="TencentTextToModelNode",
             display_name="Hunyuan3D: Text to Model (Pro)",
             category="api node/3d/Tencent",
-            essentials_category="3D",
+            main_category="3D",
             inputs=[
                 IO.Combo.Input(
                     "model",
@@ -148,7 +148,7 @@ class TencentImageToModelNode(IO.ComfyNode):
             node_id="TencentImageToModelNode",
             display_name="Hunyuan3D: Image(s) to Model (Pro)",
             category="api node/3d/Tencent",
-            essentials_category="3D",
+            main_category="3D",
             inputs=[
                 IO.Combo.Input(
                     "model",

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -1936,7 +1936,7 @@ class KlingLipSyncAudioToVideoNode(IO.ComfyNode):
             node_id="KlingLipSyncAudioToVideoNode",
             display_name="Kling Lip Sync Video with Audio",
             category="api node/video/Kling",
-            essentials_category="Video Generation",
+            main_category="Video Generation",
             description="Kling Lip Sync Audio to Video Node. Syncs mouth movements in a video file to the audio content of an audio file. When using, ensure that the audio contains clearly distinguishable vocals and that the video contains a distinct face. The audio file should not be larger than 5MB. The video file should not be larger than 100MB, should have height/width between 720px and 1920px, and should be between 2s and 10s in length.",
             inputs=[
                 IO.Video.Input("video"),

--- a/comfy_api_nodes/nodes_openai.py
+++ b/comfy_api_nodes/nodes_openai.py
@@ -576,7 +576,7 @@ class OpenAIChatNode(IO.ComfyNode):
             node_id="OpenAIChatNode",
             display_name="OpenAI ChatGPT",
             category="api node/text/OpenAI",
-            essentials_category="Text Generation",
+            main_category="Text Generation",
             description="Generate text responses from an OpenAI model.",
             inputs=[
                 IO.String.Input(

--- a/comfy_api_nodes/nodes_recraft.py
+++ b/comfy_api_nodes/nodes_recraft.py
@@ -963,7 +963,7 @@ class RecraftRemoveBackgroundNode(IO.ComfyNode):
             node_id="RecraftRemoveBackgroundNode",
             display_name="Recraft Remove Background",
             category="api node/image/Recraft",
-            essentials_category="Image Tools",
+            main_category="Image Tools",
             description="Remove background from image, and return processed image and mask.",
             inputs=[
                 IO.Image.Input("image"),

--- a/comfy_api_nodes/nodes_stability.py
+++ b/comfy_api_nodes/nodes_stability.py
@@ -624,7 +624,7 @@ class StabilityTextToAudio(IO.ComfyNode):
             node_id="StabilityTextToAudio",
             display_name="Stability AI Text To Audio",
             category="api node/audio/Stability AI",
-            essentials_category="Audio",
+            main_category="Audio",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Combo.Input(

--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -129,7 +129,7 @@ class SaveAudio(IO.ComfyNode):
             search_aliases=["export flac"],
             display_name="Save Audio (FLAC)",
             category="audio",
-            essentials_category="Audio",
+            main_category="Audio",
             inputs=[
                 IO.Audio.Input("audio"),
                 IO.String.Input("filename_prefix", default="audio/ComfyUI"),
@@ -271,7 +271,7 @@ class LoadAudio(IO.ComfyNode):
             search_aliases=["import audio", "open audio", "audio file"],
             display_name="Load Audio",
             category="audio",
-            essentials_category="Audio",
+            main_category="Audio",
             inputs=[
                 IO.Combo.Input("audio", upload=IO.UploadType.audio, options=sorted(files)),
             ],

--- a/comfy_extras/nodes_canny.py
+++ b/comfy_extras/nodes_canny.py
@@ -12,7 +12,7 @@ class Canny(io.ComfyNode):
             node_id="Canny",
             search_aliases=["edge detection", "outline", "contour detection", "line art"],
             category="image/preprocessors",
-            essentials_category="Image Tools/Preprocessing",
+            main_category="Image Tools/Preprocessing",
             inputs=[
                 io.Image.Input("image"),
                 io.Float.Input("low_threshold", default=0.4, min=0.01, max=0.99, step=0.01),

--- a/comfy_extras/nodes_hunyuan3d.py
+++ b/comfy_extras/nodes_hunyuan3d.py
@@ -621,7 +621,7 @@ class SaveGLB(IO.ComfyNode):
             display_name="Save 3D Model",
             search_aliases=["export 3d model", "save mesh"],
             category="3d",
-            essentials_category="Basic",
+            main_category="Basic",
             is_output_node=True,
             inputs=[
                 IO.MultiType.Input(

--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -25,7 +25,7 @@ class ImageCrop(IO.ComfyNode):
             search_aliases=["trim"],
             display_name="Image Crop",
             category="image/transform",
-            essentials_category="Image Tools",
+            main_category="Image Tools",
             inputs=[
                 IO.Image.Input("image"),
                 IO.Int.Input("width", default=512, min=1, max=nodes.MAX_RESOLUTION, step=1),
@@ -538,7 +538,7 @@ class ImageRotate(IO.ComfyNode):
             node_id="ImageRotate",
             search_aliases=["turn", "flip orientation"],
             category="image/transform",
-            essentials_category="Image Tools",
+            main_category="Image Tools",
             inputs=[
                 IO.Image.Input("image"),
                 IO.Combo.Input("rotation", options=["none", "90 degrees", "180 degrees", "270 degrees"]),

--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -31,7 +31,7 @@ class Load3D(IO.ComfyNode):
             node_id="Load3D",
             display_name="Load 3D & Animation",
             category="3d",
-            essentials_category="Basic",
+            main_category="Basic",
             is_experimental=True,
             inputs=[
                 IO.Combo.Input("model_file", options=sorted(files), upload=IO.UploadType.model),

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -77,7 +77,7 @@ class Blur(io.ComfyNode):
         return io.Schema(
             node_id="ImageBlur",
             category="image/postprocessing",
-            essentials_category="Image Tools",
+            main_category="Image Tools",
             inputs=[
                 io.Image.Input("image"),
                 io.Int.Input("blur_radius", default=1, min=1, max=31, step=1),

--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -73,7 +73,7 @@ class SaveVideo(io.ComfyNode):
             search_aliases=["export video"],
             display_name="Save Video",
             category="image/video",
-            essentials_category="Basic",
+            main_category="Basic",
             description="Saves the input images to your ComfyUI output directory.",
             inputs=[
                 io.Video.Input("video", tooltip="The video to save."),
@@ -147,7 +147,7 @@ class GetVideoComponents(io.ComfyNode):
             search_aliases=["extract frames", "split video", "video to images", "demux"],
             display_name="Get Video Components",
             category="image/video",
-            essentials_category="Video Tools",
+            main_category="Video Tools",
             description="Extracts all components from a video: frames, audio, and framerate.",
             inputs=[
                 io.Video.Input("video", tooltip="The video to extract components from."),
@@ -176,7 +176,7 @@ class LoadVideo(io.ComfyNode):
             search_aliases=["import video", "open video", "video file"],
             display_name="Load Video",
             category="image/video",
-            essentials_category="Basic",
+            main_category="Basic",
             inputs=[
                 io.Combo.Input("file", options=sorted(files), upload=io.UploadType.video),
             ],

--- a/nodes.py
+++ b/nodes.py
@@ -69,7 +69,7 @@ class CLIPTextEncode(ComfyNodeABC):
     FUNCTION = "encode"
 
     CATEGORY = "conditioning"
-    ESSENTIALS_CATEGORY = "Basic"
+    MAIN_CATEGORY = "Basic"
     DESCRIPTION = "Encodes a text prompt using a CLIP model into an embedding that can be used to guide the diffusion model towards generating specific images."
     SEARCH_ALIASES = ["text", "prompt", "text prompt", "positive prompt", "negative prompt", "encode text", "text encoder", "encode prompt"]
 
@@ -668,7 +668,7 @@ class CLIPSetLastLayer:
         return (clip,)
 
 class LoraLoader:
-    ESSENTIALS_CATEGORY = "Image Generation"
+    MAIN_CATEGORY = "Image Generation"
 
     def __init__(self):
         self.loaded_lora = None
@@ -1651,7 +1651,7 @@ class SaveImage:
     OUTPUT_NODE = True
 
     CATEGORY = "image"
-    ESSENTIALS_CATEGORY = "Basic"
+    MAIN_CATEGORY = "Basic"
     DESCRIPTION = "Saves the input images to your ComfyUI output directory."
     SEARCH_ALIASES = ["save", "save image", "export image", "output image", "write image", "download"]
 
@@ -1710,7 +1710,7 @@ class LoadImage:
                 }
 
     CATEGORY = "image"
-    ESSENTIALS_CATEGORY = "Basic"
+    MAIN_CATEGORY = "Basic"
     SEARCH_ALIASES = ["load image", "open image", "import image", "image input", "upload image", "read image", "image loader"]
 
     RETURN_TYPES = ("IMAGE", "MASK")
@@ -1868,7 +1868,7 @@ class ImageScale:
     FUNCTION = "upscale"
 
     CATEGORY = "image/upscaling"
-    ESSENTIALS_CATEGORY = "Image Tools"
+    MAIN_CATEGORY = "Image Tools"
     SEARCH_ALIASES = ["resize", "resize image", "scale image", "image resize", "zoom", "zoom in", "change size"]
 
     def upscale(self, image, upscale_method, width, height, crop):
@@ -1908,7 +1908,7 @@ class ImageScaleBy:
 
 class ImageInvert:
     SEARCH_ALIASES = ["reverse colors"]
-    ESSENTIALS_CATEGORY = "Image Tools"
+    MAIN_CATEGORY = "Image Tools"
 
     @classmethod
     def INPUT_TYPES(s):
@@ -1925,7 +1925,7 @@ class ImageInvert:
 
 class ImageBatch:
     SEARCH_ALIASES = ["combine images", "merge images", "stack images"]
-    ESSENTIALS_CATEGORY = "Image Tools"
+    MAIN_CATEGORY = "Image Tools"
 
     @classmethod
     def INPUT_TYPES(s):

--- a/server.py
+++ b/server.py
@@ -688,8 +688,8 @@ class PromptServer():
 
             info['search_aliases'] = getattr(obj_class, 'SEARCH_ALIASES', [])
 
-            if hasattr(obj_class, 'ESSENTIALS_CATEGORY'):
-                info['essentials_category'] = obj_class.ESSENTIALS_CATEGORY
+            if hasattr(obj_class, 'MAIN_CATEGORY'):
+                info['main_category'] = obj_class.MAIN_CATEGORY
 
             return info
 


### PR DESCRIPTION
Adds `essentials_category` field to support categorizing nodes for the Essentials tab in the redesigned node library.

## Changes
- Add `essentials_category` to `Schema` and `NodeInfoV1` dataclasses in `_io.py`
- Update `get_v1_info()` to pass the field to `NodeInfoV1`
- Add `ESSENTIALS_CATEGORY` handling in `node_info()` for v1 nodes

## Usage
- V1 nodes: `ESSENTIALS_CATEGORY = "Basic"`
- V3 nodes: `essentials_category="Basic"` in `define_schema()`

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

