### PR TITLE
Use NORMAL_VRAM instead of SHARED for MPS memory management

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -432,7 +432,7 @@ if cpu_state != CPUState.GPU:
     vram_state = VRAMState.DISABLED
 
 if cpu_state == CPUState.MPS:
-    vram_state = VRAMState.SHARED
+    vram_state = VRAMState.NORMAL_VRAM
 
 logging.info(f"Set vram state to: {vram_state.name}")
 
@@ -840,7 +840,7 @@ def unet_offload_device():
 
 def unet_inital_load_device(parameters, dtype):
     torch_dev = get_torch_device()
-    if vram_state == VRAMState.HIGH_VRAM or vram_state == VRAMState.SHARED:
+    if vram_state == VRAMState.HIGH_VRAM:
         return torch_dev
 
     cpu_dev = torch.device("cpu")
@@ -956,9 +956,6 @@ def text_encoder_device():
 def text_encoder_initial_device(load_device, offload_device, model_size=0):
     if load_device == offload_device or model_size <= 1024 * 1024 * 1024:
         return offload_device
-
-    if is_device_mps(load_device):
-        return load_device
 
     mem_l = get_free_memory(load_device)
     mem_o = get_free_memory(offload_device)


### PR DESCRIPTION
## Summary

On Apple Silicon (MPS), `VRAMState.SHARED` behaves identically to `HIGH_VRAM` — keeping all models loaded on the GPU device simultaneously and skipping all memory management checks. This causes GPU memory exhaustion on large model pipelines because Metal's GPU-accessible allocation budget gets consumed by model weights, leaving no room for inference activations.

## Why SHARED Is Wrong for MPS

The enum's own comment says:
```python
SHARED = 5  # No dedicated vram: memory shared between CPU and GPU
            # but models still need to be moved between both.
```

But the code implementing SHARED **prevents** that movement by bypassing every memory check:

| Code Path | SHARED behavior | NORMAL_VRAM behavior |
|---|---|---|
| `unet_inital_load_device` (line 843) | Always return GPU device (bypass memory check) | Check if model fits in free memory, then decide |
| `text_encoder_initial_device` (line 960) | Always return GPU device (MPS shortcut) | Check if model fits with 20% headroom |
| `load_models_gpu` (line 733) | Skip partial offloading entirely | Calculate how much fits, partially offload rest |

The assumption behind SHARED was: *"CPU and GPU share memory, so keeping everything on GPU is free."* This is **incorrect** because:

1. **Metal tracks GPU-accessible allocations separately** — an MPS tensor consumes Metal's memory budget, while a CPU tensor in the same physical RAM does not
2. **When Metal's GPU budget is exhausted**, it cannot allocate activation buffers, causing GPU hangs or kernel panics
3. **The watermark ratio** (default 1.7) governs the MPS allocator, not CPU allocations

So `tensor.to("cpu")` on unified memory releases Metal's GPU budget **without actually moving physical bytes** — it's the cheapest possible "offload" (device pointer change, same physical RAM).

## Fix

Set MPS to `NORMAL_VRAM` instead of `SHARED`. This enables ComfyUI's smart memory management, which:
- Checks available memory before loading models
- Partially offloads model layers when memory is tight
- Evicts least-recently-used models when loading new ones

## Impact Across Model Sizes

**Small models (SD 1.5, SDXL, ~3-9 GB total):** `NORMAL_VRAM` checks `model_size < free_memory` → always true on any Apple Silicon Mac → models load directly to MPS. **Zero behavior change.**

**Medium models (FLUX, SD3, ~20-27 GB total):** Same — fits with room to spare on 48GB+ systems. On smaller systems (16-24 GB), smart memory management now correctly offloads when needed instead of forcing everything onto GPU and hanging.

**Large models (14B+, multi-model pipelines, 30+ GB):** Memory checks detect that not everything fits simultaneously. Models are partially offloaded to CPU. On unified memory this is nearly free (same physical memory, just a device pointer change). **Prevents OOM and GPU hangs.**

**Multi-model pipelines (ControlNet stacks, two-pass workflows):** Smart memory management prevents model pile-up. Priority sorting in `free_memory()` ensures least-needed models get evicted first.

## Changes

1. **Line 435:** `VRAMState.SHARED` → `VRAMState.NORMAL_VRAM` for MPS
2. **Line 843:** Remove `SHARED` from `HIGH_VRAM` fast path in `unet_inital_load_device` (dead code after change 1, but makes intent clear)
3. **Lines 960-961:** Remove MPS shortcut in `text_encoder_initial_device` (let it use the standard memory-aware path)

## Test plan

- [x] Verified on macOS 26.2 / M4 Pro 48GB / PyTorch 2.10.0
- [x] Wan 2.2 14B I2V pipeline: text encoder correctly offloaded during denoising, generation completes
- [x] Previously this pipeline caused GPU hang (all 36 GB of models stayed on MPS, only 11 GB left for activations needing 15-20 GB)
- [ ] Small models (SD 1.5, SDXL): should work identically — `NORMAL_VRAM` still loads to GPU when there's enough memory
- [ ] No behavior change on CUDA (CUDA never used `SHARED`)
- [ ] `--highvram` flag still forces HIGH_VRAM behavior as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)