### PR TITLE
mp: dont deep-clone objects from model_options

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import collections
-import copy
 import inspect
 import logging
 import math
@@ -317,7 +316,7 @@ class ModelPatcher:
 
         n.object_patches = self.object_patches.copy()
         n.weight_wrapper_patches = self.weight_wrapper_patches.copy()
-        n.model_options = copy.deepcopy(self.model_options)
+        n.model_options = comfy.utils.deepcopy_list_dict(self.model_options)
         n.backup = self.backup
         n.object_patches_backup = self.object_patches_backup
         n.parent = self

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -1376,3 +1376,21 @@ def string_to_seed(data):
             else:
                 crc >>= 1
     return crc ^ 0xFFFFFFFF
+
+def deepcopy_list_dict(obj, memo=None):
+    if memo is None:
+        memo = {}
+
+    obj_id = id(obj)
+    if obj_id in memo:
+        return memo[obj_id]
+
+    if isinstance(obj, dict):
+        res = {deepcopy_list_dict(k, memo): deepcopy_list_dict(v, memo) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        res = [deepcopy_list_dict(i, memo) for i in obj]
+    else:
+        res = obj
+
+    memo[obj_id] = res
+    return res


### PR DESCRIPTION
If there are non-trivial python objects nested in the model_options, this causes all sorts of issues. Traverse lists and dicts so clones can safely override settings and BYO objects but stop there on the deepclone.

Credit to[@TK3](https://github.com/TK3R) for the joint debug session.

example test conditions:

Zimage-turbo + controlnet, 5090, Linux, --fast dynamic_vram:

<img width="1276" height="1030" alt="image" src="https://github.com/user-attachments/assets/cbac9b1e-5eb5-4858-a828-10b6abccf31a" />

Before:

```
Thread 27 "python" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffc2f6976c0 (LWP 17328)]
0x00007fffee821130 in ?? () from /lib/x86_64-linux-gnu/libcuda.so.1
(gdb)
```

After:

```
Prompt executed in 8.36 seconds
```

