### PR TITLE
Skip running model finalizers at exit

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -541,6 +541,7 @@ class LoadedModel:
         if model.parent is not None:
             self._parent_model = weakref.ref(model.parent)
             self._patcher_finalizer = weakref.finalize(model, self._switch_parent)
+            self._patcher_finalizer.atexit = False
 
     def _switch_parent(self):
         model = self._parent_model()
@@ -587,6 +588,7 @@ class LoadedModel:
 
         self.real_model = weakref.ref(real_model)
         self.model_finalizer = weakref.finalize(real_model, cleanup_models)
+        self.model_finalizer.atexit = False
         return real_model
 
     def should_reload_model(self, force_patch_weights=False):


### PR DESCRIPTION
There was a point when exiting ComfyUI became unbearably slow. Trying to exit/hitting `^C` in the console could easily take 30 seconds or more before ComfyUI would actually exit. I'm not sure if this is a complete solution, but the situation seems a lot better with this change.

The model finalizers in `model_management.py` just clean up memory (as far as I can see) which would all be released when the process exits anyway. There are cases where running a finalizer at exit is required (cleaning up temporary directories, etc) but I think it should be safe to disable here.

The `atexit` property was added in Python 3.4, so this shouldn't cause any compatibility issues WRT Python versions: https://docs.python.org/3/library/weakref.html#weakref.finalize.atexit