### PR TITLE
main: Load aimdo after logger is setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,17 +16,17 @@ from comfy_execution.progress import get_progress_state
 from comfy_execution.utils import get_executing_context
 from comfy_api import feature_flags
 
-import comfy_aimdo.control
-
-if enables_dynamic_vram():
-    comfy_aimdo.control.init()
-
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI, they are for custom nodes.
     os.environ['HF_HUB_DISABLE_TELEMETRY'] = '1'
     os.environ['DO_NOT_TRACK'] = '1'
 
 setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
+
+import comfy_aimdo.control
+
+if enables_dynamic_vram():
+    comfy_aimdo.control.init()
 
 if os.name == "nt":
     os.environ['MIMALLOC_PURGE_DELAY'] = '0'


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/12712

This was too early. Aimdo can use the logger in error paths and this causes a rogue default init if aimdo has something to log.

Example test conditions:

Windows, RTX5090, aimdo.dll deleted in venv:

Before:

```
(venvw) PS C:\Users\rattu\ComfyUI> python .\main.py --base-directory ..\comfy-base\
WARNING:root:WARNING: You need pytorch with cu130 or higher to use optimized CUDA operations.
WARNING: You need pytorch with cu130 or higher to use optimized CUDA operations.
INFO:root:Found comfy_kitchen backend cuda: {'available': True, 'disabled': True, 'unavailable_reason': None, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8']}
Found comfy_kitchen backend cuda: {'available': True, 'disabled': True, 'unavailable_reason': None, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8']}
INFO:root:Found comfy_kitchen backend triton: {'available': False, 'disabled': True, 'unavailable_reason': "ImportError: No module named 'triton'", 'capabilities': []}
Found comfy_kitchen backend triton: {'available': False, 'disabled': True, 'unavailable_reason': "ImportError: No module named 'triton'", 'capabilities': []}
INFO:root:Found comfy_kitchen backend eager: {'available': True, 'disabled': False, 'unavailable_reason': None, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8', 'scaled_mm_nvfp4']}
Found comfy_kitchen backend eager: {'available': True, 'disabled': False, 'unavailable_reason': None, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8', 'scaled_mm_nvfp4']}
INFO:root:Checkpoint files will always be loaded safely.
Checkpoint files will always be loaded safely.
INFO:root:Total VRAM 8150 MB, total RAM 32691 MB
Total VRAM 8150 MB, total RAM 32691 MB
INFO:root:pytorch version: 2.8.0+cu128
pytorch version: 2.8.0+cu128
INFO:root:Set vram state to: NORMAL_VRAM
Set vram state to: NORMAL_VRAM
INFO:root:Device: cuda:0 NVIDIA GeForce RTX 5060 : cudaMallocAsync
Device: cuda:0 NVIDIA GeForce RTX 5060 : cudaMallocAsync
INFO:root:Using async weight offloading with 2 streams
```

After:

```
(venvw) PS C:\Users\rattu\ComfyUI> python .\main.py --base-directory ..\comfy-base\
comfy-aimdo failed to load: Could not find module 'C:\Users\rattus\venvw\Lib\site-packages\comfy_aimdo\aimdo.dll' (or one of its dependencies). Try using the full path with constructor syntax.
NOTE: comfy-aimdo is currently only support for Nvidia GPUs
WARNING: You need pytorch with cu130 or higher to use optimized CUDA operations.
Found comfy_kitchen backend cuda: {'available': True, 'disabled': True, 'unavailable_reason': None, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8']}
Found comfy_kitchen backend eager: {'available': True, 'disabled': False, 'unavailable_reason': None, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8', 'scaled_mm_nvfp4']}
Found comfy_kitchen backend triton: {'available': False, 'disabled': True, 'unavailable_reason': "ImportError: No module named 'triton'", 'capabilities': []}
Checkpoint files will always be loaded safely.
Total VRAM 8150 MB, total RAM 32691 MB
pytorch version: 2.8.0+cu128
Set vram state to: NORMAL_VRAM
Device: cuda:0 NVIDIA GeForce RTX 5060 : cudaMallocAsync
Using async weight offloading with 2 streams
Enabled pinned memory 14710.0
Using pytorch attention
No working comfy-aimdo install detected. DynamicVRAM support disabled. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows
Python version: 3.12.10 (tags/v3.12.10:0cc8128, Apr  8 2025, 12:21:36) [MSC v.1943 64 bit (AMD64)]
ComfyUI version: 0.15.1
```