### PR TITLE
fix: Proper memory estimation for frame interpolation (CORE-150)

### DIFF
--- a/comfy_extras/frame_interpolation_models/film_net.py
+++ b/comfy_extras/frame_interpolation_models/film_net.py
@@ -199,6 +199,9 @@ class FILMNet(nn.Module):
     def get_dtype(self):
         return self.extract.extract_sublevels.convs[0][0].conv.weight.dtype
 
+    def memory_used_forward(self, shape, dtype):
+        return 1700 * shape[1] * shape[2] * dtype.itemsize
+
     def _build_warp_grids(self, H, W, device):
         """Pre-compute warp grids for all pyramid levels."""
         if (H, W) in self._warp_grids:

--- a/comfy_extras/frame_interpolation_models/ifnet.py
+++ b/comfy_extras/frame_interpolation_models/ifnet.py
@@ -74,6 +74,9 @@ class IFNet(nn.Module):
     def get_dtype(self):
         return self.encode.cnn0.weight.dtype
 
+    def memory_used_forward(self, shape, dtype):
+        return 300 * shape[1] * shape[2] * dtype.itemsize
+
     def _build_warp_grids(self, H, W, device):
         if (H, W) in self._warp_grids:
             return

--- a/comfy_extras/nodes_frame_interpolation.py
+++ b/comfy_extras/nodes_frame_interpolation.py
@@ -37,7 +37,7 @@ class FrameInterpolationModelLoader(io.ComfyNode):
         model = cls._detect_and_load(sd)
         dtype = torch.float16 if model_management.should_use_fp16(model_management.get_torch_device()) else torch.float32
         model.eval().to(dtype)
-        patcher = comfy.model_patcher.ModelPatcher(
+        patcher = comfy.model_patcher.CoreModelPatcher(
             model,
             load_device=model_management.get_torch_device(),
             offload_device=model_management.unet_offload_device(),
@@ -98,16 +98,13 @@ class FrameInterpolate(io.ComfyNode):
         if num_frames < 2 or multiplier < 2:
             return io.NodeOutput(images)
 
-        model_management.load_model_gpu(interp_model)
         device = interp_model.load_device
         dtype = interp_model.model_dtype()
         inference_model = interp_model.model
-
-        # Free VRAM for inference activations (model weights + ~20x a single frame's worth)
-        H, W = images.shape[1], images.shape[2]
-        activation_mem = H * W * 3 * images.element_size() * 20
-        model_management.free_memory(activation_mem, device)
+        activation_mem = inference_model.memory_used_forward(images.shape, dtype)
+        model_management.load_models_gpu([interp_model], memory_required=activation_mem)
         align = getattr(inference_model, "pad_align", 1)
+        H, W = images.shape[1], images.shape[2]
 
         # Prepare a single padded frame on device for determining output dimensions
         def prepare_frame(idx):


### PR DESCRIPTION
Should fix https://github.com/Comfy-Org/ComfyUI/issues/13583

load_model_gpu + separate free_memory could evict the just-loaded interp model back to CPU, causing a CUDA/CPU mismatch on forward. Replaced with a single load_models_gpu(memory_required=...) call (matches some existing patterns such as VAEs), profiled memory_used_forward on IFNet/FILMNet replacing the under-reserved 20× heuristic, and switched loader to CoreModelPatcher.