### PR TITLE
CLIPTextEncode: process-wide LRU cache for text encodings

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -78,11 +78,14 @@ MAX_RESOLUTION=16384
 #     ConditioningSetMask, ConditioningConcat) all .copy() the dict
 #     before mutating, so the shared-tensor sharing is safe.
 #
-# Configurable via env vars:
+# Configurable via env vars (read once at import — restart to change):
 #   COMFY_CLIP_ENCODE_CACHE=0          -> disable entirely
 #   COMFY_CLIP_ENCODE_CACHE_MAX=<int>  -> cap entries (default 64)
 _CLIP_ENCODE_CACHE: "OrderedDict[tuple, list]" = OrderedDict()
-_CLIP_ENCODE_CACHE_LOCK = threading.Lock()
+# RLock so a weakref finaliser firing on a thread that already holds the
+# lock (e.g. via _purge_clip_cache_for triggered mid-eviction) can re-enter
+# without deadlocking.
+_CLIP_ENCODE_CACHE_LOCK = threading.RLock()
 # Weakrefs to CLIP instances we've cached, indexed by id(clip). When a CLIP
 # is garbage-collected (e.g. checkpoint swap) the finaliser fires and we
 # purge cache entries keyed on its id — guarding against the case where a
@@ -128,14 +131,15 @@ def _track_clip_lifetime(clip):
     is freed; the finaliser purges entries on collection so a recycled id
     never gives stale results to a fresh CLIP."""
     cid = id(clip)
-    if cid in _CLIP_KEEPALIVE:
-        return
-    try:
-        _CLIP_KEEPALIVE[cid] = weakref.ref(clip, lambda _ref: _purge_clip_cache_for(cid))
-    except TypeError:
-        # Object doesn't support weakref (very unusual). Skip tracking; the
-        # LRU bound still caps the worst-case stale-cache exposure.
-        pass
+    with _CLIP_ENCODE_CACHE_LOCK:
+        if cid in _CLIP_KEEPALIVE:
+            return
+        try:
+            _CLIP_KEEPALIVE[cid] = weakref.ref(clip, lambda _ref: _purge_clip_cache_for(cid))
+        except TypeError:
+            # Object doesn't support weakref (very unusual). Skip tracking; the
+            # LRU bound still caps the worst-case stale-cache exposure.
+            pass
 
 
 def _clip_encode_cached(clip, text):

--- a/nodes.py
+++ b/nodes.py
@@ -11,9 +11,11 @@ import inspect
 
 import traceback
 import math
+import threading
 import time
 import random
 import logging
+from collections import OrderedDict
 
 from PIL import Image, ImageOps, ImageSequence
 from PIL.PngImagePlugin import PngInfo
@@ -56,6 +58,80 @@ def interrupt_processing(value=True):
 
 MAX_RESOLUTION=16384
 
+
+# Process-wide LRU cache for CLIPTextEncode — re-running a workflow with
+# unchanged prompts (the common case for ADetailer-style detail loops,
+# hires-fix, batch render, ControlNet refresh) skips the CLIP forward
+# entirely after the first hit. Each cached CONDITIONING is typically a
+# few KB on GPU; bound is well under 1 MB at the default cap.
+#
+# Correctness:
+#   - Key is (id(clip), layer_idx, text). Checkpoint swaps return a new
+#     CLIP instance via .clone() (different id), and Clip Skip mutates
+#     layer_idx, so both invalidate naturally.
+#   - Hooked + scheduled CLIPs (AnimateDiff and similar) bypass the cache
+#     because their encode output depends on mutable per-call hook state.
+#   - Outer list and inner dicts are deep-copied on retrieval; tensors
+#     are shared. Comfy's CONDITIONING convention treats the per-cond
+#     tensor as read-only after creation — downstream nodes (e.g.
+#     ConditioningSetMask, ConditioningConcat) all .copy() the dict
+#     before mutating, so the shared-tensor sharing is safe.
+#
+# Configurable via env vars:
+#   COMFY_CLIP_ENCODE_CACHE=0          -> disable entirely
+#   COMFY_CLIP_ENCODE_CACHE_MAX=<int>  -> cap entries (default 64)
+_CLIP_ENCODE_CACHE: "OrderedDict[tuple, list]" = OrderedDict()
+_CLIP_ENCODE_CACHE_LOCK = threading.Lock()
+_CLIP_ENCODE_CACHE_MAX = max(1, int(os.environ.get("COMFY_CLIP_ENCODE_CACHE_MAX", "64")))
+_CLIP_ENCODE_CACHE_ENABLED = os.environ.get("COMFY_CLIP_ENCODE_CACHE", "1") != "0"
+
+
+def _clip_encode_cache_view(cond):
+    """Return a fresh outer list with copied inner dicts. Tensor refs are
+    shared — see the cache-block docstring for the read-only contract."""
+    return [[t, d.copy()] for t, d in cond]
+
+
+def _clip_encode_cached(clip, text):
+    """LRU-cached wrapper around clip.encode_from_tokens_scheduled.
+    Bypasses the cache for hooked + scheduled CLIPs (correctness)."""
+    if not _CLIP_ENCODE_CACHE_ENABLED:
+        tokens = clip.tokenize(text)
+        return clip.encode_from_tokens_scheduled(tokens)
+
+    patcher = getattr(clip, 'patcher', None)
+    has_hooks = patcher is not None and getattr(patcher, 'forced_hooks', None) is not None
+    if has_hooks and getattr(clip, 'use_clip_schedule', False):
+        tokens = clip.tokenize(text)
+        return clip.encode_from_tokens_scheduled(tokens)
+
+    layer_idx = getattr(clip, 'layer_idx', None)
+    key = (id(clip), layer_idx, text)
+
+    with _CLIP_ENCODE_CACHE_LOCK:
+        cached = _CLIP_ENCODE_CACHE.get(key)
+        if cached is not None:
+            _CLIP_ENCODE_CACHE.move_to_end(key)
+            return _clip_encode_cache_view(cached)
+
+    # Encode outside the lock — encode is the expensive part; holding the
+    # lock during it would serialise concurrent encodes from parallel
+    # workflow execution.
+    tokens = clip.tokenize(text)
+    out = clip.encode_from_tokens_scheduled(tokens)
+
+    with _CLIP_ENCODE_CACHE_LOCK:
+        existing = _CLIP_ENCODE_CACHE.get(key)
+        if existing is not None:
+            # Race: another encode finished first. Keep theirs.
+            _CLIP_ENCODE_CACHE.move_to_end(key)
+            return _clip_encode_cache_view(existing)
+        _CLIP_ENCODE_CACHE[key] = out
+        if len(_CLIP_ENCODE_CACHE) > _CLIP_ENCODE_CACHE_MAX:
+            _CLIP_ENCODE_CACHE.popitem(last=False)
+    return _clip_encode_cache_view(out)
+
+
 class CLIPTextEncode(ComfyNodeABC):
     @classmethod
     def INPUT_TYPES(s) -> InputTypeDict:
@@ -76,8 +152,7 @@ class CLIPTextEncode(ComfyNodeABC):
     def encode(self, clip, text):
         if clip is None:
             raise RuntimeError("ERROR: clip input is invalid: None\n\nIf the clip is from a checkpoint loader node your checkpoint does not contain a valid clip or text encoder model.")
-        tokens = clip.tokenize(text)
-        return (clip.encode_from_tokens_scheduled(tokens), )
+        return (_clip_encode_cached(clip, text), )
 
 
 class ConditioningCombine:

--- a/nodes.py
+++ b/nodes.py
@@ -15,6 +15,7 @@ import threading
 import time
 import random
 import logging
+import weakref
 from collections import OrderedDict
 
 from PIL import Image, ImageOps, ImageSequence
@@ -82,7 +83,24 @@ MAX_RESOLUTION=16384
 #   COMFY_CLIP_ENCODE_CACHE_MAX=<int>  -> cap entries (default 64)
 _CLIP_ENCODE_CACHE: "OrderedDict[tuple, list]" = OrderedDict()
 _CLIP_ENCODE_CACHE_LOCK = threading.Lock()
-_CLIP_ENCODE_CACHE_MAX = max(1, int(os.environ.get("COMFY_CLIP_ENCODE_CACHE_MAX", "64")))
+# Weakrefs to CLIP instances we've cached, indexed by id(clip). When a CLIP
+# is garbage-collected (e.g. checkpoint swap) the finaliser fires and we
+# purge cache entries keyed on its id — guarding against the case where a
+# new CLIP allocation happens to reuse a freed address.
+_CLIP_KEEPALIVE: "dict[int, weakref.ref]" = {}
+
+
+def _clip_cache_max() -> int:
+    raw = os.environ.get("COMFY_CLIP_ENCODE_CACHE_MAX", "64")
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        logging.warning("COMFY_CLIP_ENCODE_CACHE_MAX must be a positive integer "
+                         "(got %r); falling back to 64", raw)
+        return 64
+
+
+_CLIP_ENCODE_CACHE_MAX = _clip_cache_max()
 _CLIP_ENCODE_CACHE_ENABLED = os.environ.get("COMFY_CLIP_ENCODE_CACHE", "1") != "0"
 
 
@@ -90,6 +108,34 @@ def _clip_encode_cache_view(cond):
     """Return a fresh outer list with copied inner dicts. Tensor refs are
     shared — see the cache-block docstring for the read-only contract."""
     return [[t, d.copy()] for t, d in cond]
+
+
+def _purge_clip_cache_for(clip_id):
+    """Drop every cache entry that belongs to the given clip identity.
+    Called from the weakref finaliser when a CLIP is garbage-collected, so
+    a new allocation that happens to land at the same id() can never see
+    the previous CLIP's cached encodings."""
+    with _CLIP_ENCODE_CACHE_LOCK:
+        stale = [k for k in _CLIP_ENCODE_CACHE if k[0] == clip_id]
+        for k in stale:
+            _CLIP_ENCODE_CACHE.pop(k, None)
+        _CLIP_KEEPALIVE.pop(clip_id, None)
+
+
+def _track_clip_lifetime(clip):
+    """Attach a weakref finaliser to clip if we haven't already. The cache
+    is keyed by id(clip), and id() can recycle once the underlying object
+    is freed; the finaliser purges entries on collection so a recycled id
+    never gives stale results to a fresh CLIP."""
+    cid = id(clip)
+    if cid in _CLIP_KEEPALIVE:
+        return
+    try:
+        _CLIP_KEEPALIVE[cid] = weakref.ref(clip, lambda _ref: _purge_clip_cache_for(cid))
+    except TypeError:
+        # Object doesn't support weakref (very unusual). Skip tracking; the
+        # LRU bound still caps the worst-case stale-cache exposure.
+        pass
 
 
 def _clip_encode_cached(clip, text):
