### PR TITLE
feat: add gradient-slider display mode for FLOAT inputs

### DIFF
--- a/comfy/comfy_types/node_typing.py
+++ b/comfy/comfy_types/node_typing.py
@@ -176,7 +176,7 @@ class InputTypeOptions(TypedDict):
     """COMBO type only. Specifies the configuration for a multi-select widget.
     Available after ComfyUI frontend v1.13.4
     https://github.com/Comfy-Org/ComfyUI_frontend/pull/2987"""
-    gradient_stops: NotRequired[list]
+    gradient_stops: NotRequired[list[list[float]]]
     """Gradient color stops for gradientslider display mode. Each stop is [offset, r, g, b] (``FLOAT``)."""
 
 

--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -297,7 +297,7 @@ class Float(ComfyTypeIO):
         '''Float input.'''
         def __init__(self, id: str, display_name: str=None, optional=False, tooltip: str=None, lazy: bool=None,
                     default: float=None, min: float=None, max: float=None, step: float=None, round: float=None,
-                    display_mode: NumberDisplay=None, gradient_stops: list=None,
+                    display_mode: NumberDisplay=None, gradient_stops: list[list[float]]=None,
                     socketless: bool=None, force_input: bool=None, extra_dict=None, raw_link: bool=None, advanced: bool=None):
             super().__init__(id, display_name, optional, tooltip, lazy, default, socketless, None, force_input, extra_dict, raw_link, advanced)
             self.min = min


### PR DESCRIPTION
Add a new 'gradient-slider' display mode to NumberDisplay enum, allowing FLOAT inputs to render as gradient sliders in the frontend. 
Nodes can pass gradient_stops (list of [offset, r, g, b]) to define the gradient colors shown on the slider track.

this is prerequisite for color correct and balance 
<img width="688" height="131" alt="image" src="https://github.com/user-attachments/assets/99551647-868d-4568-abe6-6915cd6d4ba0" />

FE change 