### PR TITLE
fix: use Parameter assignment for Stable_Zero123 cc_projection weights

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -578,8 +578,8 @@ class Stable_Zero123(BaseModel):
     def __init__(self, model_config, model_type=ModelType.EPS, device=None, cc_projection_weight=None, cc_projection_bias=None):
         super().__init__(model_config, model_type, device=device)
         self.cc_projection = comfy.ops.manual_cast.Linear(cc_projection_weight.shape[1], cc_projection_weight.shape[0], dtype=self.get_dtype(), device=device)
-        self.cc_projection.weight.copy_(cc_projection_weight)
-        self.cc_projection.bias.copy_(cc_projection_bias)
+        self.cc_projection.weight = torch.nn.Parameter(cc_projection_weight.clone())
+        self.cc_projection.bias = torch.nn.Parameter(cc_projection_bias.clone())
 
     def extra_conds(self, **kwargs):
         out = {}


### PR DESCRIPTION
Fixes #13492

## Problem

On Windows with aimdo enabled, `disable_weight_init.Linear.__init__` uses a lazy initialization path that sets `weight` and `bias` to `None` instead of allocating memory upfront (to avoid over-committing memory on Windows which doesn't support memory overcommit). This is triggered when:
- Running on Windows (`comfy.model_management.WINDOWS` is True)
- aimdo is enabled (`comfy.memory_management.aimdo_enabled` is True)
- The Linear subclass does not override `_load_from_state_dict` (applies to `manual_cast.Linear`)

When `Stable_Zero123.__init__` subsequently calls `self.cc_projection.weight.copy_(...)`, it fails with `AttributeError: 'NoneType' object has no attribute 'copy_'` because `weight` is `None`.

## Solution

Replace the `copy_()` calls with direct `torch.nn.Parameter` assignment. This bypasses the lazy initialization issue because it directly assigns a properly initialized tensor as a parameter, working correctly on both Windows (with aimdo) and other platforms.

The `manual_cast.Linear` forward pass handles dtype casting via `comfy_cast_weights = True`, so the dtype of the stored weight does not need to match the compute dtype — the existing casting mechanism continues to work correctly.

## Testing

- The fix avoids the crash on Windows with aimdo enabled
- On non-Windows or aimdo-disabled systems the behavior is unchanged (weight was already initialized, now we just replace it with a clone)