### PR TITLE
Change auto model selection to best match from first match (CORE-60)

### DIFF
--- a/comfy/model_detection.py
+++ b/comfy/model_detection.py
@@ -905,9 +905,16 @@ def detect_unet_config(state_dict, key_prefix, metadata=None):
     return unet_config
 
 def model_config_from_unet_config(unet_config, state_dict=None):
+    best_match = None
+    best_score = -1
     for model_config in comfy.supported_models.models:
-        if model_config.matches(unet_config, state_dict):
-            return model_config(unet_config)
+        score = model_config.match_score(unet_config, state_dict)
+        if score > best_score:
+            best_score = score
+            best_match = model_config
+
+    if best_match is not None:
+        return best_match(unet_config)
 
     logging.error("no match {}".format(unet_config))
     return None

--- a/comfy/supported_models_base.py
+++ b/comfy/supported_models_base.py
@@ -54,15 +54,31 @@ class BASE:
     optimizations = {"fp8": False}
 
     @classmethod
-    def matches(s, unet_config, state_dict=None):
+    def match_score(s, unet_config, state_dict=None):
+        """Return a non-negative specificity score if this model matches the given
+        ``unet_config``/``state_dict``, otherwise ``-1``.
+
+        The score is the total number of ``unet_config`` keys (plus ``required_keys``
+        when ``state_dict`` is provided) that this model declares and that match the
+        input. Higher scores indicate a more specific match, allowing
+        :func:`model_config_from_unet_config` to prefer the most specific model when
+        several configs would otherwise match by subset.
+        """
+        score = 0
         for k in s.unet_config:
             if k not in unet_config or s.unet_config[k] != unet_config[k]:
-                return False
+                return -1
+            score += 1
         if state_dict is not None:
             for k in s.required_keys:
                 if k not in state_dict:
-                    return False
-        return True
+                    return -1
+                score += 1
+        return score
+
+    @classmethod
+    def matches(s, unet_config, state_dict=None):
+        return s.match_score(unet_config, state_dict) >= 0
 
     def model_type(self, state_dict, prefix=""):
         return model_base.ModelType.EPS

--- a/tests-unit/comfy_test/model_detection_test.py
+++ b/tests-unit/comfy_test/model_detection_test.py
@@ -60,18 +60,38 @@ def _make_flux_schnell_comfyui_sd():
 
 
 class TestModelDetection:
-    """Verify that first-match model detection selects the correct model
-    based on list ordering and unet_config specificity."""
+    """Verify that model detection selects the most specific model regardless of
+    the ordering of entries in ``comfy.supported_models.models``."""
 
-    def test_longcat_before_schnell_in_models_list(self):
-        """LongCatImage must appear before FluxSchnell in the models list."""
-        models = comfy.supported_models.models
-        longcat_idx = next(i for i, m in enumerate(models) if m.__name__ == "LongCatImage")
-        schnell_idx = next(i for i, m in enumerate(models) if m.__name__ == "FluxSchnell")
-        assert longcat_idx < schnell_idx, (
-            f"LongCatImage (index {longcat_idx}) must come before "
-            f"FluxSchnell (index {schnell_idx}) in the models list"
-        )
+    def test_longcat_detection_is_order_independent(self):
+        """Detection must pick LongCatImage over FluxSchnell regardless of
+        their relative order in the models list, because LongCatImage has a
+        strictly more specific ``unet_config``."""
+        original_models = comfy.supported_models.models
+        sd = _make_longcat_comfyui_sd()
+        unet_config = detect_unet_config(sd, "")
+
+        try:
+            for ordering in ("longcat_first", "schnell_first"):
+                models = list(original_models)
+                longcat = next(m for m in models if m.__name__ == "LongCatImage")
+                schnell = next(m for m in models if m.__name__ == "FluxSchnell")
+                models.remove(longcat)
+                models.remove(schnell)
+                if ordering == "longcat_first":
+                    models.extend([longcat, schnell])
+                else:
+                    models.extend([schnell, longcat])
+                comfy.supported_models.models = models
+
+                model_config = model_config_from_unet_config(unet_config, sd)
+                assert model_config is not None
+                assert type(model_config).__name__ == "LongCatImage", (
+                    f"Expected LongCatImage with ordering={ordering}, "
+                    f"got {type(model_config).__name__}"
+                )
+        finally:
+            comfy.supported_models.models = original_models
 
     def test_longcat_comfyui_detected_as_longcat(self):
         sd = _make_longcat_comfyui_sd()


### PR DESCRIPTION
This is a suggestion which would eliminate the need of keeping specific order of models array. Pre-requisite is also https://github.com/Comfy-Org/ComfyUI/pull/13654 .


I asked Claude to analyze if this change could cause any issues:

### Things to be aware of
1. Tie-breaking semantics preserved
> (strict) means equal-scoring models are resolved by list order, the same as the original first-match behavior. So any model pair that already worked under the old logic will still resolve the same way.

2. Stable_Zero123 vs SD15_instructpix2pix (silent improvement)
These two share an identical 6-key unet_config (context_dim=768, model_channels=320, …, in_channels=8). They're disambiguated only by Stable_Zero123.required_keys = {cc_projection.weight, cc_projection.bias}.

Old: first-in-list (Stable_Zero123 at index 1) wins regardless of whether cc_projection.* is in the state dict.
New (with state_dict): Stable_Zero123 scores 8 (6 + 2), SD15_instructpix2pix scores 6 → Stable_Zero123 wins iff cc_projection.* is actually present, which is the correct behaviour. Loading an instructpix2pix checkpoint via model_config_from_unet will now correctly select SD15_instructpix2pix instead of misidentifying it as Stable_Zero123.
This is a behavioural change worth knowing about, but it's a strict improvement.

3. Diffusers path is unchanged-but-not-improved
model_config_from_diffusers_unet calls model_config_from_unet_config(unet_config) without a state_dict (comfy/model_detection.py:1155). With state_dict=None, required_keys are not scored — so the Stable_Zero123 / SD15_instructpix2pix ambiguity remains unresolved on that path. This is identical to the previous behavior (not a regression), but worth documenting.

4. Score-0 catch-all impossible
The default BASE.unet_config = {} would score 0 (matches anything). I confirmed no entry in comfy.supported_models.models has an empty unet_config, so a generic BASE can never out-rank a specific match. A score of 0 only "wins" if literally no model matched — which is the same fall-through behavior as before.

5. No external .matches overrides
I grepped — BASE.matches is the only definition, with one caller (model_detection.py). Refactoring matches into match_score >= 0 is API-compatible.

6. Performance
Old: O(n) with early exit. New: always O(n). With ~80 model classes evaluated once per checkpoint load, this is unmeasurable.

7. unet_extra_config is applied post-selection
BASE.__init__ merges unet_extra_config into self.unet_config only after the model is chosen, so match_score correctly scores against the class-level unet_config only. No accidental matches via extras.

8. List ordering still loosely matters as a tiebreaker
If two models truly have identical (unet_config, required_keys), list order decides. The (now-on-another-branch) test_unet_config_and_required_keys_combination_is_unique is the right safeguard for that case https://github.com/Comfy-Org/ComfyUI/pull/13654 .

### Verdict
The change is safe. The only behavioural difference beyond the intended fix is the Stable_Zero123 / SD15_instructpix2pix improvement in 2., which is a bug fix in its own right.