### PR TITLE
Add POST /free_memory: synchronous memory-free endpoint with stats

### DIFF
--- a/server.py
+++ b/server.py
@@ -1070,19 +1070,30 @@ class PromptServer():
 
             # Defer to the prompt-worker flags when something is running so
             # we never unload mid-sample. The worker honours the same flags
-            # POST /free uses, so we get correct cleanup post-prompt.
-            if self.prompt_queue.get_tasks_remaining() > 0:
+            # POST /free uses, so we get correct cleanup post-prompt. Note
+            # that the worker treats "free_memory" as a coarse trigger:
+            # setting it also runs unload + gc + empty_cache regardless of
+            # the caller's per-flag preference. We document that here rather
+            # than introduce new worker flags just for this endpoint.
+            def _defer_to_worker():
                 if unload_models:
                     self.prompt_queue.set_flag("unload_models", True)
                 if empty_cache or do_gc:
                     self.prompt_queue.set_flag("free_memory", True)
+
+            if self.prompt_queue.get_tasks_remaining() > 0:
+                _defer_to_worker()
                 return web.json_response({
                     "queued": True,
                     "reason": "prompt is currently executing or queued; "
-                              "memory will be freed after it completes",
+                              "memory will be freed after it completes "
+                              "(deferred mode unloads + gc + empty_cache "
+                              "together due to worker flag semantics)",
                 })
 
-            # Idle: do the work synchronously and report deltas.
+            # Idle: do the work in a worker thread so we don't block the
+            # event loop while unload + gc + empty_cache run (each can take
+            # 100s of ms, and we don't want to stall other HTTP handlers).
             device = comfy.model_management.get_torch_device()
             cpu_device = comfy.model_management.torch.device("cpu")
 
@@ -1091,16 +1102,32 @@ class PromptServer():
                 vram_free = comfy.model_management.get_free_memory(device)
                 return ram_free, vram_free
 
