### PR TITLE
comfy aimdo 0.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ alembic
 SQLAlchemy
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.2.2
+comfy-aimdo>=0.2.3
 requests
 
 #non essential dependencies:


### PR DESCRIPTION
Aimdo 0.2.3 while avoid "sugar-rush" shared memory spills due to the 2s cooldown in checking shared VRAM usage levels. Aimdo will react within 2s to such a spill but the damage is done, as the GPU seems to use then syncronously page in pieces of spill to VRAM which costs most than the 2s. Data below suggest this can cost 5s per event. It usually happens on a VAE after either TE or sampling, but can happen on ksampler too.

So Aimdo 0.2.3 works by calculating a projection of VRAM usage against a periodic snapshot which both keeps the accounting up-to-date every allocation while avoiding the expensive cu APIs to actually check VRAM every alloc.

It's noticeable in the task manager as temperature drops on the GPU and VRAM peaks within the ~1GB WDDM headroom before slowly coming back down as it pages.

VRAM usage is a little bit lower overall but better safe than spilling to shared.

https://github.com/Comfy-Org/comfy-aimdo/pull/8

Example test conditions:

RTX5060, Windows, 32GB RAM
WAN 2.1 fp8 scaled, 480x368x81f

<img width="1370" height="991" alt="scr" src="https://github.com/user-attachments/assets/04ce297d-93d3-4b9b-bc0b-69ebadc129ac" />

Before (First and 3rd runs get sugar rushed):

```
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:05<00:00, 16.37s/it]
0 models unloaded.
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 91.39 seconds
got prompt
0 models unloaded.
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:02<00:00, 15.52s/it]
0 models unloaded.
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 69.48 seconds
got prompt
0 models unloaded.
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:02<00:00, 15.68s/it]
0 models unloaded.
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 76.00 seconds
```

After (consistently safe below VRAM spill threshold):

```
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:03<00:00, 15.77s/it]
Requested to load WanVAE
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 84.13 seconds
got prompt
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:02<00:00, 15.57s/it]
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 70.17 seconds
got prompt
Model WAN21 prepared for dynamic VRAM loading. 13630MB Staged. 1053 patches attached.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [01:02<00:00, 15.60s/it]
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 70.11 seconds
```

Regression tests:

5090, Linux, Flux2 (always offloads) :white_check_mark: 
5090, Linux, Ace 1.5 CPU underclocked to 2GHz  :white_check_mark:  LM sampling: 100%|██████████| 975/975 [00:16<00:00, 58.82it/s]