### PR TITLE
fix: make comfy_aimdo import optional for AMD/ROCm GPU support

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,41 @@ setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
 
 faulthandler.enable(file=sys.stderr, all_threads=False)
 
-import comfy_aimdo.control
+try:
+    import comfy_aimdo.control
+except ImportError:
+    logging.info("comfy-aimdo not installed. DynamicVRAM will not be available.")
+    import types
+
+    class _AimdoStub:
+        """No-op stub for comfy_aimdo submodules when the package is not installed.
+
+        All attribute accesses return self and all calls return False (falsy),
+        which prevents any aimdo-guarded code paths from activating while still
+        allowing the import to succeed on non-NVIDIA hardware (e.g. AMD/ROCm).
+        """
+        def __getattr__(self, name):
+            return _AimdoStub()
+
+        def __call__(self, *args, **kwargs):
+            return False
+
+        def __bool__(self):
+            return False
+
+        def __int__(self):
+            return 0
+
+        def __float__(self):
+            return 0.0
+
+    _aimdo_pkg = types.ModuleType('comfy_aimdo')
+    for _submod_name in ('control', 'model_vbar', 'torch', 'host_buffer', 'model_mmap'):
+        _stub = _AimdoStub()
+        setattr(_aimdo_pkg, _submod_name, _stub)
+        sys.modules[f'comfy_aimdo.{_submod_name}'] = _stub
+    sys.modules['comfy_aimdo'] = _aimdo_pkg
+    import comfy_aimdo  # Now resolves to the stub from sys.modules
 
 if enables_dynamic_vram():
     comfy_aimdo.control.init()


### PR DESCRIPTION
Fixes #13182

## Problem

Since commit `f8acd9c40`, `main.py` contains a bare top-level import:

```python
import comfy_aimdo.control
```

`comfy-aimdo` is an NVIDIA-specific package for the DynamicVRAM feature. On AMD/ROCm systems (and any other non-NVIDIA setup where it is not installed), this import raises `ModuleNotFoundError` immediately at startup, preventing ComfyUI from running at all.

The subsequent imports in `comfy/ops.py`, `comfy/model_patcher.py`, `comfy/pinned_memory.py`, and `execution.py` also reference `comfy_aimdo.*` at module level, and would fail in turn once the first import is attempted.

## Solution

Wrap the `import comfy_aimdo.control` in a `try/except ImportError` block. On failure, a minimal no-op stub is installed into `sys.modules` so that all subsequent `import comfy_aimdo.*` statements in other modules succeed without requiring changes to those files.

The stub class:
- Returns `_AimdoStub()` from all attribute accesses (`__getattr__`)
- Returns `False` (falsy) from all calls (`__call__`)
- Implements `__bool__`, `__int__`, `__float__` returning `False`/`0`/`0.0`

This means:
- `comfy_aimdo.control.init_device(...)` returns `False` → `aimdo_enabled` stays `False`
- `comfy.memory_management.aimdo_enabled` remains `False` (its default value)
- All existing `if comfy.memory_management.aimdo_enabled:` guards correctly skip Dynamic VRAM code paths
- `comfy_aimdo.control.get_total_vram_usage()` returns `0` (correct for `comfy/windows.py` RAM calculation)

No other files need to be changed because all actual uses of `comfy_aimdo.*` functions are already guarded by runtime checks that prevent them from executing when aimdo is not active.

## Testing

- On NVIDIA systems with comfy-aimdo installed, the `try` branch succeeds and behavior is unchanged.
- On AMD/ROCm systems without comfy-aimdo, ComfyUI now starts successfully with DynamicVRAM disabled (the existing warning message is preserved via the `else` branch at line 229).