### PR TITLE
fix: pin 8 actions to commit SHA, extract 1 expressions to env vars

### DIFF
--- a/.github/workflows/pullrequest-ci-run.yml
+++ b/.github/workflows/pullrequest-ci-run.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows
-        uses: comfy-org/comfy-action@main
+        uses: comfy-org/comfy-action@2239a587d36772deab9605f1543abf0dc8aa8f92 # main
         with:
           os: ${{ matrix.os }}
           python_version: ${{ matrix.python_version }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -162,7 +162,7 @@ jobs:
           ls
 
       - name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: ComfyUI_windows_portable_${{ inputs.rel_name }}${{ inputs.rel_extra_name }}.7z
           tag_name: ${{ inputs.git_tag }}

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows
-        uses: comfy-org/comfy-action@main
+        uses: comfy-org/comfy-action@2239a587d36772deab9605f1543abf0dc8aa8f92 # main
         with:
           os: ${{ matrix.os }}
           python_version: ${{ matrix.python_version }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ${{ matrix.runner_label }}
     steps:
       - name: Test Workflows
-        uses: comfy-org/comfy-action@main
+        uses: comfy-org/comfy-action@2239a587d36772deab9605f1543abf0dc8aa8f92 # main
         with:
           os: ${{ matrix.os }}
           python_version: ${{ matrix.python_version }}

--- a/.github/workflows/update-api-stubs.yml
+++ b/.github/workflows/update-api-stubs.yml
@@ -43,7 +43,7 @@ jobs:
       
       - name: Create Pull Request
         if: steps.git-check.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           commit-message: 'chore: update API models from OpenAPI spec'
           title: 'Update API models from api.comfy.org'

--- a/.github/workflows/update-ci-container.yml
+++ b/.github/workflows/update-ci-container.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.CI_CONTAINER_PAT }}
           branch: automation/comfyui-${{ steps.version.outputs.version }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -52,8 +52,11 @@ jobs:
         run: |
           git config --local user.name "github-actions"
           git config --local user.email "github-actions@github.com"
-          git fetch origin ${{ github.head_ref }}
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }}
+          git fetch origin ${HEAD_REF}
+          git checkout -B ${HEAD_REF} origin/${HEAD_REF}
           git add comfyui_version.py
           git diff --quiet && git diff --staged --quiet || git commit -m "chore: Update comfyui_version.py to match pyproject.toml"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin HEAD:${HEAD_REF}
+
+        env:
+          HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -52,11 +52,11 @@ jobs:
         run: |
           git config --local user.name "github-actions"
           git config --local user.email "github-actions@github.com"
-          git fetch origin ${HEAD_REF}
-          git checkout -B ${HEAD_REF} origin/${HEAD_REF}
+          git fetch origin "${HEAD_REF}"
+          git checkout -B "${HEAD_REF}" "origin/${HEAD_REF}"
           git add comfyui_version.py
           git diff --quiet && git diff --staged --quiet || git commit -m "chore: Update comfyui_version.py to match pyproject.toml"
-          git push origin HEAD:${HEAD_REF}
+          git push origin "HEAD:${HEAD_REF}"
 
         env:
           HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -85,7 +85,7 @@ jobs:
             ls
 
         - name: Upload binaries to release
-          uses: svenstaro/upload-release-action@v2
+          uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
           with:
                 repo_token: ${{ secrets.GITHUB_TOKEN }}
                 file: ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -97,7 +97,7 @@ jobs:
             ls
 
         - name: Upload binaries to release
-          uses: svenstaro/upload-release-action@v2
+          uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
           with:
                 repo_token: ${{ secrets.GITHUB_TOKEN }}
                 file: new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z


### PR DESCRIPTION
Re-submission of #13164. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts expressions from `run:` blocks into `env:` mappings.

- Pin 8 unpinned actions to full 40-character SHAs
- Add version comments for readability
- Extract 1 expressions from run blocks to env vars

## Changes by file

| File | Changes |
|------|---------|
| pullrequest-ci-run.yml | Pinned actions to SHA |
| stable-release.yml | Pinned actions to SHA |
| test-ci.yml | Pinned actions to SHA |
| update-api-stubs.yml | Pinned actions to SHA |
| update-ci-container.yml | Pinned actions to SHA |
| update-version.yml | Pinned actions to SHA |
| windows_release_nightly_pytorch.yml | Pinned actions to SHA |
| windows_release_package.yml | Pinned actions to SHA |

## A note on internal action pinning

This PR pins all actions including org-owned ones. Best practice is to pin everything — the tj-actions/changed-files attack was an internally maintained action that was compromised, and every repo referencing it by tag silently executed attacker code. That said, it's your codebase. If you'd prefer to leave org-owned actions unpinned, let us know and we'll adjust the PR.

## How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` — original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `$ENV_VAR` in the script
- No workflow logic, triggers, or permissions are modified

I put up some research on this on [Twitter](https://x.com/vigilance_one/status/2036581210663616729) and a [research site](https://www.vigilantdefense.com/research/github-top-50k-repos-cicd-security-scan) if you want more context. I wrote a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard).

If you have any questions, reach out. I'll be monitoring comms.

\- Chris Nyhuis (dagecko)