### PR TITLE
dynamic_vram: ops: Fix vanilla-fp8 loaded lora quality

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -169,8 +169,8 @@ def cast_bias_weight_with_vbar(s, dtype, device, bias_dtype, non_blocking, compu
                 if orig.dtype == dtype and len(fns) == 0:
                     #The layer actually wants our freshly saved QT
                     x = y
-            else:
-                y = x
+            elif update_weight:
+                y = comfy.float.stochastic_rounding(x, orig.dtype, seed = comfy.utils.string_to_seed(s.seed_key))
             if update_weight:
                 orig.copy_(y)
         for f in fns:


### PR DESCRIPTION
This was missing the stochastic rounding required for fp8 downcast to be consistent with model_patcher.patch_weight_to_device.

Missed in testing as I spend too much time with quantized tensors and overlooked the simpler ones.

Example Test Conditions:

RTX5090 qwen fp8_e4m3 + lightning 8 steps lora, --fast dynamic_vram

<img width="1921" height="788" alt="image" src="https://github.com/user-attachments/assets/e0c2bfc5-584b-4115-ae78-a1a514effb1c" />


before:

<img width="1328" height="1328" alt="image" src="https://github.com/user-attachments/assets/4145a396-d9f8-4e07-9bf2-5e5b6e80c11c" />

after:

<img width="1328" height="1328" alt="image" src="https://github.com/user-attachments/assets/1f3217d1-f41d-4372-9a4a-b803916ce112" />