### PR TITLE
model_base: dont archive dtypes without the model

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -147,10 +147,10 @@ class BaseModel(torch.nn.Module):
                 self.diffusion_model.to(memory_format=torch.channels_last)
                 logging.debug("using channels last mode for diffusion model")
             logging.info("model weight dtype {}, manual cast: {}".format(self.get_dtype(), self.manual_cast_dtype))
+            comfy.model_management.archive_model_dtypes(self.diffusion_model)
         self.model_type = model_type
         self.model_sampling = model_sampling(model_config, model_type)
 
-        comfy.model_management.archive_model_dtypes(self.diffusion_model)
 
         self.adm_channels = unet_config.get("adm_in_channels", None)
         if self.adm_channels is None:


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/12272
https://github.com/nunchaku-ai/ComfyUI-nunchaku/issues/801

Nanchaku (and probably others) have an override to not create a  model on the BaseModel constructor. Put the model archive call inside the conditional to avoid the missing attr.

Community contributed & tested by Nanchaku:

https://github.com/nunchaku-ai/ComfyUI-nunchaku/issues/801#issuecomment-3846091598

Regression tests:

RTX5090, Linux, --fast-dynamic dynamic_vram, Flux2 with fp32 compute :white_check_mark: , SDXL :white_check_mark: LTX2 :white_check_mark: 