### PR TITLE
Add working Qwen 2512 ControlNet (Fun ControlNet) support

### DIFF
--- a/comfy/ldm/qwen_image/controlnet.py
+++ b/comfy/ldm/qwen_image/controlnet.py
@@ -39,9 +39,9 @@ class QwenImageFunControlNetModel(torch.nn.Module):
         self.dtype = dtype
         self.main_model_double = main_model_double
         self.injection_layers = tuple(injection_layers)
-        # Internal base scale for Fun hints. Keep near 1.0 and rely on user-facing
-        # ControlNet strength for tuning; too small here effectively disables control.
-        self.hint_scale = 0.9
+        # Keep base hint scaling at 1.0 so user-facing strength behaves similarly
+        # to the reference Gen2/VideoX implementation around strength=1.
+        self.hint_scale = 1.0
         self.control_img_in = operations.Linear(control_in_features, inner_dim, device=device, dtype=dtype)
 
         self.control_blocks = torch.nn.ModuleList([])


### PR DESCRIPTION
## Summary
This PR adds full support for **Qwen 2.5 Fun ControlNet** format, enabling ControlNet functionality for Qwen image generation models.

## Related Issues
- Closes #12100
- Closes #11821
- Closes #11910

## Changes Made

### Files Modified:
- `comfy/controlnet.py` - Added loader and integration support for Fun ControlNet format
- `comfy/ldm/qwen_image/controlnet.py` - New file implementing the Qwen Fun ControlNet architecture

### Key Features:
- **Core loader support** for Qwen Fun ControlNet format
- **Proper hint injection** with optimized strength scaling
- **Fallback packing/mask behavior** aligned with VideoX implementation
- **Strength=1 behavior matching** with softened high-strength response

### Commits:
1. Add core loader/support for Qwen Fun ControlNet format
2. Tone down Qwen Fun ControlNet hint injection strength
3. Align Fun ControlNet fallback packing/mask behavior with VideoX
4. Fix Fun ControlNet concat-mask mismatch and restore effective hint scale
5. Match Fun strength=1 behavior and soften high-strength response

## Testing
Tested with Qwen 2512 Image model with Fun ControlNet, verified proper hint generation and injection.