### PR TITLE
Patch frontend to 1.38.14 (from 1.38.13)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.38.13
+comfyui-frontend-package==1.38.14
 comfyui-workflow-templates==0.8.38
 comfyui-embedded-docs==0.4.1
 torch


### PR DESCRIPTION
***Primary purpose is to hotfix https://github.com/Comfy-Org/ComfyUI/issues/12323 (also reported in https://github.com/Comfy-Org/ComfyUI_frontend/issues/8778).*** Also includes 7 other relatively minor bug fixes.


Test:

```bash
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.38.14
```

---

<!--release-summary:v1.38.14-->

- Diff: [`v1.38.13...v1.38.14`](https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.38.13...v1.38.14)
- PyPI: [`1.38.14`](https://pypi.org/project/comfyui-frontend-package/1.38.14/)
- npm types: [`1.38.14`](https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.38.14)

---

<details>

<summary>Changes</summary>

* [backport core/1.38] fix: localize node definition filter names and descriptions by @AustinMroz in https://github.com/Comfy-Org/ComfyUI_frontend/pull/8564
* [backport core/1.38] fix(vue-nodes): hide slot labels for reroute nodes with empty names by @comfy-pr-bot in https://github.com/Comfy-Org/ComfyUI_frontend/pull/8727
* [backport core/1.38] fix: right-click context menu disabled when selection toolbox is off by @comfy-pr-bot in https://github.com/Comfy-Org/ComfyUI_frontend/pull/8783
* [backport core/1.38] Remove comfy logo splash screen. by @comfy-pr-bot in https://github.com/Comfy-Org/ComfyUI_frontend/pull/8788
* [backport core/1.38] Austin/fix move subgraph input by @comfy-pr-bot in https://github.com/Comfy-Org/ComfyUI_frontend/pull/8792
* [backport core/1.38] fix: handle RIFF padding for odd-sized WEBP chunks by @comfy-pr-bot in https://github.com/Comfy-Org/ComfyUI_frontend/pull/8794
* [backport core/1.38] Fix hit detection on vue node slots by @comfy-pr-bot in https://github.com/Comfy-Org/ComfyUI_frontend/pull/8798
* [backport core/1.38] fix: clear draft on workflow close to prevent stale state on reopen by @comfy-pr-bot in https://github.com/Comfy-Org/ComfyUI_frontend/pull/8868

</details>

