### PR TITLE
ImageAddNoise: use per-call torch.Generator instead of seeding global RNG

### DIFF
--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -178,7 +178,14 @@ class ImageAddNoise(IO.ComfyNode):
 
     @classmethod
     def execute(cls, image, seed, strength) -> IO.NodeOutput:
-        generator = torch.manual_seed(seed)
+        # Use a per-call generator so seeding doesn't mutate the process-wide
+        # torch RNG. The previous `torch.manual_seed(seed)` call replaced the
+        # default generator's state, which leaked into any downstream node
+        # that called torch.randn / torch.randn_like without an explicit
+        # generator argument (CFG noise injection, certain LoRA inits, etc.).
+        # Output bytes are identical to the old path because torch.Generator
+        # and the global default generator share the same RNG implementation.
+        generator = torch.Generator(device="cpu").manual_seed(seed)
         s = torch.clip((image + strength * torch.randn(image.size(), generator=generator, device="cpu").to(image)), min=0.0, max=1.0)
         return IO.NodeOutput(s)
 


### PR DESCRIPTION
### What

`ImageAddNoise.execute` currently calls `torch.manual_seed(seed)`, which **replaces the default generator's state for the entire process**. The returned generator is then used for the local `torch.randn`, but the global side effect persists after the node returns.

Switch to `torch.Generator(device='cpu').manual_seed(seed)` so the seed is local to this call.

### Why

Any downstream node that calls `torch.randn` / `torch.randn_like` without an explicit `generator=` argument inherits whatever seed the most recent `torch.manual_seed()` call set. Concrete cases that hit this in real workflows:

- **CFG noise injection** in some samplers
- **LoRA weight initialization** in custom loaders
- **Custom nodes** that do `torch.randn_like(latent)` for variation injection (very common in animation / motion-LoRA workflows)

A user who wires `ImageAddNoise(seed=42)` upstream of a KSampler can find that two runs which should be deterministic on the KSampler seed are no longer fully reproducible — because part of the noise their downstream sampler consumes was reseeded by ImageAddNoise.

The fix is a one-line swap from the global `torch.manual_seed(seed)` (which returns the default generator after seeding it as a side effect) to an explicit `torch.Generator(device='cpu').manual_seed(seed)`.

### Behaviour change

**For `ImageAddNoise` itself: none.** Output bytes are identical to the old path. Verified:

```python
import torch
shape = (1, 3, 64, 64); seed = 12345
g1 = torch.manual_seed(seed)
out_old = torch.randn(shape, generator=g1, device='cpu')
g2 = torch.Generator(device='cpu').manual_seed(seed)
out_new = torch.randn(shape, generator=g2, device='cpu')
assert torch.equal(out_old, out_new)  # passes
```

`torch.Generator` and the default generator share the same Mersenne Twister implementation, so a freshly-seeded fork produces identical output.

**For downstream nodes:** subsequent `torch.randn` calls in the same process keep their previous seeding (typically whatever the upstream KSampler set) instead of being shifted to the `ImageAddNoise` seed. This is the bug-fix half — most users wouldn't notice unless they hit one of the specific reproducibility breaks above.

### Note on the same antipattern elsewhere

Same `torch.manual_seed(seed)` → return-and-use-implicit-generator pattern also exists at:

- `comfy/sample.py:27` (`prepare_noise` — the main KSampler noise generator)
- `comfy/samplers.py:739` (random-noise inpaint mode)
- `comfy/k_diffusion/sampling.py:1891` (uses `torch.randn_like` after seeding, so the global is the actual generator — different shape)
- `comfy/ldm/modules/diffusionmodules/upscaling.py:48` (q_sample with explicit seed)

Those touch **load-bearing reproducibility paths** — changing them could shift the noise sequence for existing workflow JSON, breaking saved seed→image mappings in the wild. **Deliberately not changed in this PR.** Happy to follow up with discussion if the maintainers want them addressed.

### Risk

Trivial. One-line change in a single node. Output bytes identical for the node itself; only side effect on the global RNG is removed.