### PR TITLE
Update workflow templates to v0.9.44

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.42.8
-comfyui-workflow-templates==0.9.43
+comfyui-workflow-templates==0.9.44
 comfyui-embedded-docs==0.4.3
 torch
 torchsde


### PR DESCRIPTION
## Update workflow templates to v0.9.44

- Removed the prompt enhancement for the LTX2.3 i2v and ia2v workflow due to a subgraph issue, to make to prompt can work normally
- Updated Hunyuan3D templates' default model to 3.1

### 📦 Package Information

- **PyPI**: https://pypi.org/project/comfyui-workflow-templates/0.9.44/
- **Release**: https://github.com/Comfy-Org/workflow_templates/releases/tag/v0.9.44

### 📝 Changes
Updated dependency version in `requirements.txt`:
```diff
- comfyui-workflow-templates==0.9.43
+ comfyui-workflow-templates==0.9.44
```

---
*This is an automated draft PR created by the auto-pr-script*