### PR TITLE
fix(api-io): serialize MultiCombo multi_select as object config

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -395,7 +395,6 @@ class Combo(ComfyTypeIO):
 @comfytype(io_type="COMBO")
 class MultiCombo(ComfyTypeI):
     '''Multiselect Combo input (dropdown for selecting potentially more than one value).'''
-    # TODO: something is wrong with the serialization, frontend does not recognize it as multiselect
     Type = list[str]
     class Input(Combo.Input):
         def __init__(self, id: str, options: list[str], display_name: str=None, optional=False, tooltip: str=None, lazy: bool=None,
@@ -408,12 +407,16 @@ class MultiCombo(ComfyTypeI):
             self.default: list[str]
 
         def as_dict(self):
-            to_return = super().as_dict() | prune_dict({
-                "multi_select": self.multiselect,
+            # Frontend expects `multi_select` to be an object config (not a boolean).
+            # Keep top-level `multiselect` from Combo.Input for backwards compatibility.
+            return super().as_dict() | prune_dict({
+                "multi_select": prune_dict({
+                    "placeholder": self.placeholder,
+                    "chip": self.chip,
+                }) if self.multiselect else None,
                 "placeholder": self.placeholder,
                 "chip": self.chip,
             })
-            return to_return
 
 @comfytype(io_type="IMAGE")
 class Image(ComfyTypeIO):

--- a/tests-unit/comfy_api_test/multicombo_serialization_test.py
+++ b/tests-unit/comfy_api_test/multicombo_serialization_test.py
@@ -1,0 +1,35 @@
+from comfy_api.latest._io import MultiCombo
+
+
+def test_multicombo_serializes_multi_select_as_object():
+    multi_combo = MultiCombo.Input(
+        id="providers",
+        options=["a", "b", "c"],
+        default=["a"],
+    )
+
+    serialized = multi_combo.as_dict()
+
+    assert serialized["multiselect"] is True
+    assert "multi_select" in serialized
+    assert serialized["multi_select"] == {}
+
+
+def test_multicombo_serializes_multi_select_with_placeholder_and_chip():
+    multi_combo = MultiCombo.Input(
+        id="providers",
+        options=["a", "b", "c"],
+        default=["a"],
+        placeholder="Select providers",
+        chip=True,
+    )
+
+    serialized = multi_combo.as_dict()
+
+    assert serialized["multiselect"] is True
+    assert serialized["multi_select"] == {
+        "placeholder": "Select providers",
+        "chip": True,
+    }
+    assert serialized["placeholder"] == "Select providers"
+    assert serialized["chip"] is True


### PR DESCRIPTION
## Summary
- Fix `MultiCombo.Input.as_dict()` serialization so `multi_select` is emitted as an object config instead of a boolean.
- Keep `multiselect` field from `Combo.Input` for backward compatibility.
- Add regression tests for default and populated multi-select config serialization.

## Why
Frontend expects `multi_select` to be an object (with optional keys like `placeholder` and `chip`). When serialized as a boolean, MultiCombo is not recognized as multiselect.

## Changes
- `comfy_api/latest/_io.py`
  - Update `MultiCombo.Input.as_dict()` to emit:
    - `multi_select: {}` (or with `placeholder`/`chip` when provided)
- `tests-unit/comfy_api_test/multicombo_serialization_test.py`
  - Add two focused unit tests.

## Validation
- Ran:
  - `python -m pytest tests-unit/comfy_api_test/multicombo_serialization_test.py`
- Result:
  - `2 passed`