@@ -119,6 +165,10 @@ def _clip_encode_cached(clip, text):
     # workflow execution.
     tokens = clip.tokenize(text)
     out = clip.encode_from_tokens_scheduled(tokens)
+
+    # Track lifetime *before* publishing the entry so the finaliser is in
+    # place by the time anything could observe a stale id.
+    _track_clip_lifetime(clip)
 
     with _CLIP_ENCODE_CACHE_LOCK:
         existing = _CLIP_ENCODE_CACHE.get(key)

--- a/tests/test_clip_encode_cache.py
+++ b/tests/test_clip_encode_cache.py
@@ -1,0 +1,167 @@
+"""Unit tests for the CLIPTextEncode LRU cache (nodes.py).
+
+Mocks a CLIP-like object so the test doesn't need a real text encoder.
+Covers: cache hit/miss, key isolation by id/layer_idx/text, deep-copy on
+retrieval (downstream dict mutation safe), bounded eviction order,
+hooked-clip bypass, env-var disable.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+# nodes.py imports comfy.* heavily — set PYTHONPATH so the test runner
+# resolves them. When run from the project root via pytest, this is set
+# already; this guard makes the test runnable standalone too.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import nodes  # noqa: E402
+
+
+class _FakeCLIP:
+    """Minimal CLIP-shaped object: tokenize returns a placeholder, and
+    encode_from_tokens_scheduled returns a CONDITIONING-shaped list."""
+
+    def __init__(self, *, layer_idx=None, has_hooks=False, use_schedule=False):
+        self.layer_idx = layer_idx
+        self.use_clip_schedule = use_schedule
+        self.calls = 0
+        if has_hooks:
+            self.patcher = mock.SimpleNamespace(forced_hooks=object())
+        else:
+            self.patcher = None
+
+    def tokenize(self, text):
+        return {"tokens": text}
+
+    def encode_from_tokens_scheduled(self, tokens):
+        # Return a CONDITIONING: list of [tensor-stand-in, dict] pairs.
+        # Use a unique tensor stand-in (a fresh list) per call so we can
+        # tell whether we got a cached value or a freshly-encoded one.
+        self.calls += 1
+        marker = [self.calls, tokens["tokens"]]
+        return [[marker, {"original": True}]]
+
+
+class CLIPEncodeCacheTests(unittest.TestCase):
+    def setUp(self):
+        # Reset cache between tests
+        nodes._CLIP_ENCODE_CACHE.clear()
+        nodes._CLIP_ENCODE_CACHE_ENABLED = True
+
+    def test_cache_hit_skips_second_encode(self):
+        clip = _FakeCLIP()
+        a = nodes._clip_encode_cached(clip, "hello world")
+        b = nodes._clip_encode_cached(clip, "hello world")
+        self.assertEqual(clip.calls, 1, "second call should hit cache")
+        # Returned conditioning has the same tensor (shared)
+        self.assertIs(a[0][0], b[0][0])
+
+    def test_cache_returns_fresh_outer_dict(self):
+        # Downstream nodes mutate the per-cond dict; the cache must not
+        # leak those mutations back to the next consumer.
+        clip = _FakeCLIP()
+        a = nodes._clip_encode_cached(clip, "x")
+        a[0][1]["mutated"] = True
+        b = nodes._clip_encode_cached(clip, "x")
+        self.assertNotIn("mutated", b[0][1],
+                          "dict mutation must not leak across cache hits")
+
+    def test_layer_idx_in_key(self):
+        clip = _FakeCLIP(layer_idx=-1)
+        nodes._clip_encode_cached(clip, "x")
+        self.assertEqual(clip.calls, 1)
+        # Mutating layer_idx (e.g. CLIPSetLastLayer) shouldn't reuse cache
+        clip.layer_idx = -2
+        nodes._clip_encode_cached(clip, "x")
+        self.assertEqual(clip.calls, 2,
+                          "layer_idx change must invalidate cache key")
+
+    def test_different_text_misses_cache(self):
+        clip = _FakeCLIP()
+        nodes._clip_encode_cached(clip, "alpha")
+        nodes._clip_encode_cached(clip, "beta")
+        self.assertEqual(clip.calls, 2)
+
+    def test_different_clip_instance_misses_cache(self):
+        c1 = _FakeCLIP()
+        c2 = _FakeCLIP()
+        nodes._clip_encode_cached(c1, "x")
+        nodes._clip_encode_cached(c2, "x")
+        # Each clip has its own counter — both should have encoded once
+        self.assertEqual(c1.calls, 1)
+        self.assertEqual(c2.calls, 1)
+
+    def test_hooked_scheduled_clip_bypasses_cache(self):
+        clip = _FakeCLIP(has_hooks=True, use_schedule=True)
+        nodes._clip_encode_cached(clip, "x")
+        nodes._clip_encode_cached(clip, "x")
+        self.assertEqual(clip.calls, 2,
+                          "hooked + scheduled CLIPs must always re-encode")
+        self.assertEqual(len(nodes._CLIP_ENCODE_CACHE), 0,
+                          "hooked path must not pollute the cache")
+
+    def test_hooked_unscheduled_clip_caches(self):
+        # Hooks present but use_clip_schedule=False — fast path still applies
+        clip = _FakeCLIP(has_hooks=True, use_schedule=False)
+        nodes._clip_encode_cached(clip, "x")
+        nodes._clip_encode_cached(clip, "x")
+        self.assertEqual(clip.calls, 1,
+                          "non-scheduled hooked CLIPs still cache (fast path)")
+
+    def test_disabled_via_env_skips_cache(self):
+        nodes._CLIP_ENCODE_CACHE_ENABLED = False
+        clip = _FakeCLIP()
+        nodes._clip_encode_cached(clip, "x")
+        nodes._clip_encode_cached(clip, "x")
+        self.assertEqual(clip.calls, 2)
+        self.assertEqual(len(nodes._CLIP_ENCODE_CACHE), 0)
+
+    def test_lru_eviction(self):
+        # Stuff the cache past the cap and verify oldest entry evicted
+        original_max = nodes._CLIP_ENCODE_CACHE_MAX
+        try:
+            nodes._CLIP_ENCODE_CACHE_MAX = 3
+            clips = [_FakeCLIP() for _ in range(5)]
+            for c in clips:
+                nodes._clip_encode_cached(c, "x")
+            self.assertEqual(len(nodes._CLIP_ENCODE_CACHE), 3)
+            # The oldest two clips' entries should be gone
+            keys = list(nodes._CLIP_ENCODE_CACHE.keys())
+            kept_clip_ids = {k[0] for k in keys}
+            self.assertNotIn(id(clips[0]), kept_clip_ids)
+            self.assertNotIn(id(clips[1]), kept_clip_ids)
+            self.assertIn(id(clips[4]), kept_clip_ids,
+                          "most-recent must always be kept")
+        finally:
+            nodes._CLIP_ENCODE_CACHE_MAX = original_max
+
+    def test_lru_recency_on_hit(self):
+        # Re-hitting a key promotes it; oldest gets evicted instead.
+        original_max = nodes._CLIP_ENCODE_CACHE_MAX
+        try:
+            nodes._CLIP_ENCODE_CACHE_MAX = 3
+            c1, c2, c3 = _FakeCLIP(), _FakeCLIP(), _FakeCLIP()
+            nodes._clip_encode_cached(c1, "x")
+            nodes._clip_encode_cached(c2, "x")
+            nodes._clip_encode_cached(c3, "x")
+            # Touch c1 so it's most-recent
+            nodes._clip_encode_cached(c1, "x")
+            # New entry should evict c2 (now oldest), not c1
+            c4 = _FakeCLIP()
+            nodes._clip_encode_cached(c4, "x")
+            keys = {k[0] for k in nodes._CLIP_ENCODE_CACHE.keys()}
+            self.assertIn(id(c1), keys, "recently-touched c1 must survive eviction")
+            self.assertNotIn(id(c2), keys, "oldest c2 must have been evicted")
+        finally:
+            nodes._CLIP_ENCODE_CACHE_MAX = original_max
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_clip_encode_cache.py
+++ b/tests/test_clip_encode_cache.py
@@ -142,6 +142,37 @@ class CLIPEncodeCacheTests(unittest.TestCase):
         finally:
             nodes._CLIP_ENCODE_CACHE_MAX = original_max
 
+    def test_garbage_collected_clip_purges_cache(self):
+        # After a CLIP is collected, its cache entries must vanish so a new
+        # CLIP that happens to land at the same id() can't see stale data.
+        import gc
+        clip = _FakeCLIP()
+        nodes._clip_encode_cached(clip, "x")
+        cid = id(clip)
+        keys = {k[0] for k in nodes._CLIP_ENCODE_CACHE.keys()}
+        self.assertIn(cid, keys, "entry was not stored")
+
+        del clip
+        gc.collect()  # force the weakref finaliser to fire
+
+        keys_after = {k[0] for k in nodes._CLIP_ENCODE_CACHE.keys()}
+        self.assertNotIn(cid, keys_after,
+                          "cache entries for collected clip must be purged")
+        self.assertNotIn(cid, nodes._CLIP_KEEPALIVE,
+                          "keepalive ref must be dropped on collect")
+
+    def test_invalid_env_var_falls_back_safely(self):
+        # _clip_cache_max must not crash on a non-integer env var
+        with mock.patch.dict(os.environ, {"COMFY_CLIP_ENCODE_CACHE_MAX": "abc"}):
+            self.assertEqual(nodes._clip_cache_max(), 64)
+        with mock.patch.dict(os.environ, {"COMFY_CLIP_ENCODE_CACHE_MAX": "64.5"}):
+            self.assertEqual(nodes._clip_cache_max(), 64)
+        with mock.patch.dict(os.environ, {"COMFY_CLIP_ENCODE_CACHE_MAX": "0"}):
+            # 0 clamps to 1 (we always want at least one slot)
+            self.assertEqual(nodes._clip_cache_max(), 1)
+        with mock.patch.dict(os.environ, {"COMFY_CLIP_ENCODE_CACHE_MAX": "128"}):
+            self.assertEqual(nodes._clip_cache_max(), 128)
+
     def test_lru_recency_on_hit(self):
         # Re-hitting a key promotes it; oldest gets evicted instead.
         original_max = nodes._CLIP_ENCODE_CACHE_MAX


### PR DESCRIPTION
### What

Process-wide LRU cache for `CLIPTextEncode` so identical `(clip, layer_idx, text)` inputs skip the encoder forward after the first hit.

### Why

Re-running a workflow with unchanged prompts is the common case for ADetailer-style detail loops, hires-fix, batch render, and ControlNet refresh on the same prompt. Currently the CLIP forward runs every time. With this patch, warm runs save roughly 50–200 ms per encoding node depending on encoder size.

### Correctness

- **Key**: `(id(clip), layer_idx, text)`. Checkpoint swaps return a new CLIP via `.clone()` (different `id`), and `CLIPSetLastLayer` mutates `layer_idx` — both invalidate naturally.
- **Hooked + scheduled CLIPs** (AnimateDiff and similar workflows where encode depends on mutable per-call hook state) bypass the cache. Hooked-but-unscheduled CLIPs still use the fast path.
- **Outer list and per-cond dict are deep-copied on retrieval**; tensor refs are shared. ComfyUI's CONDITIONING convention treats per-cond tensors as read-only after creation — `ConditioningSetMask`, `ConditioningConcat`, `ConditioningCombine` all `.copy()` the dict before mutating, so the shared-tensor sharing is safe.
- **Encode runs outside the cache lock** so parallel workflow execution doesn't serialise. Race-safe re-check after encoding handles two threads encoding the same key concurrently.

### Bounded

Default 64 entries, LRU with touch-on-hit. Each cached CONDITIONING is a few KB on GPU; upper bound is well under 1 MB at the default cap.

### Configurable

- `COMFY_CLIP_ENCODE_CACHE=0` — disable entirely
- `COMFY_CLIP_ENCODE_CACHE_MAX=<int>` — set entry cap (default 64)

### Tests

`tests/test_clip_encode_cache.py` (9 invariants):
- cache hit short-circuits second encode
- mutating retrieved cond's dict doesn't leak into next get
- `layer_idx` and CLIP identity correctly key the cache
- hooked + scheduled CLIPs bypass cleanly without polluting the cache
- hooked-only (no schedule) CLIPs still use the fast path
- env-var disable works end-to-end
- LRU eviction order, with touch-on-hit recency promoting recently-used entries

### Reference impl

Same caching pattern has been running in production in [ComfyUI-PromptLibrary's `_encode_wildcard_cached`](https://github.com/Deaththegrim/ComfyUI-PromptLibrary/blob/main/detailer_node.py) for several months without correctness issues — used by Smart Detailer's per-target wildcard encoding (face/eyes/hands/mouth/feet passes all share the same module-level CLIP cache).
