### PR TITLE
Fix AttributeError when prefetched block is fully resident

### DIFF
--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -37,7 +37,8 @@ def prefetch_queue_pop(queue, device, module):
     consumed = queue.pop(0)
     if consumed is not None:
         offload_stream, prefetch_state = consumed
-        offload_stream.wait_stream(comfy.model_management.current_stream(device))
+        if offload_stream is not None:
+            offload_stream.wait_stream(comfy.model_management.current_stream(device))
         _, comfy_modules = prefetch_state
         if comfy_modules is not None:
             cleanup_prefetched_modules(comfy_modules)


### PR DESCRIPTION
Fixes `AttributeError: 'NoneType' object has no attribute 'wait_stream'` in `prefetch_queue_pop` (`comfy/model_prefetch.py:40`).

`cast_modules_with_vbar` returns `None` for `offload_stream` when every module in a prefetched block is already resident -- the `if resident: continue` path in `comfy/ops.py` skips `ensure_offload_stream`. The `None` is stored in the queue and crashes on the next pop.

Reproduces on LTXAV workflows with `prefetch_dynamic_vbars` enabled.

`sync_stream` already guards against this; this PR applies the same one-line check to the consumer side.