### PR TITLE
Minor updates for worksplit_gpu with comfy-aimdo

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -319,7 +319,8 @@ class ModelPatcher:
         #than pays for CFG. So return everything both torch and Aimdo could give us
         aimdo_mem = 0
         if comfy.memory_management.aimdo_enabled:
-            aimdo_mem = comfy_aimdo.model_vbar.vbars_analyze()
+            aimdo_device = device.index if getattr(device, "type", None) == "cuda" else None
+            aimdo_mem = comfy_aimdo.model_vbar.vbars_analyze(aimdo_device)
         return comfy.model_management.get_free_memory(device) + aimdo_mem
 
     def get_clone_model_override(self):

--- a/main.py
+++ b/main.py
@@ -192,7 +192,7 @@ import gc
 if 'torch' in sys.modules:
     logging.warning("WARNING: Potential Error in code: Torch already imported, torch should never be imported before this point.")
 
-
+import torch
 import comfy.utils
 
 import execution
@@ -210,7 +210,7 @@ import comfy.model_patcher
 if args.enable_dynamic_vram or (enables_dynamic_vram() and comfy.model_management.is_nvidia() and not comfy.model_management.is_wsl()):
     if (not args.enable_dynamic_vram) and (comfy.model_management.torch_version_numeric < (2, 8)):
         logging.warning("Unsupported Pytorch detected. DynamicVRAM support requires Pytorch version 2.8 or later. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
-    elif comfy_aimdo.control.init_device(comfy.model_management.get_torch_device().index):
+    elif comfy_aimdo.control.init_devices(range(torch.cuda.device_count())):
         if args.verbose == 'DEBUG':
             comfy_aimdo.control.set_log_debug()
         elif args.verbose == 'CRITICAL':

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy
 filelock
 av>=14.2.0
 comfy-kitchen>=0.2.8
-comfy-aimdo>=0.2.12
+comfy-aimdo==0.0.213
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
Upcoming comfy-aimdo has direct multi-GPU support (not yet released). This aimdo support symmetric device init so pass all devices to aimdo for upfront init (previous versions depended on a lazy init of non-primary GPUs). Fix the vbars_analyze call to be per-GPU and not report free-able VRAM as a global pool.

wheel that can be used here:

https://github.com/Comfy-Org/comfy-aimdo/actions/runs/24448365803

Example test conditions:

Linux, 2x4090
qwen 38GB (2512) 1328x1328 CFG=4 second run performance.

<img width="1648" height="1091" alt="image" src="https://github.com/user-attachments/assets/f70f76e3-ec0a-42c5-b894-d70b908020cc" />

```
pytorch version: 2.11.0+cu130
Set vram state to: NORMAL_VRAM
Device: cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync
Device: cuda:1 NVIDIA GeForce RTX 4090 : cudaMallocAsync
Using async weight offloading with 2 streams
Enabled pinned memory 115850.0
Using pytorch attention
aimdo: /project/src-posix/cuda-funchooks.c:126:DEBUG:aimdo_setup_hooks: hooks successfully installed
aimdo: /project/src/control.c:144:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 4090 (VRAM: 24078 MB)
aimdo: /project/src/control.c:144:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 4090 (VRAM: 24080 MB)
DynamicVRAM support detected and enabled
Python version: 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0]
ComfyUI version: 0.18.1
comfy-aimdo version: 0.2.13.dev15
comfy-kitchen version: 0.2.8
```

1 GPU:

got prompt
Model QwenImage prepared for dynamic VRAM loading. 38968MB Staged. 0 patches attached.
100%|██████████████████████████████████████████████████████████████████████████████| 20/20 [01:02<00:00,  3.13s/it]
2 GPU:

Model QwenImage prepared for dynamic VRAM loading. 38968MB Staged. 0 patches attached.
Model QwenImage prepared for dynamic VRAM loading. 38968MB Staged. 0 patches attached.
100%|███████████████████████████████████████████████████████████████████████████████████| 20/20 [00:32<00:00,  1.62s/it]
