### PR TITLE
bump manager version to 4.2.1

### DIFF
--- a/manager_requirements.txt
+++ b/manager_requirements.txt
@@ -1,1 +1,1 @@
-comfyui_manager==4.1
+comfyui_manager==4.2.1


### PR DESCRIPTION
Security hardening (CSRF Content-Type gate, litellm supply chain detection PYSEC-2026-2), scanner git error categorization, and frontend `handleFile` signature compatibility fix.

> [!IMPORTANT]
> **Do not merge this PR first.** It depends on Comfy-Org/ComfyUI_frontend#11520 (CSRF GET→POST migration). A frontend build containing that PR must be merged and released **before** this bump is merged; otherwise the 4 migrated endpoints will break in the UI.

References:
- Diff: https://github.com/Comfy-Org/ComfyUI-Manager/compare/4.1...4.2.1
- PyPI: https://pypi.org/project/comfyui-manager/4.2.1
- Frontend dependency: https://github.com/Comfy-Org/ComfyUI_frontend/pull/11520
- Previous: #13156 (4.1), #13108 (4.1b8), #13022 (4.1b6)