### PR TITLE
Fix non-contiguous audio waveform crash in video save

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -444,7 +444,7 @@ class VideoFromComponents(VideoInput):
             output.mux(packet)
 
             if audio_stream and self.__components.audio:
-                frame = av.AudioFrame.from_ndarray(waveform.float().cpu().numpy(), format='fltp', layout=layout)
+                frame = av.AudioFrame.from_ndarray(waveform.float().cpu().contiguous().numpy(), format='fltp', layout=layout)
                 frame.sample_rate = audio_sample_rate
                 frame.pts = 0
                 output.mux(audio_stream.encode(frame))


### PR DESCRIPTION
Fixes #12549

When a video with audio gets trimmed (e.g. via VHS_LoadVideo with skip_first_frames), the audio waveform tensor can end up non-contiguous in memory. `av.AudioFrame.from_ndarray` doesn't handle that and throws `ValueError: ndarray is not C-contiguous`.

The fix is just adding `.contiguous()` before `.numpy()` so the tensor is always in the right memory layout before handing it off to PyAV. This matches what you'd typically do anywhere a tensor might have been sliced or transposed before converting to numpy.

One-line change in `comfy_api/latest/_input_impl/video_types.py`.