### PR TITLE
fix: guard against KeyError on unregistered class_type in _is_intermediate_output

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -413,7 +413,9 @@ def format_value(x):
 
 def _is_intermediate_output(dynprompt, node_id):
     class_type = dynprompt.get_node(node_id)["class_type"]
-    class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
+    class_def = nodes.NODE_CLASS_MAPPINGS.get(class_type)
+    if class_def is None:
+        return False
     return getattr(class_def, 'HAS_INTERMEDIATE_OUTPUT', False)
 
 def _send_cached_ui(server, node_id, display_node_id, cached, prompt_id, ui_outputs):


### PR DESCRIPTION
## Summary

`_is_intermediate_output` (introduced in 3696c5ba) iterates over all node IDs in the prompt after execution, including orphaned/disconnected nodes that were never validated or executed. If any such node's `class_type` is absent from `NODE_CLASS_MAPPINGS` (e.g. a custom node pack that failed to load, was renamed, or was removed), the direct dict lookup raises `KeyError`.

This exception short-circuits the `while...else` block and prevents:
- `execution_success` from being sent to the frontend
- `self.history_result` from being assigned

Images are still saved to disk (since `SaveImage` runs during the main execution loop), but the Gallery never receives the success event and `/history` returns incomplete data — a silent failure that is hard to diagnose.

## Fix

Replace `NODE_CLASS_MAPPINGS[class_type]` with `.get(class_type)` and guard on `None`, so unregistered nodes are silently treated as non-intermediate-output nodes and execution continues normally.