### PR TITLE
Change temporary file permissions to 666

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -383,6 +383,7 @@ class UserManager():
                 try:
                     with os.fdopen(fd, "wb") as f:
                         f.write(body)
+                    os.chmod(tmp_path, 0o666)
                     os.replace(tmp_path, path)
                 except:
                     os.unlink(tmp_path)


### PR DESCRIPTION
Set permissions of the temporary file to 666 before replacing. 

Why?
ComfyUI can be used (as is with our case) in a collaborative environment where files and workflows are shared between users. Previous versions of ComfyUI (last version I checked was v0.11.0) were saving with readable permissions.
This change just changes the permissions of the temp file before the replace call.