### PR TITLE
main: load aimdo earlier

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,10 @@ from comfy_execution.progress import get_progress_state
 from comfy_execution.utils import get_executing_context
 from comfy_api import feature_flags
 
+import comfy_aimdo.control
+
+if enables_dynamic_vram():
+    comfy_aimdo.control.init()
 
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI, they are for custom nodes.
@@ -173,10 +177,6 @@ import gc
 if 'torch' in sys.modules:
     logging.warning("WARNING: Potential Error in code: Torch already imported, torch should never be imported before this point.")
 
-import comfy_aimdo.control
-
-if enables_dynamic_vram():
-    comfy_aimdo.control.init()
 
 import comfy.utils
 


### PR DESCRIPTION
Some custom node packs are naughty, and violate the dont-load-torch-on-load rule. This causes aimdo to lose preference on its allocator hook on linux as it uses RTLD_GLOBAL to load the hook.

Go super early on the aimdo first-stage init before custom nodes are mentioned at all.

Found by multiple discord users: 
https://discordapp.com/channels/1218270712402415686/1261174516747472937/1476261723798507662
https://discordapp.com/channels/1218270712402415686/1261174516747472937/1476265715823804608

Verified as a fix: https://discordapp.com/channels/1218270712402415686/1261174516747472937/1476273407355130047

Regression tests:

Linux 5090, Flux2 (hits the vram ceiling) :white_check_mark: 
Windows WAN 2.1 :white_check_mark: 