### PR TITLE
ModelPatcherDynamic: Force load all non-comfy weights

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -32,9 +32,6 @@ import comfy.memory_management
 import comfy.utils
 import comfy.quant_ops
 
-import comfy_aimdo.torch
-import comfy_aimdo.model_vbar
-
 class VRAMState(Enum):
     DISABLED = 0    #No vram present: no need to move models to vram
     NO_VRAM = 1     #Very low vram: enable all the options to save vram

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1435,10 +1435,6 @@ class ModelPatcherDynamic(ModelPatcher):
 
     def __init__(self, model, load_device, offload_device, size=0, weight_inplace_update=False):
         super().__init__(model, load_device, offload_device, size, weight_inplace_update)
-        #this is now way more dynamic and we dont support the same base model for both Dynamic
-        #and non-dynamic patchers.
-        if hasattr(self.model, "model_loaded_weight_memory"):
-            del self.model.model_loaded_weight_memory
         if not hasattr(self.model, "dynamic_vbars"):
             self.model.dynamic_vbars = {}
         self.non_dynamic_delegate_model = None
@@ -1461,9 +1457,7 @@ class ModelPatcherDynamic(ModelPatcher):
 
     def loaded_size(self):
         vbar = self._vbar_get()
-        if vbar is None:
-            return 0
-        return vbar.loaded_size()
+        return (vbar.loaded_size() if vbar is not None else 0) + self.model.model_loaded_weight_memory
 
     def get_free_memory(self, device):
         #NOTE: on high condition / batch counts, estimate should have already vacated
@@ -1504,6 +1498,7 @@ class ModelPatcherDynamic(ModelPatcher):
 
         num_patches = 0
         allocated_size = 0
+        self.model.model_loaded_weight_memory = 0
 
         with self.use_ejected():
             self.unpatch_hooks()
@@ -1512,10 +1507,6 @@ class ModelPatcherDynamic(ModelPatcher):
             if vbar is not None:
                 vbar.prioritize()
 
-            #We force reserve VRAM for the non comfy-weight so we dont have to deal
-            #with pin and unpin syncrhonization which can be expensive for small weights
-            #with a high layer rate (e.g. autoregressive LLMs).
-            #prioritize the non-comfy weights (note the order reverse).
             loading = self._load_list(prio_comfy_cast_weights=True, default_device=device_to)
             loading.sort(reverse=True)
 
@@ -1558,6 +1549,9 @@ class ModelPatcherDynamic(ModelPatcher):
                     if key in self.backup:
                         comfy.utils.set_attr_param(self.model, key, self.backup[key].weight)
                     self.patch_weight_to_device(key, device_to=device_to)
+                    weight, _, _ = get_key_weight(self.model, key)
+                    if weight is not None:
+                        self.model.model_loaded_weight_memory += weight.numel() * weight.element_size()
 
                 if hasattr(m, "comfy_cast_weights"):
                     m.comfy_cast_weights = True
@@ -1583,21 +1577,15 @@ class ModelPatcherDynamic(ModelPatcher):
                     for param in params:
                         key = key_param_name_to_key(n, param)
                         weight, _, _ = get_key_weight(self.model, key)
-                        weight.seed_key = key
-                        set_dirty(weight, dirty)
-                        geometry = weight
-                        model_dtype = getattr(m, param + "_comfy_model_dtype", None) or weight.dtype
-                        geometry = comfy.memory_management.TensorGeometry(shape=weight.shape, dtype=model_dtype)
-                        weight_size = geometry.numel() * geometry.element_size()
-                        if vbar is not None and not hasattr(weight, "_v"):
-                            weight._v = vbar.alloc(weight_size)
-                            weight._model_dtype = model_dtype
-                        allocated_size += weight_size
-                    vbar.set_watermark_limit(allocated_size)
+                        if key not in self.backup:
+                            self.backup[key] = collections.namedtuple('Dimension', ['weight', 'inplace_update'])(weight, False)
+                        comfy.utils.set_attr_param(self.model, key, weight.to(device=device_to))
+                        self.model.model_loaded_weight_memory += weight.numel() * weight.element_size()
 
                 move_weight_functions(m, device_to)
 
