### PR TITLE
fix: raise clear error when non-LLM model is used with TextGenerate node

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -424,6 +424,12 @@ class CLIP:
         return self.patcher.get_key_patches()
 
     def generate(self, tokens, do_sample=True, max_length=256, temperature=1.0, top_k=50, top_p=0.95, min_p=0.0, repetition_penalty=1.0, seed=None, presence_penalty=0.0):
+        if not hasattr(self.cond_stage_model, 'generate'):
+            raise RuntimeError(
+                f"The loaded model ({type(self.cond_stage_model).__name__}) does not support text generation. "
+                "The TextGenerate node requires a language model (LLM) such as Qwen, LLaMA, or Gemma, "
+                "not a CLIP text encoder. Please load the correct model type."
+            )
         self.cond_stage_model.reset_clip_options()
 
         self.load_model(tokens)


### PR DESCRIPTION
Fixes #13286

## Problem

When a user connects a CLIP text encoder model (e.g. `CLIPTextModel`) to the `TextGenerate` node instead of a language model (LLM), the node fails with a cryptic `AttributeError: 'CLIPTextModel' object has no attribute 'generate'`. This happens because standard CLIP models only support text encoding (for embeddings), not text generation.

## Solution

Added an explicit check in `CLIP.generate()` to verify that the underlying `cond_stage_model` has a `generate` method before attempting to call it. If the model doesn't support generation, a `RuntimeError` is raised with a clear, actionable error message informing the user that they need to use a language model (LLM) like Qwen, LLaMA, or Gemma.

```python
if not hasattr(self.cond_stage_model, 'generate'):
    raise RuntimeError(
        f"The loaded model ({type(self.cond_stage_model).__name__}) does not support text generation. "
        "The TextGenerate node requires a language model (LLM) such as Qwen, LLaMA, or Gemma, "
        "not a CLIP text encoder. Please load the correct model type."
    )
```

## Testing

- Verified that the check correctly identifies models without a `generate` method
- The error message clearly indicates the model type that was loaded and what type is required