### PR TITLE
ops: Handle CPU weight in VBAR caster

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -80,6 +80,21 @@ def cast_to_input(weight, input, non_blocking=False, copy=True):
 
 
 def cast_bias_weight_with_vbar(s, dtype, device, bias_dtype, non_blocking, compute_dtype, want_requant):
+
+    #vbar doesn't support CPU weights, but some custom nodes have weird paths
+    #that might switch the layer to the CPU and expect it to work. We have to take
+    #a clone conservatively as we are mmapped and some SFT files are packed misaligned
+    #If you are a custom node author reading this, please move your layer to the GPU
+    #or declare your ModelPatcher as CPU in the first place.
+    if device is not None and device.type == "cpu":
+        weight = s.weight.to(dtype=dtype, copy=True)
+        if isinstance(weight, QuantizedTensor):
+            weight = weight.dequantize()
+        bias = None
+        if s.bias is not None:
+            bias = s.bias.to(dtype=bias_dtype, copy=True)
+        return weight, bias, (None, None, None)
+
     offload_stream = None
     xfer_dest = None
 


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/12786

This shouldn't happen but custom nodes gets there. Handle it as best we can.

Example Test Conditions:

RTX5090, Linux
ComfyUI-Inspire -> PC: Encode Prompt Custom nodes -> SDXL

<img width="1747" height="860" alt="image" src="https://github.com/user-attachments/assets/61728082-897f-464b-b0c3-4279321a2821" />

Before:

```
  File "/home/rattus/venv-pyt210-cu13/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1789, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 552, in forward
    return self.forward_comfy_cast_weights(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 544, in forward_comfy_cast_weights
    x = torch.nn.functional.embedding(input, weight, self.padding_idx, self.max_norm, self.norm_type, self.scale_grad_by_freq, self.sparse).to(dtype=output_dtype)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv-pyt210-cu13/lib/python3.12/site-packages/torch/nn/functional.py", line 2567, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected all tensors to be on the same device, but got index is on cuda:0, different from other tensors on cpu (when checking argument in method wrapper_CUDA__index_select)

Prompt executed in 2.20 seconds
```

After:

```
Model SDXL prepared for dynamic VRAM loading. 4897MB Staged. 0 patches attached.
100%|██████████████████████████████████████████████████████████████████████████| 20/20 [00:01<00:00, 11.67it/s]
Requested to load AutoencoderKL
Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Prompt executed in 3.47 seconds

```

Regression tests:

RTX5090, Linux, Ace step 1.5 196S :white_check_mark: 
RTX5090, Linux, Cascade -> Flux (offloads, multi-model) :white_check_mark: 