### PR TITLE
fix: support batch broadcasting in JoinImageWithAlpha node

### DIFF
--- a/comfy_extras/nodes_compositing.py
+++ b/comfy_extras/nodes_compositing.py
@@ -202,12 +202,12 @@ class JoinImageWithAlpha(io.ComfyNode):
 
     @classmethod
     def execute(cls, image: torch.Tensor, alpha: torch.Tensor) -> io.NodeOutput:
-        batch_size = min(len(image), len(alpha))
+        batch_size = max(len(image), len(alpha))
         out_images = []
 
         alpha = 1.0 - resize_mask(alpha, image.shape[1:])
         for i in range(batch_size):
-           out_images.append(torch.cat((image[i][:,:,:3], alpha[i].unsqueeze(2)), dim=2))
+           out_images.append(torch.cat((image[i % len(image)][:,:,:3], alpha[i % len(alpha)].unsqueeze(2)), dim=2))
 
         return io.NodeOutput(torch.stack(out_images))
 


### PR DESCRIPTION
## Summary

Fixes #12580

### Problem

The `Join Image with Alpha` node only returns a single image when given a batch of images with a single alpha mask.

**Root cause:** In `comfy_extras/nodes_compositing.py` line 205, the batch size was calculated using `min(len(image), len(alpha))`. When a user passes a batch of 4 images with a single alpha mask, `min(4, 1) = 1`, so only one image is produced.

This is inconsistent with every other compositing node in ComfyUI (e.g., `ImageCompositeMasked`), which correctly broadcasts the shorter input to match the longer one.

### Fix

Changed `comfy_extras/nodes_compositing.py` to use `max()` instead of `min()` for batch size, with modulo indexing (`i % len(...)`) to repeat the shorter input:

```python
# Before
batch_size = min(len(image), len(alpha))
...
out_images.append(torch.cat((image[i][:,:,:3], alpha[i].unsqueeze(2)), dim=2))

# After
batch_size = max(len(image), len(alpha))
...
out_images.append(torch.cat((image[i % len(image)][:,:,:3], alpha[i % len(alpha)].unsqueeze(2)), dim=2))
```

This handles all cases correctly:
- **4 images + 1 mask** → 4 output images (mask repeats)
- **1 image + 4 masks** → 4 output images (image repeats)
- **4 images + 4 masks** → 4 output images (1-to-1)
- **1 image + 1 mask** → 1 output image (unchanged behavior)