### PR TITLE
[BOUNTY #8914] Fix Content-Disposition header to match RFC2183 rules

### DIFF
--- a/server.py
+++ b/server.py
@@ -555,7 +555,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -575,7 +575,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -592,7 +592,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
                     else:
                         # Use the content type from asset resolution if available,
                         # otherwise guess from the filename.
@@ -609,7 +609,7 @@ class PromptServer():
                         return web.FileResponse(
                             file,
                             headers={
-                                "Content-Disposition": f"filename=\"{filename}\"",
+                                "Content-Disposition": f"inline; filename=\"{filename}\"",
                                 "Content-Type": content_type
                             }
                         )


### PR DESCRIPTION
Closes #8914

## Summary
Fixes `Content-Disposition` headers in the `view_image` endpoint to comply with RFC 2183.

## Problem
The header was set as `filename="name.ext"` without a disposition-type. Per RFC 2183, the format must be: `disposition-type; filename="name.ext"`.

## Fix
Added `inline;` disposition-type to all 4 occurrences in `view_image`:
- Preview image response
- RGB channel response
- Alpha channel response
- Full file response

Changed from: `filename="{filename}"`
Changed to: `inline; filename="{filename}"`

This allows standard parsers (e.g. Go's `mime.ParseMediaType`) to correctly parse the header.