### PR TITLE
chore: tune CodeRabbit config to limit review scope and disable for drafts

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -87,6 +87,7 @@ reviews:
     ignore_title_keywords:
       - "WIP"
       - "DO NOT REVIEW"
+      - "DO NOT MERGE"
 
   finishing_touches:
     docstrings:


### PR DESCRIPTION
## Summary

Tunes the CodeRabbit configuration to address maintainer feedback about out-of-scope review comments discouraging community contributions.

## Problem

CodeRabbit was:
1. **Flagging pre-existing issues** in code that was merely moved or de-indented — e.g., [PR #12557](https://github.com/Comfy-Org/ComfyUI/pull/12557) received repeated "outside diff range" comments on a pre-existing unused `nullcontext` import in `execution.py` when the actual change was adding try/finally for aimdo integration
2. **Reviewing draft PRs**, adding noise when devs stage incomplete work
3. **Ruff linter** posting outside-diff-range comments on pre-existing lint issues

## Changes

| Change | What | Why |
|---|---|---|
| `tone_instructions` | Global instruction to focus on newly introduced issues | Sets baseline behavior for all reviews |
| Global `path_instructions` (`**`) | Detailed guidance to ignore moved/reformatted code | Prevents scope creep for contributors |
| `drafts: false` | Disable reviews on draft PRs | Reduces noise for WIP staging |
| `ignore_title_keywords` | Skip PRs titled "WIP" or "DO NOT REVIEW" | Additional draft/WIP coverage |
| `ruff: enabled: false` | Disable ruff linter integration | Eliminates linter-based outside-diff-range comments |