### PR TITLE
Fix torch.load missing weights_only in LoadTrainingDataset

### DIFF
--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -1453,7 +1453,9 @@ class LoadTrainingDataset(io.ComfyNode):
         output_dir = folder_paths.get_output_directory()
         dataset_dir = os.path.join(output_dir, folder_name)
         # Prevent path traversal (e.g. folder_name="../../etc")
-        if not os.path.realpath(dataset_dir).startswith(os.path.realpath(output_dir)):
+        real_output_dir = os.path.realpath(output_dir)
+        real_dataset_dir = os.path.realpath(dataset_dir)
+        if os.path.commonpath((real_output_dir, real_dataset_dir)) != real_output_dir:
             raise ValueError(f"Invalid folder_name: path traversal detected")
 
         if not os.path.exists(dataset_dir):


### PR DESCRIPTION
The rest of the codebase uses `weights_only=True`. Also adds a path check on `folder_name`.