### PR TITLE
Throttle dynamic VRAM prepare logging

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -26,6 +26,7 @@ import uuid
 from typing import Callable, Optional
 
 import torch
+import tqdm
 
 import comfy.float
 import comfy.hooks
@@ -1652,7 +1653,8 @@ class ModelPatcherDynamic(ModelPatcher):
 
             force_load_stat = f" Force pre-loaded {len(self.backup)} weights: {self.model.model_loaded_weight_memory // 1024} KB." if len(self.backup) > 0 else ""
             log_key = (self.patches_uuid, allocated_size, num_patches, len(self.backup), self.model.model_loaded_weight_memory)
-            level = logging.DEBUG if getattr(self, "_last_prepare_log_key", None) == log_key else logging.INFO
+            in_loop = bool(getattr(tqdm.tqdm, "_instances", None))
+            level = logging.DEBUG if in_loop and getattr(self, "_last_prepare_log_key", None) == log_key else logging.INFO
             self._last_prepare_log_key = log_key
             logging.log(level, f"Model {self.model.__class__.__name__} prepared for dynamic VRAM loading. {allocated_size // (1024 ** 2)}MB Staged. {num_patches} patches attached.{force_load_stat}")
 

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1651,7 +1651,10 @@ class ModelPatcherDynamic(ModelPatcher):
                 self.model.model_loaded_weight_memory += casted_buf.numel() * casted_buf.element_size()
 
             force_load_stat = f" Force pre-loaded {len(self.backup)} weights: {self.model.model_loaded_weight_memory // 1024} KB." if len(self.backup) > 0 else ""
-            logging.info(f"Model {self.model.__class__.__name__} prepared for dynamic VRAM loading. {allocated_size // (1024 ** 2)}MB Staged. {num_patches} patches attached.{force_load_stat}")
+            log_key = (self.patches_uuid, allocated_size, num_patches, len(self.backup), self.model.model_loaded_weight_memory)
+            level = logging.DEBUG if getattr(self, "_last_prepare_log_key", None) == log_key else logging.INFO
+            self._last_prepare_log_key = log_key
+            logging.log(level, f"Model {self.model.__class__.__name__} prepared for dynamic VRAM loading. {allocated_size // (1024 ** 2)}MB Staged. {num_patches} patches attached.{force_load_stat}")
 
             self.model.device = device_to
             self.model.current_weight_patches_uuid = self.patches_uuid


### PR DESCRIPTION
The "prepared for dynamic VRAM loading" line currently fires at INFO on every load() call, which spams the console when the same model is reloaded inside a tight loop (e.g. `SDPoseKeypointExtractor` running one forward pass per bbox per image). When a tqdm progress bar is active and the message would say the exact same thing as the previous load, drop it to DEBUG; the line is still recoverable under `--verbose`.

Example when running SDPose detection:

Before:
```
Requested to load Lotus
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  10%|██████                                                       | 1/10 [00:01<00:16,  1.81s/it]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  20%|████████████▏                                                | 2/10 [00:02<00:07,  1.08it/s]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  30%|██████████████████▎                                          | 3/10 [00:02<00:04,  1.57it/s]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  40%|████████████████████████▍                                    | 4/10 [00:02<00:03,  1.99it/s]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  50%|██████████████████████████████▌                              | 5/10 [00:03<00:02,  2.32it/s]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  60%|████████████████████████████████████▌                        | 6/10 [00:03<00:01,  2.62it/s]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  70%|██████████████████████████████████████████▋                  | 7/10 [00:03<00:01,  2.84it/s]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  80%|████████████████████████████████████████████████▊            | 8/10 [00:03<00:00,  2.97it/s]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints:  90%|██████████████████████████████████████████████████████▉      | 9/10 [00:04<00:00,  3.07it/s]Model AutoencoderKL prepared for dynamic VRAM loading. 159MB Staged. 0 patches attached.
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints: 100%|████████████████████████████████████████████████████████████| 10/10 [00:04<00:00,  2.23it/s]
Prompt executed in 5.10 seconds
```

After:
```
Requested to load Lotus
Model Lotus prepared for dynamic VRAM loading. 1668MB Staged. 0 patches attached.
Extracting keypoints: 100%|████████████████████████████████████████████████████████████| 10/10 [00:03<00:00,  3.33it/s]
Prompt executed in 3.04 seconds
```