### PR TITLE
wan: vae: Fix light/color issue

### DIFF
--- a/comfy/ldm/wan/vae.py
+++ b/comfy/ldm/wan/vae.py
@@ -376,22 +376,22 @@ class Decoder3d(nn.Module):
             return
 
         layer = self.upsamples[layer_idx]
-        if isinstance(layer, Resample) and layer.mode == 'upsample3d' and x.shape[2] > 1:
-            for frame_idx in range(x.shape[2]):
+        if feat_cache is not None:
+            x = layer(x, feat_cache, feat_idx)
+        else:
+            x = layer(x)
+
+        if isinstance(layer, Resample) and layer.mode == 'upsample3d' and x.shape[2] > 2:
+            for frame_idx in range(0, x.shape[2], 2):
                 self.run_up(
-                    layer_idx,
-                    [x[:, :, frame_idx:frame_idx + 1, :, :]],
+                    layer_idx + 1,
+                    [x[:, :, frame_idx:frame_idx + 2, :, :]],
                     feat_cache,
                     feat_idx.copy(),
                     out_chunks,
                 )
             del x
             return
-
-        if feat_cache is not None:
-            x = layer(x, feat_cache, feat_idx)
-        else:
-            x = layer(x)
 
         next_x_ref = [x]
         del x


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/13090

There was an issue where the resample split was too early and dropped one of the rolling convolutions a frame early. This is most noticable as a lighting/color change between pixel frames 5->6 (latent 2->3), or as a lighting change between the first and last frame in an FLF wan flow.

Example test case:

WAN2.2 FLF 640x640x81f
Same image F&L

<img width="1342" height="1132" alt="image" src="https://github.com/user-attachments/assets/0270e7c5-e796-4b4e-8acf-378c4546f90f" />


Before:

[Screencast from 2026-03-22 08-25-24.webm](https://github.com/user-attachments/assets/59fcfa06-8dcf-4b06-b67e-3f0b543e97f1)

After:

[Screencast from 2026-03-22 08-30-19.webm](https://github.com/user-attachments/assets/265362d3-d571-4f4c-ae2d-4e0715728680)

VRAM consumption checked as still lower than 17.x :white_check_mark: 

Regression Tests:
WAN 2.2 I2V :white_check_mark: 
WAN 2.2 T2V :white_check_mark: 