### PR TITLE
temporary: RemoteComboOptions widget examples

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -43,7 +43,67 @@ class UploadType(str, Enum):
     model = "file_upload"
 
 
+class RemoteItemSchema:
+    """Describes how to map API response objects to rich dropdown items.
+
+    All *_field parameters use dot-path notation (e.g. ``"labels.gender"``).
+    ``label_field`` and ``description_field`` additionally support template strings
+    with ``{field}`` placeholders (e.g. ``"{name} ({labels.accent})"``).
+    """
+    def __init__(
+        self,
+        value_field: str,
+        label_field: str,
+        preview_url_field: str | None = None,
+        preview_type: Literal["image", "video", "audio"] = "image",
+        description_field: str | None = None,
+        search_fields: list[str] | None = None,
+    ):
+        if preview_type not in ("image", "video", "audio"):
+            raise ValueError(
+                f"RemoteItemSchema: 'preview_type' must be 'image', 'video', or 'audio'; got {preview_type!r}."
+            )
+        if search_fields is not None:
+            for f in search_fields:
+                if "{" in f or "}" in f:
+                    raise ValueError(
+                        f"RemoteItemSchema: 'search_fields' must be dot-paths, not template strings (got {f!r})."
+                    )
+        self.value_field = value_field
+        """Dot-path to the unique identifier within each item.
+        This value is stored in the widget and passed to execute()."""
+        self.label_field = label_field
+        """Dot-path to the display name, or a template string with {field} placeholders."""
+        self.preview_url_field = preview_url_field
+        """Dot-path to a preview media URL. If None, no preview is shown."""
+        self.preview_type = preview_type
+        """How to render the preview: "image", "video", or "audio"."""
+        self.description_field = description_field
+        """Optional dot-path or template for a subtitle line shown below the label."""
+        self.search_fields = search_fields
+        """Dot-paths to fields included in the search index. When unset, search falls back to
+        the resolved label (i.e. ``label_field`` after template substitution). Note that template
+        label strings (e.g. ``"{first} {last}"``) are not valid path entries here — list the
+        underlying paths (``["first", "last"]``) instead."""
+
+    def as_dict(self):
+        return prune_dict({
+            "value_field": self.value_field,
+            "label_field": self.label_field,
+            "preview_url_field": self.preview_url_field,
+            "preview_type": self.preview_type,
+            "description_field": self.description_field,
+            "search_fields": self.search_fields,
+        })
+
+
 class RemoteOptions:
+    """Plain remote combo: fetches a list of strings/objects and populates a standard dropdown.
+
+    Use this for lightweight lists from endpoints that return a bare array (or an array under
+    ``response_key``). For rich dropdowns with previews, search, filtering, or pagination,
+    use :class:`RemoteComboOptions` and the ``remote_combo=`` parameter on ``Combo.Input``.
+    """
     def __init__(self, route: str, refresh_button: bool, control_after_refresh: Literal["first", "last"]="first",
                  timeout: int=None, max_retries: int=None, refresh: int=None):
         self.route = route
@@ -67,6 +127,80 @@ class RemoteOptions:
             "timeout": self.timeout,
             "max_retries": self.max_retries,
             "refresh": self.refresh,
+        })
+
+
+class RemoteComboOptions:
+    """Rich remote combo: populates a Vue dropdown with previews, search, and filtering.
+
+    Attached to a :class:`Combo.Input` via ``remote_combo=`` (not ``remote=``). Requires an
+    ``item_schema`` describing how to map API response objects to dropdown items.
+
+    Response-shape contract: the endpoint returns the full items array in a single response
+    (either at the top level, or at the dot-path given by ``response_key``). Backing endpoints
+    that paginate upstream are expected to aggregate and cache server-side.
+    """
+    def __init__(
+        self,
+        route: str,
+        item_schema: RemoteItemSchema,
+        refresh_button: bool = True,
+        auto_select: Literal["first", "last"] | None = None,
+        timeout: int | None = None,
+        max_retries: int | None = None,
+        refresh: int | None = None,
+        response_key: str | None = None,
+    ):
+        if auto_select is not None and auto_select not in ("first", "last"):
+            raise ValueError(
+                f"RemoteComboOptions: 'auto_select' must be 'first', 'last', or None; got {auto_select!r}."
+            )
+        if refresh is not None and 0 < refresh < 128:
+            raise ValueError(
+                f"RemoteComboOptions: 'refresh' must be >= 128 (ms TTL) or <= 0 (cache never expires); got {refresh}."
+            )
+        if timeout is not None and timeout < 0:
+            raise ValueError(
+                f"RemoteComboOptions: 'timeout' must be >= 0 (got {timeout})."
+            )
+        if max_retries is not None and max_retries < 0:
+            raise ValueError(
+                f"RemoteComboOptions: 'max_retries' must be >= 0 (got {max_retries})."
+            )
+        if not route.startswith("/"):
+            raise ValueError(
+                f"RemoteComboOptions: 'route' must be a relative path starting with '/'; got {route!r}."
+            )
+        self.route = route
+        """Relative path to the remote source (must start with ``/``). The frontend resolves this
+        against the comfy-api base URL and injects auth headers; absolute URLs are rejected."""
+        self.item_schema = item_schema
+        """Required: describes how each API response object maps to a dropdown item."""
+        self.refresh_button = refresh_button
+        """Specifies whether to show a refresh button next to the widget."""
+        self.auto_select = auto_select
+        """Fallback item to select when the widget's value is empty. Never overrides an existing
+        selection. Default None means no fallback."""
+        self.timeout = timeout
+        """Maximum time to wait for a response, in milliseconds."""
+        self.max_retries = max_retries
+        """Maximum number of retries before aborting the request. Default None uses the frontend's built-in limit."""
+        self.refresh = refresh
+        """TTL of the cached value in milliseconds. Must be >= 128 (ms TTL) or <= 0 (cache never expires,
+        re-fetched only via the refresh button). Default None uses the frontend's built-in behavior."""
+        self.response_key = response_key
+        """Dot-path to the items array within the response (when not at the top level)."""
+
+    def as_dict(self):
+        return prune_dict({
+            "route": self.route,
+            "item_schema": self.item_schema.as_dict(),
+            "refresh_button": self.refresh_button,
+            "auto_select": self.auto_select,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "refresh": self.refresh,
+            "response_key": self.response_key,
         })
 
 
@@ -359,11 +493,16 @@ class Combo(ComfyTypeIO):
             upload: UploadType=None,
             image_folder: FolderType=None,
             remote: RemoteOptions=None,
+            remote_combo: RemoteComboOptions=None,
             socketless: bool=None,
             extra_dict=None,
             raw_link: bool=None,
             advanced: bool=None,
         ):
