### PR TITLE
model_detection: deep clone pre edited weights

### DIFF
--- a/comfy/model_detection.py
+++ b/comfy/model_detection.py
@@ -1,4 +1,5 @@
 import json
+import comfy.memory_management
 import comfy.supported_models
 import comfy.supported_models_base
 import comfy.utils
@@ -1118,8 +1119,13 @@ def convert_diffusers_mmdit(state_dict, output_prefix=""):
                         new[:old_weight.shape[0]] = old_weight
                         old_weight = new
 
+                    if old_weight is out_sd.get(t[0], None) and comfy.memory_management.aimdo_enabled:
+                        old_weight = old_weight.clone()
+
                     w = old_weight.narrow(offset[0], offset[1], offset[2])
                 else:
+                    if comfy.memory_management.aimdo_enabled:
+                        weight = weight.clone()
                     old_weight = weight
                     w = weight
                 w[:] = fun(weight)


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/12854
https://github.com/Comfy-Org/ComfyUI/issues/12856

Deep clone these weights as needed to avoid segfaulting when it tries to touch the original mmap.

Example Test conditions:

RTX5090, Linux
Flux2 Fill OneReward: https://huggingface.co/yichengup/flux.1-fill-dev-OneReward/blob/main/unet_fp16.safetensors

<img width="2325" height="865" alt="image" src="https://github.com/user-attachments/assets/02d354b7-95db-495c-95ef-e8d0c0bf0da0" />

Before:

```
Model FluxClipModel_ prepared for dynamic VRAM loading. 9318MB Staged. 0 patches attached. Force pre-loaded 49 weights: 392 KB.
Model FluxClipModel_ prepared for dynamic VRAM loading. 9318MB Staged. 0 patches attached. Force pre-loaded 49 weights: 392 KB.
Requested to load AutoencodingEngine
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
./run.sh: line 18: 10107 Segmentation fault      (core dumped) $(which python) ${HOME}/ComfyUI/main.py --listen 0.0.0.0 --base-directory ${HOME}/comfy-base $@
```

After:

```
model_type FLUX
Requested to load Flux
Model Flux prepared for dynamic VRAM loading. 22702MB Staged. 0 patches attached.
100%|██████████| 20/20 [00:07<00:00,  2.85it/s]                                  
0 models unloaded.
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Prompt executed in 13.46 seconds
```

<img width="408" height="691" alt="image" src="https://github.com/user-attachments/assets/f4723eb0-89f3-4c79-b0f1-ea93cc2aabfb" />

RAM utilization with --disable-dynamic-vram (process allocates full model and deep copy):

```
model_type FLUX
Requested to load Flux
Unloaded partially: 5868.23 MB freed, 3451.00 MB remains loaded, 400.00 MB buffer reserved, lowvram patches: 0
loaded completely; 26396.32 MB usable, 22702.01 MB loaded, full load: True
100%|██████████| 20/20 [00:07<00:00,  2.74it/s]
Requested to load AutoencodingEngine
loaded completely; 352.08 MB usable, 159.87 MB loaded, full load: True
Prompt executed in 27.93 seconds
```

<img width="624" height="710" alt="image" src="https://github.com/user-attachments/assets/872d05ab-d49b-4644-ba30-ef7409d1f5ba" />


Regression Tests:
5090, Linux, LTX2 :white_check_mark: 