-            logging.info(f"Model {self.model.__class__.__name__} prepared for dynamic VRAM loading. {allocated_size // (1024 ** 2)}MB Staged. {num_patches} patches attached.")
+            force_load_stat = f" Force pre-loaded {len(self.backup)} weights: {self.model.model_loaded_weight_memory // 1024} KB." if len(self.backup) > 0 else ""
+            logging.info(f"Model {self.model.__class__.__name__} prepared for dynamic VRAM loading. {allocated_size // (1024 ** 2)}MB Staged. {num_patches} patches attached.{force_load_stat}")
 
             self.model.device = device_to
             self.model.current_weight_patches_uuid = self.patches_uuid
@@ -1613,7 +1601,16 @@ class ModelPatcherDynamic(ModelPatcher):
         assert self.load_device != torch.device("cpu")
 
         vbar = self._vbar_get()
-        return 0 if vbar is None else vbar.free_memory(memory_to_free)
+        freed = 0 if vbar is None else vbar.free_memory(memory_to_free)
+
+        if freed < memory_to_free:
+            for key in list(self.backup.keys()):
+                bk = self.backup.pop(key)
+                comfy.utils.set_attr_param(self.model, key, bk.weight)
+            freed += self.model.model_loaded_weight_memory
+            self.model.model_loaded_weight_memory = 0
+
+        return freed
 
     def partially_unload_ram(self, ram_to_unload):
         loading = self._load_list(prio_comfy_cast_weights=True, default_device=self.offload_device)
@@ -1639,11 +1636,6 @@ class ModelPatcherDynamic(ModelPatcher):
             self.partially_unload(None, 1e32)
             for m in self.model.modules():
                 move_weight_functions(m, device_to)
-
-            keys = list(self.backup.keys())
-            for k in keys:
-                bk = self.backup[k]
-                comfy.utils.set_attr_param(self.model, k, bk.weight)
 
     def partially_load(self, device_to, extra_memory=0, force_patch_weights=False):
         assert not force_patch_weights #See above


### PR DESCRIPTION
Recently I implemented VBAR watermark limits so that non-comfy weights could be pinned within a VBAR. This leads to the situation where the non-comfy weights need to comply with the CPU resident weight at execution time while simultaneously not being evictable.

Instead, load these weights to the GPU the old fashioned way. This means that old or custom_nodes code that just assumes the weights are loaded will operate. These weights are usually small.

There is one corner case, which is if weights are all of large, model-code-casted and non-comfy and expects the core comfy engine to manage the offload. We have already however trialled dynamic_vram with all non-comfy weights pinned to the VBAR and non-evictable with no reports.

This also leads to a little speedup on CPU bound models with a high non-comfy layer rate (like ace-step on RTX6000).

The leading test case is the wav2vec2 Audio Encoder but nn.BatchNorm2d has also been flagged as a complication.

This also means paramtrizations should work. (see tests below).

Example test case:

Linux, RTX5090
wav2vec2 encode

<img width="1801" height="545" alt="image" src="https://github.com/user-attachments/assets/edd33e95-ffb2-40a4-9ac0-5e3e030ac2c6" />


Before:

```
  File "/home/rattus/ComfyUI/comfy/audio_encoders/wav2vec2.py", line 130, in forward
    x = x + self.pos_conv_embed(x)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/audio_encoders/wav2vec2.py", line 96, in forward
    x = self.conv(x)[:, :, :-1]
        ^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/conv.py", line 371, in forward
    return self._conv_forward(input, self.weight, self.bias)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/conv.py", line 366, in _conv_forward
    return F.conv1d(
           ^^^^^^^^^
RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same

Prompt executed in 0.51 seconds

```

After:

```
To see the GUI go to: http://0.0.0.0:8188
got prompt
unexpected audio encoder: ['quantizer.codevectors', 'quantizer.weight_proj.weight', 'quantizer.weight_proj.bias', 'project_q.weight', 'project_q.bias', 'project_hid.weight', 'project_hid.bias']
Requested to load Wav2Vec2Model
Model Wav2Vec2Model prepared for dynamic VRAM loading. 341MB Staged. 0 patches attached. Force pre-loaded 2 weights: 18432 KB.
Prompt executed in 0.64 seconds
```

