### PR TITLE
AMD/ROCm - Fix VAE_KL_MEM_RATIO overestimation for modern ROCm

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -440,7 +440,7 @@ class VAE:
             sd = diffusers_convert.convert_vae_state_dict(sd)
 
         if model_management.is_amd():
-            VAE_KL_MEM_RATIO = 1.3
+            VAE_KL_MEM_RATIO = 1.3 # Conservative margin for modern ROCm 7.x, reduced from 2.73 (see PR #12685)
         else:
             VAE_KL_MEM_RATIO = 1.0
 


### PR DESCRIPTION
VAE_KL_MEM_RATIO is set to 2.73 for AMD/ROCm in comfy/sd.py. This value was introduced for older ROCm versions where memory overhead was significantly higher. On modern ROCm (7.x), this massively overestimates VRAM requirements for VAE operations, causing ComfyUI to unnecessarily offload models from VRAM before VAE encoding/decoding.

Impact: On GPUs with limited VRAM (8-16GB), this overestimation may cause frequent unnecessary model offloading, significantly impacting performance. On larger GPUs (32GB) the impact is less noticeable but still causes suboptimal memory management.

Tested on: AMD Radeon AI PRO R9700 (32GB VRAM, gfx1201), ROCm 7.2, Windows and Linux
Fix: A value of 1.0 worked correctly with no OOM errors. 1.3 is suggested as a conservative value to maintain a safety margin for older hardware or ROCm versions.

Change: comfy/sd.py: VAE_KL_MEM_RATIO = 2.73 → 1.3 for AMD

Related: WAN 2.2 i2v: Second run is 4 5to 5 times slower on AMD GPU (ROCm) #12672