### PR TITLE
fix(openapi): address oneOf review on /api/userdata (stacked on #13397)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -926,15 +926,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - type: array
-                    items:
-                      type: string
-                    description: Simple filename list
-                  - type: array
-                    items:
-                      $ref: "#/components/schemas/GetUserDataResponseFullFile"
-                    description: Full file info list (when full_info=true)
+                $ref: "#/components/schemas/ListUserdataResponse"
         "404":
           description: Directory not found
 
@@ -2618,31 +2610,45 @@ components:
     # Userdata
     # -------------------------------------------------------------------
     UserDataResponse:
-      description: Response body for `/api/userdata` — either a list of filenames or a list of full file objects, depending on the `full_info` query parameter.
+      description: |
+        Response body for the POST endpoints `/api/userdata/{file}` and
+        `/api/userdata/{file}/move/{dest}`. Returns a single item whose
+        shape depends on the `full_info` query parameter.
+      x-variant-selector:
+        full_info=true: file-info object (`GetUserDataResponseFullFile`)
+        default: relative path string
       oneOf:
-        - $ref: "#/components/schemas/UserDataResponseFull"
-        - $ref: "#/components/schemas/UserDataResponseShort"
+        - $ref: "#/components/schemas/GetUserDataResponseFullFile"
+        - type: string
+          description: Relative path of the written or moved file. Returned when `full_info` is absent or false.
 
-    UserDataResponseFull:
-      type: object
-      description: List of files in the authenticated user's data directory, as full file objects with metadata.
-      properties:
-        path:
-          type: string
-        size:
-          type: integer
-        modified:
-          type: integer
-          format: int64
-          description: Unix timestamp of last modification in milliseconds
-        created:
-          type: number
-          description: Unix timestamp of file creation
+    ListUserdataResponse:
+      description: |
+        Response body for `GET /api/userdata`. The array item shape is
+        determined by the `full_info` and `split` query parameters.
+      x-variant-selector:
+        full_info=true: array of file-info objects (`GetUserDataResponseFullFile`)
+        split=true: array of `[relative_path, ...path_components]` arrays
+        default: array of relative path strings
+      oneOf:
+        - type: array
+          items:
+            $ref: "#/components/schemas/GetUserDataResponseFullFile"
+          description: Returned when `full_info=true`.
+        - type: array
+          items:
+            type: array
+            items:
+              type: string
+            minItems: 2
+          description: |
+            Returned when `split=true` and `full_info=false`. Each inner
+            array is `[relative_path, ...path_components]`.
+        - type: array
+          items:
+            type: string
+          description: Default shape — array of file paths relative to the user data root.
 
-    UserDataResponseShort:
-      type: string
-
-      description: List of files in the authenticated user's data directory, as filename strings only.
     GetUserDataResponseFullFile:
       type: object
       description: A single entry in a full-info user data listing.


### PR DESCRIPTION
Stacked on #13397.

Addresses @jtreminio's review comment on `UserDataResponse`'s `oneOf` without a discriminator, and fixes two spec-accuracy bugs found while looking at the actual server behavior in `app/user_manager.py`.

## Why

Three things wrong with the current spec around `/api/userdata`:

1. **Missing response variant on `GET /api/userdata`.** The handler branches three ways based on `full_info` and `split`. The spec only describes two of the three shapes — the `split=true` case (array of `[relative_path, ...path_components]`) is not documented.
2. **`UserDataResponse` description says "list"**, but the schema is a single item (string or object). It's used by the POST endpoints, which return one item. Description and shape disagreed.
3. **`oneOf` without a discriminator** (jtreminio's comment). A proper OpenAPI `discriminator` doesn't apply here — the variants are type-disjoint and the selector is a query parameter, not a property of the response body. Instead, the selection rule is now explicit via an `x-variant-selector` vendor extension at each `oneOf` site.

Also fixes a malformed blank line in the old `UserDataResponseShort` schema.

## What changed

- `GET /api/userdata` response: extracted the inline `oneOf` to a new named schema `ListUserdataResponse` with three array variants.
- `UserDataResponse`: now correctly documented as a single-item response used by the POST endpoints (`/api/userdata/{file}` and `/api/userdata/{file}/move/{dest}`). Points at the canonical `GetUserDataResponseFullFile` instead of the near-duplicate `UserDataResponseFull`.
- Removed `UserDataResponseFull` and `UserDataResponseShort` (dead after the above).
- Added `x-variant-selector` on both `oneOf` sites.

## What did NOT change

- **No wire-breaking changes.** The server still returns the same shapes; the spec just describes them more completely and with a clearer selection rule.
- The cleanest long-term fix would be to normalize `/api/userdata` to always return full-object arrays (deprecating `full_info=false` and `split=true`), but that's a breaking change and deserves its own deprecation cycle — out of scope here.

## Draft status

Opening as draft for your review before landing.