### PR TITLE
Reduce WAN VAE VRAM, Save use cases for OOM/Tiler

### DIFF
--- a/comfy/ldm/wan/vae.py
+++ b/comfy/ldm/wan/vae.py
@@ -380,28 +380,25 @@ class Decoder3d(nn.Module):
 
         out_chunks = []
 
-        def run_head(x, feat_idx):
-            for layer in self.head:
-                if isinstance(layer, CausalConv3d) and feat_cache is not None:
-                    cache_x = x[:, :, -CACHE_T:, :, :]
-                    x = layer(x, feat_cache[feat_idx[0]])
-                    feat_cache[feat_idx[0]] = cache_x
-                    feat_idx[0] += 1
-                else:
-                    x = layer(x)
-            out_chunks.append(x)
-
-        def run_upsamples(layer_idx, x_ref, feat_idx):
+        def run_up(layer_idx, x_ref, feat_idx):
             x = x_ref[0]
             x_ref[0] = None
             if layer_idx >= len(self.upsamples):
-                run_head(x, feat_idx)
+                for layer in self.head:
+                    if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                        cache_x = x[:, :, -CACHE_T:, :, :]
+                        x = layer(x, feat_cache[feat_idx[0]])
+                        feat_cache[feat_idx[0]] = cache_x
+                        feat_idx[0] += 1
+                    else:
+                        x = layer(x)
+                out_chunks.append(x)
                 return
 
             layer = self.upsamples[layer_idx]
             if isinstance(layer, Resample) and layer.mode == 'upsample3d' and x.shape[2] > 1:
                 for frame_idx in range(x.shape[2]):
-                    run_upsamples(
+                    run_up(
                         layer_idx,
                         [x[:, :, frame_idx:frame_idx + 1, :, :]],
                         feat_idx.copy(),
@@ -416,9 +413,9 @@ class Decoder3d(nn.Module):
 
             next_x_ref = [x]
             del x
-            run_upsamples(layer_idx + 1, next_x_ref, feat_idx)
+            run_up(layer_idx + 1, next_x_ref, feat_idx)
 
-        run_upsamples(0, [x], feat_idx)
+        run_up(0, [x], feat_idx)
         return out_chunks
 
 


### PR DESCRIPTION
Reduce VAE VRAM for WAN but using the same recursion strategy as done for LTX. Get the chunk size down to a consistent 2 throughout all caching to avoid have to cat, slice and clone.

The primary VRAM savings comes from reducing the size of the big convolutions from 6 frames (2che + 4 Input) to 4 (2 + 2) and scrapping some un-needed clone() logic taking straight copies of tensors.

Example Test Conditions:

Linux, RTX5090
WAN 2.2 VAE encode + Decode 1024x1024x81f

<img width="1498" height="746" alt="image" src="https://github.com/user-attachments/assets/3c739394-74c8-42f8-b043-da10cebc3b83" />

Before:

```
Requested to load WanVAE
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached. Force pre-loaded 52 weights: 28 KB.
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached. Force pre-loaded 52 weights: 28 KB.
Prompt executed in 15.66 seconds
```

<img width="1174" height="1080" alt="image" src="https://github.com/user-attachments/assets/87241509-56a9-41d9-a17f-a76e3f390061" />

After:

```
Requested to load WanVAE
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached. Force pre-loaded 52 weights: 28 KB.
Model WanVAE prepared for dynamic VRAM loading. 242MB Staged. 0 patches attached. Force pre-loaded 52 weights: 28 KB.
Prompt executed in 15.63 seconds
```

<img width="1165" height="1068" alt="image" src="https://github.com/user-attachments/assets/f32e059d-2aca-4f67-ae0a-fb1beba194ad" />

Regression Tests:
Linux, 5090, WAN 2.2 I2V Template :white_check_mark: 
Windows, 5060, WAN 2.2 Template :white_check_mark: 
Linux, 5090, qwen 2048x1328 :white_check_mark: 
Linux, 5090, WAN VAE encode with t=3 :white_check_mark: (correctly truncates)