### PR TITLE
Fix progress text metadata negotiation

### DIFF
--- a/comfy_api/feature_flags.py
+++ b/comfy_api/feature_flags.py
@@ -12,6 +12,7 @@ from comfy.cli_args import args
 # Default server capabilities
 SERVER_FEATURE_FLAGS: dict[str, Any] = {
     "supports_preview_metadata": True,
+    "supports_progress_text_metadata": True,
     "max_upload_size": args.max_upload_size * 1024 * 1024, # Convert MB to bytes
     "extension": {"manager": {"supports_v4": True}},
     "node_replacements": True,

--- a/server.py
+++ b/server.py
@@ -45,6 +45,7 @@ from app.subgraph_manager import SubgraphManager
 from app.node_replace_manager import NodeReplaceManager
 from typing import Optional, Union
 from api_server.routes.internal.internal_routes import InternalRoutes
+from comfy_execution.utils import get_executing_context
 from protocol import BinaryEventTypes
 
 # Import cache control middleware
@@ -1282,7 +1283,14 @@ class PromptServer():
             text = text.encode("utf-8")
         node_id_bytes = str(node_id).encode("utf-8")
 
-        # Pack the node_id length as a 4-byte unsigned integer, followed by the node_id bytes
-        message = struct.pack(">I", len(node_id_bytes)) + node_id_bytes + text
+        target_sid = sid if sid is not None else self.client_id
+        message = b""
 
-        self.send_sync(BinaryEventTypes.TEXT, message, sid)
+        if feature_flags.supports_feature(self.sockets_metadata, target_sid, "supports_progress_text_metadata"):
+            current = get_executing_context()
+            prompt_id_bytes = str(current.prompt_id).encode("utf-8") if current is not None else b""
+            message = struct.pack(">I", len(prompt_id_bytes)) + prompt_id_bytes
+
+        message += struct.pack(">I", len(node_id_bytes)) + node_id_bytes + text
+
+        self.send_sync(BinaryEventTypes.TEXT, message, target_sid)


### PR DESCRIPTION
The preview of Get Image Size particulars broke due to FE protocol updates.

Example Test Conditions:

<img width="863" height="94" alt="image" src="https://github.com/user-attachments/assets/fa0ed418-3faf-40e2-9a61-cebb6657f0a0" />


Linux, firefox
Load Image -> Get Image Size -> Preview as Text

Before:

<img width="1775" height="713" alt="image" src="https://github.com/user-attachments/assets/1b643e84-249d-4e68-a2ce-40e69bae8ff0" />

After:

<img width="1775" height="713" alt="image" src="https://github.com/user-attachments/assets/38f77e03-f6d3-4218-80d4-b9e507dae019" />
