### PR TITLE
comfy-aimdo 0.2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy
 filelock
 av>=14.2.0
 comfy-kitchen>=0.2.7
-comfy-aimdo>=0.2.9
+comfy-aimdo>=0.2.10
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
Comfy Aimdo 0.2.10 fixes the aimdo allocator hook for legacy cudaMalloc consumers. Some consumers of cudaMalloc assume implicit synchronization built in closed source logic inside cuda. This is preserved by passing through to cuda as-is and accouting after the fact as opposed to integrating these hooks with Aimdos VMA based allocator.

This primary affects custom nodes plugging in non-pytorch cuda logic.

See https://github.com/Comfy-Org/comfy-aimdo/pull/20 for details and standalone test case.

original report: https://github.com/Comfy-Org/comfy-aimdo/pull/19

Regression Tests:

Linux, 5090, stable cascade -> Flux 2 4MP --disable-cuda-malloc :white_check_mark: 
Windows, 5060, 32GB, LTX2 :white_check_mark --disable-cuda-malloc :white_check_mark:  

Linux, 5090, FluxFill OneReward + Nvidia RTX video upscaler :white_check_mark: 
Linux, 5090, LTX2.3 720p121f + Nvidia RTX video upscaler (4x) :white_check_mark: 
Linux, 5090, 2GHZ CPU Ace Step 195s :white_check_mark: 
Linux, 5090, stable cascade -> Flux 2 :white_check_mark: 
Windows, 5060, 32GB, Wan 2.2 14Bx2 FP8 :white_check_mark: 
Windows, 5060, 32GB, LTX2 :white_check_mark:  