### PR TITLE
cli_args: Default comfy to DynamicVram mode

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -146,6 +146,7 @@ parser.add_argument("--reserve-vram", type=float, default=None, help="Set the am
 
 parser.add_argument("--async-offload", nargs='?', const=2, type=int, default=None, metavar="NUM_STREAMS", help="Use async weight offloading. An optional argument controls the amount of offload streams. Default is 2. Enabled by default on Nvidia.")
 parser.add_argument("--disable-async-offload", action="store_true", help="Disable async weight offloading.")
+parser.add_argument("--disable-dynamic-vram", action="store_true", help="Disable dynamic VRAM and use estimate based model loading.")
 
 parser.add_argument("--force-non-blocking", action="store_true", help="Force ComfyUI to use non-blocking operations for all applicable tensors. This may improve performance on some non-Nvidia systems but can cause issues with some workflows.")
 
@@ -159,7 +160,6 @@ class PerformanceFeature(enum.Enum):
     Fp8MatrixMultiplication = "fp8_matrix_mult"
     CublasOps = "cublas_ops"
     AutoTune = "autotune"
-    DynamicVRAM = "dynamic_vram"
 
 parser.add_argument("--fast", nargs="*", type=PerformanceFeature, help="Enable some untested and potentially quality deteriorating optimizations. This is used to test new features so using it might crash your comfyui. --fast with no arguments enables everything. You can pass a list specific optimizations if you only want to enable specific ones. Current valid optimizations: {}".format(" ".join(map(lambda c: c.value, PerformanceFeature))))
 
@@ -260,4 +260,4 @@ else:
     args.fast = set(args.fast)
 
 def enables_dynamic_vram():
-    return PerformanceFeature.DynamicVRAM in args.fast and not args.highvram and not args.gpu_only
+    return not args.disable_dynamic_vram and not args.highvram and not args.gpu_only and not args.novram and not args.cpu

--- a/main.py
+++ b/main.py
@@ -192,7 +192,7 @@ import hook_breaker_ac10a0
 import comfy.memory_management
 import comfy.model_patcher
 
-if enables_dynamic_vram():
+if enables_dynamic_vram() and comfy.model_management.is_nvidia():
     if comfy.model_management.torch_version_numeric < (2, 8):
         logging.warning("Unsupported Pytorch detected. DynamicVRAM support requires Pytorch version 2.8 or later. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
     elif comfy_aimdo.control.init_device(comfy.model_management.get_torch_device().index):


### PR DESCRIPTION
Default comfyUI to the dynamic_vram mode by default.

Current outstanding bigfixes to dynamic_vram:

https://github.com/Comfy-Org/ComfyUI/pull/12653
https://github.com/Comfy-Org/ComfyUI/pull/12655
https://github.com/Comfy-Org/ComfyUI/pull/12412

Startup with no args:

```
Total VRAM 32087 MB, total RAM 96108 MB
pytorch version: 2.9.1+cu128
Set vram state to: NORMAL_VRAM
Device: cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync
Using async weight offloading with 2 streams
Enabled pinned memory 91302.0
working around nvidia conv3d memory bug.
Using pytorch attention
aimdo: src/control.c:64:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 5090 (VRAM: 32086 MB)
DynamicVRAM support detected and enabled
Python version: 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0]
ComfyUI version: 0.15.0

...

model_type FLUX
Requested to load Flux2
Model Flux2 prepared for dynamic VRAM loading. 33813MB Staged. 0 patches attached.

```

With --disable-dynamic-vram:

```
Checkpoint files will always be loaded safely.
Total VRAM 32087 MB, total RAM 96108 MB
pytorch version: 2.9.1+cu128
Set vram state to: NORMAL_VRAM
Device: cuda:0 NVIDIA GeForce RTX 5090 : cudaMallocAsync
Using async weight offloading with 2 streams
Enabled pinned memory 91302.0
working around nvidia conv3d memory bug.
Using pytorch attention
Python version: 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0]
ComfyUI version: 0.15.0

...

model_type FLUX
Requested to load Flux2
loaded partially; 26081.01 MB usable, 25344.00 MB loaded, 8469.03 MB offloaded, 1296.00 MB buffer reserved, lowvram patches: 0
```