### PR TITLE
memory: Add more exclusion criteria to pinned read (fixes corrupt outputs - rare cases)

### DIFF
--- a/comfy/memory_management.py
+++ b/comfy/memory_management.py
@@ -39,7 +39,10 @@ def read_tensor_file_slice_into(tensor, destination):
     if (destination.device.type != "cpu"
             or file_obj is None
             or threading.get_ident() != info.thread_id
-            or destination.numel() * destination.element_size() < info.size):
+            or destination.numel() * destination.element_size() < info.size
+            or tensor.numel() * tensor.element_size() != info.size
+            or tensor.storage_offset() != 0
+            or not tensor.is_contiguous()):
         return False
 
     if info.size == 0:


### PR DESCRIPTION
The exclusion criteria for pinned copy needs to be more robust to catch pre-model weight usage manipulations that keep the same TensorStorage have non-contiguities.

This was causing corrupt outputs on stable-cascase when the text encoder is offloaded in dynamic VRAM. Im not sure if its even possible with a modern GPU but the code is probably broken by theory and I stumbled on this one by luck.

Example Test Conditions:

RTX5090, Linux

This change to force full offload + dynamic VRAM


```
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -98,7 +98,8 @@ def cast_bias_weight_with_vbar(s, dtype, device, bias_dtype, non_blocking, compu
     offload_stream = None
     xfer_dest = None
 
-    signature = comfy_aimdo.model_vbar.vbar_fault(s._v)
+    #signature = comfy_aimdo.model_vbar.vbar_fault(s._v)
+    signature = None
     resident = comfy_aimdo.model_vbar.vbar_signature_compare(signature, s._v_signature)
     if signature is not None:
         if resident:
```

Stable cascade:

<img width="1722" height="680" alt="image" src="https://github.com/user-attachments/assets/cdc7d1ca-159f-454b-92fa-437ca0a87bf6" />

Before:

<img width="751" height="751" alt="image" src="https://github.com/user-attachments/assets/f2da6a41-54d1-4dea-92d4-6cc11e6d1024" />


After:

<img width="834" height="834" alt="image" src="https://github.com/user-attachments/assets/733f41e3-ff6c-4433-ab80-906aeebc8b1f" />

Regression Tests:
Windows, 5060, LTX2 :white_check_mark: 
Windows, 5060, Flux Fill one-reward :white_check_mark: 