### PR TITLE
Use `ErnieTEModel_` not `ErnieTEModel`.

### DIFF
--- a/comfy/text_encoders/ernie.py
+++ b/comfy/text_encoders/ernie.py
@@ -35,4 +35,4 @@ def te(dtype_llama=None, llama_quantization_metadata=None):
                 model_options = model_options.copy()
                 model_options["quantization_metadata"] = llama_quantization_metadata
             super().__init__(device=device, dtype=dtype, model_options=model_options)
-    return ErnieTEModel
+    return ErnieTEModel_


### PR DESCRIPTION
Minor fix of ErnieTEModel.

Currently TE for ERNIE-Image refers `ErnieTEModel` and it cause,
- slow decode
- MixedPrecision model not working.

It fixes the above things.