### PR TITLE
main: switch on python faulthandler

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from app.logger import setup_logger
 import itertools
 import utils.extra_config
 from utils.mime_types import init_mime_types
+import faulthandler
 import logging
 import sys
 from comfy_execution.progress import get_progress_state
@@ -24,6 +25,8 @@ if __name__ == "__main__":
     os.environ['DO_NOT_TRACK'] = '1'
 
 setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
+
+faulthandler.enable(file=sys.stderr, all_threads=False)
 
 import comfy_aimdo.control
 


### PR DESCRIPTION
When we get segfault bug reports we don't get much. Switch on pythons inbuilt tracer for segfault.

This apparently will also backtrace the nasty torch C++ unhandled exceptions as readable python backtraces as it handles SIGABRT.

Example test conditions:

RTX5090, Linux
Flux2 Fill OneReward: https://huggingface.co/yichengup/flux.1-fill-dev-OneReward/blob/main/unet_fp16.safetensors
This PR reverted (to induce a segfault): https://github.com/Comfy-Org/ComfyUI/pull/12862

<img width="2277" height="861" alt="image" src="https://github.com/user-attachments/assets/9f000fbc-c2fe-4ae2-83ae-1b19ee1067c5" />


before:

```
Requested to load AutoencodingEngine
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
./run.sh: line 18: 16729 Segmentation fault      (core dumped) $(which python) ${HOME}/ComfyUI/main.py --listen 0.0.0.0 --base-directory ${HOME}/comfy-base $@
```

After (it poinpoints the exact root cause line in python for reverted PR^^):

```
Requested to load AutoencodingEngine
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Fatal Python error: Segmentation fault

Stack (most recent call first):
  File "/home/rattus/ComfyUI/comfy/model_detection.py", line 1125 in convert_diffusers_mmdit
  File "/home/rattus/ComfyUI/comfy/sd.py", line 1717 in load_diffusion_model_state_dict
  File "/home/rattus/ComfyUI/comfy/sd.py", line 1771 in load_diffusion_model
  File "/home/rattus/ComfyUI/nodes.py", line 972 in load_unet
  File "/home/rattus/ComfyUI/execution.py", line 295 in process_inputs
  File "/home/rattus/ComfyUI/execution.py", line 307 in _async_map_node_over_list
  File "/home/rattus/ComfyUI/execution.py", line 333 in get_output_data
  File "/home/rattus/ComfyUI/execution.py", line 524 in execute
  File "/home/rattus/ComfyUI/execution.py", line 737 in execute_async
  File "/usr/lib/python3.12/asyncio/events.py", line 88 in _run
  File "/usr/lib/python3.12/asyncio/base_events.py", line 1987 in _run_once
  File "/usr/lib/python3.12/asyncio/base_events.py", line 641 in run_forever
  File "/usr/lib/python3.12/asyncio/base_events.py", line 674 in run_until_complete
  File "/usr/lib/python3.12/asyncio/runners.py", line 118 in run
  File "/usr/lib/python3.12/asyncio/runners.py", line 194 in run
  File "/home/rattus/ComfyUI/execution.py", line 688 in execute
  File "/home/rattus/ComfyUI/main.py", line 269 in prompt_worker
  File "/usr/lib/python3.12/threading.py", line 1010 in run
  File "/usr/lib/python3.12/threading.py", line 1073 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1030 in _bootstrap

Extension modules: yaml._yaml, PIL._imaging, sqlalchemy.cyextension.collections, sqlalchemy.cyextension.immutabledict, sqlalchemy.cyextension.processors, sqlalchemy.cyextension.resultproxy, sqlalchemy.cyextension.util, greenlet._greenlet, markupsafe._speedups, numpy._core._multiarray_umath, numpy.linalg._umath_linalg, torch._C, torch._C._dynamo.autograd_compiler, torch._C._dynamo.eval_frame, torch._C._dynamo.guards, torch._C._dynamo.utils, torch._C._fft, torch._C._linalg, torch._C._nested, torch._C._nn, torch._C._sparse, torch._C._special, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._pcg64, numpy.random._generator, numpy.random._mt19937, numpy.random._philox, numpy.random._sfc64, numpy.random.mtrand, psutil._psutil_linux, PIL._imagingft, av._core, av.logging, av.bytesource, av.buffer, av.audio.format, av.error, av.dictionary, av.container.pyio, av.option, av.descriptor, av.format, av.utils, av.stream, av.container.streams, av.sidedata.motionvectors, av.sidedata.sidedata, av.opaque, av.packet, av.container.input, av.container.output, av.container.core, av.codec.context, av.video.format, av.video.reformatter, av.plane, av.video.plane, av.video.frame, av.video.stream, av.codec.hwaccel, av.codec.codec, av.frame, av.audio.layout, av.audio.plane, av.audio.frame, av.audio.stream, av.filter.link, av.filter.context, av.filter.graph, av.filter.filter, av.filter.loudnorm, av.audio.resampler, av.audio.codeccontext, av.audio.fifo, av.bitstream, av.video.codeccontext, scipy._lib._ccallback_c, charset_normalizer.md, scipy.ndimage._nd_image, scipy.ndimage._rank_filter_1d, scipy.special._ufuncs_cxx, scipy.special._ellip_harm_2, scipy.special._special_ufuncs, scipy.special._gufuncs, scipy.special._ufuncs, scipy.special._specfun, scipy.special._comb, scipy.linalg._fblas, scipy.linalg._flapack, _cyutility, scipy._cyutility, scipy.linalg.cython_lapack, scipy.linalg._cythonized_array_utils, scipy.linalg._solve_toeplitz, scipy.linalg._decomp_lu_cython, scipy.linalg._matfuncs_schur_sqrtm, scipy.linalg._matfuncs_expm, scipy.linalg._linalg_pythran, scipy.linalg.cython_blas, scipy.linalg._decomp_update, scipy.sparse._sparsetools, _csparsetools, scipy.sparse._csparsetools, _ni_label, scipy.ndimage._ni_label, chardet.models, chardet.pipeline.escape, chardet.pipeline.statistical, chardet.pipeline.structural, chardet.pipeline.utf8, chardet.pipeline.utf1632, chardet.pipeline.validity, requests.packages.chardet.models, requests.packages.chardet.pipeline.escape, requests.packages.chardet.pipeline.statistical, requests.packages.chardet.pipeline.structural, requests.packages.chardet.pipeline.utf8, requests.packages.chardet.pipeline.utf1632, requests.packages.chardet.pipeline.validity, regex._regex, sentencepiece._sentencepiece, scipy.integrate._odepack, scipy.integrate._quadpack, scipy.integrate._vode, scipy.integrate._dop, scipy.integrate._lsoda, scipy.sparse.linalg._dsolve._superlu, scipy.sparse.linalg._eigen.arpack._arpack, scipy.sparse.linalg._propack._spropack, scipy.sparse.linalg._propack._dpropack, scipy.sparse.linalg._propack._cpropack, scipy.sparse.linalg._propack._zpropack, scipy.optimize._group_columns, scipy._lib.messagestream, scipy.optimize._trlib._trlib, scipy.optimize._lbfgsb, _moduleTNC, scipy.optimize._moduleTNC, scipy.optimize._slsqplib, scipy.optimize._minpack, scipy.optimize._lsq.givens_elimination, scipy.optimize._zeros, scipy._lib._uarray._uarray, scipy.linalg._decomp_interpolative, scipy.optimize._bglu_dense, scipy.optimize._lsap, scipy.spatial._ckdtree, scipy.spatial._qhull, scipy.spatial._voronoi, scipy.spatial._hausdorff, scipy.spatial._distance_wrap, scipy.spatial.transform._rotation, scipy.spatial.transform._rigid_transform, scipy.optimize._direct, scipy.interpolate._fitpack, scipy.interpolate._dfitpack, scipy.interpolate._dierckx, scipy.interpolate._ppoly, scipy.interpolate._interpnd, scipy.interpolate._rbfinterp_pythran, scipy.interpolate._rgi_cython, scipy.special.cython_special, scipy.stats._stats, scipy.stats._biasedurn, scipy.stats._stats_pythran, scipy.stats._levy_stable.levyst, scipy.stats._ansari_swilk_statistics, scipy.sparse.csgraph._tools, scipy.sparse.csgraph._shortest_path, scipy.sparse.csgraph._traversal, scipy.sparse.csgraph._min_spanning_tree, scipy.sparse.csgraph._flow, scipy.sparse.csgraph._matching, scipy.sparse.csgraph._reordering, scipy.stats._sobol, scipy.stats._qmc_cy, scipy.stats._rcont.rcont, scipy.stats._qmvnt_cy, av.subtitles.stream, multidict._multidict, yarl._quoting_c, propcache._helpers_c, aiohttp._http_writer, aiohttp._http_parser, aiohttp._websocket.mask, aiohttp._websocket.reader_c, frozenlist._frozenlist, PIL._imagingmath (total: 190)
./run.sh: line 18: 15992 Segmentation fault      (core dumped) $(which python) ${HOME}/ComfyUI/main.py --listen 0.0.0.0 --base-directory ${HOME}/comfy-base $@
```

