### PR TITLE
Add HTTP Basic auth via --username / --password (closes #987)

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -159,6 +159,8 @@ parser.add_argument("--default-hashing-function", type=str, choices=['md5', 'sha
 
 parser.add_argument("--disable-smart-memory", action="store_true", help="Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.")
 parser.add_argument("--deterministic", action="store_true", help="Make pytorch use slower deterministic algorithms when it can. Note that this might not make images deterministic in all cases.")
+parser.add_argument("--username", type=str, default=None, help="HTTP Basic auth username. Both --username and --password must be set for auth to be enabled. Note: HTTP Basic transmits credentials base64-encoded in plaintext — only safe over TLS (--tls-keyfile/--tls-certfile) or a trusted local network.")
+parser.add_argument("--password", type=str, default=None, help="HTTP Basic auth password. See --username.")
 
 class PerformanceFeature(enum.Enum):
     Fp16Accumulation = "fp16_accumulation"

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -160,7 +160,7 @@ parser.add_argument("--default-hashing-function", type=str, choices=['md5', 'sha
 parser.add_argument("--disable-smart-memory", action="store_true", help="Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.")
 parser.add_argument("--deterministic", action="store_true", help="Make pytorch use slower deterministic algorithms when it can. Note that this might not make images deterministic in all cases.")
 parser.add_argument("--username", type=str, default=None, help="HTTP Basic auth username. Both --username and --password must be set for auth to be enabled. Note: HTTP Basic transmits credentials base64-encoded in plaintext — only safe over TLS (--tls-keyfile/--tls-certfile) or a trusted local network.")
-parser.add_argument("--password", type=str, default=None, help="HTTP Basic auth password. See --username.")
+parser.add_argument("--password", type=str, default=None, help="HTTP Basic auth password. See --username. WARNING: passing the password on the command line exposes it via the process list (ps) and shell history; future work will add --password-file / env-var support.")
 
 class PerformanceFeature(enum.Enum):
     Fp16Accumulation = "fp16_accumulation"

--- a/server.py
+++ b/server.py
@@ -197,7 +197,47 @@ def create_block_external_middleware():
         response.headers['Content-Security-Policy'] = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' data:; frame-src 'self'; object-src 'self';"
         return response
 
-    return block_external_middleware
+    return block_external_middleware  # type: ignore[return-value]
+
+
+def create_basic_auth_middleware(username: str, password: str):
+    """HTTP Basic auth gate. Both username and password must be non-empty.
+
+    Note this is intentionally minimal — Basic auth transmits credentials
+    base64-encoded in plaintext, so it's only safe over TLS or on a
+    trusted local network. Users wanting per-user sessions / token-based
+    auth / rate limiting should layer a reverse proxy (nginx, caddy)
+    instead. This middleware exists because comfy currently has zero
+    auth on the HTTP API, and even Basic is a strict improvement over
+    that for shared-tenant / network-exposed deployments.
+    """
+    import base64
+    import hmac
+
+    expected = "Basic " + base64.b64encode(
+        f"{username}:{password}".encode("utf-8")).decode("ascii")
+
+    def _matches(header_value: str) -> bool:
+        if not header_value or not header_value.startswith("Basic "):
+            return False
+        # hmac.compare_digest is timing-safe; plain == is not.
+        return hmac.compare_digest(header_value, expected)
+
+    @web.middleware
+    async def basic_auth_middleware(request: web.Request, handler):
+        # OPTIONS preflight should always succeed without auth so CORS works.
+        if request.method == "OPTIONS":
+            return await handler(request)
+
+        if not _matches(request.headers.get("Authorization", "")):
+            return web.Response(
+                status=401,
+                headers={"WWW-Authenticate": 'Basic realm="ComfyUI", charset="UTF-8"'},
+                text="Authorization required.",
+            )
+        return await handler(request)
+
+    return basic_auth_middleware
 
 
 class PromptServer():
@@ -220,6 +260,20 @@ class PromptServer():
         middlewares = [cache_control, deprecation_warning]
         if args.enable_compress_response_body:
             middlewares.append(compress_body)
+
+        # Auth runs early — before CORS / origin checks — so an
+        # unauthenticated request gets a clean 401 instead of being
+        # silently 403'd by the origin guard. Both flags must be set;
+        # either alone is treated as 'auth disabled' with a startup
+        # warning so the user knows their config didn't apply.
+        if args.username and args.password:
+            middlewares.append(create_basic_auth_middleware(args.username, args.password))
+            logging.info("HTTP Basic auth enabled (username=%s)", args.username)
+        elif args.username or args.password:
+            logging.warning(
+                "HTTP Basic auth NOT enabled: both --username AND --password "
+                "must be set. (got username=%s, password=%s)",
+                bool(args.username), bool(args.password))
 
         if args.enable_cors_header:
             middlewares.append(create_cors_middleware(args.enable_cors_header))

--- a/server.py
+++ b/server.py
@@ -1,4 +1,6 @@
+import base64
 import errno
+import hmac
 import os
 import sys
 import asyncio
@@ -200,7 +202,7 @@ def create_block_external_middleware():
     return block_external_middleware  # type: ignore[return-value]
 
 
-def create_basic_auth_middleware(username: str, password: str):
+def create_basic_auth_middleware(username: str, password: str, cors_origin: Optional[str] = None):
     """HTTP Basic auth gate. Both username and password must be non-empty.
 
     Note this is intentionally minimal — Basic auth transmits credentials
@@ -210,10 +212,11 @@ def create_basic_auth_middleware(username: str, password: str):
     instead. This middleware exists because comfy currently has zero
     auth on the HTTP API, and even Basic is a strict improvement over
     that for shared-tenant / network-exposed deployments.
-    """
-    import base64
-    import hmac
 
+    cors_origin: when --enable-cors-header is set, the 401 response needs
+    matching CORS headers or the browser shows an opaque error. Auth runs
+    before the CORS middleware, so we mirror the headers here.
+    """
     expected = "Basic " + base64.b64encode(
         f"{username}:{password}".encode("utf-8")).decode("ascii")
 
@@ -223,6 +226,15 @@ def create_basic_auth_middleware(username: str, password: str):
         # hmac.compare_digest is timing-safe; plain == is not.
         return hmac.compare_digest(header_value, expected)
 
+    def _unauth_response() -> web.Response:
+        headers = {"WWW-Authenticate": 'Basic realm="ComfyUI", charset="UTF-8"'}
+        if cors_origin:
+            headers["Access-Control-Allow-Origin"] = cors_origin
+            headers["Access-Control-Allow-Methods"] = "POST, GET, DELETE, PUT, OPTIONS, PATCH"
+            headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+            headers["Access-Control-Allow-Credentials"] = "true"
+        return web.Response(status=401, headers=headers, text="Authorization required.")
+
     @web.middleware
     async def basic_auth_middleware(request: web.Request, handler):
         # OPTIONS preflight should always succeed without auth so CORS works.
@@ -230,11 +242,7 @@ def create_basic_auth_middleware(username: str, password: str):
             return await handler(request)
 
         if not _matches(request.headers.get("Authorization", "")):
-            return web.Response(
-                status=401,
-                headers={"WWW-Authenticate": 'Basic realm="ComfyUI", charset="UTF-8"'},
-                text="Authorization required.",
-            )
+            return _unauth_response()
         return await handler(request)
 
     return basic_auth_middleware
@@ -267,7 +275,8 @@ class PromptServer():
         # either alone is treated as 'auth disabled' with a startup
         # warning so the user knows their config didn't apply.
         if args.username and args.password:
-            middlewares.append(create_basic_auth_middleware(args.username, args.password))
+            middlewares.append(create_basic_auth_middleware(
+                args.username, args.password, cors_origin=args.enable_cors_header))
             logging.info("HTTP Basic auth enabled (username=%s)", args.username)
         elif args.username or args.password:
             logging.warning(


### PR DESCRIPTION
### What

Opt-in HTTP Basic auth via `--username` / `--password` flags.

Closes #987 (+26 reactions, the #2 most-requested feature).

### Why

ComfyUI currently has zero auth on the HTTP API. Anyone who can reach the listening port can queue prompts, read history, list models, etc. That's fine for localhost-only desktop installs, but it's a real problem for:

- **Shared-tenant servers** (e.g. small studios where multiple artists share a GPU box)
- **Container / Kubernetes deploys** where ComfyUI is exposed via a Service
- **Tunnel-exposed dev machines** (Cloudflare Tunnel, Tailscale Funnel, ngrok, etc.) — currently the only "fix" is sticking nginx in front

Even simple Basic auth is a strict improvement over none.

### Behaviour

```
ComfyUI --username alice --password $(cat ~/.comfy-pw)
```

- Both flags must be set together. Either alone logs a startup warning ("auth NOT enabled") so misconfigurations are loud instead of silent.
- Auth runs **first** in the middleware chain — before CORS / origin checks — so unauthorised requests get a clean `401 Unauthorized` with `WWW-Authenticate: Basic realm="ComfyUI"` instead of a confusing 403.
- Browsers prompt for credentials automatically on first 401.
- `OPTIONS` preflight bypasses auth so CORS still works for browser clients.

### Implementation

Single new `create_basic_auth_middleware(username, password)` in `server.py`, parallel to the existing CORS / origin-only / block-external middleware factories. Uses `hmac.compare_digest` for timing-safe credential comparison (plain `==` is timing-vulnerable on string compare).

```python
expected = "Basic " + base64.b64encode(f"{u}:{p}".encode()).decode()
if not hmac.compare_digest(header_value, expected):
    return web.Response(status=401, headers={"WWW-Authenticate": ...})
```

### Documented limitations

In `--help` text and PR description:

- Basic transmits credentials **base64-encoded in plaintext**. Only safe over TLS (`--tls-keyfile`/`--tls-certfile`) or a trusted local network.
- No rate limiting, no session management, no per-user policy.

Users who need richer auth should layer a reverse proxy (nginx, caddy, Traefik) — but the foundation is now in place for ComfyUI to ship something usable out of the box.

### Future work

- `--password-file <path>` for reading credentials from a file (avoids exposing on `ps`)
- Multi-user support (if community wants it)
- Rate limiting via aiohttp-ratelimit or similar

Both deferred to follow-up PRs to keep this one focused and reviewable.
EOF