### PR TITLE
Handle invalid audio waveform values in SaveVideo without failing prompt

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -464,6 +464,8 @@ class VideoFromComponents(VideoInput):
             output.mux(packet)
 
             if audio_stream and self.__components.audio:
+                encoded_audio_packets = None
+                flush_audio_packets = None
                 try:
                     audio_np = waveform.float().cpu().contiguous().numpy()
                     if not np.isfinite(audio_np).all():
@@ -472,14 +474,16 @@ class VideoFromComponents(VideoInput):
                     frame = av.AudioFrame.from_ndarray(audio_np, format='fltp', layout=layout)
                     frame.sample_rate = audio_sample_rate
                     frame.pts = 0
-                    mux_packets(output, audio_stream.encode(frame))
-
-                    # Flush encoder
-                    mux_packets(output, audio_stream.encode(None))
-                except Exception as exc:
-                    logger.warning(
-                        "Failed to encode audio track, saving video-only output: %s", exc
+                    encoded_audio_packets = audio_stream.encode(frame)
+                    flush_audio_packets = audio_stream.encode(None)
+                except (av.error.ArgumentError, ValueError, TypeError) as exc:
+                    logger.error(
+                        "Audio encode failed due to invalid audio data; skipping audio track and saving video-only output: %s",
+                        exc,
                     )
+                else:
+                    mux_packets(output, encoded_audio_packets)
+                    mux_packets(output, flush_audio_packets)
 
     def as_trimmed(
         self,


### PR DESCRIPTION
Fixes #13192

## What
Harden `VideoFromComponents.save_to()` audio path to prevent full prompt failure when audio tensor contains malformed values.

Changes in `comfy_api/latest/_input_impl/video_types.py`:
- sanitize waveform before encode: `torch.nan_to_num(...).clamp(-1.0, 1.0)`
- re-check `audio_np` with `np.isfinite` and `np.nan_to_num`
- add small mux helper handling packet/list outputs from `encode`
- wrap audio encode/mux in `try/except` and continue with video-only output on failure

## Why
Current behavior can throw:

`av.error.ArgumentError: Invalid argument: 'avcodec_send_frame()' returned 22`

which aborts the whole prompt during save. This is especially visible in long video+audio workflows.

## Validation
- Local syntax check: `python3 -m py_compile comfy_api/latest/_input_impl/video_types.py`
- Runtime validation on Linux host with ComfyUI at `225c52f6`:
  - generated synthetic NaN/Inf audio tensor
  - `VideoFromComponents(...).save_to('/tmp/comfy_audio_nan_inf_test.mp4')` succeeded
  - output file created and non-zero size
