### PR TITLE
spec: add workflow_id / workflow_version_id to PromptRequest with x-runtime tag

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1999,6 +1999,26 @@ components:
           items:
             type: string
           description: List of node IDs to execute (partial graph execution)
+        workflow_id:
+          type: string
+          format: uuid
+          nullable: true
+          x-runtime: [cloud]
+          description: |
+            UUID identifying a hosted-cloud workflow entity to associate with this
+            job. Local ComfyUI doesn't track workflow entities and returns `null`
+            (or omits the field). The `x-runtime: [cloud]` extension marks this
+            as populated only by the hosted-cloud runtime; absence of the tag
+            means a field is populated by all runtimes.
+        workflow_version_id:
+          type: string
+          format: uuid
+          nullable: true
+          x-runtime: [cloud]
+          description: |
+            UUID identifying a hosted-cloud workflow version to associate with
+            this job. Local ComfyUI returns `null` (or omits the field). See
+            `workflow_id` above for `x-runtime` semantics.
 
     PromptResponse:
       type: object


### PR DESCRIPTION
## Summary

Adds two optional, nullable UUID fields to `PromptRequest` for runtimes that wrap workflow execution in a workflow-version entity (the hosted-cloud runtime does this; local ComfyUI does not). Both fields are tagged `x-runtime: [cloud]` to mark them as runtime-specific — local returns `null` (or omits them entirely) and that's correct behavior, not drift.

```yaml
workflow_id:
  type: string
  format: uuid
  nullable: true
  x-runtime: [cloud]
  description: |
    UUID identifying a hosted-cloud workflow entity to associate with this
    job. Local ComfyUI doesn't track workflow entities and returns `null`
    (or omits the field). ...
workflow_version_id:
  type: string
  format: uuid
  nullable: true
  x-runtime: [cloud]
  description: |
    UUID identifying a hosted-cloud workflow version to associate with
    this job. Local ComfyUI returns `null` (or omits the field). ...
```

## Why these fields belong in the OSS spec

Hosted-cloud's frontend and backend share `openapi.yaml` as their single source of truth via auto-generated client types. Without the fields declared here, the cloud runtime has to either hand-edit a vendored copy of `openapi.yaml` (drift) or maintain a separate cloud-only spec file (fork). Both produce maintenance pain. The shape that scales is: cloud-only fields live in OSS spec under their intended path, declared nullable, with an explicit `x-runtime` tag so local-only readers can ignore them programmatically and humans can see what each runtime populates.

## About the `x-runtime` extension

This PR introduces `x-runtime` as a new vendor extension on this spec. Convention:

| Tag | Meaning |
|-----|---------|
| `x-runtime: [cloud]` | Only the hosted-cloud runtime populates this field; local returns `null` or omits it. |
| `x-runtime: [local]` | Only local populates; cloud returns `null`. |
| (absent) | Both runtimes populate the field. **This is the default for everything else in the spec.** |

`x-`-prefixed properties are ignored by standard OpenAPI validators including `kin-openapi`. Local clients reading the spec see two extra optional nullable fields — which is forward-compatible with every existing reader.

## What this does not change

1. **No Python code changes.** `PromptRequest` already accepts arbitrary optional fields (`extra_data: additionalProperties: true` on the same schema is a stronger guarantee). The server silently accepts and ignores both fields today.
2. **No required-fields change.** Both fields stay outside `required`, so older clients that don't know about them keep validating.
3. **No nullability widening on existing fields.** Other fields untouched.

## Verification

1. YAML parses (`yaml.safe_load`).
2. `kin-openapi` `loader.LoadFromFile` accepts the modified spec.
3. `openapi3filter.ValidateRequest` on a `PromptRequest` with both fields set to `null`, set to a valid UUID, or omitted — all pass.