### PR TITLE
comfy-aimdo 0.2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ alembic
 SQLAlchemy
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.2.5
+comfy-aimdo>=0.2.6
 requests
 
 #non essential dependencies:


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/12763

Comfy Aimdo 0.2.6 fixes a GPU virtual address leak. This would manfiest as an error after a number of workflow runs.

Reproduced via test script:

```
import comfy_aimdo.control
comfy_aimdo.control.init()
comfy_aimdo.control.set_log_info()

import torch
from comfy_aimdo.model_vbar import ModelVBAR, vbar_fault, vbar_unpin, vbar_signature_compare

comfy_aimdo.control.init_device(torch.device(torch.cuda.current_device()).index)

#FIXME: Get rid of this
dummy = torch.randn(1, device=torch.device("cuda:0"))

gpu_size = torch.cuda.get_device_properties(torch.cuda.current_device()).total_memory
dtype = torch.float16

for i in range(5000):
    try:
        vbar1 = ModelVBAR(gpu_size * 1, device=0) #The vbar can be much bigger than VRAM
    except:
        print(f"got to {i}")
        raise
```

Before:

```
Installing collected packages: comfy-aimdo
  Attempting uninstall: comfy-aimdo
    Found existing installation: comfy-aimdo 0.2.6.dev1
    Uninstalling comfy-aimdo-0.2.6.dev1:
      Successfully uninstalled comfy-aimdo-0.2.6.dev1
Successfully installed comfy-aimdo-0.2.5
(venvw) PS C:\users\rattus> python .\example.py
aimdo: src-win/cuda-detour.c:77:INFO:aimdo_setup_hooks: found driver at 00007FF928790000, installing 4 hooks
aimdo: src/control.c:66:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 5060 (VRAM: 8150 MB)
aimdo: src/model-vbar.c:200:ERROR:Could not reseve Virtual Address space for VBAR
got to 126
Traceback (most recent call last):
  File "C:\users\rattus\example.py", line 20, in <module>
    vbar1 = ModelVBAR(gpu_size * 1, device=0) #The vbar can be much bigger than VRAM
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\users\rattus\venvw\Lib\site-packages\comfy_aimdo\model_vbar.py", line 43, in __init__
    raise MemoryError("VBAR allocation failed")
MemoryError: VBAR allocation failed
```

After:

```
Installing collected packages: comfy-aimdo
  Attempting uninstall: comfy-aimdo
    Found existing installation: comfy-aimdo 0.2.5
    Uninstalling comfy-aimdo-0.2.5:
      Successfully uninstalled comfy-aimdo-0.2.5
Successfully installed comfy-aimdo-0.2.6
(venvw) PS C:\users\rattus> python .\example.py
aimdo: src-win/cuda-detour.c:77:INFO:aimdo_setup_hooks: found driver at 00007FF927E40000, installing 4 hooks
aimdo: src/control.c:66:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 5060 (VRAM: 8150 MB)
(venvw) PS C:\users\rattus>
```

Regression Tests:

All worksflow x3. Run, Run, clear-cache, Run, clear-cache
RTX5060, Windows, WAN 2.1 :white_check_mark: 
RTX5090, Linux, stable cascade -> Flux2 :white_check_mark: 
RTX5090, Linux, Ace 1.5 195S :white_check_mark: 