### PR TITLE
Reduce video tiny VAE peak VRAM and decode time (CORE-127)

### DIFF
--- a/comfy/taesd/taehv.py
+++ b/comfy/taesd/taehv.py
@@ -7,6 +7,7 @@ from tqdm.auto import tqdm
 from collections import namedtuple, deque
 
 import comfy.ops
+import comfy.model_management
 operations=comfy.ops.disable_weight_init
 
 DecoderResult = namedtuple("DecoderResult", ("frame", "memory"))
@@ -47,11 +48,14 @@ class TGrow(nn.Module):
         x = self.conv(x)
         return x.reshape(-1, C, H, W)
 
-def apply_model_with_memblocks(model, x, parallel, show_progress_bar):
+def apply_model_with_memblocks(model, x, parallel, show_progress_bar, output_device=None,
+                               frame_preprocess=None, frame_postprocess=None):
 
     B, T, C, H, W = x.shape
     if parallel:
         x = x.reshape(B*T, C, H, W)
+        if frame_preprocess is not None:
+            x = frame_preprocess(x)
         # parallel over input timesteps, iterate over blocks
         for b in tqdm(model, disable=not show_progress_bar):
             if isinstance(b, MemBlock):
@@ -62,20 +66,33 @@ def apply_model_with_memblocks(model, x, parallel, show_progress_bar):
                 x = b(x, mem)
             else:
                 x = b(x)
-        BT, C, H, W = x.shape
+        if frame_postprocess is not None:
+            x = frame_postprocess(x)
+        BT = x.shape[0]
         T = BT // B
-        x = x.view(B, T, C, H, W)
+        x = x.view(B, T, *x.shape[1:])
+        if output_device is not None:
+            x = x.to(output_device)
     else:
         out = []
-        work_queue = deque([TWorkItem(xt, 0) for t, xt in enumerate(x.reshape(B, T * C, H, W).chunk(T, dim=1))])
+        # Chunk along the time dim directly (chunks are [B,1,C,H,W] views, squeeze to [B,C,H,W] views).
+        # Avoids forcing a contiguous copy when x is non-contiguous (e.g. after movedim in encode/decode).
+        work_queue = deque([TWorkItem(xt.squeeze(1), 0) for xt in x.chunk(T, dim=1)])
         progress_bar = tqdm(range(T), disable=not show_progress_bar)
         mem = [None] * len(model)
         while work_queue:
             xt, i = work_queue.popleft()
             if i == 0:
                 progress_bar.update(1)
+                if frame_preprocess is not None:
+                    xt = frame_preprocess(xt)
             if i == len(model):
-                out.append(xt)
+                if frame_postprocess is not None:
+                    xt = frame_postprocess(xt)
+                if output_device is not None:
+                    out.append(xt.to(output_device))
+                else:
+                    out.append(xt)
                 del xt
             else:
                 b = model[i]
@@ -165,24 +182,23 @@ class TAEHV(nn.Module):
 
     def encode(self, x, **kwargs):
         x = x.movedim(2, 1)  # [B, C, T, H, W] -> [B, T, C, H, W]
