### PR TITLE
Fix conv3d segfault for PyTorch 2.8 with cuDNN 91002

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -67,7 +67,7 @@ NVIDIA_MEMORY_CONV_BUG_WORKAROUND = False
 try:
     if comfy.model_management.is_nvidia():
         cudnn_version = torch.backends.cudnn.version()
-        if (cudnn_version >= 91002 and cudnn_version < 91500) and comfy.model_management.torch_version_numeric >= (2, 9) and comfy.model_management.torch_version_numeric <= (2, 10):
+        if (cudnn_version >= 91002 and cudnn_version < 91500) and comfy.model_management.torch_version_numeric >= (2, 8) and comfy.model_management.torch_version_numeric <= (2, 10):
             #TODO: change upper bound version once it's fixed'
             NVIDIA_MEMORY_CONV_BUG_WORKAROUND = True
             logging.info("working around nvidia conv3d memory bug.")


### PR DESCRIPTION
## Summary
- The NVIDIA conv3d memory bug workaround (`NVIDIA_MEMORY_CONV_BUG_WORKAROUND`) only activates for PyTorch >= 2.9, but PyTorch 2.8+cu129 ships with cuDNN 91002 which has the same bug
- This causes a segfault during WAN21 video generation (and any workflow using conv3d with fp16/bf16) on PyTorch 2.8
- Fix: lower the PyTorch version bound from `(2, 9)` to `(2, 8)` in the version check

## Environment
- GPU: NVIDIA GeForce RTX 5090 (Blackwell SM 12.0)
- PyTorch: 2.8.0+cu129
- cuDNN: 91002
- Crash: 100% reproducible segfault after WAN21 sampling step completes

## Test plan
- [x] Verified cuDNN 91002 is in the buggy range (>= 91002 and < 91500)
- [x] Confirmed workaround activates after fix ("working around nvidia conv3d memory bug." in logs)
- [x] WAN21 video generation completes without segfault

🤖 Generated with [Claude Code](https://claude.com/claude-code)