### PR TITLE
fix: reshape dora_scale before broadcasting in weight_decompose

### DIFF
--- a/comfy/weight_adapter/base.py
+++ b/comfy/weight_adapter/base.py
@@ -298,6 +298,16 @@ def weight_decompose(
         )
     weight_norm = weight_norm + torch.finfo(weight.dtype).eps
 
+    # Reshape dora_scale to match weight_norm dimensionality to avoid
+    # incorrect broadcasting. Without this, a 1D dora_scale [N] divided by
+    # a multi-dim weight_norm [N, 1] would broadcast to [N, N] instead of
+    # the intended element-wise [N, 1]. This caused shape mismatches for
+    # non-square weights (e.g. MLP layers where d_ff != d_model).
+    if wd_on_output_axis:
+        dora_scale = dora_scale.reshape(weight.shape[0], *[1] * (weight.dim() - 1))
+    else:
+        dora_scale = dora_scale.reshape(*[1] * (weight.dim() - 1), weight.shape[-1])
+
     weight_calc *= (dora_scale / weight_norm).type(weight.dtype)
     if strength != 1.0:
         weight_calc -= weight


### PR DESCRIPTION
## Summary

Fixes #12938

`weight_decompose()` in `comfy/weight_adapter/base.py` has a broadcasting bug that causes DoRA (LoRA with `use_dora=True`) to fail on non-square weight matrices.

### Root cause

`dora_scale` is a 1D tensor `[N]`, while `weight_norm` is multi-dimensional `[N, 1, ...]` (due to `keepdim=True`). PyTorch broadcasting aligns from the right, so:

- `dora_scale [N]` → implicitly `[1, N]`
- `weight_norm [N, 1]`
- Result: `[1, N] / [N, 1]` = `[N, N]` ← outer-product instead of element-wise

This `[N, N]` tensor then fails to multiply with `weight_calc [N, M]` when `N ≠ M`. Square attention weights (Q/K/V/O projections) are silently unaffected since `[N, N] * [N, N]` happens to not raise a shape error.

### Fix

Explicitly reshape `dora_scale` to match `weight_norm`'s dimensionality before the division, ensuring element-wise division `[N, 1] / [N, 1]` = `[N, 1]` instead of the incorrect outer-product broadcast.

This also correctly handles higher-dimensional weights (conv kernels) where `weight_norm` would be `[N, 1, 1, 1]`.

### Impact

Affects any DoRA adapter targeting non-square layers — most commonly MLP layers (`d_ff ≠ d_model`) in architectures like Anima, Cosmos Predict2, etc. Used by all 6 adapter types that call `weight_decompose`: LoRA, LoHa, LoKr, GLoRA, OFT, BOFT.

## Test plan

- [ ] Load a DoRA LoRA that targets MLP layers (non-square `nn.Linear`) — should no longer raise `"The size of tensor a (2048) must match the size of tensor b (8192)"` errors
- [ ] Load a standard DoRA LoRA targeting attention layers (square weights) — should continue to work identically (no regression)
- [ ] Test with conv-based DoRA weights (if available) to verify the fix generalizes to higher-dimensional tensors