### PR TITLE
Expand AMD ROCm Tips readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,11 @@ You can enable experimental memory efficient attention on recent pytorch in Comf
 
 ```TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 python main.py --use-pytorch-cross-attention```
 
-You can also try setting this env variable `PYTORCH_TUNABLEOP_ENABLED=1` which might speed things up at the cost of a very slow initial run.
+You can also try:
+* Tunable ops: Setting `PYTORCH_TUNABLEOP_ENABLED=1` which might speed things up at the cost of a very slow initial runs. After running online tuning for a while consider disabling it with `PYTORCH_TUNABLEOP_TUNING=0` to only used the tuned settings and avoid slowdowns.
+* MIOpen: Currently disabled by default. Enable with `COMFYUI_ENABLE_MIOPEN=1`. Be aware that miopen will autotune by default, consider disabling it with `MIOPEN_FIND_MODE=FAST` to avoid tuning slowdowns.
+* Flash attention: Install from [flash-attention](https://github.com/Dao-AILab/flash-attention) & enable with `FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE` and arg `--use-flash-attention`. See also notes in the repo on triton autotuning.
+* If you are encountering VRAM OOMs `PYTORCH_NO_HIP_MEMORY_CACHING=1` may help.
 
 # Notes
 


### PR DESCRIPTION
* Add suggestion to disable online tuning
* Add miopen info
* Add flash attention info
* Add vram oom suggestion

I have verified all these points to be effective, testing with a gfx1100 on Linux. I suspect they are generally worth at least noting for all AMD users, and this readme is one of the first things amd users might read.

For example I recently tested flash-attention on a 360x640 wan2.2 workflow:
* `--use-flash-attention`: 26.06s/it, 26.02s/it
* `--use-flash-attention` (tuned attn_fwd): 15.56s/it, 15.12s/it
* `--pytorch-cross-attention`: 30.69s/it, 30.97s/it
