### PR TITLE
Fix GLSL node requiring all input images to have same dimensions

### DIFF
--- a/comfy_extras/nodes_glsl.py
+++ b/comfy_extras/nodes_glsl.py
@@ -865,14 +865,15 @@ class GLSLShader(io.ComfyNode):
         cls, image_list: list[torch.Tensor], output_batch: torch.Tensor
     ) -> dict[str, list]:
         """Build UI output with input and output images for client-side shader execution."""
-        combined_inputs = torch.cat(image_list, dim=0)
-        input_images_ui = ui.ImageSaveHelper.save_images(
-            combined_inputs,
-            filename_prefix="GLSLShader_input",
-            folder_type=io.FolderType.temp,
-            cls=None,
-            compress_level=1,
-        )
+        input_images_ui = []
+        for img in image_list:
+            input_images_ui.extend(ui.ImageSaveHelper.save_images(
+                img,
+                filename_prefix="GLSLShader_input",
+                folder_type=io.FolderType.temp,
+                cls=None,
+                compress_level=1,
+            ))
 
         output_images_ui = ui.ImageSaveHelper.save_images(
             output_batch,


### PR DESCRIPTION
replace torch.cat for batch save requiring inputs to all be same dimensions

Fixes:
`Sizes of tensors must match except in dimension 0. Expected size X but got size Y for tensor number 1 in the list.`

<img width="1190" height="1140" alt="image" src="https://github.com/user-attachments/assets/05b68be5-a249-4211-8cb9-17ff4a7016b6" />

Test:
```
#version 300 es                                                                                                                                        
precision highp float;                                                                                                                               
                                                                                                                                                        
uniform sampler2D u_image0;                                                                                                                            
uniform sampler2D u_image1;                                                                                                                            
uniform sampler2D u_image2;                                                                                                                          
uniform sampler2D u_image3;
uniform sampler2D u_image4;

in vec2 v_texCoord;
layout(location = 0) out vec4 fragColor0;

void main() {
    vec4 color = texture(u_image0, v_texCoord);
    vec2 px = v_texCoord * vec2(textureSize(u_image0, 0));

    {
        vec2 sz = vec2(textureSize(u_image1, 0));
        if (px.x < sz.x && px.y < sz.y) {
            vec4 fg = texture(u_image1, px / sz);
            color = mix(color, fg, fg.a);
        }
    }

    {
        vec2 bg = vec2(textureSize(u_image0, 0));
        vec2 sz = vec2(textureSize(u_image2, 0));
        vec2 lc = px - vec2(bg.x - sz.x, 0.0);
        if (lc.x >= 0.0 && lc.x < sz.x && lc.y >= 0.0 && lc.y < sz.y) {
            vec4 fg = texture(u_image2, lc / sz);
            color = mix(color, fg, fg.a);
        }
    }

    {
        vec2 bg = vec2(textureSize(u_image0, 0));
        vec2 sz = vec2(textureSize(u_image3, 0));
        vec2 lc = px - vec2(0.0, bg.y - sz.y);
        if (lc.x >= 0.0 && lc.x < sz.x && lc.y >= 0.0 && lc.y < sz.y) {
            vec4 fg = texture(u_image3, lc / sz);
            color = mix(color, fg, fg.a);
        }
    }

    {
        vec2 bg = vec2(textureSize(u_image0, 0));
        vec2 sz = vec2(textureSize(u_image4, 0));
        vec2 lc = px - (bg - sz);
        if (lc.x >= 0.0 && lc.x < sz.x && lc.y >= 0.0 && lc.y < sz.y) {
            vec4 fg = texture(u_image4, lc / sz);
            color = mix(color, fg, fg.a);
        }
    }

    fragColor0 = color;
}
```