### PR TITLE
Add `width` and `height` fields to Asset schema in openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6364,6 +6364,14 @@ components:
           type: integer
           format: int64
           description: Size of the asset in bytes
+        width:
+          type: integer
+          nullable: true
+          description: "Original image width in pixels. Null for non-image assets or assets ingested before dimension extraction."
+        height:
+          type: integer
+          nullable: true
+          description: "Original image height in pixels. Null for non-image assets or assets ingested before dimension extraction."
         mime_type:
           type: string
           description: MIME type of the asset


### PR DESCRIPTION
## Summary

Adds `width` and `height` nullable integer fields to the `Asset` schema in `openapi.yaml`, exposing original image dimensions in pixels for clients that need pre-thumbnail size information.

## Changes

- Added `width` (nullable integer) to the Asset schema, placed after `size`
- Added `height` (nullable integer) to the Asset schema, placed after `width`
- Both fields are null for non-image assets or assets ingested before dimension extraction
- Both runtimes populate these fields when the asset is an image

## Verification

- YAML parses correctly
- Spectral lint passes with zero errors (existing warnings/hints unchanged)