### PR TITLE
cuda_malloc: add missing GPUs to blacklist and fix bare except clauses

### DIFF
--- a/cuda_malloc.py
+++ b/cuda_malloc.py
@@ -49,13 +49,14 @@ blacklist = {"GeForce GTX TITAN X", "GeForce GTX 980", "GeForce GTX 970", "GeFor
                 "Quadro K1200", "Quadro K2200", "Quadro M500", "Quadro M520", "Quadro M600", "Quadro M620", "Quadro M1000",
                 "Quadro M1200", "Quadro M2000", "Quadro M2200", "Quadro M3000", "Quadro M4000", "Quadro M5000", "Quadro M5500", "Quadro M6000",
                 "GeForce MX110", "GeForce MX130", "GeForce 830M", "GeForce 840M", "GeForce GTX 850M", "GeForce GTX 860M",
-                "GeForce GTX 1650", "GeForce GTX 1630", "Tesla M4", "Tesla M6", "Tesla M10", "Tesla M40", "Tesla M60"
+                "GeForce GTX 1650", "GeForce GTX 1630", "Tesla M4", "Tesla M6", "Tesla M10", "Tesla M40", "Tesla M60",
+                "Tesla P40", "Tesla P4", "NVIDIA L4", "NVIDIA A10G", "GRID A800D",
                 }
 
 def cuda_malloc_supported():
     try:
         names = get_gpu_names()
-    except:
+    except Exception:
         names = set()
     for x in names:
         if "NVIDIA" in x:
@@ -76,7 +77,7 @@ try:
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
             version = module.__version__
-except:
+except Exception:
     pass
 
 if not args.cuda_malloc:
@@ -84,7 +85,7 @@ if not args.cuda_malloc:
         if int(version[0]) >= 2 and "+cu" in version:  # enable by default for torch version 2.0 and up only on cuda torch
             if PerformanceFeature.AutoTune not in args.fast:  # Autotune has issues with cuda malloc
                 args.cuda_malloc = cuda_malloc_supported()
-    except:
+    except Exception:
         pass
 
 if enables_dynamic_vram() and comfy_aimdo.control.init():


### PR DESCRIPTION
## Summary

Fixes #940 - Adds GPU models reported by users in the issue that are missing from the `cudaMallocAsync` blacklist, and replaces bare `except:` with `except Exception:` for better Python practices.

## Changes

### 1. Added missing GPUs to the blacklist

Several users reported `CUDA error: operation not supported` on GPUs not yet in the blacklist. These have been added:

| GPU | Reporter | Context |
|---|---|---|
| **Tesla P40** | @fahadshery | Pascal datacenter GPU (CC 6.1), Driver 535.x |
| **Tesla P4** | *(proactive)* | Same Pascal architecture as P40 |
| **NVIDIA L4** | @efwfe | Cloud/datacenter GPU, Driver 535.171.04 |
| **NVIDIA A10G** | @robert-pattern | AWS EC2 GPU, confirmed `--disable-cuda-malloc` fixed it |
| **GRID A800D** | @Kimizhao | vGPU mode (A800D-80C), Driver 525.105.17 |

The blacklist uses substring matching (`if b in x`), so these entries correctly match the full GPU name strings returned by both `nvidia-smi -L` (Linux) and `EnumDisplayDevicesA` (Windows).

### 2. Replaced bare `except:` with `except Exception:`

Three locations in the file used bare `except:` which catches **all** exceptions including `KeyboardInterrupt` and `SystemExit`. This is a Python anti-pattern (PEP 8, B001/E722). Changed to `except Exception:` which still catches all operational errors (`OSError`, `FileNotFoundError`, `RuntimeError`, `CalledProcessError`, etc.) but allows clean process termination.

**Locations changed:**
- `cuda_malloc_supported()` - catches failures from `get_gpu_names()` (nvidia-smi/ctypes)
- Torch version detection block - catches import/file errors
- cuda_malloc enablement block - catches version parsing errors

## Testing

-  **8 blocked GPU tests** - All newly added GPUs correctly blocked (Tesla P40, P4, L4, A10G, GRID A800D) plus existing entries (GTX 960M, 970, 980)
-  **5 allowed GPU tests** - No false positives (RTX 4090, 3080, 2070, A100, H100 all pass through)
-  **Exception handling tests** - `except Exception:` catches `RuntimeError`, `OSError`, `FileNotFoundError`, `CalledProcessError`; correctly does NOT catch `KeyboardInterrupt` or `SystemExit`
-  **Syntax check** - `py_compile` passes