### PR TITLE
Fix for TemporalScoreRescaling node when batch_size > 1

### DIFF
--- a/comfy_extras/nodes_eps.py
+++ b/comfy_extras/nodes_eps.py
@@ -133,11 +133,11 @@ class TemporalScoreRescaling(io.ComfyNode):
         def temporal_score_rescaling(args):
             denoised = args["denoised"]
             x = args["input"]
-            sigma = args["sigma"]
+            sigma = args["sigma"][0]
             curr_model = args["model"]
 
             # No rescaling (r = 1) or no noise
-            if tsr_k == 1 or sigma == 0:
+            if tsr_k == 1 or sigma.item() == 0:
                 return denoised
 
             model_sampling = curr_model.current_patcher.get_model_object("model_sampling")
@@ -145,7 +145,7 @@ class TemporalScoreRescaling(io.ComfyNode):
             snr = (2 * half_log_snr).exp()
 
             # No rescaling needed (r = 1)
-            if snr == 0:
+            if snr.item() == 0:
                 return denoised
 
             rescaling_r = compute_tsr_rescaling_factor(snr, tsr_k, tsr_variance)


### PR DESCRIPTION
This should fix these errors when using `TemporalScoreRescaling` node on latents with bs>1:

- `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`
- `RuntimeError: The size of tensor a (128) must match the size of tensor b (2) at non-singleton dimension 3`