### PR TITLE
[API Nodes] made Reve node price badges more precise

### DIFF
--- a/comfy_api_nodes/nodes_reve.py
+++ b/comfy_api_nodes/nodes_reve.py
@@ -145,7 +145,20 @@ class ReveImageCreateNode(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.03432,"format":{"approximate":true,"note":"(base)"}}""",
+                depends_on=IO.PriceBadgeDepends(
+                    widgets=["upscale", "upscale.upscale_factor"],
+                ),
+                expr="""
+                (
+                    $factor := $lookup(widgets, "upscale.upscale_factor");
+                    $fmt := {"approximate": true, "note": "(base)"};
+                    widgets.upscale = "enabled" ? (
+                        $factor = 4 ? {"type": "usd", "usd": 0.0762, "format": $fmt}
+                        : $factor = 3 ? {"type": "usd", "usd": 0.0591, "format": $fmt}
+                        : {"type": "usd", "usd": 0.0457, "format": $fmt}
+                    ) : {"type": "usd", "usd": 0.03432, "format": $fmt}
+                )
+                """,
             ),
         )
 
@@ -225,13 +238,21 @@ class ReveImageEditNode(IO.ComfyNode):
             is_api_node=True,
             price_badge=IO.PriceBadge(
                 depends_on=IO.PriceBadgeDepends(
-                    widgets=["model"],
+                    widgets=["model", "upscale", "upscale.upscale_factor"],
                 ),
                 expr="""
                 (
+                    $fmt := {"approximate": true, "note": "(base)"};
                     $isFast := $contains(widgets.model, "fast");
-                    $base := $isFast ? 0.01001 : 0.0572;
-                    {"type": "usd", "usd": $base, "format": {"approximate": true, "note": "(base)"}}
+                    $enabled := widgets.upscale = "enabled";
+                    $factor := $lookup(widgets, "upscale.upscale_factor");
+                    $isFast
+                        ? {"type": "usd", "usd": 0.01001, "format": $fmt}
+                        : $enabled ? (
+                            $factor = 4 ? {"type": "usd", "usd": 0.0991, "format": $fmt}
+                            : $factor = 3 ? {"type": "usd", "usd": 0.0819, "format": $fmt}
+                            : {"type": "usd", "usd": 0.0686, "format": $fmt}
+                        ) : {"type": "usd", "usd": 0.0572, "format": $fmt}
                 )
                 """,
             ),
@@ -327,13 +348,21 @@ class ReveImageRemixNode(IO.ComfyNode):
             is_api_node=True,
             price_badge=IO.PriceBadge(
                 depends_on=IO.PriceBadgeDepends(
-                    widgets=["model"],
+                    widgets=["model", "upscale", "upscale.upscale_factor"],
                 ),
                 expr="""
                 (
+                    $fmt := {"approximate": true, "note": "(base)"};
                     $isFast := $contains(widgets.model, "fast");
-                    $base := $isFast ? 0.01001 : 0.0572;
-                    {"type": "usd", "usd": $base, "format": {"approximate": true, "note": "(base)"}}
+                    $enabled := widgets.upscale = "enabled";
+                    $factor := $lookup(widgets, "upscale.upscale_factor");
+                    $isFast
+                        ? {"type": "usd", "usd": 0.01001, "format": $fmt}
+                        : $enabled ? (
+                            $factor = 4 ? {"type": "usd", "usd": 0.0991, "format": $fmt}
+                            : $factor = 3 ? {"type": "usd", "usd": 0.0819, "format": $fmt}
+                            : {"type": "usd", "usd": 0.0686, "format": $fmt}
+                        ) : {"type": "usd", "usd": 0.0572, "format": $fmt}
                 )
                 """,
             ),


### PR DESCRIPTION
Added price accounting for the `upscaler` widget parameter.
The provider doesn't have any official, precise documentation on this, so I simply looked at the price and adjusted it based on testing.

<details>
<summary>Click to see images with badges</summary>

<img width="1432" height="810" alt="Screenshot From 2026-03-25 18-14-43" src="https://github.com/user-attachments/assets/258bc2d4-0ad8-4831-8c76-01b2694d4f57" />

<img width="1978" height="896" alt="Screenshot From 2026-03-25 18-10-25" src="https://github.com/user-attachments/assets/e67a2755-336f-47f8-8145-07d7431a72b6" />

<img width="2029" height="1020" alt="Screenshot From 2026-03-25 17-59-52" src="https://github.com/user-attachments/assets/6d31e409-7a77-4e35-9c24-8e012e441a8a" />
</details>

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [x] Informed **Kosinkadink**

