### PR TITLE
fix: pin 8 unpinned action(s),extract 3 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/check-ai-co-authors.yml
+++ b/.github/workflows/check-ai-co-authors.yml
@@ -16,4 +16,6 @@ jobs:
           fetch-depth: 0
 
       - name: Check commits for AI co-author trailers
-        run: bash .github/scripts/check-ai-co-authors.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+        run: bash .github/scripts/check-ai-co-authors.sh "${{ github.event.pull_request.base.sha }}" "${PR_HEAD_SHA}"
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/check-line-endings.yml
+++ b/.github/workflows/check-line-endings.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check for Windows line endings (CRLF)
         run: |
           # Get the list of changed files in the PR
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${PR_HEAD_SHA})
 
           # Flag to track if CRLF is found
           CRLF_FOUND=false
@@ -38,3 +38,6 @@ jobs:
           if [ "$CRLF_FOUND" = true ]; then
             exit 1
           fi
+
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pullrequest-ci-run.yml
+++ b/.github/workflows/pullrequest-ci-run.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows
-        uses: comfy-org/comfy-action@main
+        uses: comfy-org/comfy-action@2239a587d36772deab9605f1543abf0dc8aa8f92 # main
         with:
           os: ${{ matrix.os }}
           python_version: ${{ matrix.python_version }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -162,7 +162,7 @@ jobs:
           ls
 
       - name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: ComfyUI_windows_portable_${{ inputs.rel_name }}${{ inputs.rel_extra_name }}.7z
           tag_name: ${{ inputs.git_tag }}

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows
-        uses: comfy-org/comfy-action@main
+        uses: comfy-org/comfy-action@2239a587d36772deab9605f1543abf0dc8aa8f92 # main
         with:
           os: ${{ matrix.os }}
           python_version: ${{ matrix.python_version }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows
-        uses: comfy-org/comfy-action@main
+        uses: comfy-org/comfy-action@2239a587d36772deab9605f1543abf0dc8aa8f92 # main
         with:
           os: ${{ matrix.os }}
           python_version: ${{ matrix.python_version }}

--- a/.github/workflows/update-api-stubs.yml
+++ b/.github/workflows/update-api-stubs.yml
@@ -43,7 +43,7 @@ jobs:
       
       - name: Create Pull Request
         if: steps.git-check.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           commit-message: 'chore: update API models from OpenAPI spec'
           title: 'Update API models from api.comfy.org'

--- a/.github/workflows/update-ci-container.yml
+++ b/.github/workflows/update-ci-container.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.CI_CONTAINER_PAT }}
           branch: automation/comfyui-${{ steps.version.outputs.version }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -52,8 +52,11 @@ jobs:
         run: |
           git config --local user.name "github-actions"
           git config --local user.email "github-actions@github.com"
-          git fetch origin ${{ github.head_ref }}
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }}
+          git fetch origin ${HEAD_REF}
+          git checkout -B ${HEAD_REF} origin/${HEAD_REF}
           git add comfyui_version.py
           git diff --quiet && git diff --staged --quiet || git commit -m "chore: Update comfyui_version.py to match pyproject.toml"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin HEAD:${HEAD_REF}
+
+        env:
+          HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -85,7 +85,7 @@ jobs:
             ls
 
         - name: Upload binaries to release
-          uses: svenstaro/upload-release-action@v2
+          uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
           with:
                 repo_token: ${{ secrets.GITHUB_TOKEN }}
                 file: ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -97,7 +97,7 @@ jobs:
             ls
 
         - name: Upload binaries to release
-          uses: svenstaro/upload-release-action@v2
+          uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
           with:
                 repo_token: ${{ secrets.GITHUB_TOKEN }}
                 file: new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/check-ai-co-authors.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/check-line-endings.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/pullrequest-ci-run.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/stable-release.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/test-ci.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/update-api-stubs.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/update-ci-container.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/update-version.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/windows_release_nightly_pytorch.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/windows_release_package.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-012 | high | `.github/workflows/windows_release_nightly_pytorch.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-012 | high | `.github/workflows/windows_release_package.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-005 | medium | `.github/workflows/pullrequest-ci-run.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.