### PR TITLE
fix: register image/svg+xml MIME type for .svg files

### DIFF
--- a/utils/mime_types.py
+++ b/utils/mime_types.py
@@ -24,6 +24,7 @@ def init_mime_types():
     # Web types (used by server.py for static file serving)
     mimetypes.add_type('application/javascript; charset=utf-8', '.js')
     mimetypes.add_type('image/webp', '.webp')
+    mimetypes.add_type('image/svg+xml', '.svg')
 
     # Model and data file types (used by asset scanning / metadata extraction)
     mimetypes.add_type("application/safetensors", ".safetensors")


### PR DESCRIPTION
The `/view` endpoint returns `text/plain; charset=utf-8` for `.svg` files on some platforms because Python's `mimetypes` module does not always include SVG by default.

This causes `<img>` tags to fail rendering SVGs served via the `/view` endpoint.

**Fix:** Explicitly register `image/svg+xml` for `.svg` in `utils/mime_types.py`, which is the centralized MIME type initialization used at startup.