### PR TITLE
Partially enabled FP16 reasoning in the Qwen Image Models

### DIFF
--- a/comfy/ldm/qwen_image/model.py
+++ b/comfy/ldm/qwen_image/model.py
@@ -12,7 +12,6 @@ import comfy.ldm.common_dit
 import comfy.patcher_extension
 from comfy.ldm.flux.math import apply_rope1
 
-
 class GELU(nn.Module):
     def __init__(self, dim_in: int, dim_out: int, approximate: str = "none", bias: bool = True, dtype=None, device=None, operations=None):
         super().__init__()


### PR DESCRIPTION
The original reasoning code for Qwen Image models cannot run correctly with float16 precision, which results in completely black outputs:
https://github.com/Comfy-Org/ComfyUI/issues/10800
https://github.com/Comfy-Org/ComfyUI/issues/10668
https://github.com/Comfy-Org/ComfyUI/issues/10751

Because of this limitation, GPUs without native bfloat16 support are forced to run the model in float32, leading to noticeably slower generation.

The attached updated reasoning code enables parts of the attention computation in Qwen Image models to run safely in float16 without producing black images. Specifically, the following components can now use float16: image K, image V, text Q, text V, and the joint cross attention. When bfloat16 is selected, the code automatically falls back to native bfloat16 on supported GPUs.

I tested this improvement on a Tesla V100, and for the Qwen Image Edit 2511 model with 4-steps lora, the second-generation of the image ran in roughly half the time compared with the original implementation. In this test, I edited a 512×512 image. With the original float32‑only code, the second‑generation step took approximately 41 seconds, whereas the proposed float16‑enabled version reduced this to about 23 seconds.
<img width="953" height="1049" alt="image" src="https://github.com/user-attachments/assets/4bc15109-ed2d-48e6-adcf-b4f22a6dde1e" />
<img width="953" height="1049" alt="image" src="https://github.com/user-attachments/assets/671f5259-e5a8-4551-b3a2-3b6c2b0b57bd" />
<img width="953" height="1049" alt="image" src="https://github.com/user-attachments/assets/710f00af-b763-49b1-acf5-56b468e755f4" />