-            ram_before, vram_before = _stats()
-            t0 = time.perf_counter()
-            if unload_models:
-                comfy.model_management.unload_all_models()
-            if do_gc:
-                gc.collect()
-            if empty_cache:
-                comfy.model_management.soft_empty_cache(force=True)
-            duration_ms = int((time.perf_counter() - t0) * 1000)
-            ram_after, vram_after = _stats()
+            def _do_free_blocking():
+                ram_before, vram_before = _stats()
+                t0 = time.perf_counter()
+                if unload_models:
+                    comfy.model_management.unload_all_models()
+                if do_gc:
+                    gc.collect()
+                if empty_cache:
+                    comfy.model_management.soft_empty_cache(force=True)
+                duration_ms = int((time.perf_counter() - t0) * 1000)
+                ram_after, vram_after = _stats()
+                return ram_before, vram_before, ram_after, vram_after, duration_ms
+
+            # Re-check task count just before running — covers the TOCTOU
+            # window where a prompt arrived between our first check and now.
+            if self.prompt_queue.get_tasks_remaining() > 0:
+                _defer_to_worker()
+                return web.json_response({
+                    "queued": True,
+                    "reason": "prompt arrived during dispatch; "
+                              "memory will be freed after it completes",
+                })
+
+            ram_before, vram_before, ram_after, vram_after, duration_ms = (
+                await asyncio.to_thread(_do_free_blocking)
+            )
 
             return web.json_response({
                 "queued": False,

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 import errno
+import gc
 import os
 import sys
 import asyncio
@@ -1024,6 +1025,91 @@ class PromptServer():
             if free_memory:
                 self.prompt_queue.set_flag("free_memory", free_memory)
             return web.Response(status=200)
+
+        @routes.post("/free_memory")
+        async def post_free_memory(request):
+            """Synchronous memory-free endpoint.
+
+            POST /free_memory with optional JSON body:
+                {
+                    "unload_models": true,   // unload all loaded MODEL/CLIP/VAE objects
+                    "gc": true,              // run gc.collect() after unload
+                    "empty_cache": true      // call torch.cuda.empty_cache() etc.
+                }
+
+            All three default to true. Returns the memory deltas observed
+            during the call:
+                {
+                    "queued": false,
+                    "ram_freed": <bytes>,
+                    "vram_freed": <bytes>,
+                    "ram_free_after": <bytes>,
+                    "vram_free_after": <bytes>,
+                    "duration_ms": <int>
+                }
+
+            If a prompt is currently executing or queued, the work is
+            deferred via the same flag mechanism as POST /free (so we don't
+            yank models out from under an in-flight sample) and the response
+            reports `"queued": true` with no deltas. The prompt-worker loop
+            picks the flags up after the current item completes.
+
+            Compared to POST /free, this endpoint:
+              - Runs synchronously when the queue is idle (the common case
+                for a UI/CLI button that frees memory between sessions).
+              - Returns observed deltas so callers can show "freed N MB" UX.
+              - Defaults to all three operations on; /free defaults to off.
+            """
+            try:
+                payload = await request.json() if request.body_exists else {}
+            except Exception:
+                payload = {}
+            unload_models = bool(payload.get("unload_models", True))
+            do_gc = bool(payload.get("gc", True))
+            empty_cache = bool(payload.get("empty_cache", True))
+
+            # Defer to the prompt-worker flags when something is running so
+            # we never unload mid-sample. The worker honours the same flags
+            # POST /free uses, so we get correct cleanup post-prompt.
+            if self.prompt_queue.get_tasks_remaining() > 0:
+                if unload_models:
+                    self.prompt_queue.set_flag("unload_models", True)
+                if empty_cache or do_gc:
+                    self.prompt_queue.set_flag("free_memory", True)
+                return web.json_response({
+                    "queued": True,
+                    "reason": "prompt is currently executing or queued; "
+                              "memory will be freed after it completes",
+                })
+
+            # Idle: do the work synchronously and report deltas.
+            device = comfy.model_management.get_torch_device()
+            cpu_device = comfy.model_management.torch.device("cpu")
+
+            def _stats():
+                ram_free = comfy.model_management.get_free_memory(cpu_device)
+                vram_free = comfy.model_management.get_free_memory(device)
+                return ram_free, vram_free
+
+            ram_before, vram_before = _stats()
+            t0 = time.perf_counter()
+            if unload_models:
+                comfy.model_management.unload_all_models()
+            if do_gc:
+                gc.collect()
+            if empty_cache:
+                comfy.model_management.soft_empty_cache(force=True)
+            duration_ms = int((time.perf_counter() - t0) * 1000)
+            ram_after, vram_after = _stats()
+
+            return web.json_response({
+                "queued": False,
+                "ram_freed": max(0, ram_after - ram_before),
+                "vram_freed": max(0, vram_after - vram_before),
+                "ram_free_after": ram_after,
+                "vram_free_after": vram_after,
+                "duration_ms": duration_ms,
+            })
 
         @routes.post("/history")
         async def post_history(request):


### PR DESCRIPTION
### What

Adds `POST /free_memory` — a sibling to the existing `POST /free` that runs unload + GC + cache-empty work **synchronously** when the queue is idle, and returns observed memory deltas in the response body.

### Why

The existing `/free` endpoint sets flags on the `PromptQueue`; those flags only fire from the prompt-worker loop **after** the next prompt completes. If the queue is empty / idle, calling `/free` does nothing observable until something else triggers worker activity.

That's surprising semantics for the "free memory now" use case — a UI button between sessions, a CLI memory-flush command, a container orchestrator that wants to flush state between job batches without restarting the process. People expect calling `/free` to free memory.

### Behaviour

```
POST /free_memory
{
  "unload_models": true,   // optional, default true
  "gc": true,              // optional, default true
  "empty_cache": true      // optional, default true
}
```

**When the queue is idle** — runs `model_management.unload_all_models()` + `gc.collect()` + `model_management.soft_empty_cache(force=True)` inline, measures RAM and VRAM before and after, returns:

```json
{
  "queued": false,
  "ram_freed": 8589934592,
  "vram_freed": 4294967296,
  "ram_free_after": 17179869184,
  "vram_free_after": 8589934592,
  "duration_ms": 247
}
```

**When a prompt is running or queued** — defers via the same flag mechanism `/free` uses so we never yank models out from under an in-flight sample, and returns:

```json
{
  "queued": true,
  "reason": "prompt is currently executing or queued; memory will be freed after it completes"
}
```

### Compared to `POST /free`

| | `/free` | `/free_memory` |
|---|---|---|
| Synchronous when idle | ❌ always deferred | ✅ |
| Returns memory deltas | ❌ | ✅ |
| Body defaults | all off | all on |
| Honours queued-prompt semantics | ✅ | ✅ |
| Backwards compat | — | doesn't touch `/free` |

`/free` is preserved unchanged. New endpoint is additive.

### Use cases

- **Long-running multi-tenant ComfyUI servers** that want to flush state between job batches without restarting the process.
- **Between-session memory-flush buttons** in custom frontends — currently you can call `/free` but the user has to queue something afterwards to see the memory actually drop.
- **Container orchestrators** that need a deterministic "ready to receive next batch" signal with measurable freed-memory output.

### Risk

- New endpoint, additive. Existing `/free` semantics unchanged.
- The synchronous path is only entered when `prompt_queue.get_tasks_remaining() == 0`, so there's no chance of unloading mid-sample.
- Memory deltas use the same `model_management.get_free_memory()` helpers `/system_stats` uses, so the reported numbers are consistent across endpoints.
EOF