### PR TITLE
ops: handle multi-compute of the same weight (CORE-153)

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -253,6 +253,9 @@ def resolve_cast_module_with_vbar(s, dtype, device, bias_dtype, compute_dtype, w
     if bias is not None:
         bias = post_cast(s, "bias", bias, bias_dtype, prefetch["resident"], update_weight)
 
+    if prefetch["signature"] is not None:
+        prefetch["resident"] = True
+
     return weight, bias
 
 


### PR DESCRIPTION
If the same weight is used multiple times within the same prefetch window, it should only apply compute state mutations once. Mark the weight as fully resident on the first pass accordingly.

Example Test Conditions:

RTX5090, Linux, LTX2.3 + Content Lora + KJNodes LTXV Chunk FF
"A group of old men in suits dance in a new york street."

Before:

<img width="907" height="515" alt="image" src="https://github.com/user-attachments/assets/c9a5a6ab-79ae-435f-857a-bb31a5dbd87c" />

After:

<img width="1120" height="616" alt="image" src="https://github.com/user-attachments/assets/fb78d1a2-b311-4e22-a1e7-8fb20e07996f" />

Regression Tests:


RTX5090, Linux, LTX2.0 T2V :white_check_mark: 
RTX5090, Linux, LTX2.0 T2V --disable-async-offload :white_check_mark: 
RTX5090, Linux, WAN2.2 :white_check_mark: 
RTX5090, Linux, Stable cascade -> flux 2 :white_check_mark: 

