### PR TITLE
PrimitiveInt: default control_after_generate widget to fixed (CORE-141)

### DIFF
--- a/comfy_extras/nodes_primitive.py
+++ b/comfy_extras/nodes_primitive.py
@@ -49,7 +49,7 @@ class Int(io.ComfyNode):
             display_name="Int",
             category="utils/primitive",
             inputs=[
-                io.Int.Input("value", min=-sys.maxsize, max=sys.maxsize, control_after_generate=True),
+                io.Int.Input("value", min=-sys.maxsize, max=sys.maxsize, control_after_generate=io.ControlAfterGenerate.fixed),
             ],
             outputs=[io.Int.Output()],
         )


### PR DESCRIPTION
Sets the `control_after_generate` widget on the `PrimitiveInt` node to default to `fixed` instead of the previous default (`randomize`).

Uses the `io.ControlAfterGenerate.fixed` enum value, which is already supported by `Int.Input` (typed as `bool | ControlAfterGenerate`).

The `ControlAfterGenerate` enum exposes `fixed`, `increment`, `decrement`, and `randomize` — passing `True` previously left the default behavior up to the frontend (randomize). For a generic int primitive, `fixed` is the saner default since most integer values aren't seed-like.