### PR TITLE
Fix QuantizedTensor weight restore failure causing progressive drift across generations

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -692,7 +692,15 @@ class ModelPatcher:
         inplace_update = self.weight_inplace_update or inplace_update
 
         if key not in self.backup and not return_weight:
-            self.backup[key] = collections.namedtuple('Dimension', ['weight', 'inplace_update'])(weight.to(device=self.offload_device, copy=inplace_update), inplace_update)
+            # When set_func is present (e.g. QuantizedTensor/fp8_scaled ops), it replaces
+            # the parameter object rather than modifying it in-place.  The restore path
+            # must therefore also replace the parameter (set_attr_param) instead of doing
+            # an in-place copy (copy_to_param), because QuantizedTensor.__torch_dispatch__
+            # routes copy_() through dequant-and-fallback which silently fails to update
+            # the underlying quantized data.  Force inplace_update=False in the backup
+            # for these keys so unpatch_model uses set_attr_param for restoration.
+            backup_inplace = inplace_update if set_func is None else False
+            self.backup[key] = collections.namedtuple('Dimension', ['weight', 'inplace_update'])(weight.to(device=self.offload_device, copy=inplace_update), backup_inplace)
 
         temp_dtype = comfy.model_management.lora_compute_dtype(device_to)
         if device_to is not None:


### PR DESCRIPTION
### Problem

When using fp8_scaled (QuantizedTensor) models with LoRA and `weight_inplace_update=True`, weights are silently **not restored** after unpatching. Each subsequent generation backs up the already-LoRA'd weights and applies LoRA again on top, causing progressive quality degradation — reduced saturation, contrast, and dynamic range ("washout") that compounds with every generation.

**Affected configurations:**
- fp8_scaled model weights (QuantizedTensor) — e.g. LTX 2.3 `*fp8_scaled.safetensors`
- Any LoRA applied to those weights
- `weight_inplace_update=True` (VRAM optimization)

**Not affected:** raw fp8 models (no QuantizedTensor), non-LoRA workflows, `weight_inplace_update=False` (current default).

### Root Cause

In `ModelPatcher.patch_weight_to_device()`, when a `set_func` is present (fp8_scaled ops), it **replaces** the nn.Parameter with a new QuantizedTensor via `set_weight()`. However, the backup records `inplace_update=True` (from the global setting), which causes `unpatch_model()` to use `copy_to_param()` for restoration.

`copy_to_param()` does `param.data.copy_(backup_weight)`. For QuantizedTensor, `copy_()` is not in the dispatch table — `__torch_dispatch__` routes it through `_dequant_and_fallback()`, which:
1. Dequantizes both tensors to float
2. Copies into a **temporary** float tensor
3. The actual QuantizedTensor (`_qdata`, `_params`) is **unchanged**

Result: the weight silently remains LoRA-patched after "restore". On the next generation, `patch_weight_to_device()` backs up the already-patched weight and applies LoRA again → progressive drift.

### Fix

When `set_func` is present, force `backup_inplace=False` so that `unpatch_model()` uses `set_attr_param()` (parameter replacement) instead of `copy_to_param()` (in-place copy). `set_attr_param()` does `setattr(obj, attr, nn.Parameter(value))` which correctly replaces the parameter object — this works for both regular tensors and QuantizedTensors.

```python
# Before (line 695):
self.backup[key] = ...(weight.to(...), inplace_update)

# After:
backup_inplace = inplace_update if set_func is None else False
self.backup[key] = ...(weight.to(...), backup_inplace)
```

This is a one-line semantic change. The `set_func` codepath already asserts `inplace_update is False` in `set_weight()`, so forcing the backup to use parameter replacement is consistent with the patching direction.

### Verification

Tested with an automated washout diagnostic that runs 4 identical generations per phase and compares weight checksums, latent statistics, and video output across generations:

| Phase | Before Fix | After Fix |
|-------|-----------|-----------|
| No LoRA (baseline) | PASS | PASS |
| LoRA A + STG | FAIL (213 drift points) | PASS |
| LoRA B + STG | FAIL | PASS |
| LoRA L + STG | FAIL | PASS |

Before fix: S1 raw output std declined 39% over 4 generations (0.92 → 0.56). After fix: zero drift, bit-for-bit identical across all generations.

### Related Issues

- Fixes #11021 — "Quality degradation over multiple generations and/or LoRA effects accumulate" (exact same symptom)
- Related to #10267 — Fix LoRA patching for scaled fp8 with low VRAM
- Related to #11068 — fp8-scaled broken after recent changes
- Related to #10315 — Inference time increase with fp8_scaled + LoRA