### PR TITLE
comfy aimdo 0.2.4 - Fix unaligned allocator sizes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ alembic
 SQLAlchemy
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.2.3
+comfy-aimdo>=0.2.4
 requests
 
 #non essential dependencies:


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/12718
https://github.com/Comfy-Org/ComfyUI/issues/12726

Comfy Aimdo 0.2.4 fixes a VRAM buffer alignment issue that happens in someworkflows where action is able to bypass the pytorch allocator and go straight to the cuda hook.

Example test conditions:

Windows, RTX5060
LTX Audio VAE encode + decode
--verbose DEBUG

<img width="1948" height="618" alt="scr" src="https://github.com/user-attachments/assets/50781292-e034-4c78-84ea-2472852e72dc" />

Before:

```
loaded completely; 5543.68 MB usable, 415.20 MB loaded, full load: True
torch.Size([2, 82262]) cuda:0 cuda:0 torch.float32 torch.Size([1024])
aimdo: D:\a\comfy-aimdo\comfy-aimdo\src\plat.h:140:DEBUG:CUDA API FAILED : cuMemAddressReserve(&buf->base_ptr, max_size, 0, 0, 0) : invalid argument
aimdo: D:\a\comfy-aimdo\comfy-aimdo\src\plat.h:140:DEBUG:CUDA API FAILED : cuMemAddressReserve(&buf->base_ptr, max_size, 0, 0, 0) : invalid argument
aimdo: D:\a\comfy-aimdo\comfy-aimdo\src\plat.h:140:DEBUG:CUDA API FAILED : cuMemAddressReserve(&buf->base_ptr, max_size, 0, 0, 0) : invalid argument
aimdo: D:\a\comfy-aimdo\comfy-aimdo\src\plat.h:140:DEBUG:CUDA API FAILED : cuMemAddressReserve(&buf->base_ptr, max_size, 0, 0, 0) : invalid argument
aimdo: D:\a\comfy-aimdo\comfy-aimdo\src\plat.h:140:DEBUG:CUDA API FAILED : cuMemAddressReserve(&buf->base_ptr, max_size, 0, 0, 0) : invalid argument
aimdo: src/control.c:33:DEBUG:--- VRAM Stats ---
aimdo: src/control.c:36:DEBUG:  Aimdo Recorded Usage:      958 MB
aimdo: src/control.c:37:DEBUG:  Cuda:     6460 MB /    8150 MB Free
aimdo: src/model-vbar.c:51:DEBUG:---------------- VBAR Usage ---------------
aimdo: src/model-vbar.c:84:DEBUG:Total VRAM for VBARs: 0 MB
aimdo: src/pyt-cu-plug-alloc.c:19:DEBUG:--- Allocation Analysis Start ---
aimdo: src/pyt-cu-plug-alloc.c:28:DEBUG:  [Bucket 4048] Ptr: 00000009FA000000 | Size:    2048k
aimdo: src/pyt-cu-plug-alloc.c:28:DEBUG:  [Bucket 4072] Ptr: 00000007FD000000 | Size:    2048k
aimdo: src/pyt-cu-plug-alloc.c:28:DEBUG:  [Bucket 4073] Ptr: 00000007FD200000 | Size:    2048k
aimdo: src/pyt-cu-plug-alloc.c:28:DEBUG:  [Bucket 4074] Ptr: 00000007FD400000 | Size:    8192k
aimdo: src/pyt-cu-plug-alloc.c:37:DEBUG:4 Active Allocations for a total of      14 MB
!!! Exception during processing !!! cuFFT error: CUFFT_INTERNAL_ERROR
Traceback (most recent call last):
...\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ldm\lightricks\vae\audio_vae.py", line 189, in encode
    mel_spec = self.preprocessor.waveform_to_mel(
        waveform, waveform_sample_rate, device=self.device_manager.load_device
    )
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ldm\lightricks\vae\audio_vae.py", line 127, in waveform_to_mel
    mel = mel_transform(waveform)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
...
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\functional.py", line 684, in stft
    return _VF.stft(  # type: ignore[attr-defined]
           ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        input,
        ^^^^^^
    ...<7 lines>...
        align_to_window,
        ^^^^^^^^^^^^^^^^
    )
    ^
RuntimeError: cuFFT error: CUFFT_INTERNAL_ERROR

Prompt executed in 1.46 seconds
```

After:

```
To see the GUI go to: http://127.0.0.1:8188
got prompt
Requested to load AudioVAE
loaded completely; 5600.80 MB usable, 415.20 MB loaded, full load: True
torch.Size([2, 82262]) cuda:0 cuda:0 torch.float32 torch.Size([1024])
Prompt executed in 0.92 seconds
```

Audio output checked for consistency :white_check_mark: 

Regression tests:

Linux, 5090, Flux 2 (always offloads) :white_check_mark: 100%|██████████| 20/20 [00:45<00:00,  2.26s/it]
Linux, 5090, 2GHz underclocked CPU, Acestep 1.5 195s :white_check_mark: LM sampling: 100%|██████████| 975/975 [00:16<00:00, 58.59it/s]

