### PR TITLE
Fix lora Extraction in offload conditions (+ dynamic_vram mode)

### DIFF
--- a/comfy_extras/nodes_lora_extract.py
+++ b/comfy_extras/nodes_lora_extract.py
@@ -50,14 +50,22 @@ LORA_TYPES = {"standard": LORAType.STANDARD,
               "full_diff": LORAType.FULL_DIFF}
 
 def calc_lora_model(model_diff, rank, prefix_model, prefix_lora, output_sd, lora_type, bias_diff=False):
-    comfy.model_management.load_models_gpu([model_diff], force_patch_weights=True)
+    comfy.model_management.load_models_gpu([model_diff])
     sd = model_diff.model_state_dict(filter_prefix=prefix_model)
 
     sd_keys = list(sd.keys())
     for index in trange(len(sd_keys), unit="weight"):
         k = sd_keys[index]
-        if k.endswith(".weight"):
+        op_keys = sd_keys[index].rsplit('.', 1)
+        if len(op_keys) < 2 or op_keys[1] not in ["weight", "bias"] or (op_keys[1] == "bias" and not bias_diff):
+            continue
+        op = comfy.utils.get_attr(model_diff.model, op_keys[0])
+        if hasattr(op, "comfy_cast_weights") and not getattr(op, "comfy_patched_weights", False):
+            weight_diff = model_diff.patch_weight_to_device(k, model_diff.load_device, return_weight=True)
+        else:
             weight_diff = sd[k]
+
+        if op_keys[1] == "weight":
             if lora_type == LORAType.STANDARD:
                 if weight_diff.ndim < 2:
                     if bias_diff:
@@ -72,8 +80,8 @@ def calc_lora_model(model_diff, rank, prefix_model, prefix_lora, output_sd, lora
             elif lora_type == LORAType.FULL_DIFF:
                 output_sd["{}{}.diff".format(prefix_lora, k[len(prefix_model):-7])] = weight_diff.contiguous().half().cpu()
 
-        elif bias_diff and k.endswith(".bias"):
-            output_sd["{}{}.diff_b".format(prefix_lora, k[len(prefix_model):-5])] = sd[k].contiguous().half().cpu()
+        elif bias_diff and op_keys[1] == "bias":
+            output_sd["{}{}.diff_b".format(prefix_lora, k[len(prefix_model):-5])] = weight_diff.contiguous().half().cpu()
     return output_sd
 
 class LoraSave(io.ComfyNode):


### PR DESCRIPTION
Primary commit message:

```
    lora_extract: Support on-the-fly patching
    
    Use the on-the-fly approach from the regular model saving logic for
    lora extraction too. Switch off force_cast_weights accordingly.
    
    This gets extraction working in dynamic vram while also supporting
    extraction on GPU offloaded.
```

Also add a trange on this as it can tank.

Example Test conditions:

RTX5090, linux, SDXL, subtract -> extract and save lora

<img width="1493" height="513" alt="image" src="https://github.com/user-attachments/assets/b8519e9e-1f51-48dc-a809-f7141feacc70" />

Before:

--fast dynamic_vram:

```
Requested to load SDXL
!!! Exception during processing !!! 
Traceback (most recent call last):
  File "/home/rattus/ComfyUI/execution.py", line 530, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/execution.py", line 334, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/execution.py", line 308, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "/home/rattus/ComfyUI/execution.py", line 296, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy_api/internal/__init__.py", line 149, in wrapped_func
    return method(locked_class, **inputs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy_api/latest/_io.py", line 1710, in EXECUTE_NORMALIZED
    to_return = cls.execute(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy_extras/nodes_lora_extract.py", line 114, in execute
    output_sd = calc_lora_model(model_diff, rank, "diffusion_model.", "diffusion_model.", output_sd, lora_type, bias_diff=bias_diff)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy_extras/nodes_lora_extract.py", line 52, in calc_lora_model
    comfy.model_management.load_models_gpu([model_diff], force_patch_weights=True)
  File "/home/rattus/ComfyUI/comfy/model_management.py", line 751, in load_models_gpu
    loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
  File "/home/rattus/ComfyUI/comfy/model_management.py", line 533, in model_load
    self.model_use_more_vram(use_more_vram, force_patch_weights=force_patch_weights)
  File "/home/rattus/ComfyUI/comfy/model_management.py", line 563, in model_use_more_vram
    return self.model.partially_load(self.device, extra_memory, force_patch_weights=force_patch_weights)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/model_patcher.py", line 1606, in partially_load
    assert not force_patch_weights #See above
           ^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

--novram:

<img width="1203" height="1268" alt="image" src="https://github.com/user-attachments/assets/c4cf589c-c4eb-4d55-be0e-a3a70f847d0a" />

^^extraction happens on the CPU.

```
Requested to load SDXL
loaded partially; 0.00 MB usable, 0.00 MB loaded, 4897.05 MB offloaded, 267.20 MB buffer reserved, lowvram patches: 0
Prompt executed in 234.27 seconds
```

After:

--fast dynamic_vram:

```
Requested to load SDXL
Model SDXL prepared for dynamic VRAM loading. 4897MB Staged. 1680 patches attached.
100%|██████████| 1680/1680 [00:55<00:00, 30.36weight/s] 
Prompt executed in 60.79 seconds
```

--novram:

```
Requested to load SDXL
loaded partially; 0.00 MB usable, 0.00 MB loaded, 4897.05 MB offloaded, 267.20 MB buffer reserved, lowvram patches: 1680
100%|██████████| 1680/1680 [00:54<00:00, 30.61weight/s] 
Prompt executed in 66.72 seconds
```

no args (perf comparison data):

```
Requested to load SDXL
loaded completely; 30235.42 MB usable, 4897.05 MB loaded, full load: True
100%|██████████| 1680/1680 [00:54<00:00, 30.94weight/s] 
Prompt executed in 62.25 seconds
```

Outputs of SDXL image generation with Loras applied qualitatively checked for consistency :white_check_mark: 