### PR TITLE
[BOUNTY #8935] Run port check at the beginning of the main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -459,6 +459,19 @@ def start_comfyui(asyncio_loop=None):
 
 
 if __name__ == "__main__":
+    # Early port check before loading custom nodes (which can be slow)
+    import socket
+    try:
+        test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        test_socket.settimeout(1)
+        result = test_socket.connect_ex(('127.0.0.1', args.port))
+        test_socket.close()
+        if result == 0:
+            logging.error("Port {} is already in use. Please specify a different port with --port or stop the process using this port.".format(args.port))
+            sys.exit(1)
+    except OSError as e:
+        logging.warning("Could not check port {}: {}".format(args.port, e))
+
     # Running directly, just start ComfyUI.
     logging.info("Python version: {}".format(sys.version))
     logging.info("ComfyUI version: {}".format(comfyui_version.__version__))


### PR DESCRIPTION
Closes #8935

## Summary
Moves port availability check to the very start of `main.py` (before custom node loading), so users get an immediate error if the port is already in use instead of waiting through slow custom node initialization.

## Changes
- Added early port check using `socket.connect_ex()` on `127.0.0.1:{args.port}`
- Check runs before `start_comfyui()` which loads all custom nodes
- Prints error message and exits with code 1 if port is taken
- +13 lines, no new dependencies