### PR TITLE
Add `job_id` field to Asset schema in openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5893,7 +5893,14 @@ components:
         prompt_id:
           type: string
           format: uuid
-          description: ID of the prompt that created this asset
+          nullable: true
+          deprecated: true
+          description: "Deprecated: use job_id instead. ID of the prompt that created this asset."
+        job_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: ID of the job that created this asset
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

Adds `job_id` to the Asset schema in `openapi.yaml` and marks `prompt_id` as deprecated. `job_id` is a clearer alias for `prompt_id` on Asset responses.

Stacks on top of #13734.

## Changes

- **`job_id`** added to the `Asset` schema as a nullable UUID field
- **`prompt_id`** marked `deprecated: true` with `nullable: true` and description updated to point users to `job_id`

## Acceptance Criteria

- [x] `job_id` added to Asset schema as nullable
- [x] `prompt_id` marked `deprecated: true` with note pointing to `job_id`
- [x] Spectral lint clean (0 errors; pre-existing warnings/hints unchanged)
- [x] PR stacks on #13734