### PR TITLE
mm: reset_cast_buffers: sync compute stream before free

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1148,6 +1148,7 @@ def reset_cast_buffers():
     LARGEST_CASTED_WEIGHT = (None, 0)
     for offload_stream in STREAM_CAST_BUFFERS:
         offload_stream.synchronize()
+    synchronize()
     STREAM_CAST_BUFFERS.clear()
     soft_empty_cache()
 


### PR DESCRIPTION
Sync the compute stream before freeing the cast buffers. This can cause use after free issues when the cast stream frees the buffer while the compute stream is behind enough to still needs a casted weight.

No reproducer but the theory is behind it. Incidental find in debugging.

Regression tests:

RTX5090, Linux
LTX2.3 x16 back to back runs :white_check_mark: 
ACE 1.5 195s :white_check_mark: 
Flux2 :white_check_mark: 