### PR TITLE
Fix nested tensor noise mismatch in CFGGuider.sample

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1008,7 +1008,10 @@ class CFGGuider:
         if latent_image.is_nested:
             li_tensors = latent_image.unbind()
             if noise.is_nested:
-                n_tensors = noise.unbind()
+                # Truncate extra noise components, pad missing ones with zeros
+                n_tensors = list(noise.unbind()[:len(li_tensors)])
+                for i in range(len(n_tensors), len(li_tensors)):
+                    n_tensors.append(torch.zeros_like(li_tensors[i]))
             else:
                 # Noise only covers video -- pad remaining components (audio) with zeros
                 n_tensors = [noise]

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1006,8 +1006,16 @@ class CFGGuider:
             return latent_image
 
         if latent_image.is_nested:
-            latent_image, latent_shapes = comfy.utils.pack_latents(latent_image.unbind())
-            noise, _ = comfy.utils.pack_latents(noise.unbind())
+            li_tensors = latent_image.unbind()
+            if noise.is_nested:
+                n_tensors = noise.unbind()
+            else:
+                # Noise only covers video -- pad remaining components (audio) with zeros
+                n_tensors = [noise]
+                for i in range(1, len(li_tensors)):
+                    n_tensors.append(torch.zeros_like(li_tensors[i]))
+            latent_image, latent_shapes = comfy.utils.pack_latents(li_tensors)
+            noise, _ = comfy.utils.pack_latents(n_tensors)
         else:
             latent_shapes = [latent_image.shape]
 


### PR DESCRIPTION
#### Summary

Fixes `RuntimeError: The size of tensor a (N) must match the size of tensor b (M) at non-singleton dimension 2` when using LTXAV audio+video workflows with `SamplerCustomAdvanced`.

#### Problem

In `CFGGuider.sample()` (`comfy/samplers.py:1008-1010`), when `latent_image` is a `NestedTensor` (e.g. from `LTXVConcatAVLatent` combining video + audio latents), the code unconditionally calls `noise.unbind()`:

```python
if latent_image.is_nested:
    latent_image, latent_shapes = comfy.utils.pack_latents(latent_image.unbind())
    noise, _ = comfy.utils.pack_latents(noise.unbind())  # <-- crashes here
```

When noise is a regular (non-nested) tensor, `unbind(dim=0)` splits along the channel dimension, producing 128 small tensors instead of the expected 2 nested components (video + audio). After `pack_latents` flattens these, the shapes are completely mismatched (e.g. `[128, 1, 3751]` vs `[1, 1, 512384]`), causing the RuntimeError at `model_sampling.py:72` in `noise_scaling()`.

##### How to reproduce

1. Use the attached [ltx2-example.json](https://github.com/user-attachments/files/26535715/ltx2-example.json) or create an LTXAV image-to-video workflow using `LTXVConcatAVLatent` to combine video and audio latents
2. Feed the combined latent into `SamplerCustomAdvanced`
3. Queue the prompt -- crashes immediately at sampling

This affects any LTXAV workflow where the noise generator produces non-nested noise for a nested latent. No custom nodes required to trigger this.

#### Fix

Check `noise.is_nested` before unbinding. If noise is not nested, treat it as the first component (video) and pad remaining components (audio) with `torch.zeros_like()`. Zero noise for the audio component I believe is semantically correct. No denoising is applied to the audio padding in the video sampler.

Note: the `denoise_mask` handling a few lines below (line 1014-1018) already does this same pattern correctly. It checks `denoise_mask.is_nested` and pads with `torch.ones()` for missing components:

```python
if denoise_mask.is_nested:
    denoise_masks = denoise_mask.unbind()
    denoise_masks = denoise_masks[:len(latent_shapes)]
else:
    denoise_masks = [denoise_mask]

for i in range(len(denoise_masks), len(latent_shapes)):
    denoise_masks.append(torch.ones(latent_shapes[i]))
```

This PR applies the same defensive pattern to noise handling.