### PR TITLE
Fix/tweak pinned memory accounting

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1403,8 +1403,6 @@ def unpin_memory(tensor):
 
     if torch.cuda.cudart().cudaHostUnregister(ptr) == 0:
         TOTAL_PINNED_MEMORY -= PINNED_MEMORY.pop(ptr)
-        if len(PINNED_MEMORY) == 0:
-            TOTAL_PINNED_MEMORY = 0
         return True
     else:
         logging.warning("Unpin error.")


### PR DESCRIPTION
A bugfix and and tweak to pinned memory accounting from a shared debug session.

I never reproduced this personally.

The pinned memory accumulation was clearly under-reporting the shared-gpu-memory usage, possibly due to rounding fragmentation. Tweaking the pin ceiling saved the crash.

Example test conditions (from user report and live debug session):

Windows, RTX5080 laptop, 32GB RAM
LTX2.3 720Px12s (with latent upscaler)

Before:

```
...
  File "C:\Users\xxx\Documents\comfyui-portable\ComfyUI\comfy\lora.py", line 428, in calculate_weight
    output = v.calculate_weight(weight, key, strength, strength_model, offset, function, intermediate_dtype, original_weights)
  File "C:\Users\xxx\Documents\comfyui-portable\ComfyUI\comfy\weight_adapter\lora.py", line 236, in calculate_weight
    mat1 = comfy.model_management.cast_to_device(
        v[0], weight.device, intermediate_dtype
    )
  File "C:\Users\xxx\Documents\comfyui-portable\ComfyUI\comfy\model_management.py", line 1319, in cast_to_device
    return cast_to(tensor, dtype=dtype, device=device, non_blocking=non_blocking, copy=copy)
  File "C:\Users\xxx\Documents\comfyui-portable\ComfyUI\comfy\model_management.py", line 1314, in cast_to
    r.copy_(weight, non_blocking=non_blocking)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch.AcceleratorError: CUDA error: out of memory
Search for `cudaErrorMemoryAllocation' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
...
```

After:

Workflow runs :white_check_mark: 

Regression perf test:

Windows 5060, 64GB, LTX2 FP16.

Before (30.9GB shared mem usage):

```
Prompt executed in 230.68 seconds
```

After (27.2 GB shared mem usage):

```
Prompt executed in 231.95 seconds
```

Windows 5060, 64GB,  wan 2.2 14Bx2 FP16:

Before (29.8GB shared mem usage):

```
Prompt executed in 77.16 seconds
```

After:

```
Prompt executed in 77.44 seconds
```
