### PR TITLE
Fix Hunyuan 3D 2.1 multi-GPU worksplit: use cond_or_uncond instead of hardcoded chunk(2)

### DIFF
--- a/comfy/ldm/hunyuan3dv2_1/hunyuandit.py
+++ b/comfy/ldm/hunyuan3dv2_1/hunyuandit.py
@@ -607,9 +607,14 @@ class HunYuanDiTPlain(nn.Module):
     def forward(self, x, t, context, transformer_options = {}, **kwargs):
 
         x = x.movedim(-1, -2)
-        uncond_emb, cond_emb = context.chunk(2, dim = 0)
 
-        context = torch.cat([cond_emb, uncond_emb], dim = 0)
+        cond_or_uncond = transformer_options.get("cond_or_uncond", [])
+        swap_cfg_halves = len(cond_or_uncond) == 2 and set(cond_or_uncond) == {0, 1}
+
+        if swap_cfg_halves:
+            first_half, second_half = context.chunk(2, dim = 0)
+            context = torch.cat([second_half, first_half], dim = 0)
+
         main_condition = context
 
         t = 1.0 - t
@@ -657,5 +662,8 @@ class HunYuanDiTPlain(nn.Module):
         output = self.final_layer(combined)
         output =  output.movedim(-2, -1) * (-1.0)
 
-        cond_emb, uncond_emb = output.chunk(2, dim = 0)
-        return torch.cat([uncond_emb, cond_emb])
+        if swap_cfg_halves:
+            first_half, second_half = output.chunk(2, dim = 0)
+            output = torch.cat([second_half, first_half], dim = 0)
+
+        return output


### PR DESCRIPTION
## Problem

Hunyuan 3D 2.1 throws `ValueError: not enough values to unpack (expected 2, got 1)` when using multi-GPU worksplit (`MultiGPU CFG Split` node).

The model's `forward()` method hardcodes `context.chunk(2, dim=0)` assuming both cond and uncond are always batched together. In multi-GPU worksplit mode, a device may only receive one of them, so `chunk(2)` on a batch of 1 returns only 1 chunk.

## Fix

Use `transformer_options["cond_or_uncond"]` to detect whether both cond and uncond are present in the batch. Only perform the half-swap when both are present (`len == 2` and `set == {0, 1}`). When only one is present, skip the reordering entirely (identity operation).

## Changes

- `comfy/ldm/hunyuan3dv2_1/hunyuandit.py`: Replace hardcoded `chunk(2)` with conditional swap gated on `cond_or_uncond`

## Performance (dual RTX 4090)

### Sampling-only speed (isolating the accelerated portion)

| Resolution | Single GPU | Multi GPU | Sampling Speedup |
|------------|-----------|-----------|-----------------|
| 4096 | 3.58 it/s | 6.38 it/s | **1.78x** |
| 8192 | 1.62 it/s | 3.10 it/s | **1.91x** |

### End-to-end wall time (includes non-accelerated VAE decode + mesh generation)

| Resolution | Single GPU | Multi GPU | Overall Speedup |
|------------|-----------|-----------|----------------|
| 4096 | 22.79s | 19.22s | **1.19x** |
| 8192 | 35.76s | 28.02s | **1.28x** |

Sampling-only speedup is near-theoretical 2x for CFG split across 2 GPUs. Overall speedup is lower because VAE decode and mesh generation are not accelerated by worksplit.

*Benchmarks: 2 warmup runs + 5 timed runs, batch_size=1, 30 steps, euler sampler.*