### PR TITLE
 fix: support api_key alias for comfy api key login

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -196,7 +196,7 @@ def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=
             if io.Hidden.auth_token_comfy_org.name in hidden:
                 hidden_inputs_v3[io.Hidden.auth_token_comfy_org] = extra_data.get("auth_token_comfy_org", None)
             if io.Hidden.api_key_comfy_org.name in hidden:
-                hidden_inputs_v3[io.Hidden.api_key_comfy_org] = extra_data.get("api_key_comfy_org", None)
+                hidden_inputs_v3[io.Hidden.api_key_comfy_org] = extra_data.get("api_key_comfy_org") or extra_data.get("api_key")
     else:
         if "hidden" in valid_inputs:
             h = valid_inputs["hidden"]
@@ -212,7 +212,7 @@ def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=
                 if h[x] == "AUTH_TOKEN_COMFY_ORG":
                     input_data_all[x] = [extra_data.get("auth_token_comfy_org", None)]
                 if h[x] == "API_KEY_COMFY_ORG":
-                    input_data_all[x] = [extra_data.get("api_key_comfy_org", None)]
+                    input_data_all[x] = [extra_data.get("api_key_comfy_org") or extra_data.get("api_key")]
     v3_data["hidden_inputs"] = hidden_inputs_v3
     return input_data_all, missing_keys, v3_data
 

--- a/server.py
+++ b/server.py
@@ -904,10 +904,14 @@ class PromptServer():
                     extra_data["client_id"] = json_data["client_id"]
                 if valid[0]:
                     outputs_to_execute = valid[2]
+                    if "api_key_comfy_org" not in extra_data and "api_key" in extra_data:
+                        extra_data["api_key_comfy_org"] = extra_data.pop("api_key")
                     sensitive = {}
                     for sensitive_val in execution.SENSITIVE_EXTRA_DATA_KEYS:
                         if sensitive_val in extra_data:
                             sensitive[sensitive_val] = extra_data.pop(sensitive_val)
+                    if "api_key" in extra_data:
+                        extra_data.pop("api_key")
                     extra_data["create_time"] = int(time.time() * 1000)  # timestamp in milliseconds
                     self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute, sensitive))
                     response = {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}


### PR DESCRIPTION
fix : #12521

### Problem

- comfy API key was stored in the UI but nodes still got “Please login first” / 401.

### Cause

- frontend can send the key as api_key; backend only read api_key_comfy_org, so the key was dropped.

### Fix

- In the prompt handler: treat api_key as the Comfy API key, store it as api_key_comfy_org in sensitive data, and remove any leftover api_key from extra_data.
- when filling hidden inputs: use api_key_comfy_org or api_key so nodes always get the key.

### Result

- API key login works for both key names; nodes receive the key and can call api.comfy.org.