+            if remote is not None and remote_combo is not None:
+                raise ValueError("Combo.Input: pass either 'remote' or 'remote_combo', not both.")
+            if options is not None and remote_combo is not None:
+                raise ValueError("Combo.Input: pass either 'options' or 'remote_combo', not both.")
             if isinstance(options, type) and issubclass(options, Enum):
                 options = [v.value for v in options]
             if isinstance(default, Enum):
@@ -375,6 +514,7 @@ class Combo(ComfyTypeIO):
             self.upload = upload
             self.image_folder = image_folder
             self.remote = remote
+            self.remote_combo = remote_combo
             self.default: str
 
         def as_dict(self):
@@ -385,6 +525,7 @@ class Combo(ComfyTypeIO):
                 **({self.upload.value: True} if self.upload is not None else {}),
                 "image_folder": self.image_folder.value if self.image_folder else None,
                 "remote": self.remote.as_dict() if self.remote else None,
+                "remote_combo": self.remote_combo.as_dict() if self.remote_combo else None,
             })
 
     class Output(Output):
@@ -2221,7 +2362,9 @@ class NodeReplace:
 __all__ = [
     "FolderType",
     "UploadType",
+    "RemoteItemSchema",
     "RemoteOptions",
+    "RemoteComboOptions",
     "NumberDisplay",
     "ControlAfterGenerate",
 

--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -9,6 +9,7 @@ from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Callable, Literal, TypedDict, TypeVar, TYPE_CHECKING
 from typing_extensions import NotRequired, final
+from urllib.parse import urlparse
 
 # used for type hinting
 import torch
@@ -43,7 +44,67 @@ class UploadType(str, Enum):
     model = "file_upload"
 
 
+class RemoteItemSchema:
+    """Describes how to map API response objects to rich dropdown items.
+
+    All *_field parameters use dot-path notation (e.g. ``"labels.gender"``).
+    ``label_field`` and ``description_field`` additionally support template strings
+    with ``{field}`` placeholders (e.g. ``"{name} ({labels.accent})"``).
+    """
+    def __init__(
+        self,
+        value_field: str,
+        label_field: str,
+        preview_url_field: str | None = None,
+        preview_type: Literal["image", "video", "audio"] = "image",
+        description_field: str | None = None,
+        search_fields: list[str] | None = None,
+    ):
+        if preview_type not in ("image", "video", "audio"):
+            raise ValueError(
+                f"RemoteItemSchema: 'preview_type' must be 'image', 'video', or 'audio'; got {preview_type!r}."
+            )
+        if search_fields is not None:
+            for f in search_fields:
+                if "{" in f or "}" in f:
+                    raise ValueError(
+                        f"RemoteItemSchema: 'search_fields' must be dot-paths, not template strings (got {f!r})."
+                    )
+        self.value_field = value_field
+        """Dot-path to the unique identifier within each item.
+        This value is stored in the widget and passed to execute()."""
+        self.label_field = label_field
+        """Dot-path to the display name, or a template string with {field} placeholders."""
+        self.preview_url_field = preview_url_field
+        """Dot-path to a preview media URL. If None, no preview is shown."""
+        self.preview_type = preview_type
+        """How to render the preview: "image", "video", or "audio"."""
+        self.description_field = description_field
+        """Optional dot-path or template for a subtitle line shown below the label."""
+        self.search_fields = search_fields
+        """Dot-paths to fields included in the search index. When unset, search falls back to
+        the resolved label (i.e. ``label_field`` after template substitution). Note that template
+        label strings (e.g. ``"{first} {last}"``) are not valid path entries here — list the
+        underlying paths (``["first", "last"]``) instead."""
+
+    def as_dict(self):
+        return prune_dict({
+            "value_field": self.value_field,
+            "label_field": self.label_field,
+            "preview_url_field": self.preview_url_field,
+            "preview_type": self.preview_type,
+            "description_field": self.description_field,
+            "search_fields": self.search_fields,
+        })
+
+
 class RemoteOptions:
+    """Plain remote combo: fetches a list of strings/objects and populates a standard dropdown.
+
+    Use this for lightweight lists from endpoints that return a bare array (or an array under
+    ``response_key``). For rich dropdowns with previews, search, filtering, or pagination,
+    use :class:`RemoteComboOptions` and the ``remote_combo=`` parameter on ``Combo.Input``.
+    """
     def __init__(self, route: str, refresh_button: bool, control_after_refresh: Literal["first", "last"]="first",
                  timeout: int=None, max_retries: int=None, refresh: int=None):
         self.route = route
@@ -67,6 +128,113 @@ class RemoteOptions:
             "timeout": self.timeout,
             "max_retries": self.max_retries,
             "refresh": self.refresh,
+        })
+
+
+class RemoteComboOptions:
+    """Rich remote combo: populates a Vue dropdown with previews, search, filtering, and pagination.
+
+    Attached to a :class:`Combo.Input` via ``remote_combo=`` (not ``remote=``). Requires an
+    ``item_schema`` describing how to map API response objects to dropdown items.
+
+    Response-shape contract:
+    - Without ``page_size``: endpoint returns an array (or an array at ``response_key``).
+    - With ``page_size``: endpoint returns ``{"items": [...], "has_more": bool}`` and is fetched
+      progressively, appending each page to the dropdown.
+
+    Pagination contract (when ``page_size`` is set):
+    - The frontend issues ``GET <route>?page=<n>&page_size=<size>`` with ``page`` starting at ``0``
+      and incrementing by 1 until the endpoint returns ``has_more: false`` or an empty ``items`` list.
+    - Endpoints that use 1-based pages, ``limit``/``offset``, or cursor/continuation tokens are not
+      supported directly - adapt them via the proxy or
+      expose a small shim endpoint that translates to the ``page`` + ``page_size`` + ``{items, has_more}`` shape.
+    """
+    def __init__(
+        self,
+        route: str,
+        item_schema: RemoteItemSchema,
+        refresh_button: bool = True,
+        auto_select: Literal["first", "last"] | None = None,
+        timeout: int | None = None,
+        max_retries: int | None = None,
+        refresh: int | None = None,
+        response_key: str | None = None,
+        use_comfy_api: bool = False,
+        page_size: int | None = None,
+    ):
+        if page_size is not None:
+            if response_key is not None:
+                raise ValueError(
+                    "RemoteComboOptions: pass 'response_key' or 'page_size', not both. "
+                    "Paginated responses must use the top-level 'items' field."
+                )
+            if page_size < 1:
+                raise ValueError(
+                    f"RemoteComboOptions: 'page_size' must be >= 1 when set (got {page_size})."
+                )
+        if auto_select is not None and auto_select not in ("first", "last"):
+            raise ValueError(
+                f"RemoteComboOptions: 'auto_select' must be 'first', 'last', or None; got {auto_select!r}."
+            )
+        if refresh is not None and 0 < refresh < 128:
+            raise ValueError(
+                f"RemoteComboOptions: 'refresh' must be >= 128 (ms TTL) or <= 0 (cache never expires); got {refresh}."
+            )
+        if timeout is not None and timeout < 0:
+            raise ValueError(
+                f"RemoteComboOptions: 'timeout' must be >= 0 (got {timeout})."
+            )
+        if max_retries is not None and max_retries < 0:
+            raise ValueError(
+                f"RemoteComboOptions: 'max_retries' must be >= 0 (got {max_retries})."
+            )
+        if not route.startswith("/"):
+            parsed = urlparse(route)
+            if not (parsed.scheme and parsed.netloc):
+                raise ValueError(
+                    f"RemoteComboOptions: 'route' must start with '/' or be an absolute URL; got {route!r}."
+                )
+            if use_comfy_api:
+                raise ValueError(
+                    f"RemoteComboOptions: 'use_comfy_api=True' cannot be combined with absolute URL {route!r}."
+                )
+        self.route = route
+        """The route to the remote source."""
+        self.item_schema = item_schema
+        """Required: describes how each API response object maps to a dropdown item."""
+        self.refresh_button = refresh_button
+        """Specifies whether to show a refresh button next to the widget."""
+        self.auto_select = auto_select
+        """Fallback item to select when the widget's value is empty. Never overrides an existing
+        selection. Default None means no fallback."""
+        self.timeout = timeout
+        """Maximum time to wait for a response, in milliseconds."""
+        self.max_retries = max_retries
+        """Maximum number of retries before aborting the request. Default None uses the frontend's built-in limit."""
+        self.refresh = refresh
+        """TTL of the cached value in milliseconds. Must be >= 128 (ms TTL) or <= 0 (cache never expires,
+        re-fetched only via the refresh button). Default None uses the frontend's built-in behavior."""
+        self.response_key = response_key
+        """Dot-path to the items array in a non-paginated response. Mutually exclusive with
+        ``page_size``; paginated responses must use the top-level ``items`` field."""
+        self.use_comfy_api = use_comfy_api
+        """When True, the frontend prepends the comfy-api base URL to ``route`` and injects auth headers."""
+        self.page_size = page_size
+        """When set, switches the widget to progressive-fetch mode. The endpoint must return
+        ``{"items": [...], "has_more": bool}``."""
+
+    def as_dict(self):
+        return prune_dict({
+            "route": self.route,
+            "item_schema": self.item_schema.as_dict(),
+            "refresh_button": self.refresh_button,
+            "auto_select": self.auto_select,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "refresh": self.refresh,
+            "response_key": self.response_key,
+            "use_comfy_api": self.use_comfy_api,
+            "page_size": self.page_size,
         })
 
 
