### PR TITLE
sd: delay VAE dtype archive until after override

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -793,8 +793,6 @@ class VAE:
             self.first_stage_model = AutoencoderKL(**(config['params']))
         self.first_stage_model = self.first_stage_model.eval()
 
-        model_management.archive_model_dtypes(self.first_stage_model)
-
         if device is None:
             device = model_management.vae_device()
         self.device = device
@@ -803,6 +801,7 @@ class VAE:
             dtype = model_management.vae_dtype(self.device, self.working_dtypes)
         self.vae_dtype = dtype
         self.first_stage_model.to(self.vae_dtype)
+        model_management.archive_model_dtypes(self.first_stage_model)
         self.output_device = model_management.intermediate_device()
 
         mp = comfy.model_patcher.CoreModelPatcher


### PR DESCRIPTION
VAEs have host specific dtype logic that should override the dynamic _model_dtype. Defer the archiving of model dtypes until after.

Example test conditions:

RTX5090 WAN2.2 VAE Encode -> Decode, --fast dynamic_vram:

<img width="2294" height="710" alt="image" src="https://github.com/user-attachments/assets/1ec5d0e4-2403-498e-9c65-1548426ceee9" />

Before (Ending VRAM 3.9GB):

<img width="1248" height="726" alt="image" src="https://github.com/user-attachments/assets/2e1526f2-24c8-4d15-a6c1-6f3c58e75050" />


```
Prompt executed in 16.28 seconds
```

After (Ending VRAM 2.6GB):

<img width="1248" height="726" alt="image" src="https://github.com/user-attachments/assets/643f6896-8a96-4c03-849f-c0c30740e458" />

```
Prompt executed in 16.19 seconds
```

Regression tests:
LTX2 :white_check_mark: 
QWEN :white_check_mark: 