### PR TITLE
fix : 404 on /api/history_v2/{prompt_id} so API matches spec

### DIFF
--- a/server.py
+++ b/server.py
@@ -857,6 +857,8 @@ class PromptServer():
             prompt_id = request.match_info.get("prompt_id", None)
             return web.json_response(self.prompt_queue.get_history(prompt_id=prompt_id))
 
+        @routes.get("/history_v2/{prompt_id}")(get_history_prompt_id)
+
         @routes.get("/queue")
         async def get_queue(request):
             queue_info = {}


### PR DESCRIPTION
fix: #12483

### description

- add route for /api/history_v2/{prompt_id} so it no longer returns 404.
- refuse the existing history-by-id handler so behavior matches /api/history/{prompt_id}.
- resolves mismatch where the OpenAPI spec documents history_v2 but the server only exposed history.