### PR TITLE
fix(api-nodes): add price badge for Rodin Gen-2 node

### DIFF
--- a/comfy_api_nodes/nodes_rodin.py
+++ b/comfy_api_nodes/nodes_rodin.py
@@ -505,6 +505,9 @@ class Rodin3D_Gen2(IO.ComfyNode):
                 IO.Hidden.unique_id,
             ],
             is_api_node=True,
+            price_badge=IO.PriceBadge(
+                expr="""{"type":"usd","usd":0.4}""",
+            ),
         )
 
     @classmethod


### PR DESCRIPTION
<img width="354" height="283" alt="Screenshot From 2026-02-18 08-49-18" src="https://github.com/user-attachments/assets/d9ca8088-132f-49d5-ae1f-d86f42dfc9f0" />


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [x] Informed **Kosinkadink**

