### PR TITLE
bump manager version to 4.1b6

### DIFF
--- a/manager_requirements.txt
+++ b/manager_requirements.txt
@@ -1,1 +1,1 @@
-comfyui_manager==4.1b5
+comfyui_manager==4.1b6


### PR DESCRIPTION
Fix Windows subprocess crash in git_helper by removing comfyui_manager imports that triggered unavailable comfy modules, and add `cm-cli update-cache` command for populating CNR cache without the web server, along with purge/reinstall fallback and batch failure tracking.

References:
- Diff: https://github.com/Comfy-Org/ComfyUI-Manager/compare/4.1b5...4.1b6
- PyPI: https://pypi.org/project/comfyui-manager/4.1b6
