### PR TITLE
comfy-aimdo 0.2 - Improved pytorch allocator integration

### DIFF
--- a/comfy/memory_management.py
+++ b/comfy/memory_management.py
@@ -78,4 +78,4 @@ def interpret_gathered_like(tensors, gathered):
 
     return dest_views
 
-aimdo_allocator = None
+aimdo_enabled = False

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -836,7 +836,7 @@ def unet_inital_load_device(parameters, dtype):
 
     mem_dev = get_free_memory(torch_dev)
     mem_cpu = get_free_memory(cpu_dev)
-    if mem_dev > mem_cpu and model_size < mem_dev and comfy.memory_management.aimdo_allocator is None:
+    if mem_dev > mem_cpu and model_size < mem_dev and comfy.memory_management.aimdo_enabled:
         return torch_dev
     else:
         return cpu_dev
@@ -1121,7 +1121,6 @@ def get_cast_buffer(offload_stream, device, size, ref):
             synchronize()
             del STREAM_CAST_BUFFERS[offload_stream]
             del cast_buffer
-            #FIXME: This doesn't work in Aimdo because mempool cant clear cache
             soft_empty_cache()
         with wf_context:
             cast_buffer = torch.empty((size), dtype=torch.int8, device=device)

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -1154,7 +1154,7 @@ def tiled_scale(samples, function, tile_x=64, tile_y=64, overlap = 8, upscale_am
     return tiled_scale_multidim(samples, function, (tile_y, tile_x), overlap=overlap, upscale_amount=upscale_amount, out_channels=out_channels, output_device=output_device, pbar=pbar)
 
 def model_trange(*args, **kwargs):
-    if comfy.memory_management.aimdo_allocator is None:
+    if not comfy.memory_management.aimdo_enabled:
         return trange(*args, **kwargs)
 
     pbar = trange(*args, **kwargs, smoothing=1.0)

--- a/cuda_malloc.py
+++ b/cuda_malloc.py
@@ -1,9 +1,7 @@
 import os
 import importlib.util
-from comfy.cli_args import args, PerformanceFeature, enables_dynamic_vram
+from comfy.cli_args import args, PerformanceFeature
 import subprocess
-
-import comfy_aimdo.control
 
 #Can't use pytorch to get the GPU names because the cuda malloc has to be set before the first import.
 def get_gpu_names():
@@ -86,10 +84,6 @@ if not args.cuda_malloc:
                 args.cuda_malloc = cuda_malloc_supported()
     except:
         pass
-
-if enables_dynamic_vram() and comfy_aimdo.control.init():
-    args.cuda_malloc = False
-    os.environ['PYTORCH_CUDA_ALLOC_CONF'] = ""
 
 if args.disable_cuda_malloc:
     args.cuda_malloc = False

--- a/execution.py
+++ b/execution.py
@@ -9,7 +9,6 @@ import traceback
 from enum import Enum
 from typing import List, Literal, NamedTuple, Optional, Union
 import asyncio
-from contextlib import nullcontext
 
 import torch
 
@@ -521,19 +520,14 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 # TODO - How to handle this with async functions without contextvars (which requires Python 3.12)?
                 GraphBuilder.set_default_prefix(unique_id, call_index, 0)
 
-            #Do comfy_aimdo mempool chunking here on the per-node level. Multi-model workflows
-            #will cause all sorts of incompatible memory shapes to fragment the pytorch alloc
-            #that we just want to cull out each model run.
-            allocator = comfy.memory_management.aimdo_allocator
-            with nullcontext() if allocator is None else torch.cuda.use_mem_pool(torch.cuda.MemPool(allocator.allocator())):
-                try:
-                    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
-                finally:
-                    if allocator is not None:
-                        if args.verbose == "DEBUG":
-                            comfy_aimdo.model_vbar.vbars_analyze()
-                        comfy.model_management.reset_cast_buffers()
-                        comfy_aimdo.model_vbar.vbars_reset_watermark_limits()
+            try:
+                output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
+            finally:
+                if comfy.memory_management.aimdo_enabled:
+                    if args.verbose == "DEBUG":
+                        comfy_aimdo.control.analyze()
+                    comfy.model_management.reset_cast_buffers()
+                    comfy_aimdo.model_vbar.vbars_reset_watermark_limits()
 
             if has_pending_tasks:
                 pending_async_nodes[unique_id] = output_data

--- a/main.py
+++ b/main.py
@@ -173,6 +173,10 @@ import gc
 if 'torch' in sys.modules:
     logging.warning("WARNING: Potential Error in code: Torch already imported, torch should never be imported before this point.")
 
+import comfy_aimdo.control
+
+if enables_dynamic_vram():
+    comfy_aimdo.control.init()
 
 import comfy.utils
 
@@ -188,13 +192,9 @@ import hook_breaker_ac10a0
 import comfy.memory_management
 import comfy.model_patcher
 
-import comfy_aimdo.control
-import comfy_aimdo.torch
-
 if enables_dynamic_vram():
     if comfy.model_management.torch_version_numeric < (2, 8):
         logging.warning("Unsupported Pytorch detected. DynamicVRAM support requires Pytorch version 2.8 or later. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
-        comfy.memory_management.aimdo_allocator = None
     elif comfy_aimdo.control.init_device(comfy.model_management.get_torch_device().index):
         if args.verbose == 'DEBUG':
             comfy_aimdo.control.set_log_debug()
@@ -208,11 +208,10 @@ if enables_dynamic_vram():
             comfy_aimdo.control.set_log_info()
 
         comfy.model_patcher.CoreModelPatcher = comfy.model_patcher.ModelPatcherDynamic
-        comfy.memory_management.aimdo_allocator = comfy_aimdo.torch.get_torch_allocator()
+        comfy.memory_management.aimdo_enabled = True
         logging.info("DynamicVRAM support detected and enabled")
     else:
         logging.warning("No working comfy-aimdo install detected. DynamicVRAM support disabled. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
-        comfy.memory_management.aimdo_allocator = None
 
 
 def cuda_malloc_warning():

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ alembic
 SQLAlchemy
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.1.8
+comfy-aimdo>=0.2.0
 requests
 
 #non essential dependencies:


### PR DESCRIPTION
Integrate comfy-aimdo 0.2 which takes a different approach to installing the memory allocator hook. Instead of using the complicated and buggy pytorch MemPool+CudaPluggableAlloctor, cuda is directly hooked making the process much more transparent to both comfy and pytorch. As far as pytorch knows, aimdo doesnt exist anymore, and just operates behind the scenes.

Remove all the mempool setup stuff for dynamic_vram and bump the comfy-aimdo version. Remove the allocator object from memory_management and demote its use as an enablment check to a boolean flag.

Comfy-aimdo 0.2 also support the pytorch cuda async allocator, so remove the dynamic_vram based force disablement of cuda_malloc and just go back to the old settings of allocators based on command line input.

Example test conditions (x2) - max VRAM before OOMing:

RTX5090, Linux, Wan2.1 14B, B=3x1280x784x81f (fully offloads)
RTX5060, Windows, Wan2.1 14B, B=1x1008x720x81f (fully offloads)

<img width="2085" height="1040" alt="image" src="https://github.com/user-attachments/assets/82fbcb6d-fd44-4efd-aec1-53ecd51e2f38" />

Before:

Windows:

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.14 GiB. GPU 0 has a total capacity of 7.96 GiB of which 33.64 MiB is free. Of the allocated memory 6.71 GiB is allocated by PyTorch, with 1.33 GiB allocated in private pools (e.g., CUDA Graphs), and 0 bytes is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)

Memory summary: |===========================================================================|
|                  PyTorch CUDA memory summary, device ID 0                 |
|---------------------------------------------------------------------------|
|            CUDA OOMs: 1            |        cudaMalloc retries: 0         |
|===========================================================================|
|        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
|---------------------------------------------------------------------------|
| Allocated memory      |   3159 MiB |   6092 MiB | 119007 MiB | 115847 MiB |
|       from large pool |   3156 MiB |   6089 MiB | 118720 MiB | 115563 MiB |
|       from small pool |      2 MiB |      4 MiB |    286 MiB |    284 MiB |
|---------------------------------------------------------------------------|
| Active memory         |   3159 MiB |   6092 MiB | 119007 MiB | 115847 MiB |
|       from large pool |   3156 MiB |   6089 MiB | 118720 MiB | 115563 MiB |
|       from small pool |      2 MiB |      4 MiB |    286 MiB |    284 MiB |
|---------------------------------------------------------------------------|
| Requested memory      |   3155 MiB |   6087 MiB | 118989 MiB | 115834 MiB |
|       from large pool |   3152 MiB |   6084 MiB | 118703 MiB | 115550 MiB |
|       from small pool |      2 MiB |      4 MiB |    286 MiB |    284 MiB |
|---------------------------------------------------------------------------|
| GPU reserved memory   |   4350 MiB |   6868 MiB |   8258 MiB |   3908 MiB |
|       from large pool |   4346 MiB |   6860 MiB |   8236 MiB |   3890 MiB |
|       from small pool |      4 MiB |      8 MiB |     22 MiB |     18 MiB |
|---------------------------------------------------------------------------|
| Non-releasable memory |   1190 MiB |   1193 MiB |  33834 MiB |  32643 MiB |
|       from large pool |   1189 MiB |   1191 MiB |  33537 MiB |  32348 MiB |
|       from small pool |      1 MiB |      5 MiB |    296 MiB |    295 MiB |
...

Got an OOM, unloading all loaded models.
Prompt executed in 5.91 seconds
```

Linux:

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 5.61 GiB. GPU 0 has a total capacity of 31.33 GiB of which 4.01 GiB is free. Including non-PyTorch memory, this process has 27.20 GiB memory in use. Of the allocated memory 26.51 GiB is allocated by PyTorch, with 6.02 GiB allocated in private pools (e.g., CUDA Graphs), and 0 bytes is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)

Memory summary: |===========================================================================|
|                  PyTorch CUDA memory summary, device ID 0                 |
|---------------------------------------------------------------------------|
|            CUDA OOMs: 1            |        cudaMalloc retries: 0         |
|===========================================================================|
|        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
|---------------------------------------------------------------------------|
| Allocated memory      |  20954 MiB |  26698 MiB | 158095 MiB | 137141 MiB |
|       from large pool |  20950 MiB |  26693 MiB | 157815 MiB | 136864 MiB |
|       from small pool |      3 MiB |      6 MiB |    280 MiB |    276 MiB |
|---------------------------------------------------------------------------|
| Active memory         |  20954 MiB |  26698 MiB | 158095 MiB | 137141 MiB |
|       from large pool |  20950 MiB |  26693 MiB | 157815 MiB | 136864 MiB |
|       from small pool |      3 MiB |      6 MiB |    280 MiB |    276 MiB |
|---------------------------------------------------------------------------|
| Requested memory      |  20950 MiB |  26692 MiB | 158074 MiB | 137124 MiB |
|       from large pool |  20946 MiB |  26688 MiB | 157794 MiB | 136847 MiB |
|       from small pool |      3 MiB |      6 MiB |    280 MiB |    276 MiB |
|---------------------------------------------------------------------------|
| GPU reserved memory   |  23854 MiB |  27146 MiB |  28496 MiB |   4642 MiB |
|       from large pool |  23848 MiB |  27134 MiB |  28474 MiB |   4626 MiB |
|       from small pool |      6 MiB |     12 MiB |     22 MiB |     16 MiB |
|---------------------------------------------------------------------------|
| Non-releasable memory |   2899 MiB |   5825 MiB |  69233 MiB |  66334 MiB |
|       from large pool |   2897 MiB |   5821 MiB |  68944 MiB |  66047 MiB |
|       from small pool |      2 MiB |      5 MiB |    289 MiB |    287 MiB |
|---------------------------------------------------------------------------|
...

Got an OOM, unloading all loaded models.
Prompt executed in 2.02 seconds
```

After:

Windows:

<img width="881" height="798" alt="after" src="https://github.com/user-attachments/assets/23154978-9664-46a3-bdf4-6af518cf2b1c" />

```
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|█████████████████████████████████████████████████████████████████████████████████████| 4/4 [08:07<00:00, 121.78s/it]
Requested to load WanVAE
0 models unloaded.
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 550.42 seconds
```

Linux:

<img width="1230" height="723" alt="image" src="https://github.com/user-attachments/assets/1957da4c-854d-47cd-b39d-dfa8c01ec0a2" />

```
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|██████████| 4/4 [10:01<00:00, 150.48s/it]                                   
Requested to load WanVAE
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 00:10:34

```

without --fast dynamic_vram :

Windows (very fragile - sometimes runs - somtimes ooms):

```
torch.OutOfMemoryError: Allocation on device

Memory summary: |===========================================================================|
|                  PyTorch CUDA memory summary, device ID 0                 |
|---------------------------------------------------------------------------|
|            CUDA OOMs: 0            |        cudaMalloc retries: 0         |
|===========================================================================|
|        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
|---------------------------------------------------------------------------|
| Allocated memory      |   2546 MiB |   6616 MiB |      0 B   |      0 B   |
|       from large pool |      0 MiB |      0 MiB |      0 B   |      0 B   |
|       from small pool |      0 MiB |      0 MiB |      0 B   |      0 B   |
|---------------------------------------------------------------------------|
| Active memory         |   2546 MiB |   6616 MiB |      0 B   |      0 B   |
|       from large pool |      0 MiB |      0 MiB |      0 B   |      0 B   |
|       from small pool |      0 MiB |      0 MiB |      0 B   |      0 B   |
|---------------------------------------------------------------------------|
| Requested memory      |      0 B   |      0 B   |      0 B   |      0 B   |
|       from large pool |      0 B   |      0 B   |      0 B   |      0 B   |
|       from small pool |      0 B   |      0 B   |      0 B   |      0 B   |
|---------------------------------------------------------------------------|
| GPU reserved memory   |   7392 MiB |   7392 MiB |      0 B   |      0 B   |
|       from large pool |      0 MiB |      0 MiB |      0 B   |      0 B   |
|       from small pool |      0 MiB |      0 MiB |      0 B   |      0 B   |
|---------------------------------------------------------------------------|
...
Got an OOM, unloading all loaded models.
Prompt executed in 154.23 seconds
```

Linux:

<img width="397" height="182" alt="image" src="https://github.com/user-attachments/assets/fb8aa281-458b-493c-8044-85921b5a4bc3" />

```
loaded partially; 0.00 MB usable, 0.00 MB loaded, 13629.87 MB offloaded, 885.23 MB buffer reserved, lowvram patches: 1053
100%|██████████| 4/4 [10:00<00:00, 150.19s/it]
Requested to load WanVAE
loaded completely; 17448.69 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 00:10:40
```

Extra Regression Tests:

Windows, 5060, WAN2.1 14B, 768x480x81f, cuda sysmem fallback on, 2GB VRAM allocated outside comfy:

```
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|██████████████████████████████████████████████████████████████████████████████████████| 4/4 [02:57<00:00, 44.41s/it]
Requested to load WanVAE
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 216.33 seconds
```

Without dynamic_vram (NOTE: this data point is saved from spilling by WANs hyper-conservative VRAM estimate)

```
Prompt executed in 214.70 seconds
```

Adjusting for smaller inference VRAM to force a higher non-dynamic load level:
Windows, 5060, WAN2.1 14B, 480x368x61f, cuda sysmem fallback on, 3GB VRAM allocated outside comfy:

```
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|██████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:00<00:00, 15.06s/it]
Requested to load WanVAE
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 127.66 seconds
```

Without dynamic_vram (DNF: shared memory spill to extreme):

```
Requested to load WAN21
loaded partially; 4334.78 MB usable, 3851.46 MB loaded, 9778.41 MB offloaded, 472.55 MB buffer reserved, lowvram patches: 694
  0%|                                                                                              | 0/4 [00:00<?, ?it/s]Interrupting prompt cbeb21e2-5a12-4c6d-bdfb-ec0d212ad8c8
  0%|                                                                                              | 0/4 [07:05<?, ?it/s]
Processing interrupted
Prompt executed in 450.43 seconds
```

Linux 5090 LTX2, 1200x900x121, --fast dynamic_vram: :white_check_mark: 

Before

```
Model LTXAV prepared for dynamic VRAM loading. 20542MB Staged. 1370 patches attached.
100%|██████████| 3/3 [00:07<00:00,  2.65s/it]                                   
0 models unloaded.
Model VideoVAE prepared for dynamic VRAM loading. 2331MB Staged. 0 patches attached.
Prompt executed in 36.50 seconds
```

After:

```
Model LTXAV prepared for dynamic VRAM loading. 20542MB Staged. 1370 patches attached.
100%|██████████| 3/3 [00:08<00:00,  2.67s/it]                                   
0 models unloaded.
Model VideoVAE prepared for dynamic VRAM loading. 2331MB Staged. 0 patches attached.
Prompt executed in 36.30 seconds
```

Ace Step 1.5 AIO 195s (High CPU stress): Prompt executed in 16.69 seconds :white_check_mark:  
Flux2 1MP (always offloads on a 5090:  100%|██████████| 20/20 [00:43<00:00,  2.15s/it] :white_check_mark:
Zimage + Controlnet :white_check_mark: 
SDXL :white_check_mark: 