Example test case:

RTX5090, Linux, 2GHz underclocked CPU
Ace-step 1.5, 195s:

<img width="2407" height="910" alt="image" src="https://github.com/user-attachments/assets/163f3b04-40c6-48ff-a121-a3e8c0e64639" />

Before:

```
CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
Requested to load ACE15TEModel_
Model ACE15TEModel_ prepared for dynamic VRAM loading. 4673MB Staged. 0 patches attached.
LM sampling: 100%|██████████| 975/975 [00:16<00:00, 59.25it/s]                                 
Requested to load ACEStep15
Model ACEStep15 prepared for dynamic VRAM loading. 4565MB Staged. 0 patches attached.
100%|██████████| 8/8 [00:00<00:00, 10.43it/s]                                   
Requested to load AudioOobleckVAE
loaded completely;  321.70 MB loaded, full load: True
Prompt executed in 30.24 seconds
```

After (A little faster on the CPU bound LM sampling):

```
CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
Requested to load ACE15TEModel_
Model ACE15TEModel_ prepared for dynamic VRAM loading. 4672MB Staged. 0 patches attached. Force pre-loaded 226 weights: 370 KB.
LM sampling: 100%|██████████| 975/975 [00:15<00:00, 62.19it/s]                                 
Requested to load ACEStep15
Model ACEStep15 prepared for dynamic VRAM loading. 4565MB Staged. 0 patches attached.
100%|██████████| 8/8 [00:00<00:00, 10.45it/s]                                   
Requested to load AudioOobleckVAE
loaded completely;  321.70 MB loaded, full load: True
Prompt executed in 29.40 seconds
```

Audio output checked :white_check_mark: 

Example test case:

Ace step as above but with (this enables dynamic VRAM for the paramtrization VAEs):

```
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -590,7 +590,6 @@ class VAE:
                 self.working_dtypes = [torch.float16, torch.bfloat16, torch.float32]
-                self.disable_offload = True
             elif "blocks.2.blocks.3.stack.5.weight" in sd or "decoder.blocks.2.blocks.3.stack.5.weight" in sd or "layers.4.layers.1.attn_block.attn.qkv.weight" in sd or "encoder.layers.4.layers.1.attn_block.attn.qkv.weight" in sd: #genmo mochi vae
@@ -741,7 +740,6 @@ class VAE:
                 self.working_dtypes = [torch.bfloat16, torch.float16, torch.float32]
-                self.disable_offload = True
                 self.extra_1d_channel = 16

```

Before:

```
  File "/home/rattus/ComfyUI/comfy/ldm/audio/autoencoder.py", line 275, in decode
    return self.decoder(self.bottleneck.decode(x))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 377, in forward
    return super().forward(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/conv.py", line 371, in forward
    return self._conv_forward(input, self.weight, self.bias)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/conv.py", line 366, in _conv_forward
    return F.conv1d(
           ^^^^^^^^^
RuntimeError: Input type (torch.cuda.HalfTensor) and weight type (torch.HalfTensor) should be the same

Prompt executed in 19.65 seconds

```

After

```
Model ACE15TEModel_ prepared for dynamic VRAM loading. 4672MB Staged. 0 patches attached. Force pre-loaded 226 weights: 370 KB.
LM sampling: 100%|██████████| 975/975 [00:15<00:00, 61.05it/s]                                 
Requested to load ACEStep15
Model ACEStep15 prepared for dynamic VRAM loading. 4565MB Staged. 0 patches attached.
100%|██████████| 8/8 [00:00<00:00, 10.43it/s]                                   
Requested to load AudioOobleckVAE
Model AudioOobleckVAE prepared for dynamic VRAM loading. 0MB Staged. 0 patches attached. Force pre-loaded 292 weights: 329419 KB.
Prompt executed in 30.02 seconds
```

Regression tests:

Linux, 5090, Flux2 (always offloads): :white_check_mark: 
Linux 5090, Wan 2.2 14B (non-comfy VAE) :white_check_mark: Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached. Force pre-loaded 52 weights: 28 KB.
Windows, 5060, Wan 2.1 (share memory spill avoider) :white_check_mark: 