### PR TITLE
PorterDuffImageComposite: replace bare assert with ValueError

### DIFF
--- a/comfy_extras/nodes_compositing.py
+++ b/comfy_extras/nodes_compositing.py
@@ -135,7 +135,17 @@ class PorterDuffImageComposite(io.ComfyNode):
             src_image = source[i]
             dst_image = destination[i]
 
-            assert src_image.shape[2] == dst_image.shape[2] # inputs need to have same number of channels
+            if src_image.shape[2] != dst_image.shape[2]:
+                # `assert` here used to raise a bare AssertionError with no
+                # message, and gets stripped under `python -O`. ValueError
+                # both survives optimisation and tells the user which
+                # channel counts didn't match.
+                raise ValueError(
+                    "PorterDuffImageComposite: source and destination images "
+                    "must have the same number of channels (source={}, "
+                    "destination={}). Convert one with ImageColorChannel or "
+                    "JoinImageWithAlpha before compositing.".format(
+                        src_image.shape[2], dst_image.shape[2]))
 
             src_alpha = source_alpha[i].unsqueeze(2)
             dst_alpha = destination_alpha[i].unsqueeze(2)


### PR DESCRIPTION
### What

`assert src_image.shape[2] == dst_image.shape[2]` in `PorterDuffImageComposite.execute` had no message at all, raised a bare `AssertionError` that tells the user nothing about what mismatched, and gets silently **stripped when running under `python -O`** (any production deploy that turned on optimisation would let the mismatch propagate to the next op as a confusing tensor-shape error instead).

Switch to a `ValueError` that:
- Names both channel counts so the user sees `(source=3, destination=4)`
- Points at the loader nodes that fix the mismatch (`JoinImageWithAlpha` to add the alpha channel)
- Survives `-O`

### Risk

Trivial. Single-line semantic equivalence — same triggering condition, same failure mode (raises and aborts execution), better error UX.