### PR TITLE
fix: suppress false-positive warnings when loading whisper audio encoder

### DIFF
--- a/comfy/audio_encoders/audio_encoders.py
+++ b/comfy/audio_encoders/audio_encoders.py
@@ -76,6 +76,9 @@ def load_audio_encoder_from_sd(sd, prefix=""):
             raise RuntimeError("ERROR: audio encoder file is invalid or unsupported embed_dim: {}".format(embed_dim))
     elif "model.encoder.embed_positions.weight" in sd:
         sd = comfy.utils.state_dict_prefix_replace(sd, {"model.": ""})
+        # Full whisper checkpoints include decoder weights; discard them since
+        # WhisperLargeV3 is encoder-only.
+        sd = {k: v for k, v in sd.items() if not k.startswith("decoder.")}
         config = {
             "model_type": "whisper3",
         }
@@ -85,7 +88,18 @@ def load_audio_encoder_from_sd(sd, prefix=""):
     audio_encoder = AudioEncoderModel(config)
     m, u = audio_encoder.load_sd(sd)
     if len(m) > 0:
-        logging.warning("missing audio encoder: {}".format(m))
+        # torchaudio registers the mel-spectrogram window and filterbank as
+        # buffers whose values are deterministically computed from the config
+        # at init time; they are never saved in standard whisper checkpoints.
+        # Suppress warnings for these expected-missing buffers so that users
+        # are only alerted about genuinely unexpected missing weights.
+        whisper_computed_buffers = {
+            "feature_extractor.mel_spectrogram.spectrogram.window",
+            "feature_extractor.mel_spectrogram.mel_scale.fb",
+        }
+        significant_missing = [k for k in m if k not in whisper_computed_buffers]
+        if significant_missing:
+            logging.warning("missing audio encoder: {}".format(significant_missing))
     if len(u) > 0:
         logging.warning("unexpected audio encoder: {}".format(u))
 


### PR DESCRIPTION
Fixes #13276

## Problem

When loading a standard full whisper checkpoint (which contains both encoder and decoder weights) via `AudioEncoderLoader`, two classes of spurious warnings appear in the console:

```
missing audio encoder: ['feature_extractor.mel_spectrogram.spectrogram.window', 'feature_extractor.mel_spectrogram.mel_scale.fb']
unexpected audio encoder: ['decoder.embed_positions.weight', 'decoder.embed_tokens.weight', ...]
```

These warnings mislead users into thinking the model loaded incorrectly.

**Root causes:**

1. **Unexpected decoder keys** — Full whisper checkpoints contain `decoder.*` weights alongside `encoder.*` weights. Since `WhisperLargeV3` is encoder-only, all `decoder.*` keys are flagged as unexpected. They were never needed and should be silently discarded.

2. **Missing mel-spectrogram buffers** — `torchaudio.transforms.MelSpectrogram` registers a Hann window (`spectrogram.window`) and a mel filterbank (`mel_scale.fb`) as PyTorch buffers. Standard whisper checkpoints do not store these constants because they are deterministically computed from the model config at init time. `load_state_dict(strict=False)` flags them as missing, but they are always correctly initialised by torchaudio — the warning is misleading.

## Solution

- Strip `decoder.*` keys from the state-dict before passing it to `load_state_dict`, eliminating the "unexpected" warnings for whisper models.
- After loading, suppress warnings only for the two known torchaudio-computed buffers (`feature_extractor.mel_spectrogram.spectrogram.window` and `feature_extractor.mel_spectrogram.mel_scale.fb`); any other genuinely missing keys are still warned about.

## Testing

Verified by inspection: the decoder key filter targets only the whisper branch, and the buffer exclusion set contains only torchaudio-managed names that cannot appear in wav2vec2 checkpoints, so wav2vec2 loading is unaffected.