### PR TITLE
comfy-aimdo 0.2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ alembic
 SQLAlchemy
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.2.6
+comfy-aimdo>=0.2.7
 requests
 
 #non essential dependencies:


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/12784

Comfy-aimdo 0.2.7 fixes a crash when a spurious cudaAsyncFree comes in and would cause an infinite stack overflow (via detours hooks).

A lock is also introduced on the link list holding the free sections to avoid any possibility of threaded miscellaneous cuda allocations being the root cause.

I never reproduced this.

Regression tests:
Linux, 5090, Ace 1.5 195S :white_check_mark: 
Linux, 5090, Flux2 Klein :white_check_mark: 
Windows, 5060, LTX (big offloader) :white_check_mark: 