### PR TITLE
Fix GLSL node with pyopengl accelerate numpy textures

### DIFF
--- a/comfy_extras/nodes_glsl.py
+++ b/comfy_extras/nodes_glsl.py
@@ -717,11 +717,11 @@ def _render_shader_batch(
         gl.glUseProgram(0)
 
         for tex in input_textures:
-            gl.glDeleteTextures(tex)
+            gl.glDeleteTextures(int(tex))
         for tex in output_textures:
-            gl.glDeleteTextures(tex)
+            gl.glDeleteTextures(int(tex))
         for tex in ping_pong_textures:
-            gl.glDeleteTextures(tex)
+            gl.glDeleteTextures(int(tex))
         if fbo is not None:
             gl.glDeleteFramebuffers(1, [fbo])
         for pp_fbo in ping_pong_fbos:


### PR DESCRIPTION
pyopengl-accelerate can cause object to be numpy ints instead of bare ints, which the glDeleteTextures function does not accept, explicitly cast to int causing the following error:

```
  File ".\execution.py", line 307, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File ".\execution.py", line 295, in process_inputs
    result = f(**inputs)
  File ".\comfy_api\internal\__init__.py", line 149, in wrapped_func
    return method(locked_class, **inputs)
  File ".\comfy_api\latest\_io.py", line 1748, in EXECUTE_NORMALIZED
    to_return = cls.execute(*args, **kwargs)
  File ".\comfy_extras\nodes_glsl.py", line 848, in execute
    all_batch_outputs = _render_shader_batch(
        fragment_shader,
    ...<4 lines>...
        int_list,
    )
  File ".\comfy_extras\nodes_glsl.py", line 721, in _render_shader_batch
    gl.glDeleteTextures((tex))
    ~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "src/latebind.pyx", line 52, in OpenGL_accelerate.latebind.Curry.__call__
  File "site-packages\OpenGL\GL\exceptional.py", line 59, in glDeleteTextures
    ptr = arrays.GLuintArray.asArray( size )
  File "src/arraydatatype.pyx", line 174, in OpenGL_accelerate.arraydatatype.ArrayDatatype.asArray
  File "src/arraydatatype.pyx", line 57, in OpenGL_accelerate.arraydatatype.HandlerRegistry.c_lookup
TypeError: No array-type handler for type <class 'numpy.uintc'> (value: np.uint32(2)) registered
```

https://github.com/mcfletch/pyopengl/issues/159#issuecomment-3196149985

Validation:
```
        for tex in input_textures:
            print(f"Texture {tex} ({type(tex)}) is valid before: {gl.glIsTexture(tex)}")
            gl.glDeleteTextures(int(tex))
            print(f"Texture {tex} ({type(tex)}) is valid after: {gl.glIsTexture(tex)}")
        for tex in output_textures:
            print(f"Texture {tex} ({type(tex)}) is valid before: {gl.glIsTexture(tex)}")
            gl.glDeleteTextures(int(tex))
            print(f"Texture {tex} ({type(tex)}) is valid after: {gl.glIsTexture(tex)}")
        for tex in ping_pong_textures:
            print(f"Texture {tex} ({type(tex)}) is valid before: {gl.glIsTexture(tex)}")
            gl.glDeleteTextures(int(tex))
            print(f"Texture {tex} ({type(tex)}) is valid before: {gl.glIsTexture(tex)}")
```

`numpy.intc`:
```
got prompt
GLSL shader executed in 10.8ms (1 batch, 512x512)
Texture 2 (<class 'numpy.uintc'>) is valid before: 1
Texture 2 (<class 'numpy.uintc'>) is valid after: 0
Texture 1 (<class 'numpy.uintc'>) is valid before: 1
Texture 1 (<class 'numpy.uintc'>) is valid after: 0
Prompt executed in 0.07 seconds
```

`int`:
```
got prompt
GLSL shader executed in 22.6ms (1 batch, 512x512)
Texture 4 (<class 'int'>) is valid before: 1
Texture 4 (<class 'int'>) is valid after: 0
Texture 3 (<class 'int'>) is valid before: 1
Texture 3 (<class 'int'>) is valid after: 0
Prompt executed in 0.11 seconds
```