### PR TITLE
Fix Train LoRA crash with training_dtype "none" and bfloat16 LoRA weights

### DIFF
--- a/comfy_extras/nodes_train.py
+++ b/comfy_extras/nodes_train.py
@@ -1146,6 +1146,7 @@ class TrainLoraNode(io.ComfyNode):
         # Setup model and dtype
         mp = model.clone()
         use_grad_scaler = False
+        lora_dtype = node_helpers.string_to_torch_dtype(lora_dtype)
         if training_dtype != "none":
             dtype = node_helpers.string_to_torch_dtype(training_dtype)
             mp.set_model_compute_dtype(dtype)
@@ -1154,7 +1155,10 @@ class TrainLoraNode(io.ComfyNode):
             model_dtype = mp.model.get_dtype()
             if model_dtype == torch.float16:
                 dtype = torch.float16
-                use_grad_scaler = True
+                # GradScaler only supports float16 gradients, not bfloat16.
+                # Only enable it when lora params will also be in float16.
+                if lora_dtype != torch.bfloat16:
+                    use_grad_scaler = True
                 # Warn about fp16 accumulation instability during training
                 if PerformanceFeature.Fp16Accumulation in args.fast:
                     logging.warning(
@@ -1165,7 +1169,6 @@ class TrainLoraNode(io.ComfyNode):
             else:
                 # For fp8, bf16, or other dtypes, use bf16 autocast
                 dtype = torch.bfloat16
-        lora_dtype = node_helpers.string_to_torch_dtype(lora_dtype)
 
         # Prepare latents and compute counts
         latents_dtype = dtype if dtype not in (None,) else torch.bfloat16


### PR DESCRIPTION
## Summary

Fixes #13124

When `training_dtype` is set to `"none"` and the model's native dtype is `float16`, `GradScaler` was unconditionally enabled. However, `torch.amp.GradScaler` does not support `bfloat16` gradients -- it only works with `float16` and `float32`. Since the default `lora_dtype` is `"bf16"`, the LoRA parameter gradients are in `bfloat16`, causing `GradScaler.unscale_()` to raise:

```
NotImplementedError: "_amp_foreach_non_finite_check_and_unscale_cuda" not implemented for 'BFloat16'
```

**Root cause:** `GradScaler` was enabled based solely on the model dtype being `float16`, without considering the LoRA parameter dtype.

**Fix:** Only enable `GradScaler` when the LoRA parameters are not in `bfloat16`. This is correct because `bfloat16` has the same exponent range as `float32` and does not suffer from the gradient underflow issues that `float16` does, so gradient scaling is unnecessary.

The `lora_dtype` parsing is moved before the `use_grad_scaler` decision so it can be checked.

## Test plan

- [ ] Train a LoRA with `training_dtype` set to `"none"` and `lora_dtype` set to `"bf16"` (default) on a float16 model -- should no longer crash
- [ ] Train a LoRA with `training_dtype` set to `"none"` and `lora_dtype` set to `"fp32"` on a float16 model -- should still use GradScaler as before
- [ ] Train a LoRA with explicit `training_dtype` (e.g., `"bf16"` or `"fp16"`) -- behavior unchanged