### PR TITLE
Revert "Fix Content-Disposition header missing 'attachment;' prefix (#13093)"

### DIFF
--- a/server.py
+++ b/server.py
@@ -560,7 +560,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -580,7 +580,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -597,7 +597,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
                     else:
                         # Use the content type from asset resolution if available,
                         # otherwise guess from the filename.
@@ -614,7 +614,7 @@ class PromptServer():
                         return web.FileResponse(
                             file,
                             headers={
-                                "Content-Disposition": f"attachment; filename=\"{filename}\"",
+                                "Content-Disposition": f"filename=\"{filename}\"",
                                 "Content-Type": content_type
                             }
                         )


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Reverts [#13093](https://github.com/Comfy-Org/ComfyUI/pull/13093) (commit `ea6880b04b88629b9dd07774298bdffea6923f9b`).

## Why

PR #13093 added `attachment;` to all four `Content-Disposition` headers in the `view_image` endpoint of `server.py`. Post-merge feedback reports this regresses existing UI behavior:

- [PR comment](https://github.com/Comfy-Org/ComfyUI/pull/13093#issuecomment-4389995105): the `Open Image` context-menu option (which previously opened the image inline in a new tab) now forces a download, making it functionally identical to the existing `Save Image` option.
- This results in two context-menu entries doing the same thing and removes a workflow many users still rely on.
- Reviewers in the [commit thread](https://github.com/Comfy-Org/ComfyUI/commit/ea6880b04b88629b9dd07774298bdffea6923f9b#commitcomment-184423832) suggested the original change should live on a Cloud-specific branch rather than core ComfyUI.

## Changes

Pure `git revert` of `ea6880b` — restores the four `Content-Disposition` headers in `server.py` to `filename="..."`. No other files touched.

```
 server.py | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

## Verification

- `python -m py_compile server.py` → OK
- Started ComfyUI locally (`python main.py --cpu --listen 127.0.0.1 --port 8188`) and curled all four `/view` code paths (default channel, `channel=rgb`, `channel=a`, `preview=webp`, `preview=jpeg`). All return `Content-Disposition: filename="example.png"` (matching pre-#13093 behavior).
- Loaded `/view?filename=example.png&type=input` in a real browser via Playwright — image renders **inline** in the tab (the regressed behavior is restored). See screenshot below.
- Diff is the exact inverse of #13093.

## Reviewer notes (from automated review)

A pre-merge code review flagged that the restored `Content-Disposition: filename="..."` is technically not a fully-formed HTTP value — the spec wants either `inline` or `attachment` as the disposition type. That predates #13093 and is intentionally left as-is here to keep this PR a pure revert. If maintainers want a properly-typed header (e.g. `inline; filename="..."` for preview routes, `attachment; filename="..."` for download-only routes), that's worth doing as a follow-up alongside `/view` test coverage.

Requested by user in the #glary Slack channel.

## Screenshots

![Browser renders /view image inline in a new tab — pre-#13093 behavior restored after revert](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/4534ec0590fb9bd7de2e5cae1fcd6a8f9ddc66a105393457a6b4ac9ded036cf0/pr-images/1778086782857-1a1d6069-fee5-484c-8a6a-9ce03ddf1f5a.png)