### PR TITLE
bump manager version to 4.1b4

### DIFF
--- a/manager_requirements.txt
+++ b/manager_requirements.txt
@@ -1,1 +1,1 @@
-comfyui_manager==4.1b3
+comfyui_manager==4.1b4


### PR DESCRIPTION
Expands `--uv-compile` support to all node management commands (install, update, reinstall), with conflict attribution to identify which nodes cause dependency conflicts.

References:
- Diff: https://github.com/Comfy-Org/ComfyUI-Manager/compare/4.1b2...4.1b4
- PyPI: https://pypi.org/project/comfyui-manager/4.1b4

This patch is required to support the **--uv-compile** feature in **comfy-cli**.