### PR TITLE
fix: include searched model directories in missing-model errors

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -370,9 +370,19 @@ def get_full_path_or_raise(folder_name: str, filename: str) -> str:
     """
     Get the full path of a file in a folder, has to be a file
     """
-    full_path = get_full_path(folder_name, filename)
+    canonical_folder_name = map_legacy(folder_name)
+    full_path = get_full_path(canonical_folder_name, filename)
     if full_path is None:
-        raise FileNotFoundError(f"Model in folder '{folder_name}' with filename '{filename}' not found.")
+        search_paths = folder_names_and_paths.get(canonical_folder_name, ([], set()))[0]
+        mapped_note = f" (mapped to '{canonical_folder_name}')" if canonical_folder_name != folder_name else ""
+        if search_paths:
+            raise FileNotFoundError(
+                f"Model in folder '{folder_name}'{mapped_note} with filename '{filename}' not found. "
+                f"Searched in: {', '.join(search_paths)}"
+            )
+        raise FileNotFoundError(
+            f"Model in folder '{folder_name}'{mapped_note} with filename '{filename}' not found and no search paths are registered."
+        )
     return full_path
 
 

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -160,3 +160,30 @@ def test_base_path_change_clears_old(set_base_dir):
 
     for name in ["controlnet", "diffusion_models", "text_encoders"]:
         assert len(folder_paths.get_folder_paths(name)) == 2
+
+
+def test_get_full_path_or_raise_includes_search_paths(clear_folder_paths, temp_dir):
+    first_dir = os.path.join(temp_dir, "first")
+    second_dir = os.path.join(temp_dir, "second")
+    folder_paths.add_model_folder_path("test_folder", first_dir, is_default=True)
+    folder_paths.add_model_folder_path("test_folder", second_dir, is_default=False)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        folder_paths.get_full_path_or_raise("test_folder", "missing_model.safetensors")
+
+    message = str(exc_info.value)
+    assert "Model in folder 'test_folder'" in message
+    assert "missing_model.safetensors" in message
+    assert "Searched in:" in message
+    assert first_dir in message
+    assert second_dir in message
+
+
+def test_get_full_path_or_raise_mentions_legacy_mapping(clear_folder_paths):
+    with pytest.raises(FileNotFoundError) as exc_info:
+        folder_paths.get_full_path_or_raise("clip", "missing_encoder.safetensors")
+
+    message = str(exc_info.value)
+    assert "Model in folder 'clip' (mapped to 'text_encoders')" in message
+    assert os.path.join(folder_paths.models_dir, "text_encoders") in message
+    assert os.path.join(folder_paths.models_dir, "clip") in message


### PR DESCRIPTION
## Summary
- include the actual searched model directories in `get_full_path_or_raise` errors
- mention legacy folder aliases when a requested folder name is remapped internally
- add unit coverage for both direct search path hints and legacy mapping messages

## Why
Issue #13310 asks for missing-model errors to show users where the corresponding model should be placed. Today the error only says the model was not found, which forces users to inspect source or guess the right directory.

## Testing
- pytest tests-unit/comfy_test/folder_path_test.py
- pytest tests-unit/comfy_test/folder_path_test.py tests-unit/folder_paths_test