@@ -359,11 +527,16 @@ class Combo(ComfyTypeIO):
             upload: UploadType=None,
             image_folder: FolderType=None,
             remote: RemoteOptions=None,
+            remote_combo: RemoteComboOptions=None,
             socketless: bool=None,
             extra_dict=None,
             raw_link: bool=None,
             advanced: bool=None,
         ):
+            if remote is not None and remote_combo is not None:
+                raise ValueError("Combo.Input: pass either 'remote' or 'remote_combo', not both.")
+            if options is not None and remote_combo is not None:
+                raise ValueError("Combo.Input: pass either 'options' or 'remote_combo', not both.")
             if isinstance(options, type) and issubclass(options, Enum):
                 options = [v.value for v in options]
             if isinstance(default, Enum):
@@ -375,6 +548,7 @@ class Combo(ComfyTypeIO):
             self.upload = upload
             self.image_folder = image_folder
             self.remote = remote
+            self.remote_combo = remote_combo
             self.default: str
 
         def as_dict(self):
@@ -385,6 +559,7 @@ class Combo(ComfyTypeIO):
                 **({self.upload.value: True} if self.upload is not None else {}),
                 "image_folder": self.image_folder.value if self.image_folder else None,
                 "remote": self.remote.as_dict() if self.remote else None,
+                "remote_combo": self.remote_combo.as_dict() if self.remote_combo else None,
             })
 
     class Output(Output):
