### PR TITLE
Fix weight_norm parametrizations skipped in _load_list causing stable audio partial-load failure

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -732,7 +732,7 @@ class ModelPatcher:
             default = False
             params = { name: param for name, param in m.named_parameters(recurse=False) }
             for name, param in m.named_parameters(recurse=True):
-                if name not in params:
+                if name not in params and not name.startswith("parametrizations."):
                     default = True # default random weights in non leaf modules
                     break
             if default and default_device is not None:

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -596,7 +596,6 @@ class VAE:
                 self.process_output = lambda audio: audio
                 self.process_input = lambda audio: audio
                 self.working_dtypes = [torch.float16, torch.bfloat16, torch.float32]
-                self.disable_offload = True
             elif "blocks.2.blocks.3.stack.5.weight" in sd or "decoder.blocks.2.blocks.3.stack.5.weight" in sd or "layers.4.layers.1.attn_block.attn.qkv.weight" in sd or "encoder.layers.4.layers.1.attn_block.attn.qkv.weight" in sd: #genmo mochi vae
                 if "blocks.2.blocks.3.stack.5.weight" in sd:
                     sd = comfy.utils.state_dict_prefix_replace(sd, {"": "decoder."})


### PR DESCRIPTION
## Summary

- `_load_list()` in `model_patcher.py` incorrectly sets `default = True` (treating a module as having random weights in child sub-modules) when a module uses `torch.nn.utils.parametrizations.weight_norm`
- `weight_norm` moves the actual weight into a `parametrizations` child sub-module as `original0`/`original1`, so `named_parameters(recurse=True)` yields `parametrizations.weight.original0` while `named_parameters(recurse=False)` does not — triggering the false-positive check
- This causes weight-normed modules to be excluded from the partial-load list entirely, so their parameters are never moved to GPU during low-VRAM loading
- `AudioOobleckVAE` (Stable Audio) had a `disable_offload = True` workaround that forced full GPU load to paper over this bug; with the root cause fixed, the workaround is removed so the model can use partial VRAM offloading on low-memory systems

## Fix

Skip `parametrizations.*` parameter names in the `_load_list()` non-leaf check:

```python
# Before
if name not in params:
    default = True  # default random weights in non leaf modules
    break

# After
if name not in params and not name.startswith("parametrizations."):
    default = True  # default random weights in non leaf modules
    break
```

## Test plan

- [ ] Load a Stable Audio model on a system with limited VRAM (`--lowvram` or `--novram`) and confirm it generates audio without error
- [ ] Confirm the fix does not affect regular (non-weight-normed) models that correctly have child sub-modules with random weights

Closes #11855