### PR TITLE
FeatherMask: fix off-by-one in right/bottom edge feathering

### DIFF
--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -324,12 +324,17 @@ class FeatherMask(IO.ComfyNode):
         bottom = min(bottom, output.shape[-2])
 
         for x in range(left):
-            feather_rate = (x + 1.0) / left
+            feather_rate = (x + 1) / left
             output[:, :, x] *= feather_rate
 
         for x in range(right):
             feather_rate = (x + 1) / right
-            output[:, :, -x] *= feather_rate
+            # `-x` would resolve to `0` for x=0 (column 0 is the LEFT edge).
+            # Use `-(x + 1)` so the right loop walks the rightmost columns,
+            # mirroring the left loop. Without this fix the rightmost column
+            # never feathered and column 0 picked up the right feather (and
+            # got double-feathered when `left` was also nonzero).
+            output[:, :, -(x + 1)] *= feather_rate
 
         for y in range(top):
             feather_rate = (y + 1) / top
@@ -337,7 +342,8 @@ class FeatherMask(IO.ComfyNode):
 
         for y in range(bottom):
             feather_rate = (y + 1) / bottom
-            output[:, -y, :] *= feather_rate
+            # Same off-by-one as `right` above — see comment there.
+            output[:, -(y + 1), :] *= feather_rate
 
         return IO.NodeOutput(output)
 


### PR DESCRIPTION
### What

The right and bottom feather loops in `FeatherMask.execute` use `output[:, :, -x]` / `output[:, -y, :]` with `x` / `y` starting at `0`. `-0` resolves to `0` — i.e. the **left** column / **top** row, not the right / bottom. The bug has two visible effects:

1. **The leftmost column / topmost row** are feathered down by the `right` / `bottom` widget value (and double-feathered when `left` / `top` are also non-zero — they get `1/right * 1/left`).
2. **The rightmost column / bottommost row** are never touched at all, so masks with `right > 0` have a sharp `1.0` band at the right edge instead of a soft fade.

The fix is `-(x + 1)` / `-(y + 1)` so the loops actually walk the rightmost / bottommost rows, mirroring the left / top loops.

### Reproduction

```python
import torch
mask = torch.ones((1, 8, 8))
out = mask.reshape((-1, 8, 8)).clone()
right = 3
for x in range(right):
    feather_rate = (x + 1) / right
    out[:, :, -x] *= feather_rate     # buggy
print("col 0 (LEFT edge):", out[0, 0, 0].item())  # 0.333  <- BUG
print("col -1 (RIGHT edge):", out[0, 0, -1].item())  # 0.667  <- BUG (should be 1/3)
```

After the fix:

```
col 0 (LEFT edge): 1.0       <- correct, untouched by the right loop
col -1 (RIGHT edge): 0.333   <- correct, the new soft-fade entry point
col -2: 0.667
col -3: 1.0
```

### Risk

Low. Single-node, single-file fix; left and top loops untouched. The only "compatibility" concern is workflows that intentionally relied on the buggy "leftmost column feathered by `right`" behaviour — those are extraordinarily unlikely (the visible symptom was "rightmost mask edge is sharp" which most users would have raised as a UI bug, not a feature).

### Note

Same `-x` antipattern doesn't appear elsewhere in `comfy_extras/nodes_mask.py`. `GrowMask` (the next class in the file) uses an explicit `torch.nn.functional` morph operation and is unaffected.