### PR TITLE
samplers: stack hook patches on top of model patches

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -300,9 +300,12 @@ def _calc_cond_batch(model: BaseModel, conds: list[list[dict]], x_in: torch.Tens
 
             transformer_options = model.current_patcher.apply_hooks(hooks=hooks)
             if 'transformer_options' in model_options:
-                transformer_options = comfy.patcher_extension.merge_nested_dicts(transformer_options,
-                                                                                 model_options['transformer_options'],
-                                                                                 copy_dict1=False)
+                # Hook-derived patches must stack on top of model patches, so
+                # model's transformer_options is dict1 (existing) and the
+                # hook-derived dict is dict2 (extends model's lists).
+                transformer_options = comfy.patcher_extension.merge_nested_dicts(model_options['transformer_options'],
+                                                                                 transformer_options,
+                                                                                 copy_dict1=True)
 
             if patches is not None:
                 transformer_options["patches"] = comfy.patcher_extension.merge_nested_dicts(


### PR DESCRIPTION
### Summary

Swap the argument order of `merge_nested_dicts` in `_calc_cond_batch` so model-level transformer_options are dict1 and hook-derived options are dict2. This restores the registration order `[model_patches, hook_patches]` for list-valued keys (e.g. `attn2_patch`).

### Why

After 493b81e (#10591) swapped the semantics of `merge_nested_dicts(dict1, dict2)` so dict1's lists are extended with dict2's, the merge in `_calc_cond_batch` has been assembling the wrong order:

```py
transformer_options = model.current_patcher.apply_hooks(hooks=hooks)
if 'transformer_options' in model_options:
    transformer_options = comfy.patcher_extension.merge_nested_dicts(
        transformer_options,                       # dict1: hook-derived
        model_options['transformer_options'],      # dict2: model patches
        copy_dict1=False)
```

For `attn2_patch` this produces `[hook_patches, model_patches]` — i.e. hook patches run *before* model patches. That breaks combinations where a hook needs to run *after* a model-level attention patch.

User-visible symptom: NegPip (model patch via `set_model_attn2_patch`) + AttentionCouple (registered as a `TransformerOptionsHook` by [asagi4/comfyui-prompt-control](https://github.com/asagi4/comfyui-prompt-control)). With the swapped order, AttentionCouple's masked-attention math runs on un-NegPip'd values and per-region weighting is washed out. Reported and root-caused in [asagi4/comfyui-prompt-control#135](https://github.com/asagi4/comfyui-prompt-control/issues/135).

### Fix

```diff
             transformer_options = model.current_patcher.apply_hooks(hooks=hooks)
             if 'transformer_options' in model_options:
-                transformer_options = comfy.patcher_extension.merge_nested_dicts(transformer_options,
-                                                                                 model_options['transformer_options'],
-                                                                                 copy_dict1=False)
+                # Hook-derived patches must stack on top of model patches, so
+                # model's transformer_options is dict1 (existing) and the
+                # hook-derived dict is dict2 (extends model's lists).
+                transformer_options = comfy.patcher_extension.merge_nested_dicts(model_options['transformer_options'],
+                                                                                 transformer_options,
+                                                                                 copy_dict1=True)
```

`copy_dict1=True` is required because dict1 is now a reference to persistent model state; we must not mutate `model_options['transformer_options']` in place.

### Verification

The bug is purely about list ordering after the dict merge — no numerics, no torch — so it's deterministically reproducible at the `merge_nested_dicts` layer with no diffusion needed. The script below imports the real `comfy.patcher_extension.merge_nested_dicts` and simulates the exact dict shape `_calc_cond_batch` builds (NegPip as a model-level `attn2_patch` entry, AttentionCouple as a HookedOnly `TransformerOptionsHook` whose `on_apply_hooks` calls `merge_nested_dicts(transformer_options, self.transformers_dict, copy_dict1=False)`).

<details><summary>verification script (drop in repo root, run with cwd=ComfyUI)</summary>

```python
import sys
sys.path.insert(0, '.')
from comfy.patcher_extension import merge_nested_dicts

def negpip(*a, **kw): return 'negpip'
def couple(*a, **kw): return 'couple'

def hook_on_apply(transformer_options, transformers_dict):
    # Mirrors TransformerOptionsHook.on_apply_hooks (hooks.py:263-265)
    merge_nested_dicts(transformer_options, transformers_dict, copy_dict1=False)

def simulate_pre_fix(model_options, hook_dict):
    transformer_options = {}
    hook_on_apply(transformer_options, hook_dict)
    if 'transformer_options' in model_options:
        transformer_options = merge_nested_dicts(
            transformer_options, model_options['transformer_options'], copy_dict1=False)
    return transformer_options

def simulate_post_fix(model_options, hook_dict):
    transformer_options = {}
    hook_on_apply(transformer_options, hook_dict)
    if 'transformer_options' in model_options:
        transformer_options = merge_nested_dicts(
            model_options['transformer_options'], transformer_options, copy_dict1=True)
    return transformer_options

mo = {'transformer_options': {'patches': {'attn2_patch': [negpip]}}}
hd = {'patches': {'attn2_patch': [couple]}}

pre  = [f.__name__ for f in simulate_pre_fix(mo, hd)['patches']['attn2_patch']]
post = [f.__name__ for f in simulate_post_fix({'transformer_options': {'patches': {'attn2_patch': [negpip]}}}, hd)['patches']['attn2_patch']]

print(f'PRE-FIX  attn2_patch order: {pre}')   # ['couple', 'negpip']  (wrong)
print(f'POST-FIX attn2_patch order: {post}')  # ['negpip', 'couple']  (correct)
```

</details>

Output:
```
PRE-FIX  attn2_patch order: ['couple', 'negpip']
POST-FIX attn2_patch order: ['negpip', 'couple']
```

### Alternative considered

A larger refactor that threads `model_options['transformer_options']` into `ModelPatcher.apply_hooks(...)` via the existing `transformer_options` kwarg also fixes the symptom and was tested locally by @asagi4. That removes the if-block entirely and lets the hook system own the merge, which is closer to the intent of the `# TODO: return transformer_options dict with any additions from hooks` comment at `comfy/model_patcher.py:1333`. It's the architecturally cleaner option but a larger blast radius for a sampler hot path. Happy to switch to it if reviewers prefer.

### Credit

Patch authored and locally tested by @asagi4 in the prompt-control thread. I'm filing because asagi4 explicitly invited an upstream PR but doesn't have bandwidth to chase the core review cycle. End-to-end NegPip+COUPLE workflow validation by users with the failing setup would be welcome — the verification above proves the merge order at the dict layer; the visible image difference downstream is what this re-orders.

Marked **draft** so there's no review pressure until reviewers have time to weigh in.