### PR TITLE
Add --cache-score: score-based RAM-pressure eviction (closes #8367)

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -117,6 +117,7 @@ cache_group.add_argument("--cache-classic", action="store_true", help="Use the o
 cache_group.add_argument("--cache-lru", type=int, default=0, help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.")
 cache_group.add_argument("--cache-none", action="store_true", help="Reduced RAM/VRAM usage at the expense of executing every node for each run.")
 cache_group.add_argument("--cache-ram", nargs='?', const=CACHE_RAM_AUTO_GB, type=float, default=0, help="Use RAM pressure caching with the specified headroom threshold. If available RAM drops below the threshold the cache removes large items to free RAM. Default (when no value is provided): 25%% of system RAM (min 4GB, max 32GB).")
+cache_group.add_argument("--cache-score", nargs='?', const=CACHE_RAM_AUTO_GB, type=float, default=0, help="Score-based RAM pressure cache: like --cache-ram but additionally weights eviction by node execution time, so expensive-to-recompute outputs survive memory pressure even when they aren't in the active workflow. Same headroom semantics as --cache-ram.")
 
 attn_group = parser.add_mutually_exclusive_group()
 attn_group.add_argument("--use-split-cross-attention", action="store_true", help="Use the split cross attention optimization. Ignored when xformers is used.")

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -561,3 +561,65 @@ class RAMPressureCache(LRUCache):
             self.used_generation.pop(key, None)
             self.timestamps.pop(key, None)
             self.children.pop(key, None)
+
+
+# Floor on per-entry exec_time so an instantaneous node (timer recorded as 0)
+# doesn't blow up the size/exec_time ratio to infinity.
+SCORE_CACHE_MIN_EXEC_TIME = 0.001
+
+
+class ScoreCache(RAMPressureCache):
+    """RAM-pressure variant that scores entries by `size / exec_time`.
+
+    Closes #8367. The intuition: if memory is tight, evict entries that are
+    cheap to recompute relative to how much memory they hold. A 4 GB cached
+    output that took 0.01 s to produce should go before a 200 MB cached
+    output that took 30 s.
+
+    Compared to `RAMPressureCache` (which scores by age * size), this one
+    additionally weights by recompute cost so expensive-to-rebuild entries
+    survive memory pressure even after they age out of the active workflow.
+    Falls back to the parent's age-aware scoring when an entry has no
+    timing recorded (e.g. legacy callers using CacheEntry without
+    exec_time).
+    """
+
+    def ram_release(self, target, free_active=False):
+        if psutil.virtual_memory().available >= target:
+            return
+
+        clean_list = []
+        for key, cache_entry in self.cache.items():
+            if not free_active and self.used_generation[key] == self.generation:
+                continue
+            age_score = RAM_CACHE_OLD_WORKFLOW_OOM_MULTIPLIER ** (self.generation - self.used_generation[key])
+
+            ram_usage = RAM_CACHE_DEFAULT_RAM_USAGE
+
+            def scan_list_for_ram_usage(outputs):
+                nonlocal ram_usage
+                if outputs is None:
+                    return
+                for output in outputs:
+                    if isinstance(output, (list, tuple)):
+                        scan_list_for_ram_usage(output)
+                    elif isinstance(output, torch.Tensor) and output.device.type == 'cpu':
+                        ram_usage += output.numel() * output.element_size()
+                    elif isinstance(output, ModelPatcher) and self.used_generation[key] != self.generation:
+                        ram_usage = 1e30
+            scan_list_for_ram_usage(cache_entry.outputs)
+
+            # Eviction priority: higher score = evict first.
+            # `size / exec_time` punishes large-but-cheap entries; old
+            # workflows still get the age multiplier so they aren't
+            # camping memory forever.
+            exec_time = max(getattr(cache_entry, 'exec_time', 0.0), SCORE_CACHE_MIN_EXEC_TIME)
+            score = age_score * ram_usage / exec_time
+            bisect.insort(clean_list, (score, self.timestamps[key], key))
+
+        while psutil.virtual_memory().available < target and clean_list:
+            _, _, key = clean_list.pop()
+            del self.cache[key]
+            self.used_generation.pop(key, None)
+            self.timestamps.pop(key, None)
+            self.children.pop(key, None)

--- a/execution.py
+++ b/execution.py
@@ -28,6 +28,7 @@ from comfy_execution.caching import (
     HierarchicalCache,
     LRUCache,
     RAMPressureCache,
+    ScoreCache,
 )
 from comfy_execution.graph import (
     DynamicPrompt,
@@ -99,6 +100,7 @@ class IsChangedCache:
 class CacheEntry(NamedTuple):
     ui: dict
     outputs: list
+    exec_time: float = 0.0
 
 
 class CacheType(Enum):
@@ -106,6 +108,7 @@ class CacheType(Enum):
     LRU = 1
     NONE = 2
     RAM_PRESSURE = 3
+    SCORE = 4
 
 
 class CacheSet:
@@ -121,6 +124,9 @@ class CacheSet:
             cache_size = cache_args.get("lru", 0)
             self.init_lru_cache(cache_size)
             logging.info("Using LRU cache")
+        elif cache_type == CacheType.SCORE:
+            self.init_score_cache()
+            logging.info("Using score-based cache (size / exec_time eviction)")
         else:
             self.init_classic_cache()
 
@@ -137,6 +143,10 @@ class CacheSet:
 
     def init_ram_cache(self, min_headroom):
         self.outputs = RAMPressureCache(CacheKeySetInputSignature, enable_providers=True)
+        self.objects = HierarchicalCache(CacheKeySetID)
+
+    def init_score_cache(self):
+        self.outputs = ScoreCache(CacheKeySetInputSignature, enable_providers=True)
         self.objects = HierarchicalCache(CacheKeySetID)
 
     def init_null_cache(self):
@@ -531,6 +541,7 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 # TODO - How to handle this with async functions without contextvars (which requires Python 3.12)?
                 GraphBuilder.set_default_prefix(unique_id, call_index, 0)
 
+            node_exec_start = time.perf_counter()
             try:
                 output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
             finally:
@@ -598,7 +609,11 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
             pending_subgraph_results[unique_id] = cached_outputs
             return (ExecutionResult.PENDING, None, None)
 
-        cache_entry = CacheEntry(ui=ui_outputs.get(unique_id), outputs=output_data)
+        cache_entry = CacheEntry(
+            ui=ui_outputs.get(unique_id),
+            outputs=output_data,
+            exec_time=time.perf_counter() - node_exec_start,
+        )
         execution_list.cache_update(unique_id, cache_entry)
         await caches.outputs.set(unique_id, cache_entry)
 
@@ -727,7 +742,11 @@ class PromptExecutor:
 
         self._notify_prompt_lifecycle("start", prompt_id)
         ram_headroom = int(self.cache_args["ram"] * (1024 ** 3))
-        ram_release_callback = self.caches.outputs.ram_release if self.cache_type == CacheType.RAM_PRESSURE else None
+        ram_release_callback = (
+            self.caches.outputs.ram_release
+            if self.cache_type in (CacheType.RAM_PRESSURE, CacheType.SCORE)
+            else None
+        )
         comfy.memory_management.set_ram_cache_release_state(ram_release_callback, ram_headroom)
 
         try:
@@ -779,7 +798,7 @@ class PromptExecutor:
                     else: # result == ExecutionResult.SUCCESS:
                         execution_list.complete_node_execution()
 
-                    if self.cache_type == CacheType.RAM_PRESSURE:
+                    if self.cache_type in (CacheType.RAM_PRESSURE, CacheType.SCORE):
                         comfy.model_management.free_memory(0, None, pins_required=ram_headroom, ram_required=ram_headroom)
                         ram_release_callback(ram_headroom, free_active=True)
                 else:

--- a/main.py
+++ b/main.py
@@ -287,9 +287,17 @@ def prompt_worker(q, server_instance):
     if cache_ram < 0:
         cache_ram = min(32.0, max(4.0, comfy.model_management.total_ram * 0.25 / 1024.0))
 
+    cache_score = args.cache_score
+    if cache_score < 0:
+        cache_score = min(32.0, max(4.0, comfy.model_management.total_ram * 0.25 / 1024.0))
+
     cache_type = execution.CacheType.CLASSIC
     if args.cache_lru > 0:
         cache_type = execution.CacheType.LRU
+    elif cache_score > 0:
+        cache_type = execution.CacheType.SCORE
+        # ScoreCache shares the RAMPressureCache headroom plumbing.
+        cache_ram = cache_score
     elif cache_ram > 0:
         cache_type = execution.CacheType.RAM_PRESSURE
     elif args.cache_none:


### PR DESCRIPTION
### What

New `ScoreCache` subclass of `RAMPressureCache` plus a `--cache-score` CLI flag that mirrors `--cache-ram`'s headroom semantics.

Where the existing RAM-pressure cache scores eviction by `age * size` (so old + large entries go first), the score cache additionally divides by per-entry execution time:

```
eviction_score = age_bias * size / max(exec_time, 0.001)
```

A 4 GB cached output that took 0.01 s to recompute should leave before a 200 MB output that took 30 s. This is exactly what #8367 asks for.

Closes #8367 (the `help wanted` issue from a Comfy-Org contributor).

### Why

Current cache options all have blind spots when memory is tight:

| Mode | What it scores by | Blind spot |
|---|---|---|
| `--cache-classic` | nothing — drop ASAP | wastes recompute on always-the-same prompts |
| `--cache-lru` | recency | a 30-second VAE encode pays the same eviction cost as a 10-ms primitive |
| `--cache-none` | nothing — never store | constant recompute |
| `--cache-ram` | age × size | a small expensive output gets thrown out before a big cheap one |
| **`--cache-score`** *(new)* | age × size / exec_time | keeps the expensive-to-rebuild entries through pressure |

For typical SDXL / Flux workflows the difference shows up the most when you've got several large CLIP encodings + a handful of long-running KSampler intermediate latents. Under `--cache-ram` the latents (largest) go first; under `--cache-score` the CLIP encodings go first because they're cheaper to recompute.

### Implementation

| File | Change |
|---|---|
| `comfy_execution/caching.py` | New `ScoreCache(RAMPressureCache)` overriding `ram_release` with the new scoring formula. Floors `exec_time` at 1 ms to keep instantaneous nodes from blowing up the ratio. |
| `execution.py` | `CacheEntry` NamedTuple gains `exec_time: float = 0.0` (default keeps every existing caller unchanged). `PromptExecutor` times the `get_output_data` call per node and stores the duration on the `CacheEntry` it stashes. New `CacheType.SCORE = 4` + `CacheSet.init_score_cache()` wiring. The `ram_release_callback` gating extended to include `SCORE`. |
| `comfy/cli_args.py` | `--cache-score` added to the existing mutually-exclusive cache group with the same `nargs`/`const`/auto-headroom UX as `--cache-ram`. |
| `main.py` | Routes `--cache-score` into the same headroom plumbing `RAMPressureCache` uses. |

### Backwards compatibility

Pure addition.

- Default behaviour unchanged. `--cache-classic` / `--cache-lru` / `--cache-none` / `--cache-ram` all behave identically.
- `exec_time` defaults to `0.0` so any third-party code that constructs `CacheEntry` without the new field keeps working.
- `ScoreCache` floors `exec_time` at `0.001` s so legacy entries (with `exec_time == 0`) fall back to roughly the parent's `age * size` scoring instead of dividing by zero.

### Risk

Low. The new path is opt-in. `ScoreCache` reuses the parent's `ram_release` plumbing; the only change is the per-entry score formula. The exec-time recording is a single `time.perf_counter()` pair around the existing `await get_output_data(...)` call — no new exceptions paths, no dependency on the cache type being SCORE.

### Manual benchmark plan (for reviewers with a long-running test setup)

1. Heavy workflow: SDXL → multi-CLIP encode → KSampler → VAE decode → upscale.
2. Run a sweep that touches different KSampler seeds (so latent caches change but CLIP encodings don't).
3. Compare `--cache-ram 4` vs `--cache-score 4` recompute counts on the CLIP encode nodes — score cache should retain them more often under pressure.