### PR TITLE
LoadImage: support subfolders in the input directory (closes #1220)

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1678,11 +1678,50 @@ class PreviewImage(SaveImage):
                 "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},
                 }
 
+def _list_input_files_recursive(input_dir, max_files=20000):
+    """Walk `input_dir` recursively and return a sorted list of relative file
+    paths (forward-slash separators for cross-platform consistency).
+
+    Skips hidden directories / files (anything starting with `.`), follows no
+    symlinks, and bounds the result at `max_files` so a misconfigured input
+    folder can't make the node-info response take forever. Existing
+    `folder_paths.get_annotated_filepath` already handles `subdir/file.ext`
+    paths via os.path.join, so the resolver side needs no change."""
+    files = []
+    if not os.path.isdir(input_dir):
+        return files
+    truncated = False
+    for root, dirs, names in os.walk(input_dir, followlinks=False):
+        # Filter hidden in-place so os.walk doesn't descend into them.
+        dirs[:] = [d for d in dirs if not d.startswith('.')]
+        rel_root = os.path.relpath(root, input_dir)
+        for name in names:
+            if name.startswith('.'):
+                continue
+            full = os.path.join(root, name)
+            if not os.path.isfile(full):
+                continue
+            rel = name if rel_root == '.' else os.path.join(rel_root, name)
+            files.append(rel.replace(os.sep, '/'))
+            if len(files) >= max_files:
+                truncated = True
+                break
+        if truncated:
+            break
+    if truncated:
+        logging.warning(
+            "LoadImage: input directory has more than %d files; truncating "
+            "dropdown. Raise the cap by patching _list_input_files_recursive "
+            "if you need every file.", max_files)
+    files.sort()
+    return files
+
+
 class LoadImage:
     @classmethod
     def INPUT_TYPES(s):
         input_dir = folder_paths.get_input_directory()
-        files = [f for f in os.listdir(input_dir) if os.path.isfile(os.path.join(input_dir, f))]
+        files = _list_input_files_recursive(input_dir)
         files = folder_paths.filter_files_content_types(files, ["image"])
         return {"required":
                     {"image": (sorted(files), {"image_upload": True})},


### PR DESCRIPTION
### What

`LoadImage`'s dropdown now walks `input/` recursively, so users can browse images in subdirectories instead of having to flatten everything into the top level.

Closes #1220 (+21 reactions, multi-year open).

### Why

Current behaviour is a flat `os.listdir(input_dir)`. Users with organised input folders (e.g. `portraits/`, `references/`, `controlnet/poses/`) can't access files there — the dropdown only shows top-level files. Workaround: dump everything into one folder, lose all organisation. Highest-demand still-open LoadImage UX issue.

### Behaviour

Before:

```
input/
├── top.png         # ✅ shown
├── portraits/
│   └── sonic.png   # ❌ hidden
└── controlnet/
    └── poses/
        └── jump.png # ❌ hidden
```

Dropdown: `['top.png']`

After:

```
input/
├── top.png
├── portraits/
│   └── sonic.png
└── controlnet/
    └── poses/
        └── jump.png
```

Dropdown: `['controlnet/poses/jump.png', 'portraits/sonic.png', 'top.png']`

### Implementation

New module-level `_list_input_files_recursive()` helper used by `LoadImage.INPUT_TYPES` (and inherited by `LoadImageMask` via `super().INPUT_TYPES()`):

- `os.walk(..., followlinks=False)` so symlink loops can't hang the listing
- Skips hidden directories and files (anything starting with `.`) — keeps OS-level cruft out
- Forward-slash separators (`portraits/sonic.png`) for cross-platform consistency in workflow JSON
- Bounded at 20,000 files with a logged warning so a misconfigured input folder can't make `/object_info` take forever
- Output sorted alphabetically end-to-end, so the dropdown is browsable

The resolver side needs **zero** changes — `folder_paths.get_annotated_filepath` and `exists_annotated_filepath` already use `os.path.join(base_dir, name)` which handles `subdir/file.ext` correctly. `IS_CHANGED` and `VALIDATE_INPUTS` continue to work without modification.

`LoadImageOutput` is unaffected — it uses a separate `/internal/files/output` route via the `'remote'` COMBO mechanism, which already supports its own subfolder handling.

### Testing

Validated standalone with a fixture covering top-level files, two-deep subfolder, hidden file, hidden directory, empty directory, non-existent directory, and the truncation cap at `max_files=10`. All 6 expectations match.

Manual verification path: drop a `portraits/test.png` in your `input/` folder, restart ComfyUI, observe `portraits/test.png` in the LoadImage dropdown, queue a workflow that uses it.

### Backwards compatibility

- API-identical from the user's perspective. Same node interface, same outputs, same error semantics.
- Existing workflows referencing `top.png` continue to work — the helper still emits top-level files first-letter-sorted alongside subfolder ones.
- Workflows saved on this PR use `subdir/file.ext` paths in `widgets_values`. These work fine on the existing master because `get_annotated_filepath` already handles them — the dropdown listing was the only blocker.
EOF