### PR TITLE
Modify SQLAlchemy version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ scipy
 tqdm
 psutil
 alembic
-SQLAlchemy>=2.0
+SQLAlchemy
 filelock
 av>=14.2.0
 comfy-kitchen>=0.2.8


### PR DESCRIPTION
Updated SQLAlchemy version specification.

error message is: Invalid version format in requirements.txt: 2.0

(SQLAlchemy>=2.0)
change to as it was before: no version number