### PR TITLE
First step of supporting save filenames without trailing _

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -432,7 +432,9 @@ def get_save_image_path(filename_prefix: str, output_dir: str, image_width=0, im
         prefix_len = len(os.path.basename(filename_prefix))
         prefix = filename[:prefix_len + 1]
         try:
-            digits = int(filename[prefix_len + 1:].split('_')[0])
+            remainder = filename[prefix_len + 1:]
+            base_remainder = remainder.split('.')[0]
+            digits = int(base_remainder.split('_')[0])
         except:
             digits = 0
         return digits, prefix


### PR DESCRIPTION
get_save_image_path now properly supports filenames without trailing underscores.

This will be the saving behavior when using a mix of save image nodes using the old and the new format.

ComfyUI_00001_.png
ComfyUI_00002.png
ComfyUI_00003.png
ComfyUI_00004_.png