@@ -2184,7 +2359,9 @@ class NodeReplace:
 __all__ = [
     "FolderType",
     "UploadType",
+    "RemoteItemSchema",
     "RemoteOptions",
+    "RemoteComboOptions",
     "NumberDisplay",
     "ControlAfterGenerate",
 

--- a/comfy_api_nodes/apis/bytedance.py
+++ b/comfy_api_nodes/apis/bytedance.py
@@ -132,6 +132,10 @@ class GetAssetResponse(BaseModel):
     error: TaskStatusError | None = Field(None)
 
 
+class SeedanceCreateVisualValidateSessionRequest(BaseModel):
+    name: str | None = Field(None, max_length=64)
+
+
 class SeedanceCreateVisualValidateSessionResponse(BaseModel):
     session_id: str = Field(...)
     h5_link: str = Field(...)
@@ -141,6 +145,7 @@ class SeedanceGetVisualValidateSessionResponse(BaseModel):
     session_id: str = Field(...)
     status: str = Field(...)
     group_id: str | None = Field(None)
+    name: str | None = Field(None)
     error_code: str | None = Field(None)
     error_message: str | None = Field(None)
 

--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -1948,7 +1948,7 @@ async def process_video_task(
 
 
 def _seedance_group_picker_input() -> IO.Combo.Input:
-    """Combo populated from /proxy/seedance/groups. Empty selection triggers H5 enrollment."""
+    """Combo populated from /proxy/seedance/visual-validate/groups. Empty selection triggers H5 enrollment."""
     return IO.Combo.Input(
         "group_id",
         default="",
@@ -1957,7 +1957,7 @@ def _seedance_group_picker_input() -> IO.Combo.Input:
             "authentication and create a new group."
         ),
         remote_combo=IO.RemoteComboOptions(
-            route="/proxy/seedance/groups",
+            route="/proxy/seedance/visual-validate/groups",
             response_key="groups",
             item_schema=IO.RemoteItemSchema(
                 value_field="group_id",

--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -19,6 +19,7 @@ from comfy_api_nodes.apis.bytedance import (
     Seedance2TaskCreationRequest,
     SeedanceCreateAssetRequest,
     SeedanceCreateAssetResponse,
+    SeedanceCreateVisualValidateSessionRequest,
     SeedanceCreateVisualValidateSessionResponse,
     SeedanceGetVisualValidateSessionResponse,
     SeedanceVirtualLibraryCreateAssetRequest,
@@ -196,11 +197,16 @@ def _rewrite_asset_refs(prompt: str, labels: dict[int, str]) -> str:
     return _ASSET_REF_RE.sub(_sub, prompt)
 
 
-async def _obtain_group_id_via_h5_auth(cls: type[IO.ComfyNode]) -> str:
+async def _obtain_group_id_via_h5_auth(
+    cls: type[IO.ComfyNode],
+    group_name: str | None = None,
+) -> str:
+    payload = SeedanceCreateVisualValidateSessionRequest(name=group_name)
     session = await sync_op(
         cls,
         ApiEndpoint(path="/proxy/seedance/visual-validate/sessions", method="POST"),
         response_model=SeedanceCreateVisualValidateSessionResponse,
+        data=payload,
     )
     logger.warning("Seedance authentication required. Open link: %s", session.h5_link)
 
@@ -229,10 +235,15 @@ async def _obtain_group_id_via_h5_auth(cls: type[IO.ComfyNode]) -> str:
     return result.group_id
 
 
-async def _resolve_group_id(cls: type[IO.ComfyNode], group_id: str) -> str:
+async def _resolve_group_id(
+    cls: type[IO.ComfyNode],
+    group_id: str,
+    group_name: str | None = None,
+) -> str:
     if group_id and group_id.strip():
         return group_id.strip()
-    return await _obtain_group_id_via_h5_auth(cls)
+    label = (group_name or "").strip() or None
+    return await _obtain_group_id_via_h5_auth(cls, group_name=label)
 
 
 async def _create_seedance_asset(
@@ -1936,6 +1947,43 @@ async def process_video_task(
     return IO.NodeOutput(await download_url_to_video_output(response.content.video_url))
 
 
+def _seedance_group_picker_input() -> IO.Combo.Input:
+    """Combo populated from /proxy/seedance/groups. Empty selection triggers H5 enrollment."""
+    return IO.Combo.Input(
+        "group_id",
+        default="",
+        tooltip=(
+            "Pick an existing verified group, or leave empty to run real-person H5 "
+            "authentication and create a new group."
+        ),
+        remote_combo=IO.RemoteComboOptions(
+            route="/proxy/seedance/groups",
+            response_key="groups",
+            item_schema=IO.RemoteItemSchema(
+                value_field="group_id",
+                label_field="name",
+                description_field="created_at",
+                search_fields=["name", "group_id"],
+            ),
+            refresh=60_000,
+        ),
+        optional=True,
+    )
+
+
+def _seedance_group_name_input() -> IO.String.Input:
+    return IO.String.Input(
+        "group_name",
+        default="",
+        tooltip=(
+            "Optional label for a new group. Used only when group_id is empty; the label is "
+            "shown later in the group picker so you can identify this group at a glance. "
+            "Up to 64 characters."
+        ),
+        optional=True,
+    )
+
+
 class ByteDanceCreateImageAsset(IO.ComfyNode):
 
     @classmethod
@@ -1946,22 +1994,14 @@ class ByteDanceCreateImageAsset(IO.ComfyNode):
             category="api node/image/ByteDance",
             description=(
                 "Create a Seedance 2.0 personal image asset. Uploads the input image and "
-                "registers it in the given asset group. If group_id is empty, runs a real-person "
-                "H5 authentication flow to create a new group before adding the asset."
+                "registers it in the selected asset group. Leave group_id empty to run a "
+                "real-person H5 authentication flow and create a new group; provide group_name "
+                "to label the new group."
             ),
             inputs=[
                 IO.Image.Input("image", tooltip="Image to register as a personal asset."),
-                IO.String.Input(
-                    "group_id",
-                    default="",
-                    tooltip="Reuse an existing Seedance asset group ID to skip repeated human verification for the "
-                    "same person. Leave empty to run real-person authentication in the browser and create a new group.",
-                ),
-                # IO.String.Input(
-                #     "name",
-                #     default="",
-                #     tooltip="Asset name (up to 64 characters).",
-                # ),
+                _seedance_group_picker_input(),
+                _seedance_group_name_input(),
             ],
             outputs=[
                 IO.String.Output(display_name="asset_id"),
@@ -1980,13 +2020,11 @@ class ByteDanceCreateImageAsset(IO.ComfyNode):
         cls,
         image: Input.Image,
         group_id: str = "",
-        # name: str = "",
+        group_name: str = "",
     ) -> IO.NodeOutput:
-        # if len(name) > 64:
-        #     raise ValueError("Name of asset can not be greater then 64 symbols")
         validate_image_dimensions(image, min_width=300, max_width=6000, min_height=300, max_height=6000)
         validate_image_aspect_ratio(image, min_ratio=(0.4, 1), max_ratio=(2.5, 1))
-        resolved_group = await _resolve_group_id(cls, group_id)
+        resolved_group = await _resolve_group_id(cls, group_id, group_name=group_name)
         asset_id = await _create_seedance_asset(
             cls,
             group_id=resolved_group,
@@ -2013,22 +2051,14 @@ class ByteDanceCreateVideoAsset(IO.ComfyNode):
             category="api node/video/ByteDance",
             description=(
                 "Create a Seedance 2.0 personal video asset. Uploads the input video and "
-                "registers it in the given asset group. If group_id is empty, runs a real-person "
-                "H5 authentication flow to create a new group before adding the asset."
+                "registers it in the selected asset group. Leave group_id empty to run a "
+                "real-person H5 authentication flow and create a new group; provide group_name "
+                "to label the new group."
             ),
             inputs=[
                 IO.Video.Input("video", tooltip="Video to register as a personal asset."),
-                IO.String.Input(
-                    "group_id",
-                    default="",
-                    tooltip="Reuse an existing Seedance asset group ID to skip repeated human verification for the "
-                    "same person. Leave empty to run real-person authentication in the browser and create a new group.",
-                ),
-                # IO.String.Input(
-                #     "name",
-                #     default="",
-                #     tooltip="Asset name (up to 64 characters).",
-                # ),
+                _seedance_group_picker_input(),
+                _seedance_group_name_input(),
             ],
             outputs=[
                 IO.String.Output(display_name="asset_id"),
@@ -2047,10 +2077,8 @@ class ByteDanceCreateVideoAsset(IO.ComfyNode):
         cls,
         video: Input.Video,
         group_id: str = "",
-        # name: str = "",
+        group_name: str = "",
     ) -> IO.NodeOutput:
-        # if len(name) > 64:
-        #     raise ValueError("Name of asset can not be greater then 64 symbols")
         validate_video_duration(video, min_duration=2, max_duration=15)
         validate_video_dimensions(video, min_width=300, max_width=6000, min_height=300, max_height=6000)
 
@@ -2069,7 +2097,7 @@ class ByteDanceCreateVideoAsset(IO.ComfyNode):
         if not (24 <= fps <= 60):
             raise ValueError(f"Asset video FPS must be in [24, 60], got {fps:.2f}.")
 
-        resolved_group = await _resolve_group_id(cls, group_id)
+        resolved_group = await _resolve_group_id(cls, group_id, group_name=group_name)
         asset_id = await _create_seedance_asset(
             cls,
             group_id=resolved_group,
@@ -2084,6 +2112,92 @@ class ByteDanceCreateVideoAsset(IO.ComfyNode):
             cls.hidden.unique_id,
         )
         return IO.NodeOutput(asset_id, resolved_group)
+
+
+def _seedance_asset_picker_input(asset_type: str, preview_type: str) -> IO.Combo.Input:
+    """Combo populated from /proxy/seedance/assets, scoped to one asset_type."""
+    return IO.Combo.Input(
+        "asset_id",
+        tooltip=(
+            f"Pick a previously-created Seedance {asset_type.lower()} asset. The dropdown shows "
+            "your assets across all your verified groups; type a group name to filter."
+        ),
+        remote_combo=IO.RemoteComboOptions(
+            route=f"/proxy/seedance/assets?asset_type={asset_type}",
+            response_key="assets",
+            item_schema=IO.RemoteItemSchema(
+                value_field="asset_id",
+                label_field="name",
+                description_field="group_name",
+                preview_url_field="url",
+                preview_type=preview_type,
+                search_fields=["name", "asset_id", "group_name", "group_id"],
+            ),
+            refresh=60_000,
+        ),
+    )
+
+
+class ByteDanceSelectImageAsset(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="ByteDanceSelectImageAsset",
+            display_name="ByteDance Select Image Asset",
+            category="api node/image/ByteDance",
+            description=(
+                "Pick a previously-created Seedance image asset. Outputs the selected asset_id "
+                "for use with downstream Seedance 2.0 reference/first-last-frame nodes."
+            ),
+            inputs=[
+                _seedance_asset_picker_input("Image", "image"),
+            ],
+            outputs=[IO.String.Output(display_name="asset_id")],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            # is_api_node=True,
+        )
+
+    @classmethod
+    async def execute(cls, asset_id: str) -> IO.NodeOutput:
+        if not asset_id or not asset_id.strip():
+            raise ValueError("asset_id is required. Pick an asset from the dropdown.")
+        return IO.NodeOutput(asset_id.strip())
+
+
+class ByteDanceSelectVideoAsset(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="ByteDanceSelectVideoAsset",
+            display_name="ByteDance Select Video Asset",
+            category="api node/video/ByteDance",
+            description=(
+                "Pick a previously-created Seedance video asset. Outputs the selected asset_id "
+                "for use with downstream Seedance 2.0 reference/first-last-frame nodes."
+            ),
+            inputs=[
+                _seedance_asset_picker_input("Video", "video"),
+            ],
+            outputs=[IO.String.Output(display_name="asset_id")],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            # is_api_node=True,
+        )
+
+    @classmethod
+    async def execute(cls, asset_id: str) -> IO.NodeOutput:
+        if not asset_id or not asset_id.strip():
+            raise ValueError("asset_id is required. Pick an asset from the dropdown.")
+        return IO.NodeOutput(asset_id.strip())
 
 
 class ByteDanceExtension(ComfyExtension):
@@ -2101,6 +2215,8 @@ class ByteDanceExtension(ComfyExtension):
             ByteDance2ReferenceNode,
             ByteDanceCreateImageAsset,
             ByteDanceCreateVideoAsset,
+            ByteDanceSelectImageAsset,
+            ByteDanceSelectVideoAsset,
         ]
 
 

--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -1984,6 +1984,18 @@ def _seedance_group_name_input() -> IO.String.Input:
     )
 
 
+def _seedance_asset_name_input() -> IO.String.Input:
+    return IO.String.Input(
+        "asset_name",
+        default="",
+        tooltip=(
+            "Optional label for the asset, shown in the asset selector dropdown. "
+            "Up to 64 characters. Leave empty to identify the asset by its id."
+        ),
+        optional=True,
+    )
+
+
 class ByteDanceCreateImageAsset(IO.ComfyNode):
 
     @classmethod
@@ -2002,6 +2014,7 @@ class ByteDanceCreateImageAsset(IO.ComfyNode):
                 IO.Image.Input("image", tooltip="Image to register as a personal asset."),
                 _seedance_group_picker_input(),
                 _seedance_group_name_input(),
+                _seedance_asset_name_input(),
             ],
             outputs=[
                 IO.String.Output(display_name="asset_id"),
@@ -2021,6 +2034,7 @@ class ByteDanceCreateImageAsset(IO.ComfyNode):
         image: Input.Image,
         group_id: str = "",
         group_name: str = "",
+        asset_name: str = "",
     ) -> IO.NodeOutput:
         validate_image_dimensions(image, min_width=300, max_width=6000, min_height=300, max_height=6000)
         validate_image_aspect_ratio(image, min_ratio=(0.4, 1), max_ratio=(2.5, 1))
@@ -2029,7 +2043,7 @@ class ByteDanceCreateImageAsset(IO.ComfyNode):
             cls,
             group_id=resolved_group,
             url=await upload_image_to_comfyapi(cls, image),
-            name="",
+            name=asset_name.strip()[:64],
             asset_type="Image",
         )
         await _wait_for_asset_active(cls, asset_id, resolved_group)
@@ -2059,6 +2073,7 @@ class ByteDanceCreateVideoAsset(IO.ComfyNode):
                 IO.Video.Input("video", tooltip="Video to register as a personal asset."),
                 _seedance_group_picker_input(),
                 _seedance_group_name_input(),
+                _seedance_asset_name_input(),
             ],
             outputs=[
                 IO.String.Output(display_name="asset_id"),
@@ -2078,6 +2093,7 @@ class ByteDanceCreateVideoAsset(IO.ComfyNode):
         video: Input.Video,
         group_id: str = "",
         group_name: str = "",
+        asset_name: str = "",
     ) -> IO.NodeOutput:
         validate_video_duration(video, min_duration=2, max_duration=15)
         validate_video_dimensions(video, min_width=300, max_width=6000, min_height=300, max_height=6000)
@@ -2102,7 +2118,7 @@ class ByteDanceCreateVideoAsset(IO.ComfyNode):
             cls,
             group_id=resolved_group,
             url=await upload_video_to_comfyapi(cls, video),
-            name="",
+            name=asset_name.strip()[:64],
             asset_type="Video",
         )
         await _wait_for_asset_active(cls, asset_id, resolved_group)

--- a/comfy_api_nodes/nodes_elevenlabs.py
+++ b/comfy_api_nodes/nodes_elevenlabs.py
@@ -233,6 +233,85 @@ class ElevenLabsVoiceSelector(IO.ComfyNode):
         return IO.NodeOutput(voice_id)
 
 
+class ElevenLabsRichVoiceSelector(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="ElevenLabsRichVoiceSelector",
+            display_name="ElevenLabs Voice Selector (Rich)",
+            category="api node/audio/ElevenLabs",
+            description="Select an ElevenLabs voice with audio preview and rich metadata.",
+            inputs=[
+                IO.Combo.Input(
+                    "voice",
+                    remote_combo=IO.RemoteComboOptions(
+                        route="/proxy/elevenlabs/v2/voices",
+                        refresh_button=True,
+                        refresh=43200000,
+                        use_comfy_api=True,
+                        page_size=100,
+                        item_schema=IO.RemoteItemSchema(
+                            value_field="voice_id",
+                            label_field="name",
+                            preview_url_field="preview_url",
+                            preview_type="audio",
+                            search_fields=["name", "labels.gender", "labels.accent", "labels.use_case"],
+                        ),
+                    ),
+                    tooltip="Choose a voice with audio preview.",
+                ),
+            ],
+            outputs=[
+                IO.Custom(ELEVENLABS_VOICE).Output(display_name="voice"),
+            ],
+            is_api_node=False,
+        )
+
+    @classmethod
+    def execute(cls, voice: str) -> IO.NodeOutput:
+        return IO.NodeOutput(voice)  # voice is already the voice_id from item_schema.value_field
+
+
+class ElevenLabsSharedVoiceSelector(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="ElevenLabsSharedVoiceSelector",
+            display_name="ElevenLabs Shared Voice Selector",
+            category="api node/audio/ElevenLabs",
+            description="Browse the ElevenLabs shared voice library (11K+ community voices) with audio preview.",
+            inputs=[
+                IO.Combo.Input(
+                    "voice",
+                    remote_combo=IO.RemoteComboOptions(
+                        route="/proxy/elevenlabs/v1/shared-voices",
+                        refresh_button=True,
+                        refresh=43200000,
+                        use_comfy_api=True,
+                        page_size=100,
+                        item_schema=IO.RemoteItemSchema(
+                            value_field="voice_id",
+                            label_field="name",
+                            preview_url_field="preview_url",
+                            preview_type="audio",
+                            description_field="descriptive",
+                            search_fields=["name", "gender", "accent", "use_case", "descriptive"],
+                        ),
+                    ),
+                    tooltip="Browse shared voices with audio preview.",
+                ),
+            ],
+            outputs=[
+                IO.Custom(ELEVENLABS_VOICE).Output(display_name="voice"),
+            ],
+            is_api_node=False,
+        )
+
+    @classmethod
+    def execute(cls, voice: str) -> IO.NodeOutput:
+        return IO.NodeOutput(voice)
+
+
 class ElevenLabsTextToSpeech(IO.ComfyNode):
     @classmethod
     def define_schema(cls) -> IO.Schema:
@@ -911,6 +990,8 @@ class ElevenLabsExtension(ComfyExtension):
         return [
             ElevenLabsSpeechToText,
             ElevenLabsVoiceSelector,
+            ElevenLabsRichVoiceSelector,
+            ElevenLabsSharedVoiceSelector,
             ElevenLabsTextToSpeech,
             ElevenLabsAudioIsolation,
             ElevenLabsTextToSoundEffects,

--- a/comfy_api_nodes/nodes_elevenlabs.py
+++ b/comfy_api_nodes/nodes_elevenlabs.py
@@ -233,6 +233,44 @@ class ElevenLabsVoiceSelector(IO.ComfyNode):
         return IO.NodeOutput(voice_id)
 
 
+class ElevenLabsRichVoiceSelector(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="ElevenLabsRichVoiceSelector",
+            display_name="ElevenLabs Voice Selector (Rich)",
+            category="api node/audio/ElevenLabs",
+            description="Select an ElevenLabs voice with audio preview and rich metadata.",
+            inputs=[
+                IO.Combo.Input(
+                    "voice",
+                    remote_combo=IO.RemoteComboOptions(
+                        route="/proxy/elevenlabs/v2/voices?page_size=100",
+                        response_key="items",
+                        refresh_button=True,
+                        refresh=43200000,
+                        item_schema=IO.RemoteItemSchema(
+                            value_field="voice_id",
+                            label_field="name",
+                            preview_url_field="preview_url",
+                            preview_type="audio",
+                            search_fields=["name", "labels.gender", "labels.accent", "labels.use_case"],
+                        ),
+                    ),
+                    tooltip="Choose a voice with audio preview.",
+                ),
+            ],
+            outputs=[
+                IO.Custom(ELEVENLABS_VOICE).Output(display_name="voice"),
+            ],
+            is_api_node=False,
+        )
+
+    @classmethod
+    def execute(cls, voice: str) -> IO.NodeOutput:
+        return IO.NodeOutput(voice)  # voice is already the voice_id from item_schema.value_field
+
+
 class ElevenLabsTextToSpeech(IO.ComfyNode):
     @classmethod
     def define_schema(cls) -> IO.Schema:
@@ -911,6 +949,7 @@ class ElevenLabsExtension(ComfyExtension):
         return [
             ElevenLabsSpeechToText,
             ElevenLabsVoiceSelector,
+            ElevenLabsRichVoiceSelector,
             ElevenLabsTextToSpeech,
             ElevenLabsAudioIsolation,
             ElevenLabsTextToSoundEffects,

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -3242,6 +3242,54 @@ class KlingAvatarNode(IO.ComfyNode):
         return IO.NodeOutput(await download_url_to_video_output(final_response.data.task_result.videos[0].url))
 
 
+KLING_ELEMENT_ID = "KLING_ELEMENT_ID"
+
+
+class KlingElementSelector(IO.ComfyNode):
+    """Select a Kling preset element (character, scene, effect, etc.) for use in video generation."""
+
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="KlingElementSelector",
+            display_name="Kling Element Selector",
+            category="api node/video/Kling",
+            description="Browse and select a Kling preset element with image preview. Elements provide consistent characters, scenes, costumes, and effects for video generation.",
+            inputs=[
+                IO.Combo.Input(
+                    "element",
+                    remote_combo=IO.RemoteComboOptions(
+                        route="/proxy/kling/v1/general/advanced-presets-elements",
+                        refresh_button=True,
+                        refresh=43200000,
+                        use_comfy_api=True,
+                        response_key="data",
+                        item_schema=IO.RemoteItemSchema(
+                            value_field="task_result.elements.0.element_id",
+                            label_field="task_result.elements.0.element_name",
+                            preview_url_field="task_result.elements.0.element_image_list.frontal_image",
+                            preview_type="image",
+                            description_field="task_result.elements.0.element_description",
+                            search_fields=["task_result.elements.0.element_name", "task_result.elements.0.element_description"],
+                        ),
+                    ),
+                    tooltip="Select a preset element to use in video generation.",
+                ),
+            ],
+            outputs=[IO.Custom(KLING_ELEMENT_ID).Output(display_name="element_id")],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=False,
+        )
+
+    @classmethod
+    async def execute(cls, element: str) -> IO.NodeOutput:
+        return IO.NodeOutput(element)
+
+
 class KlingExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
@@ -3271,6 +3319,7 @@ class KlingExtension(ComfyExtension):
             KlingVideoNode,
             KlingFirstLastFrameNode,
             KlingAvatarNode,
+            KlingElementSelector,
         ]
 
 

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -3288,6 +3288,53 @@ class KlingAvatarNode(IO.ComfyNode):
         return IO.NodeOutput(await download_url_to_video_output(final_response.data.task_result.videos[0].url))
 
 
+KLING_ELEMENT_ID = "KLING_ELEMENT_ID"
+
+
+class KlingElementSelector(IO.ComfyNode):
+    """Select a Kling preset element (character, scene, effect, etc.) for use in video generation."""
+
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="KlingElementSelector",
+            display_name="Kling Element Selector",
+            category="api node/video/Kling",
+            description="Browse and select a Kling preset element with image preview. Elements provide consistent characters, scenes, costumes, and effects for video generation.",
+            inputs=[
+                IO.Combo.Input(
+                    "element",
+                    remote_combo=IO.RemoteComboOptions(
+                        route="/proxy/kling/v1/general/advanced-presets-elements",
+                        refresh_button=True,
+                        refresh=43200000,
+                        response_key="data",
+                        item_schema=IO.RemoteItemSchema(
+                            value_field="task_result.elements.0.element_id",
+                            label_field="task_result.elements.0.element_name",
+                            preview_url_field="task_result.elements.0.element_image_list.frontal_image",
+                            preview_type="image",
+                            description_field="task_result.elements.0.element_description",
+                            search_fields=["task_result.elements.0.element_name", "task_result.elements.0.element_description"],
+                        ),
+                    ),
+                    tooltip="Select a preset element to use in video generation.",
+                ),
+            ],
+            outputs=[IO.Custom(KLING_ELEMENT_ID).Output(display_name="element_id")],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=False,
+        )
+
+    @classmethod
+    async def execute(cls, element: str) -> IO.NodeOutput:
+        return IO.NodeOutput(element)
+
+
 class KlingExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
@@ -3317,6 +3364,7 @@ class KlingExtension(ComfyExtension):
             KlingVideoNode,
             KlingFirstLastFrameNode,
             KlingAvatarNode,
+            KlingElementSelector,
         ]
 
 

