### PR TITLE
Fix mutable default arguments causing state pollution across model loads

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -204,7 +204,13 @@ def load_bypass_lora_for_models(model, clip, lora, strength_model, strength_clip
 
 
 class CLIP:
-    def __init__(self, target=None, embedding_directory=None, no_init=False, tokenizer_data={}, parameters=0, state_dict=[], model_options={}, disable_dynamic=False):
+    def __init__(self, target=None, embedding_directory=None, no_init=False, tokenizer_data=None, parameters=0, state_dict=None, model_options=None, disable_dynamic=False):
+        if tokenizer_data is None:
+            tokenizer_data = {}
+        if state_dict is None:
+            state_dict = []
+        if model_options is None:
+            model_options = {}
         if no_init:
             return
         params = target.params.copy()
@@ -415,7 +421,9 @@ class CLIP:
             sd_clip[k] = sd_tokenizer[k]
         return sd_clip
 
-    def load_model(self, tokens={}):
+    def load_model(self, tokens=None):
+        if tokens is None:
+            tokens = {}
         memory_used = 0
         if hasattr(self.cond_stage_model, "memory_estimation_function"):
             memory_used = self.cond_stage_model.memory_estimation_function(tokens, device=self.patcher.load_device)
@@ -935,7 +943,9 @@ class VAE:
         encode_fn = lambda a: self.first_stage_model.encode((self.process_input(a)).to(self.vae_dtype).to(self.device)).float()
         return comfy.utils.tiled_scale_multidim(samples, encode_fn, tile=(tile_t, tile_x, tile_y), overlap=overlap, upscale_amount=self.downscale_ratio, out_channels=self.latent_channels, downscale=True, index_formulas=self.downscale_index_formula, output_device=self.output_device)
 
-    def decode(self, samples_in, vae_options={}):
+    def decode(self, samples_in, vae_options=None):
+        if vae_options is None:
+            vae_options = {}
         self.throw_exception_if_invalid()
         pixel_samples = None
         do_tile = False
@@ -1166,11 +1176,15 @@ class CLIPType(Enum):
 
 
 
-def load_clip_model_patcher(ckpt_paths, embedding_directory=None, clip_type=CLIPType.STABLE_DIFFUSION, model_options={}, disable_dynamic=False):
+def load_clip_model_patcher(ckpt_paths, embedding_directory=None, clip_type=CLIPType.STABLE_DIFFUSION, model_options=None, disable_dynamic=False):
+    if model_options is None:
+        model_options = {}
     clip = load_clip(ckpt_paths, embedding_directory, clip_type, model_options, disable_dynamic)
     return clip.patcher
 
-def load_clip(ckpt_paths, embedding_directory=None, clip_type=CLIPType.STABLE_DIFFUSION, model_options={}, disable_dynamic=False):
+def load_clip(ckpt_paths, embedding_directory=None, clip_type=CLIPType.STABLE_DIFFUSION, model_options=None, disable_dynamic=False):
+    if model_options is None:
+        model_options = {}
     clip_data = []
     for p in ckpt_paths:
         sd, metadata = comfy.utils.load_torch_file(p, safe_load=True, return_metadata=True)
@@ -1284,7 +1298,11 @@ def llama_detect(clip_data):
 
     return {}
 
-def load_text_encoder_state_dicts(state_dicts=[], embedding_directory=None, clip_type=CLIPType.STABLE_DIFFUSION, model_options={}, disable_dynamic=False):
+def load_text_encoder_state_dicts(state_dicts=None, embedding_directory=None, clip_type=CLIPType.STABLE_DIFFUSION, model_options=None, disable_dynamic=False):
+    if state_dicts is None:
+        state_dicts = []
+    if model_options is None:
+        model_options = {}
     clip_data = state_dicts
 
     class EmptyClass:
@@ -1544,7 +1562,11 @@ def load_checkpoint(config_path=None, ckpt_path=None, output_vae=True, output_cl
 
     return (model, clip, vae)
 
-def load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True, model_options={}, te_model_options={}, disable_dynamic=False):
+def load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True, model_options=None, te_model_options=None, disable_dynamic=False):
+    if model_options is None:
+        model_options = {}
+    if te_model_options is None:
+        te_model_options = {}
     sd, metadata = comfy.utils.load_torch_file(ckpt_path, return_metadata=True)
     out = load_state_dict_guess_config(sd, output_vae, output_clip, output_clipvision, embedding_directory, output_model, model_options, te_model_options=te_model_options, metadata=metadata, disable_dynamic=disable_dynamic)
     if out is None:
