### PR TITLE
make control-net load order deterministic (CORE-139)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -721,13 +721,15 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
     else:
         minimum_memory_required = max(inference_memory, minimum_memory_required + extra_reserved_memory())
 
-    models_temp = set()
+    # Order-preserving dedup. A plain set() would randomize iteration order across runs
+    models_temp = {}
     for m in models:
-        models_temp.add(m)
+        models_temp[m] = None
         for mm in m.model_patches_models():
-            models_temp.add(mm)
+            models_temp[mm] = None
 
-    models = models_temp
+    models = list(models_temp)
+    models.reverse()
 
     models_to_load = []
 

--- a/comfy/sampler_helpers.py
+++ b/comfy/sampler_helpers.py
@@ -89,7 +89,8 @@ def get_additional_models(conds, dtype):
         gligen += get_models_from_cond(conds[k], "gligen")
         add_models += get_models_from_cond(conds[k], "additional_models")
 
-    control_nets = set(cnets)
+    # Order-preserving dedup. A plain set() would randomize iteration order across runs
+    control_nets = list(dict.fromkeys(cnets))
 
     inference_memory = 0
     control_models = []


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/13668

Make this deterministic so speeds dont change base of load order. Load them in reverse order so whatever the caller lists first is the top priority.

I never reproduced this, however we should make this deterministic to deconfuse performance. Use the OPs preference to load the diffusion model over the control net.

Example test conditions:

Windows, RTX5060, PCIE2x8 (bus downgrade)
SDXL + controlnet with latent2rgb preview

<img width="1566" height="853" alt="scr" src="https://github.com/user-attachments/assets/5fc98178-7d44-4ace-ab0c-98d1f50080dd" />


```
100%|██████████████████████████████████████████████████████████████████████████████████| 30/30 [00:30<00:00,  1.00s/it]
Requested to load AutoencoderKL
0 models unloaded.
Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Prompt executed in 37.47 seconds
```

Load pattern matches OPs preferred load as per the report ^^ and is now deterministic.