### PR TITLE
Allow graph expansion nodes to return lists and handle OUTPUT_IS_LIST correctly

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -474,7 +474,7 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                                     node_cached = execution_list.get_cache(source_node, unique_id)
                                     _resolved.extend(node_cached.outputs[source_output])
                                 else:
-                                    _resolved.extend(output)
+                                    _resolved.append(output)
                             resolved_output.append(_resolved)
                     resolved_outputs.append(tuple(resolved_output))
             output_data = merge_result_data(resolved_outputs, class_def)

--- a/execution.py
+++ b/execution.py
@@ -424,6 +424,7 @@ def resolve_subgraph_outputs(subgraph_results, unique_id, output_is_list, execut
                         source_node, source_output = _result[0], _result[1]
                         node_cached = execution_list.get_cache(source_node, unique_id)
                         if node_cached.outputs[source_output]:
+                            # Output is not expected to be a list here - take only the first cached output
                             resolved_output.append(node_cached.outputs[source_output][0])
                     else:
                         resolved_output.append(_result)

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -522,6 +522,58 @@ class TestExecution:
         for i in range(3):
             assert numpy.array(images_literal[i]).min() == 255 and numpy.array(images_literal[i]).max() == 255, "All images should be white"
 
+    # Tests functionality of defining OUTPUT_IS_LIST for expanding nodes.
+    def test_output_is_list_expansion_results(self, client: ComfyClient, builder: GraphBuilder):
+        g = builder
+        list_out = g.node("TestListExpansionResult", value1=0.1)
+        output = g.node("SaveImage", images=list_out.out(0))
+        output_constant = g.node("SaveImage", images=list_out.out(1))
+
+        # return list of one image (list of one link)
+        result = client.run(g)
+        images = result.get_images(output)
+        assert len(images) == 1, "Should have 1 image"
+        assert numpy.array(images[0]).min() == 25 and numpy.array(images[0]).max() == 25, "First image should be 0.1"
+        images_constant = result.get_images(output_constant)
+        assert len(images_constant) == 1, "Should have 1 image"
+        assert numpy.array(images_constant[0]).min() == 255 and numpy.array(images_constant[0]).max() == 255, "Image should be white"
+
+        # test return list of two images (list of two links)
+        list_out.set_input("value2", 0.2)
+        result = client.run(g)
+        images = result.get_images(output)
+        assert len(images) == 2, "Should have 2 images"
+        assert numpy.array(images[0]).min() == 25 and numpy.array(images[0]).max() == 25, "First image should be 0.1"
+        assert numpy.array(images[1]).min() == 51 and numpy.array(images[1]).max() == 51, "Second image should be 0.2"
+        images_constant = result.get_images(output_constant)
+        assert len(images_constant) == 1, "Should have 1 image"
+        assert numpy.array(images_constant[0]).min() == 255 and numpy.array(images_constant[0]).max() == 255, "Image should be white"
+
+        # test mixed links and non-link values in returned list
+        list_out.set_input("value3", 0.3)
+        result = client.run(g)
+        images = result.get_images(output)
+        assert len(images) == 3, "Should have 3 images"
+        assert numpy.array(images[0]).min() == 25 and numpy.array(images[0]).max() == 25, "First image should be 0.1"
+        assert numpy.array(images[1]).min() == 51 and numpy.array(images[1]).max() == 51, "Second image should be 0.2"
+        assert numpy.array(images[2]).min() == 76 and numpy.array(images[2]).max() == 76, "Third image should be 0.3"
+        images_constant = result.get_images(output_constant)
+        assert len(images_constant) == 1, "Should have 1 image"
+        assert numpy.array(images_constant[0]).min() == 255 and numpy.array(images_constant[0]).max() == 255, "Image should be white"
+
+        # test returning list of a single link from an list output subnode
+        list_out.set_input("value4", 0.4)
+        result = client.run(g)
+        images = result.get_images(output)
+        assert len(images) == 4, "Should have 4 images"
+        assert numpy.array(images[0]).min() == 25 and numpy.array(images[0]).max() == 25, "First image should be 0.1"
+        assert numpy.array(images[1]).min() == 51 and numpy.array(images[1]).max() == 51, "Second image should be 0.2"
+        assert numpy.array(images[2]).min() == 76 and numpy.array(images[2]).max() == 76, "Third image should be 0.3"
+        assert numpy.array(images[3]).min() == 102 and numpy.array(images[3]).max() == 102, "Fourth image should be 0.4"
+        images_constant = result.get_images(output_constant)
+        assert len(images_constant) == 1, "Should have 1 image"
+        assert numpy.array(images_constant[0]).min() == 255 and numpy.array(images_constant[0]).max() == 255, "Image should be white"
+
     def test_mixed_lazy_results(self, client: ComfyClient, builder: GraphBuilder):
         g = builder
         val_list = g.node("TestMakeListNode", value1=0.0, value2=0.5, value3=1.0)

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -554,6 +554,24 @@ class TestExecution:
             images_constant = result.get_images(output_constant)
             assert_constant_image(images_constant)
 
+    # Test case of a subgraph node returning a list when the parent node has output_is_list defined as false for that slot.
+    def test_expansion_result_truncation(self, client: ComfyClient, builder: GraphBuilder):
+        g = builder
+        test_node = g.node("TestListExpansionResultTruncation", value1=0.0, value2=0.5, value3=1.0)
+        output_trunc = g.node("SaveImage", images=test_node.out(0))
+        output = g.node("SaveImage", images=test_node.out(1))
+        result = client.run(g)
+
+        images_trunc = result.get_images(output_trunc)
+        assert len(images_trunc) == 1, "Should have 1 image"
+        assert numpy.array(images_trunc[0]).min() == 0 and numpy.array(images_trunc[0]).max() == 0, "Image should be 0.0"
+
+        images = result.get_images(output)
+        assert len(images) == 3, "Should have 3 images"
+        assert numpy.array(images[0]).min() == 0 and numpy.array(images[0]).max() == 0, "First image should be 0.0"
+        assert numpy.array(images[1]).min() == 127 and numpy.array(images[1]).max() == 127, "Second image should be 0.5"
+        assert numpy.array(images[2]).min() == 255 and numpy.array(images[2]).max() == 255, "Third image should be 1.0"
+        
     def test_mixed_lazy_results(self, client: ComfyClient, builder: GraphBuilder):
         g = builder
         val_list = g.node("TestMakeListNode", value1=0.0, value2=0.5, value3=1.0)

--- a/tests/execution/testing_nodes/testing-pack/specific_tests.py
+++ b/tests/execution/testing_nodes/testing-pack/specific_tests.py
@@ -338,6 +338,65 @@ class TestMixedExpansionReturns:
                 "expand": g.finalize(),
             }
 
