### PR TITLE
model_mangament: make dynamic --disable-smart-memory work

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -260,4 +260,4 @@ else:
     args.fast = set(args.fast)
 
 def enables_dynamic_vram():
-    return not args.disable_dynamic_vram and not args.highvram and not args.gpu_only and not args.novram and not args.cpu and not args.disable_smart_memory
+    return not args.disable_dynamic_vram and not args.highvram and not args.gpu_only and not args.novram and not args.cpu

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -639,12 +639,11 @@ def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, ram_
         if not DISABLE_SMART_MEMORY:
             memory_to_free = memory_required - get_free_memory(device)
             ram_to_free = ram_required - get_free_ram()
-
-        if current_loaded_models[i].model.is_dynamic() and for_dynamic:
-            #don't actually unload dynamic models for the sake of other dynamic models
-            #as that works on-demand.
-            memory_required -= current_loaded_models[i].model.loaded_size()
-            memory_to_free = 0
+            if current_loaded_models[i].model.is_dynamic() and for_dynamic:
+                #don't actually unload dynamic models for the sake of other dynamic models
+                #as that works on-demand.
+                memory_required -= current_loaded_models[i].model.loaded_size()
+                memory_to_free = 0
         if memory_to_free > 0 and current_loaded_models[i].model_unload(memory_to_free):
             logging.debug(f"Unloading {current_loaded_models[i].model.model.__class__.__name__}")
             unloaded_model.append(i)


### PR DESCRIPTION
This was previously considering the pool of dynamic models as one giant entity for the sake of smart memory, but that isn't really that useful or what a user would reasonably expect. Make Dynamic VRAM properly purge its models just like the old --disable-smart-memory by conditioning the dynamic-for-dynamic bypass on smart memory.

Re-enable dynamic + disable-smart-memory.

Example Test Conditions:

RTX5090, Linux, 96GB RAM
WAN2.2 scaledfp8 14B MoE
--disable-smart-memory

<img width="2047" height="994" alt="image" src="https://github.com/user-attachments/assets/eccfbbda-ab1d-4240-ad98-fba162c63382" />


Before disable (rev-c0d472e5):

```
Model WAN21 prepared for dynamic VRAM loading. 13631MB Staged. 0 patches attached.
100%|██████████| 2/2 [00:07<00:00,  3.69s/it]                                   
Found quantization metadata version 1
Detected mixed precision quantization
Using mixed precision operations
model weight dtype torch.float16, manual cast: torch.float16
model_type FLOW
Requested to load WAN21
Model WAN21 prepared for dynamic VRAM loading. 13631MB Staged. 0 patches attached.
100%|██████████| 2/2 [00:07<00:00,  3.70s/it]                                   
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 27.93 seconds
```

<img width="1147" height="711" alt="before" src="https://github.com/user-attachments/assets/68ea3a33-e553-4d2d-8cae-48f9e63abf04" />

master (non-dynamic):

```
Requested to load WAN21
100%|██████████| 2/2 [00:08<00:00,  4.25s/it]
Found quantization metadata version 1
Detected mixed precision quantization
Using mixed precision operations
model weight dtype torch.float16, manual cast: torch.float16
model_type FLOW
Requested to load WAN21
loaded completely; 27853.17 MB usable, 13631.42 MB loaded, full load: True
100%|██████████| 2/2 [00:08<00:00,  4.24s/it]
Requested to load WanVAE
loaded completely; 27373.38 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 41.55 seconds
```

<img width="1147" height="711" alt="non-dyn" src="https://github.com/user-attachments/assets/fb156e24-2b68-467f-8090-dd0bbddbf997" />

After:

```
Requested to load WAN21
Model WAN21 prepared for dynamic VRAM loading. 13631MB Staged. 0 patches attached.
100%|██████████| 2/2 [00:07<00:00,  3.69s/it]                                   
Found quantization metadata version 1
Detected mixed precision quantization
Using mixed precision operations
model weight dtype torch.float16, manual cast: torch.float16
model_type FLOW
Requested to load WAN21
Model WAN21 prepared for dynamic VRAM loading. 13631MB Staged. 0 patches attached.
100%|██████████| 2/2 [00:07<00:00,  3.69s/it]                                   
Requested to load WanVAE
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached.
Prompt executed in 30.61 seconds
```

<img width="1147" height="711" alt="Screenshot from 2026-03-02 08-47-48" src="https://github.com/user-attachments/assets/e28ca7cf-6180-45b2-8625-4bcf746092cc" />
