### PR TITLE
Fix: dimension error and single image output in save_images_to_folder

### DIFF
--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -168,10 +168,15 @@ def save_images_to_folder(image_list, output_dir, prefix="image"):
     saved_files = []
 
     if isinstance(image_list, torch.Tensor):
-        if image_list.dim() == 4:
-            image_list = [image_list[i] for i in range(image_list.shape[0])]
+        image_list = [image_list]
+
+    normalized_images = []
+    for img in image_list:
+        if isinstance(img, torch.Tensor) and img.dim() == 4:
+            normalized_images.extend([img[i] for i in range(img.shape[0])])
         else:
-            image_list = [image_list]
+            normalized_images.append(img)
+    image_list = normalized_images
 
     for idx, img_tensor in enumerate(image_list):
         # Handle different tensor shapes


### PR DESCRIPTION
## Description
This PR fixes a dimension mismatch error and an issue where only a single image was saved when multiple images (batch) were loaded into the `save_images_to_folder` function.

## Changes
- Modified `save_images_to_folder` to correctly handle batch dimensions.
- Ensured all images in the input batch are iterated and saved properly instead of just the first one.

## How to test
1. Connect a node that outputs multiple images (e.g., Batch Image or Load Images from path) to the `save_images_to_folder` function.
2. Observe that previously it would either throw a dimension error or only save one image.
3. With this fix, all images in the batch are saved correctly without errors.

## Checklist
- [x] Tested with single image input
- [x] Tested with multi-image (batch) input
- [x] Verified no regression in other saving functions