### PR TITLE
Disable SageAttention for Hunyuan3D v2.1 DiT

### DIFF
--- a/comfy/ldm/hunyuan3dv2_1/hunyuandit.py
+++ b/comfy/ldm/hunyuan3dv2_1/hunyuandit.py
@@ -343,6 +343,7 @@ class CrossAttention(nn.Module):
             k.reshape(b, s2, self.num_heads * self.head_dim),
             v,
             heads=self.num_heads,
+            low_precision_attention=False,
         )
 
         out = self.out_proj(x)
@@ -412,6 +413,7 @@ class Attention(nn.Module):
             key.reshape(B, N, self.num_heads * self.head_dim),
             value,
             heads=self.num_heads,
+            low_precision_attention=False,
         )
 
         x = self.out_proj(x)


### PR DESCRIPTION
## Summary

SageAttention produces NaN in the Hunyuan3D v2.1 DiT, causing empty meshes and a crash in `save_glb`:

```
ValueError: zero-size array to reduction operation maximum which has no identity
```

This adds `low_precision_attention=False` to both `optimized_attention` calls in the v2.1 DiT, following the same pattern as ACE Step 1.5 (#12297). SageAttention falls back to pytorch attention for Hunyuan3D only.

## Diagnosis

Debug logging on the VAE decode input confirmed the DiT output is entirely NaN when SageAttention is active. The 3D occupancy prediction requires higher precision at voxel boundaries than SageAttention's quantized kernels provide. Image/video diffusion tolerates this precision loss; 3D does not.

Fixes #10943

## Test plan

- [x] Hunyuan3D 2.1 image-to-3D produces valid mesh with `--use-sage-attention` enabled
- [x] Image/video workflows still use SageAttention (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)