### PR TITLE
fix: Content-Disposition header to comply with RFC2183

### DIFF
--- a/server.py
+++ b/server.py
@@ -523,7 +523,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -543,7 +543,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -560,7 +560,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
                     else:
                         # Get content type from mimetype, defaulting to 'application/octet-stream'
                         content_type = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
@@ -572,7 +572,7 @@ class PromptServer():
                         return web.FileResponse(
                             file,
                             headers={
-                                "Content-Disposition": f"filename=\"{filename}\"",
+                                "Content-Disposition": f"attachment; filename=\"{filename}\"",
                                 "Content-Type": content_type
                             }
                         )


### PR DESCRIPTION
## Summary

Changed `Content-Disposition` header from `filename="..."` to `attachment; filename="..."` to comply with [RFC 2183](https://www.rfc-editor.org/rfc/rfc2183.html).

This fixes issue #8914 where third-party downloading libraries (e.g., golang grab, mime.ParseMediaType) fail to parse the filename correctly due to incorrect header format.

## Changes

- Fixed 4 occurrences in `server.py`:
  - Line 526: Image download response (JPEG/PNG)
  - Line 546: RGB channel image download
  - Line 563: Alpha channel image download  
  - Line 575: General file download (FileResponse)

## Before

```
Content-Disposition: filename="example.png"
```

## After

```
Content-Disposition: attachment; filename="example.png"
```

Fixes: https://github.com/Comfy-Org/ComfyUI/issues/8914