### PR TITLE
Add inverse switch nodes and register them

### DIFF
--- a/comfy_extras/nodes_logic.py
+++ b/comfy_extras/nodes_logic.py
@@ -91,6 +91,46 @@ class SoftSwitchNode(io.ComfyNode):
         return io.NodeOutput(on_true if switch else on_false)
 
 
+class SwitchInverseNode(SwitchNode):
+    @classmethod
+    def define_schema(cls):
+        template = io.MatchType.Template("switch")
+        return io.Schema(
+            node_id="ComfySwitchInverseNode",
+            display_name="Switch (Inverse)",
+            category="logic",
+            is_experimental=True,
+            inputs=[
+                io.Boolean.Input("switch"),
+                io.MatchType.Input("on_true", template=template, lazy=True),
+                io.MatchType.Input("on_false", template=template, lazy=True),
+            ],
+            outputs=[
+                io.MatchType.Output(template=template, display_name="output"),
+            ],
+        )
+
+
+class SoftSwitchInverseNode(SoftSwitchNode):
+    @classmethod
+    def define_schema(cls):
+        template = io.MatchType.Template("switch")
+        return io.Schema(
+            node_id="ComfySoftSwitchInverseNode",
+            display_name="Soft Switch (Inverse)",
+            category="logic",
+            is_experimental=True,
+            inputs=[
+                io.Boolean.Input("switch"),
+                io.MatchType.Input("on_true", template=template, lazy=True, optional=True),
+                io.MatchType.Input("on_false", template=template, lazy=True, optional=True),
+            ],
+            outputs=[
+                io.MatchType.Output(template=template, display_name="output"),
+            ],
+        )
+
+
 class CustomComboNode(io.ComfyNode):
     """
     Frontend node that allows user to write their own options for a combo.
@@ -260,8 +300,10 @@ class LogicExtension(ComfyExtension):
     async def get_node_list(self) -> list[type[io.ComfyNode]]:
         return [
             SwitchNode,
+            SwitchInverseNode,
             CustomComboNode,
             # SoftSwitchNode,
+            # SoftSwitchInverseNode,
             # ConvertStringToComboNode,
             # DCTestNode,
             # AutogrowNamesTestNode,


### PR DESCRIPTION
To compensate for the default switch added being inversed from the common method. Either this would work or disregard this PR and make default same as the historically commonly used order in custom nodes.