@@ -1555,7 +1577,11 @@ def load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, o
         out[1].patcher.cached_patcher_init = (load_checkpoint_guess_config_clip_only, (ckpt_path, embedding_directory, model_options, te_model_options))
     return out
 
-def load_checkpoint_guess_config_model_only(ckpt_path, embedding_directory=None, model_options={}, te_model_options={}, disable_dynamic=False):
+def load_checkpoint_guess_config_model_only(ckpt_path, embedding_directory=None, model_options=None, te_model_options=None, disable_dynamic=False):
+    if model_options is None:
+        model_options = {}
+    if te_model_options is None:
+        te_model_options = {}
     model, *_ = load_checkpoint_guess_config(ckpt_path, False, False, False,
             embedding_directory=embedding_directory,
             model_options=model_options,
@@ -1563,7 +1589,11 @@ def load_checkpoint_guess_config_model_only(ckpt_path, embedding_directory=None,
             disable_dynamic=disable_dynamic)
     return model
 
-def load_checkpoint_guess_config_clip_only(ckpt_path, embedding_directory=None, model_options={}, te_model_options={}, disable_dynamic=False):
+def load_checkpoint_guess_config_clip_only(ckpt_path, embedding_directory=None, model_options=None, te_model_options=None, disable_dynamic=False):
+    if model_options is None:
+        model_options = {}
+    if te_model_options is None:
+        te_model_options = {}
     _, clip, *_ = load_checkpoint_guess_config(ckpt_path, False, True, False,
             embedding_directory=embedding_directory, output_model=False,
             model_options=model_options,
@@ -1571,7 +1601,11 @@ def load_checkpoint_guess_config_clip_only(ckpt_path, embedding_directory=None, 
             disable_dynamic=disable_dynamic)
     return clip.patcher
 
-def load_state_dict_guess_config(sd, output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True, model_options={}, te_model_options={}, metadata=None, disable_dynamic=False):
+def load_state_dict_guess_config(sd, output_vae=True, output_clip=True, output_clipvision=False, embedding_directory=None, output_model=True, model_options=None, te_model_options=None, metadata=None, disable_dynamic=False):
+    if model_options is None:
+        model_options = {}
+    if te_model_options is None:
+        te_model_options = {}
     clip = None
     clipvision = None
     vae = None
@@ -1672,7 +1706,9 @@ def load_state_dict_guess_config(sd, output_vae=True, output_clip=True, output_c
     return (model_patcher, clip, vae, clipvision)
 
 
-def load_diffusion_model_state_dict(sd, model_options={}, metadata=None, disable_dynamic=False):
+def load_diffusion_model_state_dict(sd, model_options=None, metadata=None, disable_dynamic=False):
+    if model_options is None:
+        model_options = {}
     """
     Loads a UNet diffusion model from a state dictionary, supporting both diffusers and regular formats.
 
@@ -1766,7 +1802,9 @@ def load_diffusion_model_state_dict(sd, model_options={}, metadata=None, disable
         logging.info("left over keys in diffusion model: {}".format(left_over))
     return model_patcher
 
-def load_diffusion_model(unet_path, model_options={}, disable_dynamic=False):
+def load_diffusion_model(unet_path, model_options=None, disable_dynamic=False):
+    if model_options is None:
+        model_options = {}
     sd, metadata = comfy.utils.load_torch_file(unet_path, return_metadata=True)
     model = load_diffusion_model_state_dict(sd, model_options=model_options, metadata=metadata, disable_dynamic=disable_dynamic)
     if model is None:
@@ -1783,7 +1821,9 @@ def load_unet_state_dict(sd, dtype=None):
     logging.warning("The load_unet_state_dict function has been deprecated and will be removed please switch to: load_diffusion_model_state_dict")
     return load_diffusion_model_state_dict(sd, model_options={"dtype": dtype})
 
-def save_checkpoint(output_path, model, clip=None, vae=None, clip_vision=None, metadata=None, extra_keys={}):
+def save_checkpoint(output_path, model, clip=None, vae=None, clip_vision=None, metadata=None, extra_keys=None):
+    if extra_keys is None:
+        extra_keys = {}
     clip_sd = None
     load_models = [model]
     if clip is not None:

--- a/comfy/sd1_clip.py
+++ b/comfy/sd1_clip.py
@@ -484,7 +484,11 @@ def load_embed(embedding_name, embedding_directory, embedding_size, embed_key=No
     return embed_out
 
 class SDTokenizer:
-    def __init__(self, tokenizer_path=None, max_length=77, pad_with_end=True, embedding_directory=None, embedding_size=768, embedding_key='clip_l', tokenizer_class=CLIPTokenizer, has_start_token=True, has_end_token=True, pad_to_max_length=True, min_length=None, pad_token=None, end_token=None, start_token=None, min_padding=None, pad_left=False, disable_weights=False, tokenizer_data={}, tokenizer_args={}):
+    def __init__(self, tokenizer_path=None, max_length=77, pad_with_end=True, embedding_directory=None, embedding_size=768, embedding_key='clip_l', tokenizer_class=CLIPTokenizer, has_start_token=True, has_end_token=True, pad_to_max_length=True, min_length=None, pad_token=None, end_token=None, start_token=None, min_padding=None, pad_left=False, disable_weights=False, tokenizer_data=None, tokenizer_args=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
+        if tokenizer_args is None:
+            tokenizer_args = {}
         if tokenizer_path is None:
             tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "sd1_tokenizer")
         self.tokenizer = tokenizer_class.from_pretrained(tokenizer_path, **tokenizer_args)
@@ -563,7 +567,9 @@ class SDTokenizer:
         else:
             tokens.extend([(self.pad_token, 1.0, 0)] * amount)
 
-    def tokenize_with_weights(self, text:str, return_word_ids=False, tokenizer_options={}, **kwargs):
+    def tokenize_with_weights(self, text:str, return_word_ids=False, tokenizer_options=None, **kwargs):
+        if tokenizer_options is None:
+            tokenizer_options = {}
         '''
         Takes a prompt and converts it to a list of (token, weight, word id) elements.
         Tokens can both be integer tokens and pre computed CLIP tensors.
@@ -678,7 +684,9 @@ class SDTokenizer:
         return self.tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
 
 class SD1Tokenizer:
-    def __init__(self, embedding_directory=None, tokenizer_data={}, clip_name="l", tokenizer=SDTokenizer, name=None):
+    def __init__(self, embedding_directory=None, tokenizer_data=None, clip_name="l", tokenizer=SDTokenizer, name=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         if name is not None:
             self.clip_name = name
             self.clip = "{}".format(self.clip_name)
@@ -704,11 +712,15 @@ class SD1Tokenizer:
         return getattr(self, self.clip).decode(token_ids, skip_special_tokens=skip_special_tokens)
 
 class SD1CheckpointClipModel(SDClipModel):
-    def __init__(self, device="cpu", dtype=None, model_options={}):
+    def __init__(self, device="cpu", dtype=None, model_options=None):
+        if model_options is None:
+            model_options = {}
         super().__init__(device=device, return_projected_pooled=False, dtype=dtype, model_options=model_options)
 
 class SD1ClipModel(torch.nn.Module):
-    def __init__(self, device="cpu", dtype=None, model_options={}, clip_name="l", clip_model=SD1CheckpointClipModel, name=None, **kwargs):
+    def __init__(self, device="cpu", dtype=None, model_options=None, clip_name="l", clip_model=SD1CheckpointClipModel, name=None, **kwargs):
+        if model_options is None:
+            model_options = {}
         super().__init__()
 
         if name is not None:

--- a/comfy/text_encoders/flux.py
+++ b/comfy/text_encoders/flux.py
@@ -10,13 +10,17 @@ import json
 import base64
 
 class T5XXLTokenizer(sd1_clip.SDTokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "t5_tokenizer")
         super().__init__(tokenizer_path, embedding_directory=embedding_directory, pad_with_end=False, embedding_size=4096, embedding_key='t5xxl', tokenizer_class=T5TokenizerFast, has_start_token=False, pad_to_max_length=False, max_length=99999999, min_length=256, tokenizer_data=tokenizer_data)
 
 
 class FluxTokenizer:
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         self.clip_l = sd1_clip.SDTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
         self.t5xxl = T5XXLTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
 
@@ -34,7 +38,9 @@ class FluxTokenizer:
 
 
 class FluxClipModel(torch.nn.Module):
-    def __init__(self, dtype_t5=None, device="cpu", dtype=None, model_options={}):
+    def __init__(self, dtype_t5=None, device="cpu", dtype=None, model_options=None):
+        if model_options is None:
+            model_options = {}
         super().__init__()
         dtype_t5 = comfy.model_management.pick_weight_dtype(dtype_t5, dtype, device)
         self.clip_l = sd1_clip.SDClipModel(device=device, dtype=dtype, return_projected_pooled=False, model_options=model_options)
@@ -65,7 +71,9 @@ class FluxClipModel(torch.nn.Module):
 
 def flux_clip(dtype_t5=None, t5_quantization_metadata=None):
     class FluxClipModel_(FluxClipModel):
-        def __init__(self, device="cpu", dtype=None, model_options={}):
+        def __init__(self, device="cpu", dtype=None, model_options=None):
+            if model_options is None:
+                model_options = {}
             if t5_quantization_metadata is not None:
                 model_options = model_options.copy()
                 model_options["t5xxl_quantization_metadata"] = t5_quantization_metadata
@@ -116,7 +124,9 @@ class MistralTokenizerClass:
         return LlamaTokenizerFast(**kwargs)
 
 class Mistral3Tokenizer(sd1_clip.SDTokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         self.tekken_data = tokenizer_data.get("tekken_model", None)
         super().__init__("", pad_with_end=False, embedding_directory=embedding_directory, embedding_size=5120, embedding_key='mistral3_24b', tokenizer_class=MistralTokenizerClass, has_end_token=False, pad_to_max_length=False, pad_token=11, start_token=1, max_length=99999999, min_length=1, pad_left=True, tokenizer_args=load_mistral_tokenizer(self.tekken_data), tokenizer_data=tokenizer_data)
 
@@ -124,7 +134,9 @@ class Mistral3Tokenizer(sd1_clip.SDTokenizer):
         return {"tekken_model": self.tekken_data}
 
 class Flux2Tokenizer(sd1_clip.SD1Tokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         super().__init__(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data, name="mistral3_24b", tokenizer=Mistral3Tokenizer)
         self.llama_template = '[SYSTEM_PROMPT]You are an AI that reasons about image descriptions. You give structured responses focusing on object relationships, object\nattribution and actions without speculation.[/SYSTEM_PROMPT][INST]{}[/INST]'
 
@@ -138,7 +150,9 @@ class Flux2Tokenizer(sd1_clip.SD1Tokenizer):
         return tokens
 
 class Mistral3_24BModel(sd1_clip.SDClipModel):
-    def __init__(self, device="cpu", layer=[10, 20, 30], layer_idx=None, dtype=None, attention_mask=True, model_options={}):
+    def __init__(self, device="cpu", layer=[10, 20, 30], layer_idx=None, dtype=None, attention_mask=True, model_options=None):
+        if model_options is None:
+            model_options = {}
         textmodel_json_config = {}
         num_layers = model_options.get("num_layers", None)
         if num_layers is not None:
@@ -148,7 +162,9 @@ class Mistral3_24BModel(sd1_clip.SDClipModel):
         super().__init__(device=device, layer=layer, layer_idx=layer_idx, textmodel_json_config=textmodel_json_config, dtype=dtype, special_tokens={"start": 1, "pad": 0}, layer_norm_hidden_state=False, model_class=comfy.text_encoders.llama.Mistral3Small24B, enable_attention_masks=attention_mask, return_attention_masks=attention_mask, model_options=model_options)
 
 class Flux2TEModel(sd1_clip.SD1ClipModel):
-    def __init__(self, device="cpu", dtype=None, model_options={}, name="mistral3_24b", clip_model=Mistral3_24BModel):
+    def __init__(self, device="cpu", dtype=None, model_options=None, name="mistral3_24b", clip_model=Mistral3_24BModel):
+        if model_options is None:
+            model_options = {}
         super().__init__(device=device, dtype=dtype, name=name, clip_model=clip_model, model_options=model_options)
 
     def encode_token_weights(self, token_weight_pairs):
@@ -161,7 +177,9 @@ class Flux2TEModel(sd1_clip.SD1ClipModel):
 
 def flux2_te(dtype_llama=None, llama_quantization_metadata=None, pruned=False):
     class Flux2TEModel_(Flux2TEModel):
-        def __init__(self, device="cpu", dtype=None, model_options={}):
+        def __init__(self, device="cpu", dtype=None, model_options=None):
+            if model_options is None:
+                model_options = {}
             if dtype_llama is not None:
                 dtype = dtype_llama
             if llama_quantization_metadata is not None:
@@ -174,17 +192,23 @@ def flux2_te(dtype_llama=None, llama_quantization_metadata=None, pruned=False):
     return Flux2TEModel_
 
 class Qwen3Tokenizer(sd1_clip.SDTokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "qwen25_tokenizer")
         super().__init__(tokenizer_path, pad_with_end=False, embedding_directory=embedding_directory, embedding_size=2560, embedding_key='qwen3_4b', tokenizer_class=Qwen2Tokenizer, has_start_token=False, has_end_token=False, pad_to_max_length=False, max_length=99999999, min_length=512, pad_token=151643, tokenizer_data=tokenizer_data)
 
 class Qwen3Tokenizer8B(sd1_clip.SDTokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "qwen25_tokenizer")
         super().__init__(tokenizer_path, pad_with_end=False, embedding_directory=embedding_directory, embedding_size=4096, embedding_key='qwen3_8b', tokenizer_class=Qwen2Tokenizer, has_start_token=False, has_end_token=False, pad_to_max_length=False, max_length=99999999, min_length=512, pad_token=151643, tokenizer_data=tokenizer_data)
 
 class KleinTokenizer(sd1_clip.SD1Tokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}, name="qwen3_4b"):
+    def __init__(self, embedding_directory=None, tokenizer_data=None, name="qwen3_4b"):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         if name == "qwen3_4b":
             tokenizer = Qwen3Tokenizer
         elif name == "qwen3_8b":
@@ -203,15 +227,21 @@ class KleinTokenizer(sd1_clip.SD1Tokenizer):
         return tokens
 
 class KleinTokenizer8B(KleinTokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}, name="qwen3_8b"):
+    def __init__(self, embedding_directory=None, tokenizer_data=None, name="qwen3_8b"):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         super().__init__(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data, name=name)
 
 class Qwen3_4BModel(sd1_clip.SDClipModel):
-    def __init__(self, device="cpu", layer=[9, 18, 27], layer_idx=None, dtype=None, attention_mask=True, model_options={}):
+    def __init__(self, device="cpu", layer=[9, 18, 27], layer_idx=None, dtype=None, attention_mask=True, model_options=None):
+        if model_options is None:
+            model_options = {}
         super().__init__(device=device, layer=layer, layer_idx=layer_idx, textmodel_json_config={}, dtype=dtype, special_tokens={"pad": 151643}, layer_norm_hidden_state=False, model_class=comfy.text_encoders.llama.Qwen3_4B, enable_attention_masks=attention_mask, return_attention_masks=attention_mask, model_options=model_options)
 
 class Qwen3_8BModel(sd1_clip.SDClipModel):
-    def __init__(self, device="cpu", layer=[9, 18, 27], layer_idx=None, dtype=None, attention_mask=True, model_options={}):
+    def __init__(self, device="cpu", layer=[9, 18, 27], layer_idx=None, dtype=None, attention_mask=True, model_options=None):
+        if model_options is None:
+            model_options = {}
         super().__init__(device=device, layer=layer, layer_idx=layer_idx, textmodel_json_config={}, dtype=dtype, special_tokens={"pad": 151643}, layer_norm_hidden_state=False, model_class=comfy.text_encoders.llama.Qwen3_8B, enable_attention_masks=attention_mask, return_attention_masks=attention_mask, model_options=model_options)
 
 def klein_te(dtype_llama=None, llama_quantization_metadata=None, model_type="qwen3_4b"):
@@ -221,7 +251,9 @@ def klein_te(dtype_llama=None, llama_quantization_metadata=None, model_type="qwe
         model = Qwen3_8BModel
 
     class Flux2TEModel_(Flux2TEModel):
-        def __init__(self, device="cpu", dtype=None, model_options={}):
+        def __init__(self, device="cpu", dtype=None, model_options=None):
+            if model_options is None:
+                model_options = {}
             if llama_quantization_metadata is not None:
                 model_options = model_options.copy()
                 model_options["quantization_metadata"] = llama_quantization_metadata

--- a/comfy/text_encoders/sd3_clip.py
+++ b/comfy/text_encoders/sd3_clip.py
@@ -9,7 +9,9 @@ import logging
 import comfy.utils
 
 class T5XXLModel(sd1_clip.SDClipModel):
-    def __init__(self, device="cpu", layer="last", layer_idx=None, dtype=None, attention_mask=False, model_options={}):
+    def __init__(self, device="cpu", layer="last", layer_idx=None, dtype=None, attention_mask=False, model_options=None):
+        if model_options is None:
+            model_options = {}
         textmodel_json_config = os.path.join(os.path.dirname(os.path.realpath(__file__)), "t5_config_xxl.json")
         t5xxl_quantization_metadata = model_options.get("t5xxl_quantization_metadata", None)
         if t5xxl_quantization_metadata is not None:
@@ -33,13 +35,17 @@ def t5_xxl_detect(state_dict, prefix=""):
     return out
 
 class T5XXLTokenizer(sd1_clip.SDTokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}, min_length=77, max_length=99999999):
+    def __init__(self, embedding_directory=None, tokenizer_data=None, min_length=77, max_length=99999999):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         tokenizer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "t5_tokenizer")
         super().__init__(tokenizer_path, embedding_directory=embedding_directory, pad_with_end=False, embedding_size=4096, embedding_key='t5xxl', tokenizer_class=T5TokenizerFast, has_start_token=False, pad_to_max_length=False, max_length=max_length, min_length=min_length, tokenizer_data=tokenizer_data)
 
 
 class SD3Tokenizer:
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         self.clip_l = sd1_clip.SDTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
         self.clip_g = sdxl_clip.SDXLClipGTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
         self.t5xxl = T5XXLTokenizer(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data)
@@ -58,7 +64,9 @@ class SD3Tokenizer:
         return {}
 
 class SD3ClipModel(torch.nn.Module):
-    def __init__(self, clip_l=True, clip_g=True, t5=True, dtype_t5=None, t5_attention_mask=False, device="cpu", dtype=None, model_options={}):
+    def __init__(self, clip_l=True, clip_g=True, t5=True, dtype_t5=None, t5_attention_mask=False, device="cpu", dtype=None, model_options=None):
+        if model_options is None:
+            model_options = {}
         super().__init__()
         self.dtypes = set()
         if clip_l:
@@ -159,7 +167,9 @@ class SD3ClipModel(torch.nn.Module):
 
 def sd3_clip(clip_l=True, clip_g=True, t5=True, dtype_t5=None, t5_quantization_metadata=None, t5_attention_mask=False):
     class SD3ClipModel_(SD3ClipModel):
-        def __init__(self, device="cpu", dtype=None, model_options={}):
+        def __init__(self, device="cpu", dtype=None, model_options=None):
+            if model_options is None:
+                model_options = {}
             if t5_quantization_metadata is not None:
                 model_options = model_options.copy()
                 model_options["t5xxl_quantization_metadata"] = t5_quantization_metadata

--- a/comfy/text_encoders/wan.py
+++ b/comfy/text_encoders/wan.py
@@ -4,12 +4,16 @@ import comfy.text_encoders.t5
 import os
 
 class UMT5XXlModel(sd1_clip.SDClipModel):
-    def __init__(self, device="cpu", layer="last", layer_idx=None, dtype=None, model_options={}):
+    def __init__(self, device="cpu", layer="last", layer_idx=None, dtype=None, model_options=None):
+        if model_options is None:
+            model_options = {}
         textmodel_json_config = os.path.join(os.path.dirname(os.path.realpath(__file__)), "umt5_config_xxl.json")
         super().__init__(device=device, layer=layer, layer_idx=layer_idx, textmodel_json_config=textmodel_json_config, dtype=dtype, special_tokens={"end": 1, "pad": 0}, model_class=comfy.text_encoders.t5.T5, enable_attention_masks=True, zero_out_masked=True, model_options=model_options)
 
 class UMT5XXlTokenizer(sd1_clip.SDTokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         tokenizer = tokenizer_data.get("spiece_model", None)
         super().__init__(tokenizer, pad_with_end=False, embedding_size=4096, embedding_key='umt5xxl', tokenizer_class=SPieceTokenizer, has_start_token=False, pad_to_max_length=False, max_length=99999999, min_length=512, pad_token=0, tokenizer_data=tokenizer_data)
 
@@ -18,16 +22,22 @@ class UMT5XXlTokenizer(sd1_clip.SDTokenizer):
 
 
 class WanT5Tokenizer(sd1_clip.SD1Tokenizer):
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
+        if tokenizer_data is None:
+            tokenizer_data = {}
         super().__init__(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data, clip_name="umt5xxl", tokenizer=UMT5XXlTokenizer)
 
 class WanT5Model(sd1_clip.SD1ClipModel):
-    def __init__(self, device="cpu", dtype=None, model_options={}, **kwargs):
+    def __init__(self, device="cpu", dtype=None, model_options=None, **kwargs):
+        if model_options is None:
+            model_options = {}
         super().__init__(device=device, dtype=dtype, model_options=model_options, name="umt5xxl", clip_model=UMT5XXlModel, **kwargs)
 
 def te(dtype_t5=None, t5_quantization_metadata=None):
     class WanTEModel(WanT5Model):
-        def __init__(self, device="cpu", dtype=None, model_options={}):
+        def __init__(self, device="cpu", dtype=None, model_options=None):
+            if model_options is None:
+                model_options = {}
             if t5_quantization_metadata is not None:
                 model_options = model_options.copy()
                 model_options["quantization_metadata"] = t5_quantization_metadata


### PR DESCRIPTION
Fixes #11657. Replace mutable default arguments (`{}`, `[]`) with `None` in function signatures to prevent state pollution across multiple model loads.

This fixes a bug where settings like `quantization_metadata` from a previously loaded model leak into subsequent loads, causing incorrect behavior when loading different model types sequentially.

Changes:
- `comfy/sd.py`: Fix mutable defaults in CLIP, load_clip, load_text_encoder_state_dicts, load_checkpoint_guess_config, load_diffusion_model_state_dict, load_diffusion_model, save_checkpoint
- `comfy/sd1_clip.py`: Fix mutable defaults in SDTokenizer, SD1Tokenizer, SD1CheckpointClipModel, SD1ClipModel
- `comfy/text_encoders/flux.py`: Fix mutable defaults in T5XXLTokenizer, FluxTokenizer, FluxClipModel, Mistral3Tokenizer, Flux2Tokenizer, Qwen3Tokenizer, KleinTokenizer
- `comfy/text_encoders/sd3_clip.py`: Fix mutable defaults in T5XXLModel, T5XXLTokenizer, SD3Tokenizer, SD3ClipModel
- `comfy/text_encoders/wan.py`: Fix mutable defaults in UMT5XXlModel, UMT5XXlTokenizer, WanT5Tokenizer, WanT5Model