### PR TITLE
security: refine path traversal validation to allow consecutive dots in filenames

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import asyncio
-from pathlib import PurePosixPath
+from pathlib import PurePosixPath, PureWindowsPath
 import traceback
 import time
 
@@ -464,7 +464,8 @@ class PromptServer():
                 # Normalize backslashes and use standard library to parse path components
                 normalized = filename.replace('\\', '/')
                 path = PurePosixPath(normalized)
-                if path.is_absolute() or '..' in path.parts:
+                win_path = PureWindowsPath(normalized)
+                if path.is_absolute() or win_path.is_absolute() or win_path.drive or '..' in path.parts:
                     return web.Response(status=400)
 
                 if output_dir is None:

--- a/tests-unit/server_test/test_view_endpoint.py
+++ b/tests-unit/server_test/test_view_endpoint.py
@@ -5,7 +5,7 @@ from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 import os
 import tempfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
 class TestViewEndpointSecurity(AioHTTPTestCase):
@@ -40,7 +40,8 @@ class TestViewEndpointSecurity(AioHTTPTestCase):
             # Normalize backslashes and use standard library to parse path components
             normalized = filename.replace('\\', '/')
             path = PurePosixPath(normalized)
-            if path.is_absolute() or '..' in path.parts:
+            win_path = PureWindowsPath(normalized)
+            if path.is_absolute() or win_path.is_absolute() or win_path.drive or '..' in path.parts:
                 return web.Response(status=400)
 
             # For testing, just check if file exists in test directory
@@ -146,3 +147,21 @@ class TestViewEndpointSecurity(AioHTTPTestCase):
         """Test that Windows absolute paths with backslash are blocked (e.g., C:\\)"""
         resp = await self.client.request("GET", "/view?filename=%5Cetc%5Cpasswd")
         assert resp.status == 400, "Should block backslash absolute paths"
+
+    @unittest_run_loop
+    async def test_blocks_windows_drive_absolute_path(self):
+        """Test that Windows drive-qualified absolute paths (C:/...) are blocked"""
+        resp = await self.client.request("GET", "/view?filename=C:/Windows/secret.png")
+        assert resp.status == 400, "Should block Windows drive-qualified absolute paths"
+
+    @unittest_run_loop
+    async def test_blocks_windows_drive_relative_path(self):
+        """Test that Windows drive-qualified relative paths (C:secret.png) are blocked"""
+        resp = await self.client.request("GET", "/view?filename=C:secret.png")
+        assert resp.status == 400, "Should block Windows drive-qualified relative paths"
+
+    @unittest_run_loop
+    async def test_blocks_windows_drive_backslash_path(self):
+        """Test that Windows drive paths with backslashes are blocked"""
+        resp = await self.client.request("GET", "/view?filename=C:%5CWindows%5Csecret.png")
+        assert resp.status == 400, "Should block Windows drive backslash paths"


### PR DESCRIPTION
## Summary
Fixes #12352

The API incorrectly rejects files with consecutive dots in their filename (e.g., `test..png`) due to overly broad path traversal validation.

## Problem
The current validation checks if `'..'` exists anywhere in the filename:
```python
if filename[0] == '/' or '..' in filename:
    return web.Response(status=400)
```

This incorrectly blocks legitimate filenames like `test..png`, `my...file.jpg`, etc.

## Solution
Refined the validation to specifically detect path traversal patterns while allowing consecutive dots:
```python
if filename[0] == '/' or '/..' in filename or filename.startswith('..'):
    return web.Response(status=400)
```

This now:
- ✅ Blocks path traversal: `../etc/passwd`, `folder/../secret`
- ✅ Blocks filenames starting with `..` (e.g., `..secret`)
- ✅ Blocks absolute paths: `/etc/passwd`
- ✅ Allows consecutive dots in filenames: `test..png`, `my...file.jpg`

## Changes
- Updated validation in `/view` endpoint (line 488)
- Updated validation in `/upload/mask` endpoint (line 443)
- Added comprehensive test suite covering:
  - Security: blocks all path traversal patterns
  - Functionality: allows valid filenames with consecutive dots

## Test Results
All 8 tests pass:
```
tests-unit/server_test/test_view_endpoint.py::TestViewEndpointSecurity::test_allows_consecutive_dots_in_filename PASSED
tests-unit/server_test/test_view_endpoint.py::TestViewEndpointSecurity::test_allows_normal_filenames PASSED
tests-unit/server_test/test_view_endpoint.py::TestViewEndpointSecurity::test_blocks_absolute_paths PASSED
tests-unit/server_test/test_view_endpoint.py::TestViewEndpointSecurity::test_blocks_dotdot_at_start PASSED
tests-unit/server_test/test_view_endpoint.py::TestViewEndpointSecurity::test_blocks_path_traversal_dotdot_slash PASSED
tests-unit/server_test/test_view_endpoint.py::TestViewEndpointSecurity::test_blocks_path_traversal_slash_dotdot PASSED
tests-unit/server_test/test_view_endpoint.py::TestViewEndpointSecurity::test_dots_in_middle_of_filename PASSED
tests-unit/server_test/test_view_endpoint.py::TestViewEndpointSecurity::test_multiple_consecutive_dots PASSED
```