Windows version:

```
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
0 models unloaded.
Model AutoencodingEngine prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Windows fatal exception: access violation

Stack (most recent call first):
  File "C:\Users\rattus\ComfyUI\comfy\model_detection.py", line 1125 in convert_diffusers_mmdit
  File "C:\Users\rattus\ComfyUI\comfy\sd.py", line 1717 in load_diffusion_model_state_dict
  File "C:\Users\rattus\ComfyUI\comfy\sd.py", line 1771 in load_diffusion_model
  File "C:\Users\rattus\ComfyUI\nodes.py", line 972 in load_unet
  File "C:\Users\rattus\ComfyUI\execution.py", line 295 in process_inputs
  File "C:\Users\rattus\ComfyUI\execution.py", line 307 in _async_map_node_over_list
  File "C:\Users\rattus\ComfyUI\execution.py", line 333 in get_output_data
  File "C:\Users\rattus\ComfyUI\execution.py", line 524 in execute
  File "C:\Users\rattus\ComfyUI\execution.py", line 737 in execute_async
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\asyncio\events.py", line 88 in _run
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\asyncio\base_events.py", line 1999 in _run_once
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\asyncio\base_events.py", line 645 in run_forever
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\asyncio\windows_events.py", line 322 in run_forever
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\asyncio\base_events.py", line 678 in run_until_complete
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\asyncio\runners.py", line 118 in run
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\asyncio\runners.py", line 195 in run
  File "C:\Users\rattus\ComfyUI\execution.py", line 688 in execute
  File "C:\Users\rattus\ComfyUI\main.py", line 269 in prompt_worker
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\threading.py", line 1012 in run
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\threading.py", line 1075 in _bootstrap_inner
  File "C:\Users\rattu\AppData\Local\Programs\Python\Python312\Lib\threading.py", line 1032 in _bootstrap
```

Regression Tests:

Linux, 5090, Flux2 stable cascade -> flux2 (multi model WF) :white_check_mark: 
Linux, 5090, 2GHZ CPU, Ace step 1.5 (cpu bound) :white_check_mark: 