### PR TITLE
fix: accept PEP 440 multi-part versions in install_util version parser

### DIFF
--- a/utils/install_util.py
+++ b/utils/install_util.py
@@ -21,8 +21,12 @@ If you are on the portable package you can run: update\\update_comfyui.bat to so
 
 
 def is_valid_version(version: str) -> bool:
-    """Validate if a string is a valid semantic version (X.Y.Z format)."""
-    pattern = r"^(\d+)\.(\d+)\.(\d+)$"
+    """Validate if a string is a valid version number.
+
+    Accepts PEP 440-style numeric versions with one or more dot-separated
+    components (e.g. ``2``, ``2.0``, ``2.0.0``, ``1.25.3``).
+    """
+    pattern = r"^\d+(\.\d+)*$"
     return bool(re.match(pattern, version))
 
 
@@ -39,7 +43,7 @@ def get_required_packages_versions():
                 if len(s) == 2:
                     version_str = s[-1]
                     if not is_valid_version(version_str):
-                        logging.error(f"Invalid version format in requirements.txt: {version_str}")
+                        logging.warning(f"Skipping unrecognised version format in requirements.txt: {version_str}")
                         continue
                     out[s[0]] = version_str
         return out.copy()

--- a/utils/install_util.py
+++ b/utils/install_util.py
@@ -43,7 +43,7 @@ def get_required_packages_versions():
                 if len(s) == 2:
                     version_str = s[-1]
                     if not is_valid_version(version_str):
-                        logging.warning(f"Skipping unrecognised version format in requirements.txt: {version_str}")
+                        logging.warning(f"Skipping unrecognized version format in requirements.txt for package {s[0]}: {version_str}")
                         continue
                     out[s[0]] = version_str
         return out.copy()


### PR DESCRIPTION
Fixes #12813 (recurring)

## Problem

ComfyUI logs a false `ERROR` on every startup:

`
The `is_valid_version()` function in [`utils/install_util.py`](utils/install_util.py)
only accepts strict 3-part semver (`X.Y.Z`). It rejects the `SQLAlchemy>=2.0`
entry added in #13316, which produces version string `2.0` after the internal
`>=` → `==` substitution.

## Root Cause

The regex `r"^(\d+)\.(\d+)\.(\d+)$"` requires exactly three numeric parts.
[PEP 440](https://peps.python.org/pep-0440/#final-releases) treats `2.0` and
`2.0.0` as equivalent release identifiers — both are valid. The validator was
too strict.

## Solution

- Replace the regex with `r"^\d+(\.\d+)*$"` — accepts 1-, 2-, or 3-part
  all-numeric release identifiers (`2`, `2.0`, `2.0.0`, `1.25.3`)
- Downgrade the log level from `ERROR` to `WARNING`, since unrecognised entries
  are safely skipped and do not affect installation

## History

Issue #12813 (March 2026) hit the same bug with `simpleeval>=1.0`. It was
worked around by bumping the entry to `simpleeval>=1.0.0` in
[`requirements.txt`](requirements.txt). This fix addresses the underlying
parser so that workaround is no longer needed for future entries.

## Testing

| Expression | Before | After |
|---|---|---|
| `is_valid_version("2.0")` | `False` ❌ | `True` ✓ |
| `is_valid_version("2.0.0")` | `True` ✓ | `True` ✓ |
| `is_valid_version("1.25.3")` | `True` ✓ | `True` ✓ |
| `is_valid_version("not-a-version")` | `False` ✓ | `False` ✓ |
| `is_valid_version(">=2.0")` | `False` ✓ | `False` ✓ |

Confirmed: `SQLAlchemy>=2.0` no longer produces any log output on startup.

## Scope

Change is confined to one regex and one log level in `utils/install_util.py`.
All callers of `get_required_packages_versions()` consume the returned string
values via `packaging.version.parse()`, which already handles multi-part
versions correctly.`