+class TestListExpansionResult:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "value1": ("FLOAT",),
+            },
+            "optional": {
+                "value2": ("FLOAT",),
+                "value3": ("FLOAT",),
+                "value4": ("FLOAT",),
+            },
+        }
+    
+    RETURN_TYPES = ("IMAGE", "IMAGE")
+    FUNCTION = "result_as_list"
+    OUTPUT_IS_LIST = (True, False)
+    
+    CATEGORY = "Testing/Nodes"
+
+    def result_as_list(self, **kwargs):
+        g = GraphBuilder()
+        values = []
+        for i in range(4):
+            key = f"value{i+1}"
+            if key in kwargs:
+                values.append(kwargs[key])
+        white = g.node("StubImage", content="WHITE", height=512, width=512, batch_size=1)
+        if len(values) == 1:
+            image1 = g.node("StubConstantImage", value=values[0], height=512, width=512, batch_size=1)
+            return {
+                "result": ([image1.out(0)], white.out(0)),
+                "expand": g.finalize(),
+            }
+        elif len(values) == 2:
+            image1 = g.node("StubConstantImage", value=values[0], height=512, width=512, batch_size=1)
+            image2 = g.node("StubConstantImage", value=values[1], height=512, width=512, batch_size=1)
+            return {
+                "result": ([image1.out(0), image2.out(0)], white.out(0)),
+                "expand": g.finalize(),
+            }
+        elif len(values) == 3:
+            image1 = g.node("StubConstantImage", value=values[0], height=512, width=512, batch_size=1)
+            image2 = g.node("StubConstantImage", value=values[1], height=512, width=512, batch_size=1)
+            image3 = torch.ones(1, 512, 512, 3) * values[2]
+            return {
+                "result": ([image1.out(0), image2.out(0), image3], white.out(0)),
+                "expand": g.finalize(),
+            }
+        elif len(values) == 4:
+            list_out = g.node("TestMakeListNode")
+            for i, value in enumerate(values):
+                image = g.node("StubConstantImage", value=value, height=512, width=512, batch_size=1)
+                list_out.set_input(f"value{i+1}", image.out(0))
+            return {
+                "result": ([list_out.out(0)], white.out(0)),
+                "expand": g.finalize(),
+            }
+
 class TestSamplingInExpansion:
     @classmethod
     def INPUT_TYPES(cls):
