### PR TITLE
Derive InterruptProcessingException from BaseException

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1801,7 +1801,7 @@ def debug_memory_summary():
         return torch.cuda.memory.memory_summary()
     return ""
 
-class InterruptProcessingException(Exception):
+class InterruptProcessingException(BaseException):
     pass
 
 interrupt_processing_mutex = threading.RLock()


### PR DESCRIPTION
This tiny change is intended to prevent user code from doing something like:

```python
try:
    blah()
except Exception:
    # Anything but reraising it
```

This breaks interrupt processing, because `throw_exception_if_processing_interrupted` clears the interrupt flag when it raises the exception. So the user's request to cancel the job is simply ignored and processing continues.

People should never be using that pattern in the first place, but it's actually not completely obvious that catching an exception in this way in something like a model patch would cause this kind of breakage.

I realized this was an issue because I'd been having a problem with my cancel requests being ignored and it was driving me crazy. Unfortunately, the culprit in that case was doing `except:` with _no_ class, and this change won't help there.

The only direct uses of this exception in ComfyUI are catching it (or throwing it in this one place) explicitly, which will be exactly the same whether it subclasses `Exception` or `BaseException`. I have a lot of custom nodes installed and the only use I could find was catching it explicitly. I can't think of a way this change could cause issues and it makes it harder for extensions to break ComfyUI's core features.