### PR TITLE
Create custom input directory when configured

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -117,12 +117,12 @@ def set_temp_directory(temp_dir: str) -> None:
 
 def set_input_directory(input_dir: str) -> None:
     global input_directory
+    try:
+        os.makedirs(input_dir, exist_ok=True)
+    except OSError:
+        logging.exception("Failed to create input directory: %s", input_dir)
+        raise
     input_directory = input_dir
-    if not os.path.exists(input_directory):
-        try:
-            os.makedirs(input_directory)
-        except:
-            logging.error("Failed to create input directory")
 
 def get_output_directory() -> str:
     global output_directory

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -118,6 +118,11 @@ def set_temp_directory(temp_dir: str) -> None:
 def set_input_directory(input_dir: str) -> None:
     global input_directory
     input_directory = input_dir
+    if not os.path.exists(input_directory):
+        try:
+            os.makedirs(input_directory)
+        except:
+            logging.error("Failed to create input directory")
 
 def get_output_directory() -> str:
     global output_directory

--- a/tests/test_folder_paths.py
+++ b/tests/test_folder_paths.py
@@ -1,3 +1,5 @@
+import pytest
+
 import folder_paths
 
 
@@ -11,3 +13,18 @@ def test_set_input_directory_creates_missing_directory(tmp_path):
         assert custom_input_directory.is_dir()
     finally:
         folder_paths.set_input_directory(original_input_directory)
+
+
+def test_set_input_directory_keeps_original_when_creation_fails(tmp_path, monkeypatch):
+    original_input_directory = folder_paths.get_input_directory()
+    custom_input_directory = tmp_path / "custom-input"
+
+    def fail_to_create_directory(path, exist_ok=False):
+        raise OSError("create failed")
+
+    monkeypatch.setattr(folder_paths.os, "makedirs", fail_to_create_directory)
+
+    with pytest.raises(OSError, match="create failed"):
+        folder_paths.set_input_directory(str(custom_input_directory))
+
+    assert folder_paths.get_input_directory() == original_input_directory

--- a/tests/test_folder_paths.py
+++ b/tests/test_folder_paths.py
@@ -1,0 +1,13 @@
+import folder_paths
+
+
+def test_set_input_directory_creates_missing_directory(tmp_path):
+    original_input_directory = folder_paths.get_input_directory()
+    custom_input_directory = tmp_path / "custom-input"
+
+    try:
+        folder_paths.set_input_directory(str(custom_input_directory))
+
+        assert custom_input_directory.is_dir()
+    finally:
+        folder_paths.set_input_directory(original_input_directory)


### PR DESCRIPTION
## Summary
- create a custom input directory immediately when `set_input_directory()` is called
- add a regression test for configuring a missing input directory

Fixes #13688.

This is a small current-issue slice of the missing-data-directory behavior discussed in #8115. That older PR is broader and currently conflicted, while this change only handles the startup failure reported in #13688.

## Tests
- `python3 -m pytest tests/test_folder_paths.py`
- `python3 -m py_compile folder_paths.py`