### PR TITLE
fix: remove deprecated gemini-2.5-flash-image-preview from model enum

### DIFF
--- a/comfy_api_nodes/nodes_gemini.py
+++ b/comfy_api_nodes/nodes_gemini.py
@@ -644,6 +644,7 @@ class GeminiImage(IO.ComfyNode):
                 IO.Hidden.unique_id,
             ],
             is_api_node=True,
+            is_deprecated=True,
             price_badge=IO.PriceBadge(
                 expr="""{"type":"usd","usd":0.039,"format":{"suffix":"/Image (1K)","approximate":true}}""",
             ),


### PR DESCRIPTION
## Problem
Google removed the `gemini-2.5-flash-image-preview` model from Vertex AI, causing 404 errors for users selecting it.

## Fix
Remove the deprecated `gemini_2_5_flash_image_preview` enum value from `GeminiImageModel`, so new users only see the GA model `gemini-2.5-flash-image`.

## Related
- comfy-api PR adds a proxy sanitization rule so existing workflows/cached UIs still work

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

