### PR TITLE
fix: append directory type annotation to internal files endpoint (CORE-71)

### DIFF
--- a/api_server/routes/internal/internal_routes.py
+++ b/api_server/routes/internal/internal_routes.py
@@ -67,7 +67,7 @@ class InternalRoutes:
                 (entry for entry in os.scandir(directory) if is_visible_file(entry)),
                 key=lambda entry: -entry.stat().st_mtime
             )
-            return web.json_response([entry.name for entry in sorted_files], status=200)
+            return web.json_response([f"{entry.name} [{directory_type}]" for entry in sorted_files], status=200)
 
 
     def get_app(self):


### PR DESCRIPTION
## Summary

Fixes #13078

### Problem

The `Load Image (from Outputs)` node was completely broken — selecting any image from the dropdown resulted in:

1. **404 Not Found** in the browser console when trying to preview the image
2. **"Invalid image file"** validation error preventing workflow execution

**Root cause:** The `/internal/files/{directory_type}` endpoint in `api_server/routes/internal/internal_routes.py` (line 70) returned plain filenames like `image.png`. However, `LoadImageOutput` inherits from `LoadImage`, which uses `folder_paths.get_annotated_filepath()` and `folder_paths.exists_annotated_filepath()` to resolve file paths. These functions rely on a `[directory_type]` suffix convention (e.g., `image.png [output]`) to determine which directory to look in.

Without the annotation, the system defaulted to looking in the **input** directory instead of the **output** directory, so:
- The frontend built incorrect preview URLs (`type=input` instead of `type=output`), causing **404 errors**
- `VALIDATE_INPUTS` couldn't find the file in the input folder, causing **validation failures**

### Fix

Changed the response format in `api_server/routes/internal/internal_routes.py` line 70 from:

```python
return web.json_response([entry.name for entry in sorted_files], status=200)
```

to:

```python
return web.json_response([f"{entry.name} [{directory_type}]" for entry in sorted_files], status=200)
```

This appends the directory type annotation (e.g., `[output]`, `[input]`, `[temp]`) to each filename, allowing `annotated_filepath()` in `folder_paths.py` to correctly resolve the file to the right directory.


