### PR TITLE
Add alexisrolland and rattus128 as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Admins
-* @comfyanonymous @kosinkadink @guill
+* @comfyanonymous @kosinkadink @guill @alexisrolland @kijai @rattus128

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Admins
-* @comfyanonymous @kosinkadink @guill @alexisrolland @kijai @rattus128
+* @comfyanonymous @kosinkadink @guill @alexisrolland @rattus128


### PR DESCRIPTION
Adds @alexisrolland and @rattus128 as code owners in CODEOWNERS.

@kijai will be added in a follow-up PR once the collaborator invite is accepted (CODEOWNERS validator rejects users without write access).