### PR TITLE
dynamicVRAM + --cache-ram 2 (CORE-117)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -663,6 +663,7 @@ def minimum_inference_memory():
 
 def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, pins_required=0, ram_required=0):
     cleanup_models_gc()
+    comfy.memory_management.extra_ram_release(max(pins_required, ram_required))
     unloaded_model = []
     can_unload = []
     unloaded_models = []

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -2,7 +2,6 @@ import comfy.model_management
 import comfy.memory_management
 import comfy_aimdo.host_buffer
 import comfy_aimdo.torch
-import psutil
 
 from comfy.cli_args import args
 
@@ -12,11 +11,6 @@ def get_pin(module):
 def pin_memory(module):
     if module.pin_failed or args.disable_pinned_memory or get_pin(module) is not None:
         return
-    #FIXME: This is a RAM cache trigger event
-    ram_headroom = comfy.memory_management.RAM_CACHE_HEADROOM
-    #we split the difference and assume half the RAM cache headroom is for us
-    if ram_headroom > 0 and psutil.virtual_memory().available < (ram_headroom * 0.5):
-        comfy.memory_management.extra_ram_release(ram_headroom)
 
     size = comfy.memory_management.vram_aligned_size([ module.weight, module.bias ])
 

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -523,13 +523,15 @@ class RAMPressureCache(LRUCache):
         self.timestamps[self.cache_key_set.get_data_key(node_id)] = time.time()
         super().set_local(node_id, value)
 
-    def ram_release(self, target):
+    def ram_release(self, target, free_active=False):
         if psutil.virtual_memory().available >= target:
             return
 
         clean_list = []
 
         for key, cache_entry in self.cache.items():
+            if not free_active and self.used_generation[key] == self.generation:
+                continue
             oom_score =  RAM_CACHE_OLD_WORKFLOW_OOM_MULTIPLIER ** (self.generation - self.used_generation[key])
 
             ram_usage = RAM_CACHE_DEFAULT_RAM_USAGE

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -5,6 +5,7 @@ import psutil
 import time
 import torch
 from typing import Sequence, Mapping, Dict
+from comfy.model_patcher import ModelPatcher
 from comfy_execution.graph import DynamicPrompt
 from abc import ABC, abstractmethod
 
@@ -544,6 +545,9 @@ class RAMPressureCache(LRUCache):
                         scan_list_for_ram_usage(output)
                     elif isinstance(output, torch.Tensor) and output.device.type == 'cpu':
                         ram_usage += output.numel() * output.element_size()
+                    elif isinstance(output, ModelPatcher) and self.used_generation[key] != self.generation:
+                        #old ModelPatchers are the first to go
+                        ram_usage = 1e30
             scan_list_for_ram_usage(cache_entry.outputs)
 
             oom_score *= ram_usage

--- a/execution.py
+++ b/execution.py
@@ -779,7 +779,7 @@ class PromptExecutor:
 
                     if self.cache_type == CacheType.RAM_PRESSURE:
                         comfy.model_management.free_memory(0, None, pins_required=ram_headroom, ram_required=ram_headroom)
-                        comfy.memory_management.extra_ram_release(ram_headroom)
+                        ram_release_callback(ram_headroom, free_active=True)
                 else:
                     # Only execute when the while-loop ends without break
                     # Send cached UI for intermediate output nodes that weren't executed


### PR DESCRIPTION
These RAM priority heuristics need improvement before defaulting RAM pressure and the default cache mode for comfyUI.

The new priority order for RAM retention the try and get and close to possible at making everyone happy:

1: Intermediates that are active in the current WF (still evictable under RAM pressure)
2: Model memory (incl pins) of the current model
3: Model memory (incl pins) of other models in the workflow
4: Intermediates from old workflows
5: ModelPatchers (and their memory) from old workflows


Example Test Conditions:

Windows, RTX5060, 64GB RAM, --cache-ram
4 workflows back to back no restart

<img width="1129" height="617" alt="scr" src="https://github.com/user-attachments/assets/adda94a1-8da4-4ba6-b4eb-1bc9ac7d52db" />

<img width="1156" height="677" alt="scr" src="https://github.com/user-attachments/assets/d58b33a2-de54-4d83-b3e9-a37d4f5dafde" />

Before:

WAN 2.2 2x14B FP16 320x320
```
Prompt executed in 85.51 seconds
```

WAN 2.2 2x14B FP16 320x320 (again) - This should cache hit TE / pins :red_circle: 
```
Prompt executed in 75.77 seconds
```

Zimage-Turbo BF16 768x768
```
Prompt executed in 26.67 seconds
```

WAN 2.2 2x14B FP16 320x320 (again)
```
Prompt executed in 86.69 seconds
```

After:

WAN 2.2 2x14B FP16 320x320

```
Prompt executed in 80.53 seconds
```

WAN 2.2 2x14B FP16 320x320 (again) :white_check_mark: 

```
Prompt executed in 60.41 seconds
```

Zimage-Turbo BF16 768x768

```
Prompt executed in 30.35 seconds
```

WAN 2.2 2x14B FP16 320x320 (again) - NEW - This cache hits the TE (see below for compare) :white_check_mark: :white_check_mark: 

```
Prompt executed in 75.94 seconds
```

Compare to --cache-classic

WAN
```
Prompt executed in 83.38 seconds
```

WAN
```
Prompt executed in 57.70 seconds
```

ZIT
```
Prompt executed in 32.63 seconds
```

WAN - Cache Miss on TE
```
Prompt executed in 84.27 seconds
```

Regression Tests:

Windows RTX5060, 64GB, flux fill inpaint :white_check_mark: 
Windows RTX5060, LTX2 :white_check_mark: 

Linux, 5090, 96GB (all run back to back with --cache-ram) :white_check_mark: 
SDXL (w torch compile)
LTX2.3
Ace Step Turbo XL
Stable cascade -> Flux 2
wan 2.2

