### PR TITLE
feat: add node_replacements server feature flag

### DIFF
--- a/comfy_api/feature_flags.py
+++ b/comfy_api/feature_flags.py
@@ -14,6 +14,7 @@ SERVER_FEATURE_FLAGS: dict[str, Any] = {
     "supports_preview_metadata": True,
     "max_upload_size": args.max_upload_size * 1024 * 1024, # Convert MB to bytes
     "extension": {"manager": {"supports_v4": True}},
+    "node_replacements": True,
 }
 
 


### PR DESCRIPTION
## Summary

Adds `"node_replacements": True` to `SERVER_FEATURE_FLAGS` so the frontend can detect whether the backend supports the node replacement API before calling `/api/node_replacements`.

## Changes

- Added `"node_replacements": True` to `SERVER_FEATURE_FLAGS` in `comfy_api/feature_flags.py`

## Context

The frontend uses `api.serverSupportsFeature("node_replacements")` to gate calls to the replacement endpoint. Without this flag the frontend would call an endpoint that may not exist on older backends.

Companion frontend PR: https://github.com/Comfy-Org/ComfyUI_frontend/pull/8750