### PR TITLE
comfy aimdo 0.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ alembic
 SQLAlchemy
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.2.1
+comfy-aimdo>=0.2.2
 requests
 
 #non essential dependencies:


### PR DESCRIPTION
Comfy Aimdo 0.2.2 moves the cuda allocator hook from the cudart API to the cuda driver API on windows. This is needed to handle Windows+cu13 where cudart is statically linked.

Before:


```
Checkpoint files will always be loaded safely.
Total VRAM 12282 MB, total RAM 32607 MB
pytorch version: 2.10.0+cu130
Set vram state to: NORMAL_VRAM
Device: cuda:0 NVIDIA GeForce RTX 4070 : cudaMallocAsync
Using async weight offloading with 2 streams
Enabled pinned memory 14672.0
working around nvidia conv3d memory bug.
Using pytorch attention
aimdo: src-win/cuda-detour.c:35:ALL:aimdo_setup_hooks: cudart64_12.dll not foundNo working comfy-aimdo install detected. DynamicVRAM support disabled. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows
Python version: 3.13.11 (tags/v3.13.11:6278944, Dec  5 2025, 16:26:58) [MSC v.1944 64 bit (AMD64)]
ComfyUI version: 0.15.0
ComfyUI frontend version: 1.39.16
```

After:

```
Total VRAM 8150 MB, total RAM 32691 MB
pytorch version: 2.10.0+cu130
Set vram state to: NORMAL_VRAM
Device: cuda:0 NVIDIA GeForce RTX 5060 : native
Using async weight offloading with 2 streams
Enabled pinned memory 14710.0
working around nvidia conv3d memory bug.
Using pytorch attention
aimdo: src-win/cuda-detour.c:77:INFO:aimdo_setup_hooks: found driver at 00007FFBAD8C0000, installing 4 hooksaimdo: src-win/cuda-detour.c:61:DEBUG:install_hook_entrys: hooks successfully installed
aimdo: src/control.c:65:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 5060 (VRAM: 8150 MB)
DynamicVRAM support detected and enabled
Python version: 3.13.11 (tags/v3.13.11:6278944, Dec  5 2025, 16:26:58) [MSC v.1944 64 bit (AMD64)]
ComfyUI version: 0.14.1
ComfyUI frontend version: 1.39.16
[Prompt Server] web root: C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\comfyui_frontend_package\static
Context impl SQLiteImpl.
Will assume non-transactional DDL.
Assets scan(roots=['models']) completed in 0.039s (created=0, skipped_existing=123, orphans_pruned=0, total_seen=123)
Starting server
```

Regression Tests:

For each of pyt 2.8+cu128 and pyt 2.12dev+cu130:
RTX5090, Linux, WAN 2.2 (multiple large models) :white_check_mark: 
RTX5090, Linux, Flux2 (linux offload) :white_check_mark: 
RTX5090, Linux, CPU@2GHZ Ace Step (CPU throttle) :white_check_mark: 

For each for pyt 2.8+cu128 and pyt2.10.0+cu130
Windows, RTX5060, WAN 2.1 640x400 :white_check_mark:

Performance is roughly on par with non dynamic in the Windows WAN flow. A little faster (5-10s) on first runs due to load overlapping.


