### PR TITLE
Add category to Normalized Attention Guidance node

### DIFF
--- a/comfy_extras/nodes_nag.py
+++ b/comfy_extras/nodes_nag.py
@@ -10,7 +10,7 @@ class NAGuidance(io.ComfyNode):
             node_id="NAGuidance",
             display_name="Normalized Attention Guidance",
             description="Applies Normalized Attention Guidance to models, enabling negative prompts on distilled/schnell models.",
-            category="",
+            category="advanced/guidance",
             is_experimental=True,
             inputs=[
                 io.Model.Input("model", tooltip="The model to apply NAG to."),


### PR DESCRIPTION
## Summary

Sets the `category` field of the NAGuidance node from `""` (empty string) to `"advanced/guidance"`.

## Problem

The Normalized Attention Guidance (NAG) node has an empty `CATEGORY` field, causing it to appear at the root level in the UI without a category folder — inconsistent with all other nodes.

## Solution

Set `category="advanced/guidance"` to match the convention used by other guidance-technique nodes:

| Node | File | Category |
|------|------|----------|
| CFGZeroStar | `nodes_cfg.py` | `advanced/guidance` |
| CFGNorm | `nodes_cfg.py` | `advanced/guidance` |
| SkipLayerGuidanceDiT | `nodes_slg.py` | `advanced/guidance` |
| SkipLayerGuidanceSD3 | `nodes_sd3.py` | `advanced/guidance` |
| TCFG | `nodes_tcfg.py` | `advanced/guidance` |
| **NAGuidance** | `nodes_nag.py` | `advanced/guidance` ✅ |