-        if self.patch_size > 1:
-            B, T, C, H, W = x.shape
-            x = x.reshape(B * T, C, H, W)
-            x = F.pixel_unshuffle(x, self.patch_size)
-            x = x.reshape(B, T, C * self.patch_size ** 2, H // self.patch_size, W // self.patch_size)
         if x.shape[1] % self.t_downscale != 0:
             # pad at end to multiple of t_downscale
             n_pad = self.t_downscale - x.shape[1] % self.t_downscale
             padding = x[:, -1:].repeat_interleave(n_pad, dim=1)
             x = torch.cat([x, padding], 1)
-        x = apply_model_with_memblocks(self.encoder, x, self.parallel, self.show_progress_bar).movedim(2, 1)
+        ps = self.patch_size
+        preproc = (lambda f: F.pixel_unshuffle(f, ps)) if ps > 1 else None
+        x = apply_model_with_memblocks(self.encoder, x, self.parallel, self.show_progress_bar, frame_preprocess=preproc).movedim(2, 1)
         return self.process_out(x)
 
     def decode(self, x, **kwargs):
         x = x.unsqueeze(0) if x.ndim == 4 else x  # [T, C, H, W] -> [1, T, C, H, W]
         x = x.movedim(1, 2) if x.shape[1] != self.latent_channels else x  # [B, T, C, H, W] or [B, C, T, H, W]
         x = self.process_in(x).movedim(2, 1)  # [B, C, T, H, W] -> [B, T, C, H, W]
-        x = apply_model_with_memblocks(self.decoder, x, self.parallel, self.show_progress_bar)
-        if self.patch_size > 1:
-            x = F.pixel_shuffle(x, self.patch_size)
+        ps = self.patch_size
+        postproc = (lambda f: F.pixel_shuffle(f, ps)) if ps > 1 else None
+        x = apply_model_with_memblocks(self.decoder, x, self.parallel, self.show_progress_bar,
+                                        output_device=comfy.model_management.intermediate_device(),
+                                        frame_postprocess=postproc)
         return x[:, self.frames_to_trim:].movedim(2, 1)

--- a/comfy/taesd/taehv.py
+++ b/comfy/taesd/taehv.py
@@ -71,8 +71,7 @@ def apply_model_with_memblocks(model, x, parallel, show_progress_bar, output_dev
         BT = x.shape[0]
         T = BT // B
         x = x.view(B, T, *x.shape[1:])
-        if output_device is not None:
-            x = x.to(output_device)
+        x = x.to(output_device)
     else:
         out = []
         # Chunk along the time dim directly (chunks are [B,1,C,H,W] views, squeeze to [B,C,H,W] views).
@@ -89,10 +88,7 @@ def apply_model_with_memblocks(model, x, parallel, show_progress_bar, output_dev
             if i == len(model):
                 if frame_postprocess is not None:
                     xt = frame_postprocess(xt)
-                if output_device is not None:
-                    out.append(xt.to(output_device))
-                else:
-                    out.append(xt)
+                out.append(xt.to(output_device))
                 del xt
             else:
                 b = model[i]

--- a/comfy/taesd/taehv.py
+++ b/comfy/taesd/taehv.py
@@ -49,13 +49,13 @@ class TGrow(nn.Module):
         return x.reshape(-1, C, H, W)
 
 def apply_model_with_memblocks(model, x, parallel, show_progress_bar, output_device=None,
-                               frame_preprocess=None, frame_postprocess=None):
+                               patch_size=1, decode=False):
 
     B, T, C, H, W = x.shape
     if parallel:
         x = x.reshape(B*T, C, H, W)
-        if frame_preprocess is not None:
-            x = frame_preprocess(x)
+        if not decode and patch_size > 1:
+            x = F.pixel_unshuffle(x, patch_size)
         # parallel over input timesteps, iterate over blocks
         for b in tqdm(model, disable=not show_progress_bar):
             if isinstance(b, MemBlock):
@@ -66,11 +66,9 @@ def apply_model_with_memblocks(model, x, parallel, show_progress_bar, output_dev
                 x = b(x, mem)
             else:
                 x = b(x)
-        if frame_postprocess is not None:
-            x = frame_postprocess(x)
-        BT = x.shape[0]
-        T = BT // B
-        x = x.view(B, T, *x.shape[1:])
+        if decode and patch_size > 1:
+            x = F.pixel_shuffle(x, patch_size)
+        x = x.view(B, x.shape[0] // B, *x.shape[1:])
         x = x.to(output_device)
     else:
         out = []
@@ -83,11 +81,11 @@ def apply_model_with_memblocks(model, x, parallel, show_progress_bar, output_dev
             xt, i = work_queue.popleft()
             if i == 0:
                 progress_bar.update(1)
-                if frame_preprocess is not None:
-                    xt = frame_preprocess(xt)
+                if not decode and patch_size > 1:
+                    xt = F.pixel_unshuffle(xt, patch_size)
             if i == len(model):
-                if frame_postprocess is not None:
-                    xt = frame_postprocess(xt)
+                if decode and patch_size > 1:
+                    xt = F.pixel_shuffle(xt, patch_size)
                 out.append(xt.to(output_device))
                 del xt
             else:
@@ -183,18 +181,15 @@ class TAEHV(nn.Module):
             n_pad = self.t_downscale - x.shape[1] % self.t_downscale
             padding = x[:, -1:].repeat_interleave(n_pad, dim=1)
             x = torch.cat([x, padding], 1)
-        ps = self.patch_size
-        preproc = (lambda f: F.pixel_unshuffle(f, ps)) if ps > 1 else None
-        x = apply_model_with_memblocks(self.encoder, x, self.parallel, self.show_progress_bar, frame_preprocess=preproc).movedim(2, 1)
+        x = apply_model_with_memblocks(self.encoder, x, self.parallel, self.show_progress_bar,
+                                        patch_size=self.patch_size).movedim(2, 1)
         return self.process_out(x)
 
     def decode(self, x, **kwargs):
         x = x.unsqueeze(0) if x.ndim == 4 else x  # [T, C, H, W] -> [1, T, C, H, W]
         x = x.movedim(1, 2) if x.shape[1] != self.latent_channels else x  # [B, T, C, H, W] or [B, C, T, H, W]
         x = self.process_in(x).movedim(2, 1)  # [B, C, T, H, W] -> [B, T, C, H, W]
-        ps = self.patch_size
-        postproc = (lambda f: F.pixel_shuffle(f, ps)) if ps > 1 else None
         x = apply_model_with_memblocks(self.decoder, x, self.parallel, self.show_progress_bar,
                                         output_device=comfy.model_management.intermediate_device(),
-                                        frame_postprocess=postproc)
+                                        patch_size=self.patch_size, decode=True)
         return x[:, self.frames_to_trim:].movedim(2, 1)


### PR DESCRIPTION
- Stream completed frames to intermediate_device() as they finish in
  apply_model_with_memblocks, instead of accumulating the full output on
  GPU before returning.
- Push pixel_(un)shuffle into the streaming loop as per-frame pre/post
  hooks so they run on GPU one frame at a time, avoiding the full-video
  spike.
- Drop the x.reshape that forced a contiguous copy of the (non-contiguous,
  post-movedim) input; chunk along the time dim with views instead.

Bit-exact vs. previous code (fp16).


LTX2, 1024×1024, T_in=128:
```
  Decode peak: 12.97 GB → 0.13 GB
  Decode time: 2780 ms → 1841 ms (−34%)
  Encode peak: 1.70 GB → 0.90 GB (delta over input flat in T)
```