### PR TITLE
fix: allow multi-segment paths in userdata API routes

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -330,7 +330,7 @@ class UserManager():
 
             return path
 
-        @routes.get("/userdata/{file}")
+        @routes.get("/userdata/{file:.*}")
         async def getuserdata(request):
             path = get_user_data_path(request, check_exists=True)
             if not isinstance(path, str):
@@ -338,7 +338,7 @@ class UserManager():
 
             return web.FileResponse(path)
 
-        @routes.post("/userdata/{file}")
+        @routes.post("/userdata/{file:.*}")
         async def post_userdata(request):
             """
             Upload or update a user data file.
@@ -394,7 +394,7 @@ class UserManager():
 
             return web.json_response(resp)
 
-        @routes.delete("/userdata/{file}")
+        @routes.delete("/userdata/{file:.*}")
         async def delete_userdata(request):
             path = get_user_data_path(request, check_exists=True)
             if not isinstance(path, str):
@@ -404,7 +404,7 @@ class UserManager():
 
             return web.Response(status=204)
 
-        @routes.post("/userdata/{file}/move/{dest}")
+        @routes.post("/userdata/{file:.*}/move/{dest:.*}")
         async def move_userdata(request):
             """
             Move or rename a user data file.


### PR DESCRIPTION
## Summary

- Change aiohttp route parameters from `{file}` to `{file:.*}` in all `/userdata/` routes to allow paths containing slashes (e.g. `workflows/my-workflow.json`)
- The `{file}` parameter only matches a single path segment in aiohttp, causing 404 errors when requesting files in subdirectories without URL-encoding the slash
- While the frontend uses `encodeURIComponent` as a workaround, this fix ensures routes work correctly with both encoded and unencoded paths

## Problem

Requests to `/userdata/workflows/filename.json` return **404** because aiohttp's `{file}` route parameter only captures a single path segment (`workflows`), not the full path (`workflows/filename.json`).

The existing `parse.unquote()` workaround (from PR #4801) only helps when the frontend URL-encodes the slash as `%2F`. External API consumers and some frontend code paths that construct URLs with literal slashes are affected.

## Changes

**`app/user_manager.py`** — 4 route definitions updated:

| Route | Before | After |
|-------|--------|-------|
| GET | `/userdata/{file}` | `/userdata/{file:.*}` |
| POST | `/userdata/{file}` | `/userdata/{file:.*}` |
| DELETE | `/userdata/{file}` | `/userdata/{file:.*}` |
| POST (move) | `/userdata/{file}/move/{dest}` | `/userdata/{file:.*}/move/{dest:.*}` |

## Test plan

- [ ] Verify `GET /userdata/workflows/test.json` returns 200 (was 404)
- [ ] Verify `GET /userdata/workflows%2Ftest.json` still works (backward compatible)
- [ ] Verify workflow sidebar loading works for files in subdirectories
- [ ] Verify saving workflows to subdirectories works
- [ ] Verify file move/rename still works

Closes #10151