### PR TITLE
cascade: remove dead weight init code

### DIFF
--- a/comfy/ldm/cascade/stage_a.py
+++ b/comfy/ldm/cascade/stage_a.py
@@ -136,16 +136,7 @@ class ResBlock(nn.Module):
             ops.Linear(c_hidden, c),
         )
 
-        self.gammas = nn.Parameter(torch.zeros(6), requires_grad=True)
-
-        # Init weights
-        def _basic_init(module):
-            if isinstance(module, nn.Linear) or isinstance(module, nn.Conv2d):
-                torch.nn.init.xavier_uniform_(module.weight)
-                if module.bias is not None:
-                    nn.init.constant_(module.bias, 0)
-
-        self.apply(_basic_init)
+        self.gammas = nn.Parameter(torch.zeros(6), requires_grad=False)
 
     def _norm(self, x, norm):
         return norm(x.permute(0, 2, 3, 1)).permute(0, 3, 1, 2)


### PR DESCRIPTION
This weight init process is fully shadowed be the weight load and doesnt work in dynamic_vram were the weight allocation is deferred.

Example test conditions:
Linux, 5090
Stable cascade -> Flux 2

<img width="1770" height="1147" alt="image" src="https://github.com/user-attachments/assets/4840f796-222f-43a0-b287-8d932c9caa4f" />


This change to emulate windows:

```
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -337,8 +337,7 @@ class disable_weight_init:
 
         def __init__(self, in_features, out_features, bias=True, device=None, dtype=None):
             # don't trust subclasses that BYO state dict loader to call us.
-            if (not comfy.model_management.WINDOWS
-                or not comfy.memory_management.aimdo_enabled
+            if (not comfy.memory_management.aimdo_enabled
                 or type(self)._load_from_state_dict is not disable_weight_init.Linear._load_from_state_dict):
                 super().__init__(in_features, out_features, bias, device, dtype)
                 return
@@ -360,8 +359,7 @@ class disable_weight_init:
         def _load_from_state_dict(self, state_dict, prefix, local_metadata,
                                 strict, missing_keys, unexpected_keys, error_msgs):
 
-            if (not comfy.model_management.WINDOWS
-                or not comfy.memory_management.aimdo_enabled
+            if (not comfy.memory_management.aimdo_enabled
                 or type(self)._load_from_state_dict is not disable_weight_init.Linear._load_from_state_dict):
                 return super()._load_from_state_dict(state_dict, prefix, local_metadata, strict,
                                                      missing_keys, unexpected_keys, error_msgs)
```

Before:

```
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1063, in apply
    module.apply(fn)
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1064, in apply
    fn(self)
  File "/home/rattus/ComfyUI/comfy/ldm/cascade/stage_a.py", line 144, in _basic_init
    torch.nn.init.xavier_uniform_(module.weight)
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/init.py", line 463, in xavier_uniform_
    fan_in, fan_out = _calculate_fan_in_and_fan_out(tensor)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/init.py", line 417, in _calculate_fan_in_and_fan_out
    dimensions = tensor.dim()
                 ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'dim'

Prompt executed in 0.69 seconds
```

After:

```
Model AutoencoderKL prepared for dynamic VRAM loading. 160MB Staged. 0 patches attached.
Prompt executed in 64.76 seconds
```

Same seed outputs checked for consistency :white_check_mark: 
