### PR TITLE
feat(server): expose comfy_api_base in /api/system_stats response

### DIFF
--- a/server.py
+++ b/server.py
@@ -668,7 +668,8 @@ class PromptServer():
                     "python_version": sys.version,
                     "pytorch_version": comfy.model_management.torch_version,
                     "embedded_python": os.path.split(os.path.split(sys.executable)[0])[1] == "python_embeded",
-                    "argv": sys.argv
+                    "argv": sys.argv,
+                    "comfy_api_base": args.comfy_api_base
                 },
                 "devices": [
                     {


### PR DESCRIPTION
## Problem

The static preview frontend (and other thin clients) need to know which cloud environment a ComfyUI instance is configured for. Currently the only way to determine this is to parse the raw `argv` array from `/api/system_stats` and look for `--comfy-api-base`. This is fragile and doesn't handle the default case cleanly.

## Solution

Add `comfy_api_base` directly to `system.system_stats` response. The value comes from `args.comfy_api_base`, which already defaults to `https://api.comfy.org` when the flag is not specified.

```diff
 "system": {
   ...
   "argv": sys.argv,
+  "comfy_api_base": args.comfy_api_base
 }
```

### Before
```json
{ "system": { "argv": ["main.py", "--comfy-api-base", "https://api.comfy.org", ...] } }
```
Clients had to scan argv for the flag, handle both `--flag value` and `--flag=value` forms, and guess the default when the flag was absent.

### After
```json
{ "system": { "argv": [...], "comfy_api_base": "https://api.comfy.org" } }
```
Clients read a single field. Default is always explicit.

## Companion frontend PR

Comfy-Org/ComfyUI_frontend#11118 — the preview frontend will consume `comfy_api_base` directly when present, with argv parsing as a fallback for older backends.

## Testing

No behavioural change for existing installs — the field just becomes visible. Can be verified by curling a running instance:

```bash
curl -s http://localhost:8188/api/system_stats | python3 -m json.tool | grep comfy_api_base
```

Expected: `"comfy_api_base": "https://api.comfy.org"` (or the value passed via `--comfy-api-base`).