### PR TITLE
add causal-forcing I2V support

### DIFF
--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -1860,6 +1860,35 @@ def sample_ar_video(model, x, sigmas, extra_args=None, callback=None, disable=No
     s_in = x.new_ones([x.shape[0]])
     current_start_frame = 0
     num_sigma_steps = len(sigmas) - 1
+
+    def set_ar_state(start_frame):
+        transformer_options["ar_state"] = {
+            "start_frame": start_frame,
+            "kv_caches": kv_caches,
+            "crossattn_caches": crossattn_caches,
+        }
+    def cache_frames(latent, start_frame):
+        set_ar_state(start_frame)
+        model(latent, sigmas.new_zeros([1]) * s_in, **extra_args)
+
+
+    # ── I2V: cache initial frame(s) at σ=0 before the denoising loop ──
+    ar_initial_latent = transformer_options.get("ar_initial_latent", None)
+    if ar_initial_latent is not None:
+        init_latent = ar_initial_latent.to(device=device, dtype=x.dtype)
+
+        init_frames = min(init_latent.shape[2], lat_t)
+        init_latent = init_latent[:, :, :init_frames]
+
+        if init_latent.shape[0] != bs:
+            init_latent = init_latent.expand(bs, -1, -1, -1, -1)
+        init_latent = inner_model.process_latent_in(init_latent)
+        output[:, :, :init_frames] = init_latent
+        cache_frames(init_latent, 0)
+        current_start_frame = init_frames
+        remaining_frames = lat_t - init_frames
+        num_blocks = max(0, -(-remaining_frames // num_frame_per_block))
+
     total_real_steps = num_blocks * num_sigma_steps
     step_count = 0
 
@@ -1868,14 +1897,7 @@ def sample_ar_video(model, x, sigmas, extra_args=None, callback=None, disable=No
             bf = min(num_frame_per_block, lat_t - current_start_frame)
             fs, fe = current_start_frame, current_start_frame + bf
             noisy_input = x[:, :, fs:fe]
-
-            ar_state = {
-                "start_frame": current_start_frame,
-                "kv_caches": kv_caches,
-                "crossattn_caches": crossattn_caches,
-            }
-            transformer_options["ar_state"] = ar_state
-
+            set_ar_state(current_start_frame)
             for i in range(num_sigma_steps):
                 denoised = model(noisy_input, sigmas[i] * s_in, **extra_args)
 
@@ -1898,13 +1920,11 @@ def sample_ar_video(model, x, sigmas, extra_args=None, callback=None, disable=No
                 step_count += 1
 
             output[:, :, fs:fe] = noisy_input
-
             for cache in kv_caches:
                 cache["end"] -= bf * frame_seq_len
-            zero_sigma = sigmas.new_zeros([1])
-            _ = model(noisy_input, zero_sigma * s_in, **extra_args)
-
+            cache_frames(noisy_input, fs)
             current_start_frame += bf
+
     finally:
         transformer_options.pop("ar_state", None)
 

--- a/comfy_extras/nodes_ar_video.py
+++ b/comfy_extras/nodes_ar_video.py
@@ -2,6 +2,7 @@
 ComfyUI nodes for autoregressive video generation (Causal Forcing, Self-Forcing, etc.).
   - EmptyARVideoLatent: create 5D [B, C, T, H, W] video latent tensors
   - SamplerARVideo: SAMPLER for the block-by-block autoregressive denoising loop
+  - ARVideoImageToVideo: I2V conditioning — encodes an image and patches the model
 """
 
 import torch
@@ -9,7 +10,9 @@ from typing_extensions import override
 
 import comfy.model_management
 import comfy.samplers
+import comfy.utils
 from comfy_api.latest import ComfyExtension, io
+import nodes
 
 
 class EmptyARVideoLatent(io.ComfyNode):
@@ -19,10 +22,10 @@ class EmptyARVideoLatent(io.ComfyNode):
             node_id="EmptyARVideoLatent",
             category="latent/video",
             inputs=[
-                io.Int.Input("width", default=832, min=16, max=8192, step=16),
-                io.Int.Input("height", default=480, min=16, max=8192, step=16),
-                io.Int.Input("length", default=81, min=1, max=1024, step=4),
-                io.Int.Input("batch_size", default=1, min=1, max=64),
+                io.Int.Input("width", default=832, min=16, max=nodes.MAX_RESOLUTION, step=16),
+                io.Int.Input("height", default=480, min=16, max=nodes.MAX_RESOLUTION, step=16),
+                io.Int.Input("length", default=81, min=1, max=nodes.MAX_RESOLUTION, step=4),
+                io.Int.Input("batch_size", default=1, min=1, max=4096),
             ],
             outputs=[
                 io.Latent.Output(display_name="LATENT"),
@@ -37,6 +40,44 @@ class EmptyARVideoLatent(io.ComfyNode):
             device=comfy.model_management.intermediate_device(),
         )
         return io.NodeOutput({"samples": latent})
+
+
+class ARVideoImageToVideo(io.ComfyNode):
+    """
+    The Causal Forcing I2V mechanism uses the same T2V model, no separate
+    I2V checkpoint needed.
+    """
+
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="ARVideoImageToVideo",
+            display_name="ARVideo Image To Video",
+            category="conditioning/video_models",
+            inputs=[
+                io.Model.Input("model"),
+                io.Vae.Input("vae"),
+                io.Int.Input("width", default=832, min=16, max=nodes.MAX_RESOLUTION, step=16),
+                io.Int.Input("height", default=480, min=16, max=nodes.MAX_RESOLUTION, step=16),
+                io.Int.Input("length", default=81, min=1, max=nodes.MAX_RESOLUTION, step=4),
+                io.Int.Input("batch_size", default=1, min=1, max=4096),
+                io.Image.Input("start_image"),
+            ],
+            outputs=[
+                io.Model.Output(display_name="MODEL"),
+                io.Latent.Output(display_name="LATENT"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, model, vae, width, height, length, batch_size, start_image) -> io.NodeOutput:
+        lat_t = ((length - 1) // 4) + 1
+        latent = torch.zeros([batch_size, 16, lat_t, height // 8, width // 8], device=comfy.model_management.intermediate_device())
+        start_image = comfy.utils.common_upscale(start_image[:1].movedim(-1, 1), width, height, "bilinear", "center").movedim(1, -1)
+        init_latent = vae.encode(start_image[:, :, :, :3])
+        model_clone = model.clone()
+        model_clone.model_options.setdefault("transformer_options", {})["ar_initial_latent"] = init_latent
+        return io.NodeOutput(model_clone, {"samples": latent})
 
 
 class SamplerARVideo(io.ComfyNode):
@@ -76,6 +117,7 @@ class ARVideoExtension(ComfyExtension):
     async def get_node_list(self) -> list[type[io.ComfyNode]]:
         return [
             EmptyARVideoLatent,
+            ARVideoImageToVideo,
             SamplerARVideo,
         ]
 


### PR DESCRIPTION
Related to: [[#13082](https://github.com/Comfy-Org/ComfyUI/pull/13082)] by @Talmaj 
This PR try to extends the recently merged Causal Forcing T2V implementation by adding I2V generation support for the Causal Forcing frame-wise model.

Since the same model is used for both I2V and T2V (`causal_forcing_framewise`), there is no need to provide a separately repackaged model:
https://huggingface.co/TalmajM/causal_forcing_framewise_ComfyUI_repackaged/tree/main/split_files/diffusion_models

This PR also introduces the `ARVideo ImageToVideo` node for I2V generation using an input start image and model patching to inject the start image.

<img width="1340" height="818" alt="python_eZmHny5RLr" src="https://github.com/user-attachments/assets/6c0a97ac-8884-4b80-a445-df6e1e776487" />