### PR TITLE
fix: close mask image file handle in /upload/mask endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -485,7 +485,8 @@ class PromptServer():
                             for key in original_pil.text:
                                 metadata.add_text(key, original_pil.text[key])
                         original_pil = original_pil.convert('RGBA')
-                        mask_pil = Image.open(image.file).convert('RGBA')
+                        with Image.open(image.file) as mask_pil_raw:
+                            mask_pil = mask_pil_raw.convert('RGBA')
 
                         # alpha copy
                         new_alpha = mask_pil.getchannel('A')


### PR DESCRIPTION
Fixes #13335

## What

In the `/upload/mask` handler, the uploaded mask image was opened without a context manager:

```python
# before
mask_pil = Image.open(image.file).convert('RGBA')
```

`Image.open()` returns a lazy-loaded image that keeps the underlying file descriptor open. Calling `.convert()` produces a new in-memory copy but does **not** close the original. Without an explicit close the file handle leaks — it's only reclaimed when CPython's refcount drops to zero (i.e. next GC cycle), which is non-deterministic.

The original image a couple lines above was already using a context manager correctly; this PR brings the mask open in line with that pattern:

```python
# after
with Image.open(image.file) as mask_pil_raw:
    mask_pil = mask_pil_raw.convert('RGBA')
```

## Why it matters

Under sustained mask-upload load the leaked descriptors can push the process past the OS limit (ulimit -n, default 1024 on most Linux distros), causing "Too many open files" errors.

## Change

- `server.py`: wrap `Image.open(image.file)` in a `with` block (1-line net change)