### PR TITLE
fix: prevent --cpu flag from allocating GPU memory

### DIFF
--- a/comfy/quant_ops.py
+++ b/comfy/quant_ops.py
@@ -1,33 +1,38 @@
 import torch
 import logging
+from comfy.cli_args import args
 
-try:
-    import comfy_kitchen as ck
-    from comfy_kitchen.tensor import (
-        QuantizedTensor,
-        QuantizedLayout,
-        TensorCoreFP8Layout as _CKFp8Layout,
-        TensorCoreNVFP4Layout as _CKNvfp4Layout,
-        register_layout_op,
-        register_layout_class,
-        get_layout_class,
-    )
-    _CK_AVAILABLE = True
-    if torch.version.cuda is None:
-        ck.registry.disable("cuda")
-    else:
-        cuda_version = tuple(map(int, str(torch.version.cuda).split('.')))
-        if cuda_version < (13,):
-            ck.registry.disable("cuda")
-            logging.warning("WARNING: You need pytorch with cu130 or higher to use optimized CUDA operations.")
-
-    ck.registry.disable("triton")
-    for k, v in ck.list_backends().items():
-        logging.info(f"Found comfy_kitchen backend {k}: {v}")
-except ImportError as e:
-    logging.error(f"Failed to import comfy_kitchen, Error: {e}, fp8 and fp4 support will not be available.")
+if args.cpu:
     _CK_AVAILABLE = False
+else:
+    try:
+        import comfy_kitchen as ck
+        from comfy_kitchen.tensor import (
+            QuantizedTensor,
+            QuantizedLayout,
+            TensorCoreFP8Layout as _CKFp8Layout,
+            TensorCoreNVFP4Layout as _CKNvfp4Layout,
+            register_layout_op,
+            register_layout_class,
+            get_layout_class,
+        )
+        _CK_AVAILABLE = True
+        if torch.version.cuda is None:
+            ck.registry.disable("cuda")
+        else:
+            cuda_version = tuple(map(int, str(torch.version.cuda).split('.')))
+            if cuda_version < (13,):
+                ck.registry.disable("cuda")
+                logging.warning("WARNING: You need pytorch with cu130 or higher to use optimized CUDA operations.")
 
+        ck.registry.disable("triton")
+        for k, v in ck.list_backends().items():
+            logging.info(f"Found comfy_kitchen backend {k}: {v}")
+    except ImportError as e:
+        logging.error(f"Failed to import comfy_kitchen, Error: {e}, fp8 and fp4 support will not be available.")
+        _CK_AVAILABLE = False
+
+if not _CK_AVAILABLE:
     class QuantizedTensor:
         pass
 


### PR DESCRIPTION
## Problem

When running ComfyUI with `--cpu`, PyTorch still initializes a CUDA context and allocates 150-500MB of GPU VRAM. This defeats the purpose of the `--cpu` flag for users who want to avoid GPU usage entirely.

Reported regression: users who rolled back to v0.4.0 saw the issue disappear.

## Root Causes

**1. Missing CPU guard in `soft_empty_cache()` and `synchronize()`** (`comfy/model_management.py`)

Both functions fall through to `torch.cuda.synchronize()` / `torch.cuda.empty_cache()` without checking `cpu_state == CPUState.CPU`. These torch.cuda calls trigger `_lazy_init()`, which creates the primary CUDA device context and allocates VRAM.

**2. Unconditional `comfy_kitchen` import** (`comfy/quant_ops.py`)

`comfy_kitchen` is imported at module load time regardless of `--cpu`. Its import chain calls `torch.cuda.is_available()` → `cudaGetDeviceCount` → `cuInit`, which initializes the CUDA driver.

## Fix

- Add early `return` in `synchronize()` and `soft_empty_cache()` when `cpu_state == CPUState.CPU`
- Gate `comfy_kitchen` import behind `args.cpu` check, skipping it entirely in CPU mode
- Consolidate fallback stubs into a single `if not _CK_AVAILABLE` block (also adds missing `QuantizedLayout` and `register_layout_op` stubs that were absent from the original `except ImportError` handler)