### PR TITLE
Add `hash` field to Asset schemas in openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5857,9 +5857,16 @@ components:
         name:
           type: string
           description: Name of the asset file
+        hash:
+          type: string
+          nullable: true
+          description: Blake3 content hash of the asset (preferred over asset_hash)
+          pattern: "^blake3:[a-f0-9]{64}$"
         asset_hash:
           type: string
-          description: Blake3 hash of the asset content
+          nullable: true
+          deprecated: true
+          description: "Deprecated: use `hash` instead. Blake3 hash of the asset content."
           pattern: "^blake3:[a-f0-9]{64}$"
         size:
           type: integer
@@ -5931,8 +5938,16 @@ components:
           format: uuid
         name:
           type: string
+        hash:
+          type: string
+          nullable: true
+          description: Blake3 content hash of the asset (preferred over asset_hash)
+          pattern: "^blake3:[a-f0-9]{64}$"
         asset_hash:
           type: string
+          nullable: true
+          deprecated: true
+          description: "Deprecated: use `hash` instead. Blake3 hash of the asset content."
           pattern: "^blake3:[a-f0-9]{64}$"
         tags:
           type: array


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `hash` as the preferred alias for `asset_hash` on Asset response schemas, and marks `asset_hash` as deprecated.

## Changes

- **`Asset` schema**: Added `hash` field (nullable string, blake3 pattern) and marked `asset_hash` as `deprecated: true` with a note directing users to `hash`.
- **`AssetUpdated` schema**: Same additions — `hash` field added, `asset_hash` deprecated.
- **`AssetCreated` schema**: Inherits `hash` automatically via `allOf` from `Asset`.

## Why

`hash` is a clearer, more concise field name for the blake3 content hash. This change introduces the preferred alias while keeping `asset_hash` available for backward compatibility.

## Validation

- Spectral lint passes with no new warnings or errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

