### PR TITLE
comfy-aimdo 0.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy
 filelock
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.2.7
+comfy-aimdo>=0.2.9
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
Comfy-aimdo 0.2.9 fixes a context issue where if a non-main thread does a spurious garbage collection, cudaFrees are attempted with bad context.

Some new APIs for displaying aimdo stats in UI widgets are also added. These are purely additive getters that dont touch cuda APIs.

Example Test Conditions:

LTX VAE workflow B=17, Encode->Decode->encode-Decode

<img width="1434" height="726" alt="image" src="https://github.com/user-attachments/assets/3c9b1390-f567-4c99-a507-80f6cf8d2841" />


Apply this extra change to create chaos agent (emulating custom node behaviour):

```
 from comfy_api import feature_flags
 from app.database.db import init_db, dependencies_available
 
+import gc
+import asyncio
+import threading
+
+async def _evil_gc_loop():
+    while True:
+        gc.collect()
+        time.sleep(0.5)
+
+threading.Thread(target=lambda: asyncio.run(_evil_gc_loop()), daemon=True).start()
+
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI, they are for custom nodes.
     os.environ['HF_HUB_DISABLE_TELEMETRY'] = '1'
```

Before:

```
AE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
no CLIP/text encoder weights in checkpoint, the text encoder model will not be loaded.
Requested to load VideoVAE
Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
terminate called after throwing an instance of 'c10::AcceleratorError'
  what():  CUDA error: invalid device context
Search for `cudaErrorDeviceUninitialized' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.

Exception raised from c10_cuda_check_implementation at /pytorch/c10/cuda/CUDAException.cpp:44 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x772f4857cb80 in /home/rattus/venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0x11fb7 (0x772f48966fb7 in /home/rattus/venv/lib/python3.12/site-packages/torch/lib/libc10_cuda.so)
frame #2: <unknown function> + 0x5b639 (0x772f489b0639 in /home/rattus/venv/lib/python3.12/site-packages/torch/lib/libc10_cuda.so)
frame #3: <unknown function> + 0x5c0e4 (0x772f489b10e4 in /home/rattus/venv/lib/python3.12/site-packages/torch/lib/libc10_cuda.so)
frame #4: <unknown function> + 0x4827af (0x772f302827af in /home/rattus/venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #5: c10::TensorImpl::~TensorImpl() + 0x9 (0x772f48559d69 in /home/rattus/venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #6: <unknown function> + 0x7cb658 (0x772f305cb658 in /home/rattus/venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #7: <unknown function> + 0x7cb6c5 (0x772f305cb6c5 in /home/rattus/venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #8: /home/rattus/venv/bin/python() [0x61ce2d]
```

After:

```
Requested to load VideoVAE
Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
Prompt executed in 4.73 seconds
```

Regression Tests:

Linux, RTX5090, 96GB, LTX2.3 720P :white_check_mark: 
Linux, RTX5090, 2GHZ CPU, Ace step 1.5, 195S :white_check_mark: 
Windows, RTX5060, 32GB, LTX2 720P :white_check_mark: 
Windows, RTX5060, 32GB, WAN 2.2 2x14B FP16 320x320x81f :white_check_mark: 
Windows, RTX5060, 32GB, SDXL :white_check_mark: 

