### PR TITLE
Reduce tiled decode peak memory

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -1135,8 +1135,8 @@ def tiled_scale_multidim(samples, function, tile=(64, 64), overlap=8, upscale_am
                 pbar.update(1)
             continue
 
-        out = torch.zeros([s.shape[0], out_channels] + mult_list_upscale(s.shape[2:]), device=output_device)
-        out_div = torch.zeros([s.shape[0], out_channels] + mult_list_upscale(s.shape[2:]), device=output_device)
+        out = output[b:b+1].zero_()
+        out_div = torch.zeros([s.shape[0], 1] + mult_list_upscale(s.shape[2:]), device=output_device)
 
         positions = [range(0, s.shape[d+2] - overlap[d], tile[d] - overlap[d]) if s.shape[d+2] > tile[d] else [0] for d in range(dims)]
 
@@ -1151,7 +1151,7 @@ def tiled_scale_multidim(samples, function, tile=(64, 64), overlap=8, upscale_am
                 upscaled.append(round(get_pos(d, pos)))
 
             ps = function(s_in).to(output_device)
-            mask = torch.ones_like(ps)
+            mask = torch.ones([1, 1] + list(ps.shape[2:]), device=output_device)
 
             for d in range(2, dims + 2):
                 feather = round(get_scale(d - 2, overlap[d - 2]))
@@ -1174,7 +1174,7 @@ def tiled_scale_multidim(samples, function, tile=(64, 64), overlap=8, upscale_am
             if pbar is not None:
                 pbar.update(1)
 
-        output[b:b+1] = out/out_div
+        out.div_(out_div)
     return output
 
 def tiled_scale(samples, function, tile_x=64, tile_y=64, overlap = 8, upscale_amount = 4, out_channels = 3, output_device="cpu", pbar = None):


### PR DESCRIPTION
Reduces peak RAM usage on tiled VAE decode:

- Reuse output as accumulator — avoid allocating a separate blend buffer.
- Single-channel mask and blend weights — feathering is the same across channels, no need to store per-channel.
- In-place normalization — divide in-place instead of allocating a temporary.

---
LTX23 test, 2 decode runs at 720p for 601 frames, using spatial tiling:

Before:

<img width="414" height="176" alt="I87LTf4qXg" src="https://github.com/user-attachments/assets/35649745-51e2-450d-ab6e-9f57d1c20e68" />

After:

<img width="414" height="176" alt="WindowsTerminal_VkOZEjApoQ" src="https://github.com/user-attachments/assets/a25c3272-63b3-4f1b-b810-a85862827cf3" />
