### PR TITLE
fix(ace15): handle missing lm_metadata in memory estimation during ch…

### DIFF
--- a/comfy/text_encoders/ace15.py
+++ b/comfy/text_encoders/ace15.py
@@ -328,14 +328,14 @@ class ACE15TEModel(torch.nn.Module):
                 return getattr(self, self.lm_model).load_sd(sd)
 
     def memory_estimation_function(self, token_weight_pairs, device=None):
-        lm_metadata = token_weight_pairs["lm_metadata"]
+        lm_metadata = token_weight_pairs.get("lm_metadata", {})
         constant = self.constant
         if comfy.model_management.should_use_bf16(device):
             constant *= 0.5
 
         token_weight_pairs = token_weight_pairs.get("lm_prompt", [])
         num_tokens = sum(map(lambda a: len(a), token_weight_pairs))
-        num_tokens += lm_metadata['min_tokens']
+        num_tokens += lm_metadata.get("min_tokens", 0)
         return num_tokens * constant * 1024 * 1024
 
 def te(dtype_llama=None, llama_quantization_metadata=None, lm_model="qwen3_2b"):


### PR DESCRIPTION
This PR adds fallback LM metadata to solve issue #12669 

# Test instructions

## Confirm that an AIO checkpoint is created without issues

- Download all the [split files for ACE-Step 1.5 Turbo](https://huggingface.co/Comfy-Org/ace_step_1.5_ComfyUI_files/tree/main/split_files).
- Import the following workflow to generate an all-in-one checkpoint for ACE-Step 1.5:
```
{"id":"88ac5dad-efd7-40bb-84fe-fbaefdee1fa9","revision":0,"last_node_id":96,"last_link_id":237,"nodes":[{"id":78,"type":"ModelSamplingAuraFlow","pos":[460,480],"size":[270,58],"flags":{},"order":3,"mode":0,"inputs":[{"name":"model","type":"MODEL","link":174}],"outputs":[{"name":"MODEL","type":"MODEL","links":[236]}],"properties":{"cnr_id":"comfy-core","ver":"0.15.0","Node name for S&R":"ModelSamplingAuraFlow"},"widgets_values":[1]},{"id":69,"type":"VAELoader","pos":[80,860],"size":[270,58],"flags":{},"order":0,"mode":0,"inputs":[],"outputs":[{"name":"VAE","type":"VAE","links":[237]}],"properties":{"cnr_id":"comfy-core","ver":"0.15.0","Node name for S&R":"VAELoader"},"widgets_values":["ace_1.5_vae.safetensors"]},{"id":80,"type":"DualCLIPLoader","pos":[-180,640],"size":[532.70464044488,140.79608111417315],"flags":{},"order":1,"mode":0,"inputs":[],"outputs":[{"name":"CLIP","type":"CLIP","links":[234]}],"properties":{"cnr_id":"comfy-core","ver":"0.15.0","Node name for S&R":"DualCLIPLoader"},"widgets_values":["qwen_0.6b_ace15.safetensors","qwen_1.7b_ace15.safetensors","ace","default"]},{"id":68,"type":"UNETLoader","pos":[-20,480],"size":[374.41897679754186,82],"flags":{},"order":2,"mode":0,"inputs":[],"outputs":[{"name":"MODEL","type":"MODEL","links":[174]}],"properties":{"cnr_id":"comfy-core","ver":"0.15.0","Node name for S&R":"UNETLoader"},"widgets_values":["acestep_v1.5_sft.safetensors","default"]},{"id":96,"type":"CheckpointSave","pos":[860,820],"size":[270,98],"flags":{},"order":4,"mode":0,"inputs":[{"name":"model","type":"MODEL","link":236},{"name":"clip","type":"CLIP","link":234},{"name":"vae","type":"VAE","link":237}],"outputs":[],"properties":{"cnr_id":"comfy-core","ver":"0.15.0","Node name for S&R":"CheckpointSave"},"widgets_values":["checkpoints/acestep_1.5"]}],"links":[[174,68,0,78,0,"MODEL"],[234,80,0,96,1,"CLIP"],[236,78,0,96,0,"MODEL"],[237,69,0,96,2,"VAE"]],"groups":[],"config":{},"extra":{"frontendVersion":"1.41.5","workflowRendererVersion":"LG","ds":{"scale":0.6481621089303967,"offset":[732.9512428627305,77.526590620635]},"VHS_latentpreview":false,"VHS_latentpreviewrate":0,"VHS_MetadataImage":true,"VHS_KeepIntermediate":true},"version":0.4}
```
- Run the workflow. 

A checkpoint should be created in the target folder instead of getting an error like `KeyError: 'lm_metadata'`

## Confirm that the generated checkpoint is working

- Load the workflow "ACE-Step 1.5 Music Generation AIO" from the Templates
- Replace the checkpoint with the one you just generated (might require to Refresh Node Definitions)
- Run the workflow. 

The music should be generated without any issues.