--- a/execution.py
+++ b/execution.py
@@ -1016,6 +1016,10 @@ async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
 
                 if isinstance(input_type, list) or input_type == io.Combo.io_type:
                     if input_type == io.Combo.io_type:
+                        # Skip validation for combos with remote options — options
+                        # are fetched client-side and not available on the server.
+                        if extra_info.get("remote_combo"):
+                            continue
                         combo_options = extra_info.get("options", [])
                     else:
                         combo_options = input_type

--- a/execution.py
+++ b/execution.py
@@ -991,6 +991,10 @@ async def validate_inputs(prompt_id, prompt, item, validated):
 
                 if isinstance(input_type, list) or input_type == io.Combo.io_type:
                     if input_type == io.Combo.io_type:
+                        # Skip validation for combos with remote options — options
+                        # are fetched client-side and not available on the server.
+                        if extra_info.get("remote_combo"):
+                            continue
                         combo_options = extra_info.get("options", [])
                     else:
                         combo_options = input_type

--- a/tests-unit/comfy_api_test/remote_combo_options_test.py
+++ b/tests-unit/comfy_api_test/remote_combo_options_test.py
@@ -1,0 +1,139 @@
+import pytest
+
+from comfy_api.latest._io import (
+    Combo,
+    RemoteComboOptions,
+    RemoteItemSchema,
+    RemoteOptions,
+)
+
+
+def _schema(**overrides):
+    defaults = dict(value_field="id", label_field="name")
+    return RemoteItemSchema(**{**defaults, **overrides})
+
+
+def _combo(**overrides):
+    defaults = dict(route="/proxy/foo", item_schema=_schema())
+    return RemoteComboOptions(**{**defaults, **overrides})
+
+
+def test_item_schema_defaults_accepted():
+    d = _schema().as_dict()
+    assert d == {"value_field": "id", "label_field": "name", "preview_type": "image"}
+
+
+def test_item_schema_full_config_accepted():
+    d = _schema(
+        preview_url_field="preview",
+        preview_type="audio",
+        description_field="desc",
+        search_fields=["first", "last", "profile.email"],
+    ).as_dict()
+    assert d["preview_type"] == "audio"
+    assert d["search_fields"] == ["first", "last", "profile.email"]
+
+
+@pytest.mark.parametrize(
+    "bad_fields",
+    [
+        ["{first} {last}"],
+        ["name", "{age}"],
+        ["leading{"],
+        ["trailing}"],
+    ],
+)
+def test_item_schema_rejects_template_strings_in_search_fields(bad_fields):
+    with pytest.raises(ValueError, match="search_fields"):
+        _schema(search_fields=bad_fields)
+
+
+@pytest.mark.parametrize("bad_preview_type", ["middle", "IMAGE", "", "gif"])
+def test_item_schema_rejects_unknown_preview_type(bad_preview_type):
+    with pytest.raises(ValueError, match="preview_type"):
+        _schema(preview_type=bad_preview_type)
+
+
+def test_combo_options_minimal_accepted():
+    d = _combo().as_dict()
+    assert d["route"] == "/proxy/foo"
+    assert d["refresh_button"] is True
+    assert "item_schema" in d
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/proxy/foo",
+        "/voices",
+    ],
+)
+def test_combo_options_accepts_valid_routes(route):
+    _combo(route=route)
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "",
+        "api.example.com/voices",
+        "voices",
+        "ftp-no-scheme",
+        "http://localhost:9000/voices",
+        "https://api.example.com/v1/voices",
+    ],
+)
+def test_combo_options_rejects_non_relative_routes(route):
+    with pytest.raises(ValueError, match="'route'"):
+        _combo(route=route)
+
+
+@pytest.mark.parametrize("bad_auto_select", ["middle", "FIRST", "", "firstlast"])
+def test_combo_options_rejects_unknown_auto_select(bad_auto_select):
+    with pytest.raises(ValueError, match="auto_select"):
+        _combo(auto_select=bad_auto_select)
+
+
+@pytest.mark.parametrize("bad_refresh", [1, 127])
+def test_combo_options_refresh_in_forbidden_range_rejected(bad_refresh):
+    with pytest.raises(ValueError, match="refresh"):
+        _combo(refresh=bad_refresh)
+
+
+@pytest.mark.parametrize("ok_refresh", [0, -1, 128])
+def test_combo_options_refresh_valid_values_accepted(ok_refresh):
+    _combo(refresh=ok_refresh)
+
+
+def test_combo_options_timeout_negative_rejected():
+    with pytest.raises(ValueError, match="timeout"):
+        _combo(timeout=-1)
+
+
+def test_combo_options_max_retries_negative_rejected():
+    with pytest.raises(ValueError, match="max_retries"):
+        _combo(max_retries=-1)
+
+
+def test_combo_options_as_dict_prunes_none_fields():
+    d = _combo().as_dict()
+    for pruned in ("response_key", "refresh", "timeout", "max_retries", "auto_select"):
+        assert pruned not in d
+
+
+def test_combo_input_accepts_remote_combo_alone():
+    Combo.Input("voice", remote_combo=_combo())
+
+
+def test_combo_input_rejects_remote_plus_remote_combo():
+    with pytest.raises(ValueError, match="remote.*remote_combo"):
+        Combo.Input(
+            "voice",
+            remote=RemoteOptions(route="/r", refresh_button=True),
+            remote_combo=_combo(),
+        )
+
+
+def test_combo_input_rejects_options_plus_remote_combo():
+    with pytest.raises(ValueError, match="options.*remote_combo"):
+        Combo.Input("voice", options=["a", "b"], remote_combo=_combo())

