### PR TITLE
Support standalone LTXV audio VAEs

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -807,6 +807,7 @@ class VAE:
                     self.memory_used_encode = lambda shape, dtype: (700 * (max(1, (shape[-3] ** 0.66 * 0.11)) * shape[-2] * shape[-1]) * model_management.dtype_size(dtype))
                     self.memory_used_decode = lambda shape, dtype: (50 * (max(1, (shape[-3] ** 0.65 * 0.26)) * shape[-2] * shape[-1] * 32 * 32) * model_management.dtype_size(dtype))
             elif "vocoder.resblocks.0.convs1.0.weight" in sd or "vocoder.vocoder.resblocks.0.convs1.0.weight" in sd: # LTX Audio
+                sd = comfy.utils.state_dict_prefix_replace(sd, {"audio_vae.": "autoencoder."})
                 self.first_stage_model = comfy.ldm.lightricks.vae.audio_vae.AudioVAE(metadata=metadata)
                 self.memory_used_encode = lambda shape, dtype: (shape[2] * 330) * model_management.dtype_size(dtype)
                 self.memory_used_decode = lambda shape, dtype: (shape[2] * shape[3] * 87000) * model_management.dtype_size(dtype)


### PR DESCRIPTION
Since the recent PR https://github.com/Comfy-Org/ComfyUI/commit/ad94d472216ba52ab2660536af44faa92cf4b5d0
Supporting standalone extracted LTXV audio VAEs would be one additional line.

<img width="1923" height="631" alt="image" src="https://github.com/user-attachments/assets/6bbce621-195f-4401-935b-e1ff1d2198ba" />
