### PR TITLE
view_metadata: 422 instead of 500 on malformed safetensors header

### DIFF
--- a/server.py
+++ b/server.py
@@ -639,7 +639,17 @@ class PromptServer():
             out = comfy.utils.safetensors_header(safetensors_path, max_size=1024*1024)
             if out is None:
                 return web.Response(status=404)
-            dt = json.loads(out)
+            try:
+                dt = json.loads(out)
+            except json.JSONDecodeError as ex:
+                # A truncated or corrupted .safetensors file produces a
+                # header that won't decode — return 422 with a clear error
+                # rather than letting the bare JSONDecodeError become a 500.
+                logging.warning("view_metadata: %s has malformed safetensors header: %s",
+                                safetensors_path, ex)
+                return web.json_response(
+                    {"error": "Malformed safetensors header (file may be truncated or corrupted)"},
+                    status=422)
             if "__metadata__" not in dt:
                 return web.Response(status=404)
             return web.json_response(dt["__metadata__"])


### PR DESCRIPTION
### What

`GET /view_metadata/{folder_name}?filename=...` calls `json.loads(out)` on the safetensors header bytes without exception handling. A truncated or corrupted file produces malformed JSON, which currently bubbles up as an unhandled `JSONDecodeError` → HTTP 500.

Catch and return HTTP 422 with an explicit message so the frontend can show "this file looks corrupted" instead of a stack trace.

### Behaviour

Before:
```
HTTP 500
Internal Server Error (long traceback in console)
```

After:
```
HTTP 422
{"error": "Malformed safetensors header (file may be truncated or corrupted)"}
```

Plus a `WARNING view_metadata: <path> has malformed safetensors header: <details>` log line so operators can find the offending file.

### Risk

Trivial. New exception path catches a specific exception type; valid files take the existing happy path unchanged.