### PR TITLE
prefetch: guard against no offload (CORE-149)

### DIFF
--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -37,7 +37,8 @@ def prefetch_queue_pop(queue, device, module):
     consumed = queue.pop(0)
     if consumed is not None:
         offload_stream, prefetch_state = consumed
-        offload_stream.wait_stream(comfy.model_management.current_stream(device))
+        if offload_stream is not None:
+            offload_stream.wait_stream(comfy.model_management.current_stream(device))
         _, comfy_modules = prefetch_state
         if comfy_modules is not None:
             cleanup_prefetched_modules(comfy_modules)


### PR DESCRIPTION
(Urgent) crasher fix for LTX2.3 on RTX5090 or greater.

Example test conditions:

RTX5090, linux LTX2.3 FP8

<img width="1015" height="571" alt="image" src="https://github.com/user-attachments/assets/fbb6b972-d9d6-4f77-b503-9b06da2d0e30" />

Before:

```
  File "/home/rattus/ComfyUI/comfy/ldm/lightricks/av_model.py", line 1067, in forward
    return super().forward(
           ^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ldm/lightricks/model.py", line 879, in forward
    return comfy.patcher_extension.WrapperExecutor.new_class_executor(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/patcher_extension.py", line 112, in execute
    return self.original(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ldm/lightricks/model.py", line 932, in _forward
    x = self._process_transformer_blocks(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ldm/lightricks/av_model.py", line 915, in _process_transformer_blocks
    comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, vx.device, block)
  File "/home/rattus/ComfyUI/comfy/model_prefetch.py", line 40, in prefetch_queue_pop
    offload_stream.wait_stream(comfy.model_management.current_stream(device))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'wait_stream'
```

After:

```
Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
Prompt executed in 23.79 seconds
```