### PR TITLE
IsChangedCache: include node_id + class in IS_CHANGED failure warning

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -89,7 +89,11 @@ class IsChangedCache:
             is_changed = await resolve_map_node_over_list_results(is_changed)
             node["is_changed"] = [None if isinstance(x, ExecutionBlocker) else x for x in is_changed]
         except Exception as e:
-            logging.warning("WARNING: {}".format(e))
+            # Include node_id + class_type so the user can find the offending
+            # node in a 50-node graph instead of just seeing a bare exception
+            # message. Mirrors the diagnostic shape used by the main
+            # executor's failure path.
+            logging.warning("WARNING: IS_CHANGED failed for node_id=%s class=%s :: %s", node_id, class_type, e)
             node["is_changed"] = float("NaN")
         finally:
             self.is_changed[node_id] = node["is_changed"]


### PR DESCRIPTION
### What

When a node's `IS_CHANGED` / `fingerprint_inputs` raises, `IsChangedCache.get` falls back to a `NaN` sentinel and logs a warning. The warning currently contains only the bare exception message — no node ID, no class — so a user with a 50-node graph has no way to find the offending node short of disabling custom nodes one at a time.

This PR adds `node_id` and `class_type` to the warning. Same diagnostic shape as #13760 (Better diagnostics on node failures) added to the main executor's failure path.

### Behaviour

Before:
```
WARNING: cannot convert 'NoneType' object to ...
```

After:
```
WARNING: IS_CHANGED failed for node_id=42 class=KSampler :: cannot convert 'NoneType' object to ...
```

The remediation behaviour (NaN sentinel that bypasses the cache for the failing node) is unchanged. This is purely a logging/diagnostic improvement.

### Risk

Trivial. Single log-line change, same exception path.