### PR TITLE
fix(spec): mark DeviceStats.index and NodeInfo.essentials_category as nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2347,7 +2347,12 @@ components:
           description: Device type (cuda, mps, cpu, etc.)
         index:
           type: number
-          description: Device index
+          nullable: true
+          description: |
+            Device index within its type (e.g. CUDA ordinal for `cuda:0`,
+            `cuda:1`). `null` for devices with no index, including the CPU
+            device returned in `--cpu` mode (PyTorch's `torch.device('cpu').index`
+            is `None`).
         vram_total:
           type: number
           description: Total VRAM in bytes
@@ -2503,7 +2508,11 @@ components:
           description: Alternative search terms for finding this node
         essentials_category:
           type: string
-          description: Category override used by the essentials pack
+          nullable: true
+          description: |
+            Category override used by the essentials pack. `null` for nodes
+            that don't set `ESSENTIALS_CATEGORY` (V1) or whose `Schema`
+            doesn't populate `essentials_category` (V3 / `comfy_api.latest.io`).
 
     # -------------------------------------------------------------------
     # Models

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2510,9 +2510,16 @@ components:
           type: string
           nullable: true
           description: |
-            Category override used by the essentials pack. `null` for nodes
-            that don't set `ESSENTIALS_CATEGORY` (V1) or whose `Schema`
-            doesn't populate `essentials_category` (V3 / `comfy_api.latest.io`).
+            Category override used by the essentials pack. The
+            `essentials_category` key may be present with a string value,
+            present and `null`, or absent entirely:
+
+            - V1 nodes: `essentials_category` is **omitted** when the node
+              class doesn't define an `ESSENTIALS_CATEGORY` attribute, and
+              **`null`** if the attribute is explicitly set to `None`.
+            - V3 nodes (`comfy_api.latest.io`): `essentials_category` is
+              **always present**, and **`null`** for nodes whose `Schema`
+              doesn't populate it.
 
     # -------------------------------------------------------------------
     # Models


### PR DESCRIPTION
## Summary

Two fields in `openapi.yaml` are declared non-nullable but the Python implementation legitimately returns `null` for them. This PR marks both fields `nullable: true` so spec-driven response validators don't fail on conformant responses.

## `DeviceStats.index` (used by `GET /api/system_stats`)

[`server.py:677`](https://github.com/Comfy-Org/ComfyUI/blob/master/server.py#L677) emits `\"index\": device.index` unconditionally. For the CPU device (`--cpu` mode), `torch.device(\"cpu\").index` is `None` per PyTorch convention, so the JSON response includes `\"index\": null`.

The field stays in `required` — it's always present in the response. Only the value can be null.

## `NodeInfo.essentials_category` (used by `GET /api/object_info`)

Two emitters disagree on this field:

1. The legacy V1 path in [`server.py:739-740`](https://github.com/Comfy-Org/ComfyUI/blob/master/server.py#L739-L740) only sets the key when `hasattr(obj_class, 'ESSENTIALS_CATEGORY')`. Field absent for nodes that don't set it.
2. The V3 schema path in [`comfy_api/latest/_io.py:1654`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy_api/latest/_io.py#L1654) unconditionally passes `essentials_category=self.essentials_category` into `NodeInfoV1`, then serializes via `dataclasses.asdict()`. The dataclass default is `None`, so for V3 nodes that don't set `essentials_category` in `define_schema` (e.g. APG, in `comfy_extras/nodes_apg.py`) the JSON response includes `\"essentials_category\": null`.

The field stays optional (already not in `required`). Marking it nullable lets the V3-generated `null` validate cleanly while still allowing the V1 \"key absent\" shape.

## Reproduction

Stand up ComfyUI in `--cpu` mode and validate the responses against the current spec with any OpenAPI 3.1 response validator (e.g. `kin-openapi`'s `openapi3filter.ValidateResponse`):

- `GET /api/system_stats` → \`response body doesn't match schema #/components/schemas/SystemStatsResponse: Error at \"/devices/0/index\": Value is not nullable\`
- `GET /api/object_info` → \`response body doesn't match schema: Error at \"/APG/essentials_category\": Value is not nullable\`

After this PR both validate cleanly.

## Notes

- No Python code changes — the runtime behavior is correct, only the spec was wrong.
- Descriptions expanded to spell out exactly when `null` is expected, so future readers don't have to re-derive it.
- Spec validates under `kin-openapi` after the change.