### PR TITLE
Use PEP 639 license-files in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 name = "ComfyUI"
 version = "0.14.1"
 readme = "README.md"
-license = "GPL-3.0-only"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "ComfyUI"
 version = "0.14.1"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "GPL-3.0-only"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Replace deprecated `license = { file = "LICENSE" }` with `license-files = ["LICENSE"]` (PEP 639)

## Motivation

[PEP 639](https://peps.python.org/pep-0639/#deprecate-license-field) deprecates the table-based `license` field. The old `{ file = "..." }` format causes issues with tools that expect machine-readable SPDX identifiers (e.g. [pixi-build-python](https://github.com/prefix-dev/pixi-build-backends/issues/488)).

This PR only migrates the file reference syntax. The SPDX `license` identifier is left for maintainers to decide if/when needed.

## Test plan

- [x] No functional change, only metadata format update