### PR TITLE
gitignore venv*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ extra_model_paths.yaml
 /.vs
 .vscode/
 .idea/
-venv/
+venv*/
 .venv/
 /web/extensions/*
 !/web/extensions/logging.js.example


### PR DESCRIPTION
Just a mini change to ignore `venv*` dirs. I sometimes want to test a new venv "venv2", "venv-rocm7.2" or whatever. It would be slightly helpful to have these ignored by default.