### PR TITLE
fix: atomic writes for userdata to prevent data loss on crash

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -6,6 +6,7 @@ import uuid
 import glob
 import shutil
 import logging
+import tempfile
 from aiohttp import web
 from urllib import parse
 from comfy.cli_args import args
@@ -377,8 +378,15 @@ class UserManager():
             try:
                 body = await request.read()
 
-                with open(path, "wb") as f:
-                    f.write(body)
+                dir_name = os.path.dirname(path)
+                fd, tmp_path = tempfile.mkstemp(dir=dir_name)
+                try:
+                    with os.fdopen(fd, "wb") as f:
+                        f.write(body)
+                    os.replace(tmp_path, path)
+                except:
+                    os.unlink(tmp_path)
+                    raise
             except OSError as e:
                 logging.warning(f"Error saving file '{path}': {e}")
                 return web.Response(


### PR DESCRIPTION
## Summary

The `POST /userdata/{file}` endpoint opens the target path with `"wb"` (truncating it to zero bytes immediately) then writes the body. If the process crashes between truncation and write completion, the file is left as a zero-byte file and the workflow is lost.

This changes the write to use `tempfile.mkstemp` in the same directory followed by `os.replace()`, so either the old file remains intact or the new file is fully written — never a zero-byte intermediate state.

Fixes #11298

## Tradeoffs

| Concern | Assessment |
|---|---|
| **Extra syscalls** | One additional `mkstemp` + `rename` per save. Negligible vs. the HTTP round-trip + JSON serialization already happening. |
| **Temp file cleanup on crash** | If the process dies between `mkstemp` and `os.replace`, an orphaned temp file is left in the directory. This is strictly better than the current behavior (losing the workflow entirely). |
| **Windows `os.replace` atomicity** | `os.replace` is not truly atomic on NTFS but is the best available primitive. A concurrent process holding a handle (antivirus, file indexer) could cause a `PermissionError`, but this is the same failure mode as the current direct `open("wb")` — no regression. |
| **Custom node ecosystem** | No backend hooks or file watchers exist on the `user/` directory. Custom nodes reading via `GET /userdata` are unaffected. Nodes writing to the same path concurrently already have no coordination — atomic writes actually improve this by preventing partial reads. |

## Why this is not a performance concern

- **Autosave is off by default.** When enabled, it is debounced at a minimum of 1000ms with an in-flight guard that serializes writes — this path cannot fire more than ~1x/sec regardless of edit rate.
- **Manual saves are human-rate-limited** (Ctrl+S).
- The only non-debounced writes through this path are bookmark toggles (`.index.json`), which are infrequent user actions.
- The assets system (`app/assets/`) already uses this same `os.replace` pattern in `ingest.py` for asset uploads with no reported performance issues.