### PR TITLE
Fix missing history outputs for cached prompts without client_id

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -418,12 +418,11 @@ def _is_intermediate_output(dynprompt, node_id):
     return getattr(class_def, 'HAS_INTERMEDIATE_OUTPUT', False)
 
 def _send_cached_ui(server, node_id, display_node_id, cached, prompt_id, ui_outputs):
-    if server.client_id is None:
-        return
     cached_ui = cached.ui or {}
-    server.send_sync("executed", { "node": node_id, "display_node": display_node_id, "output": cached_ui.get("output", None), "prompt_id": prompt_id }, server.client_id)
     if cached.ui is not None:
         ui_outputs[node_id] = cached.ui
+    if server.client_id is not None:
+        server.send_sync("executed", { "node": node_id, "display_node": display_node_id, "output": cached_ui.get("output", None), "prompt_id": prompt_id }, server.client_id)
 
 async def execute(server, dynprompt, caches, current_item, extra_data, executed, prompt_id, execution_list, pending_subgraph_results, pending_async_nodes, ui_outputs):
     unique_id = current_item

--- a/tests-unit/execution_test/test_cached_ui.py
+++ b/tests-unit/execution_test/test_cached_ui.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from execution import _send_cached_ui
+
+
+class FakeServer:
+    def __init__(self, client_id=None):
+        self.client_id = client_id
+        self.sent = []
+
+    def send_sync(self, event, data, client_id):
+        self.sent.append((event, data, client_id))
+
+
+def test_cached_ui_populates_outputs_without_client_id():
+    cached_ui = {
+        "meta": {"node_id": "1"},
+        "output": {"images": [{"filename": "cached.png"}]},
+    }
+    cached = SimpleNamespace(ui=cached_ui)
+    server = FakeServer(client_id=None)
+    ui_outputs = {}
+
+    _send_cached_ui(server, "1", "1", cached, "prompt-id", ui_outputs)
+
+    assert ui_outputs == {"1": cached_ui}
+    assert server.sent == []
+
+
+def test_cached_ui_sends_executed_event_with_client_id():
+    cached_ui = {
+        "meta": {"node_id": "1"},
+        "output": {"images": [{"filename": "cached.png"}]},
+    }
+    cached = SimpleNamespace(ui=cached_ui)
+    server = FakeServer(client_id="client-id")
+    ui_outputs = {}
+
+    _send_cached_ui(server, "1", "display-1", cached, "prompt-id", ui_outputs)
+
+    assert ui_outputs == {"1": cached_ui}
+    assert server.sent == [
+        (
+            "executed",
+            {
+                "node": "1",
+                "display_node": "display-1",
+                "output": cached_ui["output"],
+                "prompt_id": "prompt-id",
+            },
+            "client-id",
+        )
+    ]


### PR DESCRIPTION
## Summary

Fixes `/history/{prompt_id}` missing cached node outputs when a prompt is submitted without `client_id`.

When the same API prompt is submitted more than once, unchanged nodes can be served from ComfyUI's execution cache. In that cached path, `_send_cached_ui()` returned early if `server.client_id` was `None`. This skipped the WebSocket `executed` event, but also skipped adding the cached UI payload to `ui_outputs`.

As a result, API clients that submit prompts without a WebSocket `client_id` could see a successful execution in `/history/{prompt_id}`, but the `outputs` field would be empty or missing cached UI outputs on cache hits.

This change decouples those behaviors:
- cached UI is always added to `ui_outputs` so it is available in history
- the WebSocket `executed` event is only sent when `client_id` is available

## Test plan

- Added unit coverage for cached UI handling with and without `client_id`.
- Ran `python3 -m py_compile execution.py tests-unit/execution_test/test_cached_ui.py`.
- Ran `uvx ruff check execution.py tests-unit/execution_test/test_cached_ui.py`.