### PR TITLE
fix comfy manager (--enable-manager) doesn't work when --disable-api-nodes is used (Content-Security-Policy error)

### DIFF
--- a/server.py
+++ b/server.py
@@ -192,8 +192,18 @@ def create_block_external_middleware():
             response = web.Response()
         else:
             response = await handler(request)
-
-        response.headers['Content-Security-Policy'] = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' data:; frame-src 'self'; object-src 'self';"
+        connectSrc = "'self' data:"
+        if args.enable_manager:
+            connectSrc += " https://api.comfy.org"
+        response.headers['Content-Security-Policy'] = (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data: blob:; "
+            "font-src 'self'; "
+            f"connect-src {connectSrc}; "
+            "frame-src 'self'; "
+            "object-src 'self';")
         return response
 
     return block_external_middleware

--- a/server.py
+++ b/server.py
@@ -194,7 +194,7 @@ def create_block_external_middleware():
             response = await handler(request)
         connectSrc = "'self' data:"
         if args.enable_manager:
-            connectSrc += " https://api.comfy.org"
+            connectSrc += " " + args.comfy_api_base
         response.headers['Content-Security-Policy'] = (
             "default-src 'self'; "
             "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; "


### PR DESCRIPTION
This PR fixes the built-in nodes manager `--enable-manager`, that doesn't work due to `Content-Security-Policy`. This policy is enabled only when the flag `--disable-api-nodes` is passed

https://github.com/Comfy-Org/ComfyUI/blob/f6d5068ac0163e7f626c9cec2e7c663cf6fa64a8/server.py#L222-L233

I've tested this patch, it works. 
Before:
<img width="2236" height="1421" alt="Screenshot_ComfyUI - *Unsaved Workflow - ComfyUI_20260503_074732" src="https://github.com/user-attachments/assets/451c5391-f08a-409c-853e-ed5b58d24651" />

After:
<img width="2236" height="1421" alt="Screenshot_ComfyUI - *Unsaved Workflow - ComfyUI_20260503_084657" src="https://github.com/user-attachments/assets/4d6a2612-a427-48e7-9ca5-e020d3c5de73" />

I've added `--comfy-api-base` (`https://api.comfy.org`) into allowed content sources if `--enable-manager` is used