### PR TITLE
fix: Handle un-inited meta-tensors in models (fixes a CPU TE crash) (CORE-67)

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -31,6 +31,7 @@ import comfy.float
 import comfy.hooks
 import comfy.lora
 import comfy.model_management
+import comfy.ops
 import comfy.patcher_extension
 import comfy.utils
 from comfy.comfy_types import UnetWrapperFunction
@@ -856,7 +857,9 @@ class ModelPatcher:
                     if m.comfy_patched_weights == True:
                         continue
 
-                for param in params:
+                for param, param_value in params.items():
+                    if hasattr(m, "comfy_cast_weights") and getattr(param_value, "is_meta", False):
+                        comfy.ops.disable_weight_init._zero_init_parameter(m, param)
                     key = key_param_name_to_key(n, param)
                     self.unpin_weight(key)
                     self.patch_weight_to_device(key, device_to=device_to)

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -307,6 +307,12 @@ class CastWeightBiasOp:
 
 class disable_weight_init:
     @staticmethod
+    def _zero_init_parameter(module, name):
+        param = getattr(module, name)
+        device = None if getattr(param, "is_meta", False) else param.device
+        setattr(module, name, torch.nn.Parameter(torch.zeros(param.shape, device=device, dtype=param.dtype), requires_grad=False))
+
+    @staticmethod
     def _lazy_load_from_state_dict(module, state_dict, prefix, local_metadata,
                                    missing_keys, unexpected_keys, weight_shape,
                                    bias_shape=None):

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -79,14 +79,21 @@ def cast_to_input(weight, input, non_blocking=False, copy=True):
     return comfy.model_management.cast_to(weight, input.dtype, input.device, non_blocking=non_blocking, copy=copy)
 
 
-def cast_bias_weight_with_vbar(s, dtype, device, bias_dtype, non_blocking, compute_dtype, want_requant):
+def materialize_meta_param(s, param_keys):
+    for param_key in param_keys:
+        param = getattr(s, param_key, None)
+        if param is not None and getattr(param, "is_meta", False):
+            setattr(s, param_key, torch.nn.Parameter(torch.zeros(param.shape, dtype=param.dtype), requires_grad=param.requires_grad))
 
+
+def cast_bias_weight_with_vbar(s, dtype, device, bias_dtype, non_blocking, compute_dtype, want_requant):
     #vbar doesn't support CPU weights, but some custom nodes have weird paths
     #that might switch the layer to the CPU and expect it to work. We have to take
     #a clone conservatively as we are mmapped and some SFT files are packed misaligned
     #If you are a custom node author reading this, please move your layer to the GPU
     #or declare your ModelPatcher as CPU in the first place.
     if comfy.model_management.is_device_cpu(device):
+        materialize_meta_param(s, ["weight", "bias"])
         weight = s.weight.to(dtype=dtype, copy=True)
         if isinstance(weight, QuantizedTensor):
             weight = weight.dequantize()
@@ -108,6 +115,7 @@ def cast_bias_weight_with_vbar(s, dtype, device, bias_dtype, non_blocking, compu
             xfer_dest = comfy_aimdo.torch.aimdo_to_tensor(s._v, device)
 
     if not resident:
+        materialize_meta_param(s, ["weight", "bias"])
         cast_geometry = comfy.memory_management.tensors_to_geometries([ s.weight, s.bias ])
         cast_dest = None
 


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/13426

If the dynamic loader is used on a dead-code tensor the non-dynamic ModelPatcher might try and .to() the non-existent tensor. Zero-init this tensor JIT to get past the crash.

Fix the same pathc for dynamic VRAM as well as reproduced by GlamoramaAttack in ^^, however in that instance it only proceeds to a follow up crash that is model code specific. The fix should still be merged as it is theoretically sound and may improve for OPs custom nodes case.

Example Test case:

Windows RTX5060, LTX2
Community Gemma3 TE with missing embedding weights on CPU

<img width="2027" height="977" alt="scr" src="https://github.com/user-attachments/assets/f6a68a31-79f1-45c0-b52a-cc39c95a9f73" />

Before:

```
    self.model_use_more_vram(use_more_vram, force_patch_weights=force_patch_weights)
  File "C:\users\rattu\ComfyUI\comfy\model_management.py", line 613, in model_use_more_vram
    return self.model.partially_load(self.device, extra_memory, force_patch_weights=force_patch_weights)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\users\rattu\ComfyUI\comfy\model_patcher.py", line 1066, in partially_load
    self.detach()
  File "C:\users\rattu\ComfyUI\comfy\model_patcher.py", line 1082, in detach
    self.unpatch_model(self.offload_device, unpatch_weights=unpatch_all)
  File "C:\users\rattu\ComfyUI\comfy\model_patcher.py", line 943, in unpatch_model
    self.model.to(device_to)
  File "C:\users\rattu\venvw\Lib\site-packages\torch\nn\modules\module.py", line 1369, in to
    return self._apply(convert)
           ^^^^^^^^^^^^^^^^^^^^
  File "C:\users\rattu\venvw\Lib\site-packages\torch\nn\modules\module.py", line 928, in _apply
    module._apply(fn)
  File "C:\users\rattu\venvw\Lib\site-packages\torch\nn\modules\module.py", line 928, in _apply
    module._apply(fn)
  File "C:\users\rattu\venvw\Lib\site-packages\torch\nn\modules\module.py", line 928, in _apply
    module._apply(fn)
  [Previous line repeated 2 more times]
  File "C:\users\rattu\venvw\Lib\site-packages\torch\nn\modules\module.py", line 955, in _apply
    param_applied = fn(param)
                    ^^^^^^^^^
  File "C:\users\rattu\venvw\Lib\site-packages\torch\nn\modules\module.py", line 1362, in convert
    raise NotImplementedError(
NotImplementedError: Cannot copy out of meta tensor; no data! Please use torch.nn.Module.to_empty() instead of torch.nn.Module.to() when moving module from meta to a different device.

Prompt executed in 3.39 seconds
```

After:

```
...
Requested to load LTXAVTEModel_
loaded completely;  18627.56 MB loaded, full load: True
CLIP/text encoder model load device: cpu, offload device: cpu, current: cpu, dtype: torch.float16
Found quantization metadata version 1
Detected mixed precision quantization
Using mixed precision operations
model weight dtype torch.bfloat16, manual cast: torch.bfloat16
model_type FLUX
VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
no CLIP/text encoder weights in checkpoint, the text encoder model will not be loaded.
Requested to load LTXAV
Model LTXAV prepared for dynamic VRAM loading. 21892MB Staged. 0 patches attached. Force pre-loaded 1176 weights: 43 KB.
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:31<00:00,  1.56s/it]
lora key not loaded: text_embedding_projection.aggregate_embed.lora_A.weight
lora key not loaded: text_embedding_projection.aggregate_embed.lora_B.weight
Requested to load LTXAV
Model LTXAV prepared for dynamic VRAM loading. 21892MB Staged. 1370 patches attached. Force pre-loaded 1176 weights: 43 KB.
100%|████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:23<00:00,  7.97s/it]
Requested to load AudioVAE
loaded completely;  415.20 MB loaded, full load: True
Requested to load VideoVAE
0 models unloaded.
Model VideoVAE prepared for dynamic VRAM loading. 2331MB Staged. 0 patches attached.
Prompt executed in 268.55 seconds
```

Regression Tests:

Linux, 5090, ACE step turbo XL :white_check_mark: 
Linux, 5090, LTX2.3 :white_check_mark: 
Linux, 5090, Flux1 canny :white_check_mark: 
