### PR TITLE
send executed events for cached nodes with UI output

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -727,6 +727,20 @@ class PromptExecutor:
             for node_id in list(execute_outputs):
                 execution_list.add_node(node_id)
 
+            if self.server.client_id is not None:
+                for node_id in cached_nodes:
+                    if node_id in execution_list.pendingNodes:
+                        continue
+                    cached = self.caches.outputs.get(node_id)
+                    if cached is not None and cached.ui is not None:
+                        display_node_id = dynamic_prompt.get_display_node_id(node_id)
+                        self.server.send_sync("executed", {
+                            "node": node_id,
+                            "display_node": display_node_id,
+                            "output": cached.ui.get("output", None),
+                            "prompt_id": prompt_id
+                        }, self.server.client_id)
+
             while not execution_list.is_empty():
                 node_id, error, ex = await execution_list.stage_node_execution()
                 if error is not None:


### PR DESCRIPTION
Cached dependency nodes are skipped by ExecutionList (not added to pendingNodes), so they never enter the execution loop and never receive an 'executed' WebSocket event. 
This means the frontend loses their UI output after a page refresh when all nodes hit the cache.

After building the execution list, iterate cached nodes that are NOT in pendingNodes and send 'executed' for those with cached UI data. Only nodes with ui output are affected; pure computation nodes are skipped.

The frontend needs their UI output to display intermediate results (e.g. ImageCrop preview consumed by a downstream Painter node).

 Performance impact is minimal. The loop iterates cached_nodes but applies three filters that skip most nodes:                                                                                                                                                                   
  1. node_id in execution_list.pendingNodes — nodes already in the execution list are skipped (they'll get executed events normally during the loop at lines 421-425).                                                  
  3. cached.ui is not None — the vast majority of nodes are pure computation (math, tensor ops, conditioning, etc.) with no UI output. Only nodes that explicitly return UI data (e.g. UI.PreviewImage, UI.SavedImages) pass this check.                                                                                                                                                                                  
3. self.server.client_id is not None — the entire block is skipped when there's no connected client.                                                                                                                

  In practice, for a typical workflow, this sends zero or very few messages — only when a cached intermediate node happens to have a UI preview that the frontend hasn't seen yet (e.g. after a page refresh). 
The common case (first run, or re-run with some nodes invalidated) is unaffected since those nodes enter the execution list normally.

**Before**

https://github.com/user-attachments/assets/4b6b3def-abee-49a2-b5a4-42fafafd8fd6


**After**

https://github.com/user-attachments/assets/d6c7eeab-e776-4c69-acb9-9df1f98b928a