@@ -494,6 +553,7 @@ TEST_NODE_CLASS_MAPPINGS = {
     "TestCustomValidation5": TestCustomValidation5,
     "TestDynamicDependencyCycle": TestDynamicDependencyCycle,
     "TestMixedExpansionReturns": TestMixedExpansionReturns,
+    "TestListExpansionResult": TestListExpansionResult,
     "TestSamplingInExpansion": TestSamplingInExpansion,
     "TestSleep": TestSleep,
     "TestParallelSleep": TestParallelSleep,
@@ -512,6 +572,7 @@ TEST_NODE_DISPLAY_NAME_MAPPINGS = {
     "TestCustomValidation5": "Custom Validation 5",
     "TestDynamicDependencyCycle": "Dynamic Dependency Cycle",
     "TestMixedExpansionReturns": "Mixed Expansion Returns",
+    "TestListExpansionResult": "Output is List Expansion Result",
     "TestSamplingInExpansion": "Sampling In Expansion",
     "TestSleep": "Test Sleep",
     "TestParallelSleep": "Test Parallel Sleep",

--- a/tests/execution/testing_nodes/testing-pack/specific_tests.py
+++ b/tests/execution/testing_nodes/testing-pack/specific_tests.py
@@ -390,6 +390,7 @@ class TestListExpansionResult:
         }
     
 class TestListExpansionResultTruncation:
+    @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
@@ -415,7 +416,7 @@ class TestListExpansionResultTruncation:
         list_out_node.set_input("value2", image2.out(0))
         list_out_node.set_input("value3", image3.out(0))
         return {
-            "result": (list_out_node.out(0), list_out_node.out(0)),
+            "result": (list_out_node.out(0), [list_out_node.out(0)]),
             "expand": g.finalize(),
         }
 

--- a/tests/execution/testing_nodes/testing-pack/specific_tests.py
+++ b/tests/execution/testing_nodes/testing-pack/specific_tests.py
@@ -388,6 +388,36 @@ class TestListExpansionResult:
             "result": (images_out, white.out(0)),
             "expand": g.finalize(),
         }
+    
+class TestListExpansionResultTruncation:
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "value1": ("FLOAT",),
+                "value2": ("FLOAT",),
+                "value3": ("FLOAT",),
+            },
+        }
+    
+    RETURN_TYPES = ("IMAGE", "IMAGE")
+    FUNCTION = "result_truncation"
+    OUTPUT_IS_LIST = (False, True)
+    
+    CATEGORY = "Testing/Nodes"
+
+    def result_truncation(self, value1, value2, value3):
+        g = GraphBuilder()
+        image1 = g.node("StubConstantImage", value=value1, height=512, width=512, batch_size=1)
+        image2 = g.node("StubConstantImage", value=value2, height=512, width=512, batch_size=1)
+        image3 = g.node("StubConstantImage", value=value3, height=512, width=512, batch_size=1)
+        list_out_node = g.node("TestMakeListNode")
+        list_out_node.set_input("value1", image1.out(0))
+        list_out_node.set_input("value2", image2.out(0))
+        list_out_node.set_input("value3", image3.out(0))
+        return {
+            "result": (list_out_node.out(0), list_out_node.out(0)),
+            "expand": g.finalize(),
+        }
 
 class TestSamplingInExpansion:
     @classmethod
@@ -546,6 +576,7 @@ TEST_NODE_CLASS_MAPPINGS = {
     "TestDynamicDependencyCycle": TestDynamicDependencyCycle,
     "TestMixedExpansionReturns": TestMixedExpansionReturns,
     "TestListExpansionResult": TestListExpansionResult,
+    "TestListExpansionResultTruncation": TestListExpansionResultTruncation,
     "TestSamplingInExpansion": TestSamplingInExpansion,
     "TestSleep": TestSleep,
     "TestParallelSleep": TestParallelSleep,
@@ -565,6 +596,7 @@ TEST_NODE_DISPLAY_NAME_MAPPINGS = {
     "TestDynamicDependencyCycle": "Dynamic Dependency Cycle",
     "TestMixedExpansionReturns": "Mixed Expansion Returns",
     "TestListExpansionResult": "Output is List Expansion Result",
+    "TestListExpansionResultTruncation": "Output is List Expansion Result Truncation",
     "TestSamplingInExpansion": "Sampling In Expansion",
     "TestSleep": "Test Sleep",
     "TestParallelSleep": "Test Parallel Sleep",


### PR DESCRIPTION
### Summary
This expands the functionality of node expansion by adding the logic required to handle lists returned. Including handling the lists having a mix of links and real values. This is mostly the same as it is now except, this will take `OUTPUT_IS_LIST` into consideration such that it is explicitly defined on the expansion node how to handle the results. This should not impact any nodes currently using node expansion since lists, like this allows, were basically not possible to be used before and this shouldn't effect normal usage. Let me know if I'm missing something though.

The issue is that it is not possible to return list outputs when using node expansion. More specifically you can't return links in lists and you can't return a link from a node that does have `OUTPUT_IS_LIST` as true (if it returns more than one value). Doing so results in attempting to unwrap returned values, returned lists getting spread across output slots on the expansion node, or the literal link being passed along.

### Key Changes
Expansion nodes can now utilize `OUTPUT_IS_LIST` in the exact same way you would expect it to work in normal nodes. When defining `OUTPUT_IS_LIST` for an output, you are expected to return a list for that output. This list can contain links from subnodes or other values. Any returned links/values are resolved in the original order and any links are expanded to include all of that slot's values resulting from that node's execution.

### Tests
Added a test for expansion nodes returning different types of lists including:
- A list containing one or more links.
- A list containing mixed links and values.
- A list containing a link from a node that has `OUTPUT_IS_LIST` set to `True`.