### PR TITLE
comfy aimdo 0.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ alembic
 SQLAlchemy
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.2.0
+comfy-aimdo>=0.2.1
 requests
 
 #non essential dependencies:


### PR DESCRIPTION
Changes:

throttle VRAM threshold checks to restore performance in high-layer-rate conditions.
Merge the cuda VRAM consumption estimate with WDDM to mitigate lag in async allocator frees.

Example test conditions:

RTX 5090, PCIE5x16, Ryzen 9600 underclocked to 2GHz. Linux
Ace-step 1.5, 195s

<img width="1260" height="606" alt="image" src="https://github.com/user-attachments/assets/b056c8e3-4a07-4741-8746-f81eaca176ea" />


Before:

```
LM sampling: 100%|██████████| 975/975 [00:23<00:00, 42.36it/s]
```

After:

```
LM sampling: 100%|██████████| 975/975 [00:16<00:00, 57.90it/s]
```

--------------------------------------------------------------------------------------------
RTX5060, Windows WAN 2.1 608x400x81f

<img width="1057" height="917" alt="scr" src="https://github.com/user-attachments/assets/fa3e6301-2634-4bee-91a9-f35c4d6b2c8e" />


No arguments:

```
loaded partially; 2692.32 MB usable, 2206.05 MB loaded, 11423.82 MB offloaded, 472.63 MB buffer reserved, lowvram patches: 744
100%|██████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:41<00:00, 25.33s/it]
Requested to load WanVAE
loaded completely; 914.76 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 132.54 seconds
```

With --fast dynamic_vram:

```
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|██████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:40<00:00, 25.17s/it]
Requested to load WanVAE
0 models unloaded.
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 125.67 seconds
```
