### PR TITLE
fix: make VAEDecodeAudio usable for LTX-2.x generated audio latents (CORE-157)

### DIFF
--- a/comfy_extras/nodes_lt_audio.py
+++ b/comfy_extras/nodes_lt_audio.py
@@ -147,7 +147,6 @@ class LTXVEmptyLatentAudio(io.ComfyNode):
 
         z_channels = audio_vae.latent_channels
         audio_freq = audio_vae.first_stage_model.latent_frequency_bins
-        sampling_rate = int(audio_vae.first_stage_model.sample_rate)
 
         num_audio_latents = audio_vae.first_stage_model.num_of_latents_from_frames(frames_number, frame_rate)
 
@@ -159,7 +158,6 @@ class LTXVEmptyLatentAudio(io.ComfyNode):
         return io.NodeOutput(
             {
                 "samples": audio_latents,
-                "sample_rate": sampling_rate,
                 "type": "audio",
             }
         )


### PR DESCRIPTION
## Summary

`LTXVEmptyLatentAudio` writes `sample_rate = int(audio_vae.first_stage_model.sample_rate)` into the empty latent dict, but that value is the encoder's internal mel rate (16000 Hz on LTXV-2), not the vocoder output rate (24000 Hz). `vae_decode_audio` prefers `samples["sample_rate"]` over `vae.audio_sample_rate_output`, so the standard `VAEDecodeAudio` tags audio at the encoder rate and playback runs ~33% slower with pitch shifted down a perfect fifth. `LTXVAudioVAEDecode` dodges this by reading `first_stage_model.output_sample_rate` directly.

Fix is to drop the `sample_rate` key. `EmptyLatentAudio` (Stable Audio) already follows the convention of not setting this field on latent dicts, and `vae.audio_sample_rate_output` is the canonical source: `comfy/sd.py:831` already populates it for the LTX Audio detection branch. LTX Audio is the only audio VAE in the codebase whose encoder rate differs from its vocoder output rate, which is why this only surfaces here.

## Tests using `VAE Decode Audio` node:
Before fix (LTX-2.3 Text-To-Video):

https://github.com/user-attachments/assets/20cec3c0-4f6f-4e9d-858c-082c5c0858df

After fix (LTX-2.3 Text-To-Video):

https://github.com/user-attachments/assets/a86ccf35-7ffa-40eb-ab1c-47a238bfbb4a

Confirm Stable-Audio still works fine:

https://github.com/user-attachments/files/27410472/ComfyUI_00003_.mp3


