### PR TITLE
model_patcher: Improve dynamic offload heuristic

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -699,7 +699,7 @@ class ModelPatcher:
         for key in list(self.pinned):
             self.unpin_weight(key)
 
-    def _load_list(self, prio_comfy_cast_weights=False, default_device=None):
+    def _load_list(self, for_dynamic=False, default_device=None):
         loading = []
         for n, m in self.model.named_modules():
             default = False
@@ -727,8 +727,13 @@ class ModelPatcher:
                         return 0
                     module_offload_mem += check_module_offload_mem("{}.weight".format(n))
                     module_offload_mem += check_module_offload_mem("{}.bias".format(n))
-                prepend = (not hasattr(m, "comfy_cast_weights"),) if prio_comfy_cast_weights else ()
-                loading.append(prepend + (module_offload_mem, module_mem, n, m, params))
+                # Dynamic: small weights (<64KB) first, then larger weights prioritized by size.
+                # Non-dynamic: prioritize by module offload cost.
+                if for_dynamic:
+                    sort_criteria = (module_offload_mem >= 64 * 1024, -module_offload_mem)
+                else:
+                    sort_criteria = (module_offload_mem,)
+                loading.append(sort_criteria + (module_mem, n, m, params))
         return loading
 
     def load(self, device_to=None, lowvram_model_memory=0, force_patch_weights=False, full_load=False):
@@ -1508,11 +1513,11 @@ class ModelPatcherDynamic(ModelPatcher):
             if vbar is not None:
                 vbar.prioritize()
 
-            loading = self._load_list(prio_comfy_cast_weights=True, default_device=device_to)
-            loading.sort(reverse=True)
+            loading = self._load_list(for_dynamic=True, default_device=device_to)
+            loading.sort()
 
             for x in loading:
-                _, _, _, n, m, params = x
+                *_, module_mem, n, m, params = x
 
                 def set_dirty(item, dirty):
                     if dirty or not hasattr(item, "_v_signature"):
@@ -1627,9 +1632,9 @@ class ModelPatcherDynamic(ModelPatcher):
         return freed
 
     def partially_unload_ram(self, ram_to_unload):
-        loading = self._load_list(prio_comfy_cast_weights=True, default_device=self.offload_device)
+        loading = self._load_list(for_dynamic=True, default_device=self.offload_device)
         for x in loading:
-            _, _, _, _, m, _ = x
+            *_, m, _ = x
             ram_to_unload -= comfy.pinned_memory.unpin_memory(m)
             if ram_to_unload <= 0:
                 return


### PR DESCRIPTION
Define a threshold below which a weight's loading takes priority. This actually makes the offload consistent with non-dynamic, because what happens, is when non-dynamic fills its to_load list, it will fill-up any left-over pieces that could not fit large weights with small weights and ultimately load them, even though they were lower priority. This actually improves performance because the tiny weights don't cost any VRAM and aren't worth the control overhead of the DMA etc.

I have a more complex heuristic that goes even faster than this for Flux2, but I cant get it consistent on other models. Next dev cycle.

Example Test Conditions:

Windows, 5060, 32GB RAM
Flux2 Klein
Based on 

<img width="1763" height="777" alt="scr" src="https://github.com/user-attachments/assets/da89830c-1a43-4939-a3e8-888f35e49aee" />


Before:

```
Model Flux2 prepared for dynamic VRAM loading. 17316MB Staged. 0 patches attached.
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:36<00:00,  1.83s/it]
Model AutoencoderKL prepared for dynamic VRAM loading. 160MB Staged. 0 patches attached.
Prompt executed in 37.49 seconds
```

After:

```
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:34<00:00,  1.70s/it]
Model AutoencoderKL prepared for dynamic VRAM loading. 160MB Staged. 0 patches attached.
Prompt executed in 35.35 seconds
```

Regression tests:

RTX5090, Linux, stable-cascade -> Flux2 (always offloads) :white_check_mark: 
RTX5090, Linux, 2GHz CPU, ACE.1.5 :white_check_mark: 
RTX5060, Windows, Wan 2.1 368x480x82f :white_check_mark: - No performance regression
All above with --disable-dynamic-vram :white_check_mark: 