--- a/tests-unit/comfy_api_test/remote_combo_options_test.py
+++ b/tests-unit/comfy_api_test/remote_combo_options_test.py
@@ -1,0 +1,165 @@
+import pytest
+
+from comfy_api.latest._io import (
+    Combo,
+    RemoteComboOptions,
+    RemoteItemSchema,
+    RemoteOptions,
+)
+
+
+def _schema(**overrides):
+    defaults = dict(value_field="id", label_field="name")
+    return RemoteItemSchema(**{**defaults, **overrides})
+
+
+def _combo(**overrides):
+    defaults = dict(route="/proxy/foo", item_schema=_schema())
+    return RemoteComboOptions(**{**defaults, **overrides})
+
+
+def test_item_schema_defaults_accepted():
+    d = _schema().as_dict()
+    assert d == {"value_field": "id", "label_field": "name", "preview_type": "image"}
+
+
+def test_item_schema_full_config_accepted():
+    d = _schema(
+        preview_url_field="preview",
+        preview_type="audio",
+        description_field="desc",
+        search_fields=["first", "last", "profile.email"],
+    ).as_dict()
+    assert d["preview_type"] == "audio"
+    assert d["search_fields"] == ["first", "last", "profile.email"]
+
+
+@pytest.mark.parametrize(
+    "bad_fields",
+    [
+        ["{first} {last}"],
+        ["name", "{age}"],
+        ["leading{"],
+        ["trailing}"],
+    ],
+)
+def test_item_schema_rejects_template_strings_in_search_fields(bad_fields):
+    with pytest.raises(ValueError, match="search_fields"):
+        _schema(search_fields=bad_fields)
+
+
+@pytest.mark.parametrize("bad_preview_type", ["middle", "IMAGE", "", "gif"])
+def test_item_schema_rejects_unknown_preview_type(bad_preview_type):
+    with pytest.raises(ValueError, match="preview_type"):
+        _schema(preview_type=bad_preview_type)
+
+
+def test_combo_options_minimal_accepted():
+    d = _combo().as_dict()
+    assert d["route"] == "/proxy/foo"
+    assert d["refresh_button"] is True
+    assert "item_schema" in d
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/proxy/foo",
+        "http://localhost:9000/voices",
+        "https://api.example.com/v1/voices",
+    ],
+)
+def test_combo_options_accepts_valid_routes(route):
+    _combo(route=route)
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "",
+        "api.example.com/voices",
+        "voices",
+        "ftp-no-scheme",
+    ],
+)
+def test_combo_options_rejects_invalid_routes(route):
+    with pytest.raises(ValueError, match="'route'"):
+        _combo(route=route)
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "http://localhost:9000/voices",
+        "https://api.example.com/v1/voices",
+    ],
+)
+def test_combo_options_use_comfy_api_rejects_absolute_route(route):
+    with pytest.raises(ValueError, match="use_comfy_api"):
+        _combo(route=route, use_comfy_api=True)
+
+
+def test_combo_options_use_comfy_api_accepts_relative_route():
+    _combo(route="/proxy/foo", use_comfy_api=True)
+
+
+def test_combo_options_page_size_with_response_key_rejected():
+    with pytest.raises(ValueError, match="response_key.*page_size"):
+        _combo(page_size=50, response_key="data.items")
+
+
+@pytest.mark.parametrize("bad_page_size", [0, -1])
+def test_combo_options_page_size_must_be_positive(bad_page_size):
+    with pytest.raises(ValueError, match="page_size"):
+        _combo(page_size=bad_page_size)
+
+
+@pytest.mark.parametrize("bad_auto_select", ["middle", "FIRST", "", "firstlast"])
+def test_combo_options_rejects_unknown_auto_select(bad_auto_select):
+    with pytest.raises(ValueError, match="auto_select"):
+        _combo(auto_select=bad_auto_select)
+
+
+@pytest.mark.parametrize("bad_refresh", [1, 127])
+def test_combo_options_refresh_in_forbidden_range_rejected(bad_refresh):
+    with pytest.raises(ValueError, match="refresh"):
+        _combo(refresh=bad_refresh)
+
+
+@pytest.mark.parametrize("ok_refresh", [0, -1, 128])
+def test_combo_options_refresh_valid_values_accepted(ok_refresh):
+    _combo(refresh=ok_refresh)
+
+
+def test_combo_options_timeout_negative_rejected():
+    with pytest.raises(ValueError, match="timeout"):
+        _combo(timeout=-1)
+
+
+def test_combo_options_max_retries_negative_rejected():
+    with pytest.raises(ValueError, match="max_retries"):
+        _combo(max_retries=-1)
+
+
+def test_combo_options_as_dict_prunes_none_fields():
+    d = _combo().as_dict()
+    for pruned in ("page_size", "response_key", "refresh", "timeout", "max_retries", "auto_select"):
+        assert pruned not in d
+
+
+def test_combo_input_accepts_remote_combo_alone():
+    Combo.Input("voice", remote_combo=_combo())
+
+
+def test_combo_input_rejects_remote_plus_remote_combo():
+    with pytest.raises(ValueError, match="remote.*remote_combo"):
+        Combo.Input(
+            "voice",
+            remote=RemoteOptions(route="/r", refresh_button=True),
+            remote_combo=_combo(),
+        )
+
+
+def test_combo_input_rejects_options_plus_remote_combo():
+    with pytest.raises(ValueError, match="options.*remote_combo"):
+        Combo.Input("voice", options=["a", "b"], remote_combo=_combo())


### PR DESCRIPTION
This is a **temporary** PR that includes all changes of the https://github.com/Comfy-Org/ComfyUI/pull/13432 PR and also 3 new nodes that uses this new feature:

<details> 
<summary>Screenshots</summary>
<img width="1957" height="1302" alt="Screenshot From 2026-04-16 15-42-10" src="https://github.com/user-attachments/assets/4556e935-0d11-47f8-abc9-3a486060ab9b" />

<img width="556" height="780" alt="Screenshot From 2026-04-16 15-43-42" src="https://github.com/user-attachments/assets/ead92f63-ad96-41b1-a89f-b970e93f6f44" />
</details>

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

