### PR TITLE
fix: skip $$-prefixed inputs in cache signature computation

### DIFF
--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -117,6 +117,8 @@ class CacheKeySetInputSignature(CacheKeySet):
             signature.append(node_id)
         inputs = node["inputs"]
         for key in sorted(inputs.keys()):
+            if key.startswith("$$"):
+                continue
             if is_link(inputs[key]):
                 (ancestor_id, ancestor_socket) = inputs[key]
                 ancestor_index = ancestor_order_mapping[ancestor_id]


### PR DESCRIPTION
Frontend now sends `$$node-text-preview` in node inputs with values that change between runs (e.g. execution timing). The cache signature was computed over all input keys, causing cache misses on identical re-runs.

Skip `$$-prefixed` keys in `get_immediate_node_signature` - these are frontend metadata already ignored during execution.
