### PR TITLE
fix: add disposition type to Content-Disposition header (RFC 2183)

### DIFF
--- a/server.py
+++ b/server.py
@@ -523,7 +523,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -543,7 +543,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -560,7 +560,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
                     else:
                         # Get content type from mimetype, defaulting to 'application/octet-stream'
                         content_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
@@ -572,7 +572,7 @@ class PromptServer():
                         return web.FileResponse(
                             file,
                             headers={
-                                "Content-Disposition": f"filename=\"{filename}\"",
+                                "Content-Disposition": f"inline; filename=\"{filename}\"",
                                 "Content-Type": content_type
                             }
                         )


### PR DESCRIPTION
## Summary

Fixes #8914

The `Content-Disposition` header in the `/view` endpoint was set to `filename="name.ext"` without a disposition type, violating [RFC 2183](https://www.rfc-editor.org/rfc/rfc2183.html).

This caused third-party HTTP clients (e.g. Go's `mime.ParseMediaType`) to fail parsing the filename from the header, leading to downloaded files being named `view` instead of the correct filename.

## Changes

Added `inline;` disposition type prefix to all four `Content-Disposition` headers in `server.py`:

```
# Before
Content-Disposition: filename="image.png"

# After  
Content-Disposition: inline; filename="image.png"
```

`inline` is used (rather than `attachment`) to preserve the current browser behavior of displaying content directly rather than triggering a download dialog.