### PR TITLE
docs: remove outdated ROCm 7.1 nightly install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,6 @@ AMD users can install rocm and pytorch with pip if you don't have it already ins
 
 ```pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm7.1```
 
-This is the command to install the nightly with ROCm 7.1 which might have some performance improvements:
-
-```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1```
-
 
 ### AMD GPUs (Experimental: Windows and Linux), RDNA 3, 3.5 and 4 only.
 


### PR DESCRIPTION
## Description

Fixes #12427

Removes the broken ROCm 7.1 nightly installation command from the README that was causing 404 errors.

## Issue

The nightly ROCm 7.1 index (`--pre ... nightly/rocm7.1`) is no longer maintained by PyTorch and returns 404 errors when users try to install:

```
ERROR: HTTP error 404 while getting https://download-r2.pytorch.org/whl/nightly/rocm7.1/torch-2.11.0.dev20260212%2Brocm7.1-cp314-cp314-manylinux_2_28_x86_64.whl
```

## Root Cause

Once a ROCm version graduates to stable, the nightly index stops receiving new builds. This is a [known issue](https://dev-discuss.pytorch.org/t/s3-access-denied-for-rocm-nightlies/3277) with PyTorch's ROCm nightlies.

## Solution

- Removed the broken nightly command
- The stable ROCm 7.1 command already provides the latest compatible PyTorch version
- Users can check [pytorch.org/get-started/locally](https://pytorch.org/get-started/locally/) for current stable/nightly options

## Testing

Verified that the stable command works correctly:
```bash
pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm7.1
```
