### PR TITLE
fix: skip NaN keypoints in SDPoseDrawKeypoints to prevent ValueError

### DIFF
--- a/comfy_extras/nodes_sdpose.py
+++ b/comfy_extras/nodes_sdpose.py
@@ -251,6 +251,10 @@ class KeypointDraw:
 
                 Y = [keypoints[idx1][0], keypoints[idx2][0]]
                 X = [keypoints[idx1][1], keypoints[idx2][1]]
+
+                if math.isnan(X[0]) or math.isnan(X[1]) or math.isnan(Y[0]) or math.isnan(Y[1]):
+                    continue
+
                 mX, mY = (X[0] + X[1]) / 2, (Y[0] + Y[1]) / 2
                 length = math.sqrt((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2)
 
@@ -268,6 +272,8 @@ class KeypointDraw:
             for i in range(18):
                 if scores is not None and scores[i] < threshold:
                     continue
+                if math.isnan(keypoints[i][0]) or math.isnan(keypoints[i][1]):
+                    continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
                 if 0 <= x < W and 0 <= y < H:
                     self.draw.circle(canvas, (x, y), 4, self.colors[i % len(self.colors)], thickness=-1)
@@ -276,6 +282,8 @@ class KeypointDraw:
         if draw_feet and len(keypoints) >= 24:
             for i in range(18, 24):
                 if scores is not None and scores[i] < threshold:
+                    continue
+                if math.isnan(keypoints[i][0]) or math.isnan(keypoints[i][1]):
                     continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
                 if 0 <= x < W and 0 <= y < H:
@@ -289,6 +297,9 @@ class KeypointDraw:
                 if scores is not None:
                     if scores[idx1] < threshold or scores[idx2] < threshold:
                         continue
+
+                if math.isnan(keypoints[idx1][0]) or math.isnan(keypoints[idx1][1]) or math.isnan(keypoints[idx2][0]) or math.isnan(keypoints[idx2][1]):
+                    continue
 
                 x1, y1 = int(keypoints[idx1][0]), int(keypoints[idx1][1])
                 x2, y2 = int(keypoints[idx2][0]), int(keypoints[idx2][1])
@@ -304,6 +315,8 @@ class KeypointDraw:
             for i in range(92, 113):
                 if scores is not None and scores[i] < threshold:
                     continue
+                if math.isnan(keypoints[i][0]) or math.isnan(keypoints[i][1]):
+                    continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
                 if x > eps and y > eps and 0 <= x < W and 0 <= y < H:
                     self.draw.circle(canvas, (x, y), 4, (0, 0, 255), thickness=-1)
@@ -316,6 +329,9 @@ class KeypointDraw:
                 if scores is not None:
                     if scores[idx1] < threshold or scores[idx2] < threshold:
                         continue
+
+                if math.isnan(keypoints[idx1][0]) or math.isnan(keypoints[idx1][1]) or math.isnan(keypoints[idx2][0]) or math.isnan(keypoints[idx2][1]):
+                    continue
 
                 x1, y1 = int(keypoints[idx1][0]), int(keypoints[idx1][1])
                 x2, y2 = int(keypoints[idx2][0]), int(keypoints[idx2][1])
@@ -331,6 +347,8 @@ class KeypointDraw:
             for i in range(113, 134):
                 if scores is not None and i < len(scores) and scores[i] < threshold:
                     continue
+                if math.isnan(keypoints[i][0]) or math.isnan(keypoints[i][1]):
+                    continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
                 if x > eps and y > eps and 0 <= x < W and 0 <= y < H:
                     self.draw.circle(canvas, (x, y), 4, (0, 0, 255), thickness=-1)
@@ -340,6 +358,8 @@ class KeypointDraw:
             eps = 0.01
             for i in range(24, 92):
                 if scores is not None and scores[i] < threshold:
+                    continue
+                if math.isnan(keypoints[i][0]) or math.isnan(keypoints[i][1]):
                     continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
                 if x > eps and y > eps and 0 <= x < W and 0 <= y < H:


### PR DESCRIPTION
## Summary

Fixes #13149

### Problem

The `SDPoseDrawKeypoints` node crashes with:

```
ValueError: cannot convert float NaN to integer
```

when the pose detection model produces NaN coordinates for undetected keypoints. The crash occurs at the `int()` conversion in `draw_wholebody_keypoints()` (line 262):

```python
polygon = self.draw.ellipse2Poly((int(mY), int(mX)), (int(length / 2), stick_width), int(angle), 0, 360, 1)
```

**Root cause:** When keypoint coordinates are NaN (from undetected body parts), existing guards like `length < 1` don't catch them because **NaN comparisons always return False** in Python. So NaN values flow through all checks and reach `int()`, which raises `ValueError`.

### Fix

Added `math.isnan()` checks before every `int()` conversion on keypoint coordinates in `draw_wholebody_keypoints()`, covering all 8 drawing sections in `comfy_extras/nodes_sdpose.py`:

- **Body limbs** — NaN check on X/Y coordinates before midpoint and angle calculation
- **Body keypoints** — NaN check before drawing circles
- **Foot keypoints** — NaN check before drawing circles
- **Right hand edges** — NaN check on both endpoint coordinates before drawing lines
- **Right hand keypoints** — NaN check before drawing circles
- **Left hand edges** — NaN check on both endpoint coordinates before drawing lines
- **Left hand keypoints** — NaN check before drawing circles
- **Face keypoints** — NaN check before drawing circles

Keypoints with NaN coordinates are simply skipped, which is the correct behavior — an undetected keypoint should not be drawn rather than crashing the entire node.