### PR TITLE
fix(veo): reject 4K resolution for veo-3.0 models

### DIFF
--- a/comfy_api_nodes/nodes_veo2.py
+++ b/comfy_api_nodes/nodes_veo2.py
@@ -393,8 +393,8 @@ class Veo3VideoGenerationNode(IO.ComfyNode):
         model="veo-3.0-generate-001",
         generate_audio=False,
     ):
-        if "lite" in model and resolution == "4k":
-            raise Exception("4K resolution is not supported by the veo-3.1-lite model.")
+        if resolution == "4k" and ("lite" in model or "3.0" in model):
+            raise Exception("4K resolution is not supported by the veo-3.1-lite or veo-3.0 models.")
 
         model = MODELS_MAP[model]
 


### PR DESCRIPTION
## Description

`Veo3VideoGenerationNode` advertises in its `resolution` tooltip that 4K is not available for `veo-3.1-lite` or `veo-3.0` models, but the execute-time guard added in #13330 only rejected the `lite` combination:

```python
if "lite" in model and resolution == "4k":
    raise Exception("4K resolution is not supported by the veo-3.1-lite model.")
```

Selecting 4K with `veo-3.0-generate-001` or `veo-3.0-fast-generate-001` would fall through to `/proxy/veo/<model>/generate`; the upstream Google API would reject it, surfacing as a generic API error rather than the intended client-side validation message.

_Not observed — #13330 only landed today, so filing this as a code-review finding rather than a bug report._

This PR broadens the guard and updates the error message to match the tooltip.

```python
if resolution == "4k" and ("lite" in model or "3.0" in model):
    raise Exception("4K resolution is not supported by the veo-3.1-lite or veo-3.0 models.")
```

## Notes

- `Veo3FirstLastFrameNode` has the same-shaped guard but only exposes `veo-3.1-generate`, `veo-3.1-fast-generate`, and `veo-3.1-lite`, so its existing `lite`-only check is already correct — no change needed there.
- The `price_badge` expression still falls through to the standard 3.0 rate for the now-rejected 4K + 3.0 combo. With the stricter guard the combo can no longer execute, so the mispriced badge is display-only. Happy to tighten that in a follow-up if preferred.
- No test changes: this file has no existing unit tests for the execute guards.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

