### PR TITLE
Add manual cast to LTX2 vocoder conv_transpose1d

### DIFF
--- a/comfy/ldm/lightricks/vocoders/vocoder.py
+++ b/comfy/ldm/lightricks/vocoders/vocoder.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn.functional as F
 import torch.nn as nn
 import comfy.ops
+import comfy.model_management
 import numpy as np
 import math
 


### PR DESCRIPTION
Should fix:

```
File "N:\AI\ComfyUI\comfy\ldm\lightricks\vocoders\vocoder.py", line 127, in forward
    x = self.ratio * F.conv_transpose1d(
                     ^^^^^^^^^^^^^^^^^^^
RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same
```

Which seems to happen in some circumstances