### PR TITLE
VAE.decode: pinned-host async D2H path overlaps decode + copy (refs #1147)

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -990,23 +990,59 @@ class VAE:
             batch_number = int(free_memory / memory_used)
             batch_number = max(1, batch_number)
 
-            # Pre-allocate output for VAEs that support direct buffer writes
+            # Async D2H overlap is only safe + useful for CUDA/ROCm devices
+            # decoding to CPU output. The pinned host buffer + non_blocking
+            # copy_() lets the cuda copy engine run the transfer concurrently
+            # with the next batch's decode kernels — near-free for batch>=2.
+            # For single-batch decodes the gain is small but the only cost
+            # is pin allocation. Disabled in the preallocated chunked-io
+            # path because those VAEs blocking-copy_() into the buffer
+            # internally and pinning wouldn't help.
             preallocated = False
             if getattr(self.first_stage_model, 'comfy_has_chunked_io', False):
                 pixel_samples = torch.empty(self.first_stage_model.decode_output_shape(samples_in.shape), device=self.output_device, dtype=self.vae_output_dtype())
                 preallocated = True
 
+            async_d2h = (
+                not preallocated
+                and self.output_device.type == 'cpu'
+                and getattr(self.device, 'type', None) == 'cuda'
+            )
+
             for x in range(0, samples_in.shape[0], batch_number):
                 samples = samples_in[x:x + batch_number].to(device=self.device, dtype=self.vae_dtype)
                 if preallocated:
                     self.first_stage_model.decode(samples, output_buffer=pixel_samples[x:x+batch_number], **vae_options)
+                    self.process_output(pixel_samples[x:x+batch_number])
+                elif async_d2h:
+                    decoded = self.first_stage_model.decode(samples, **vae_options)
+                    # On-device copy + cast so we can mutate without aliasing
+                    # the decoder's internal output. Then run process_output
+                    # on the GPU side and queue the D2H copy as non_blocking
+                    # — the next iteration's decode runs while this copy is
+                    # still in flight on the cuda copy engine.
+                    gpu_buf = decoded.to(dtype=self.vae_output_dtype(), copy=True)
+                    self.process_output(gpu_buf)
+                    if pixel_samples is None:
+                        pixel_samples = torch.empty(
+                            (samples_in.shape[0],) + tuple(gpu_buf.shape[1:]),
+                            device=self.output_device, dtype=self.vae_output_dtype(),
+                            pin_memory=True)
+                    pixel_samples[x:x+batch_number].copy_(gpu_buf, non_blocking=True)
+                    del decoded, gpu_buf
                 else:
                     out = self.first_stage_model.decode(samples, **vae_options).to(device=self.output_device, dtype=self.vae_output_dtype(), copy=True)
                     if pixel_samples is None:
                         pixel_samples = torch.empty((samples_in.shape[0],) + tuple(out.shape[1:]), device=self.output_device, dtype=self.vae_output_dtype())
                     pixel_samples[x:x+batch_number].copy_(out)
                     del out
-                self.process_output(pixel_samples[x:x+batch_number])
+                    self.process_output(pixel_samples[x:x+batch_number])
+
+            # Single sync at the end materialises the async copies. Without
+            # this, the first downstream host-side read could race with an
+            # in-flight DMA. CUDA-only — other backends are sequential.
+            if async_d2h:
+                torch.cuda.synchronize(self.device)
         except Exception as e:
             model_management.raise_non_oom(e)
             logging.warning("Warning: Ran out of memory when regular VAE decoding, retrying with tiled VAE decoding.")


### PR DESCRIPTION
### What

Adds a per-batch async copy-back path to `VAE.decode` for the common "CUDA decoder, CPU output" case. Pinned host buffer + `non_blocking=True` `copy_()` lets the cuda copy engine run the D2H transfer concurrently with the next batch's decode kernels.

Refs #1147 (the ancient "transition from KSampler to VAE Decode can be optimised" ticket — modern memory management already handles the OOM half via `load_models_gpu(memory_required=…)` + tiled fallback; this PR addresses the other half: making the throughput of well-fitting batch decodes actually overlap the host transfer rather than serialise on it).

### Why

Currently, the per-batch loop in `VAE.decode` does:
```python
out = self.first_stage_model.decode(samples).to(device=output_device, copy=True)  # blocking D2H
pixel_samples[x:x+batch].copy_(out)
process_output(pixel_samples[x:x+batch])
```

The `.to(device=output_device)` is a blocking D2H copy. The next iteration's decode kernel can't launch until the host copy completes. For batch decodes (animation frames, X/Y plot grids, batch render) this serialises wall-clock as `decode_n + copy_n + decode_{n+1} + copy_{n+1} + …` rather than `decode_n + max(copy_n, decode_{n+1}) + …`.

PyTorch's stock `non_blocking=True` D2H copy with a **pinned** host destination uses the cuda copy engine (separate from the compute engine), so it overlaps cleanly with the next decode. No new abstractions, no manual stream juggling.

### Behaviour

For the gated path (`output_device=cpu`, `device.type=='cuda'`, non-chunked-io VAE):

```
n=4 batch decode (illustrative)
==============================
                    BEFORE                                AFTER
  decode_0 ──── copy_0 ────                  decode_0 ──── copy_0 ─┐
                          decode_1 ── copy_1                       decode_1 ── copy_1 ─┐
                                          decode_2 ── copy_2                       decode_2 ── copy_2 ─┐
                                                          decode_3 ── copy_3                       decode_3 ── copy_3
```

The copy duration is hidden behind the next decode. Single `torch.cuda.synchronize` at the end of the loop materialises everything before any downstream host read can race with an in-flight DMA.

### Implementation

Three branches in the per-batch loop:

1. **`preallocated`** (chunked-io VAEs like LTX-V audio/video) — unchanged from master. Those VAEs blocking-`copy_()` into `output_buffer` internally; pinning wouldn't help.
2. **`async_d2h`** (new path, CUDA decoder + CPU output) — runs `process_output` on the GPU side first (in-place arith on a fresh on-device cast/copy buffer that's safe to mutate), then queues `pixel_samples[x:x+batch].copy_(gpu_buf, non_blocking=True)` against the pinned destination.
3. **`else`** (everything else: MPS / XPU / NPU / MLU / IXUCA / CPU-only / GPU output) — unchanged from master. Verbatim original code.

### Risk

Low.
- Existing master code path runs verbatim for any device that isn't `cuda` (or any output that isn't `cpu`). MPS, XPU, NPU, MLU, IXUCA, CPU, DirectML, and the rare GPU-output workflow all hit the unchanged `else` branch.
- ROCm uses the same `torch.cuda.*` API surface, so the path applies there too. Pinned host memory and `non_blocking` copies are both supported on ROCm — verified the code paths in PyTorch's `caching_host_allocator.cpp` and `aten/src/ATen/cuda/CachingHostAllocator.cpp`.
- New allocations: one pinned host buffer per `VAE.decode` call (the `pixel_samples` output). On a 1024×1024 SDXL decode this is ~12 MB — pin allocation is cheap and is freed when `pixel_samples` goes out of scope.
- Synchronisation: `torch.cuda.synchronize(self.device)` at end of `try` block. Same model_management/CUDA semantics as the existing `comfy.model_management.synchronize_device` callsites.

### Testing

The change is gated behind a runtime-detectable condition (`output_device='cpu' and device.type=='cuda'`). Manual benchmarking on the gated path should show measurable wall-time improvement for batch decodes ≥ 2; the size of the win scales with how close decode-time and copy-time are to each other (i.e. the gain is largest for small VAEs decoding large batches).

Existing `tests/inference/` integration tests should continue to pass — the change preserves API shape, return values, and dtype guarantees. Just removes the implicit serialisation between decode and host copy.