### PR TITLE
Pause Queue: POST /queue/pause + /queue/resume (closes #1032)

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -1228,6 +1228,11 @@ class PromptQueue:
         self.currently_running = {}
         self.history = {}
         self.flags = {}
+        # When paused, the worker stops PULLING new items off the queue —
+        # any item already in `currently_running` finishes normally, but
+        # the next get() blocks until resume() is called. Items can still
+        # be queued (POST /prompt), reordered, or deleted while paused.
+        self.paused = False
 
     def put(self, item):
         with self.mutex:
@@ -1237,9 +1242,9 @@ class PromptQueue:
 
     def get(self, timeout=None):
         with self.not_empty:
-            while len(self.queue) == 0:
+            while len(self.queue) == 0 or self.paused:
                 self.not_empty.wait(timeout=timeout)
-                if timeout is not None and len(self.queue) == 0:
+                if timeout is not None and (len(self.queue) == 0 or self.paused):
                     return None
             item = heapq.heappop(self.queue)
             i = self.task_counter
@@ -1247,6 +1252,23 @@ class PromptQueue:
             self.task_counter += 1
             self.server.queue_updated()
             return (item, i)
+
+    def set_paused(self, paused: bool):
+        """Pause or resume the queue worker. Pausing leaves the currently-
+        running item alone (it finishes naturally); resuming wakes the
+        worker so it pulls the next item from the queue."""
+        with self.mutex:
+            previous = self.paused
+            self.paused = bool(paused)
+            if previous and not self.paused:
+                # Resume: wake any waiter so they re-evaluate the loop.
+                self.not_empty.notify_all()
+            self.server.queue_updated()
+        return previous
+
+    def is_paused(self) -> bool:
+        with self.mutex:
+            return self.paused
 
     class ExecutionStatus(NamedTuple):
         status_str: Literal['success', 'error']

--- a/server.py
+++ b/server.py
@@ -911,7 +911,23 @@ class PromptServer():
             current_queue = self.prompt_queue.get_current_queue_volatile()
             queue_info['queue_running'] = _remove_sensitive_from_queue(current_queue[0])
             queue_info['queue_pending'] = _remove_sensitive_from_queue(current_queue[1])
+            queue_info['paused'] = self.prompt_queue.is_paused()
             return web.json_response(queue_info)
+
+        @routes.post("/queue/pause")
+        async def post_queue_pause(request):
+            """Pause the queue worker. The currently-running item (if any)
+            finishes; subsequent items wait until /queue/resume. Items can
+            still be queued / reordered / deleted while paused."""
+            previous = self.prompt_queue.set_paused(True)
+            return web.json_response({"paused": True, "was_paused": previous})
+
+        @routes.post("/queue/resume")
+        async def post_queue_resume(request):
+            """Resume the queue worker. Wakes any waiter so it picks the
+            next item off the queue immediately."""
+            previous = self.prompt_queue.set_paused(False)
+            return web.json_response({"paused": False, "was_paused": previous})
 
         @routes.post("/prompt")
         async def post_prompt(request):


### PR DESCRIPTION
### What

Adds a queue-pause mechanism: `PromptQueue.paused` state + `POST /queue/pause` + `POST /queue/resume` routes. The `GET /queue` response gains a `paused: bool` field so frontends can render the correct button state.

Closes #1032 (+26 reactions — the highest-traction still-open feature request on the tracker).

### Behaviour

- **`POST /queue/pause`** → queue worker stops pulling new items. Currently-running item finishes naturally (no kill). Items can still be queued / reordered / deleted while paused. Returns `{"paused": true, "was_paused": <bool>}`.
- **`POST /queue/resume`** → wakes the worker; next item is picked up immediately. Returns `{"paused": false, "was_paused": <bool>}`.
- **`GET /queue`** → response now includes `"paused": bool`. Existing keys (`queue_running`, `queue_pending`) unchanged.

### Implementation

Three small pieces:

1. **`PromptQueue`** gains `self.paused`, `set_paused(bool)`, `is_paused()`. The existing `get()` loop's wait predicate becomes `len(queue) == 0 or self.paused`. Set inside the mutex; resume calls `not_empty.notify_all()` so any waiter re-evaluates immediately.

2. **`/queue/pause` and `/queue/resume`** — thin routes that flip the flag and return both new state and `was_paused`. The `was_paused` field makes pause-while-paused / resume-while-running idempotent without losing prior-state info.

3. **`/queue` response gains `paused`** — additive, no removal. Existing frontends that ignore the field continue to work.

### Why this fits in ~40 lines

The queue worker already uses a `threading.Condition` for "wait until queue is non-empty." Adding a paused predicate to the existing wait loop composes cleanly with that mechanism — no new threading primitives, no new race conditions, the check sits inside the existing mutex. Most of the diff is the new server routes + comments.

### Manual verification

```bash
# pause
curl -X POST http://localhost:8188/queue/pause
# enqueue some prompts — they'll sit in queue_pending
curl -X POST http://localhost:8188/prompt -d '{"prompt": ...}'
# resume
curl -X POST http://localhost:8188/queue/resume
# observe queue draining
curl http://localhost:8188/queue
```

### Backwards compatibility

- `paused` defaults to False — nothing changes for users who don't call the new routes.
- `GET /queue` gains a key, doesn't remove anything.
- Existing `/free` flag mechanism is unaffected (different concern — `paused` is about scheduling, `/free` is about memory).
EOF