### PR TITLE
POST /history: return cleared / deleted counts in JSON body

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -1341,11 +1341,13 @@ class PromptQueue:
 
     def wipe_history(self):
         with self.mutex:
+            cleared = len(self.history)
             self.history = {}
+        return cleared
 
     def delete_history_item(self, id_to_delete):
         with self.mutex:
-            self.history.pop(id_to_delete, None)
+            return self.history.pop(id_to_delete, None) is not None
 
     def set_flag(self, name, data):
         with self.mutex:

--- a/server.py
+++ b/server.py
@@ -1028,15 +1028,18 @@ class PromptServer():
         @routes.post("/history")
         async def post_history(request):
             json_data =  await request.json()
+            cleared = 0
+            deleted = 0
             if "clear" in json_data:
                 if json_data["clear"]:
-                    self.prompt_queue.wipe_history()
+                    cleared = self.prompt_queue.wipe_history()
             if "delete" in json_data:
                 to_delete = json_data['delete']
                 for id_to_delete in to_delete:
-                    self.prompt_queue.delete_history_item(id_to_delete)
+                    if self.prompt_queue.delete_history_item(id_to_delete):
+                        deleted += 1
 
-            return web.Response(status=200)
+            return web.json_response({"cleared": cleared, "deleted": deleted})
 
     async def setup(self):
         timeout = aiohttp.ClientTimeout(total=None) # no timeout


### PR DESCRIPTION
### What

`POST /history` (the wipe / delete endpoint) currently returns a bare HTTP 200 with no body. A caller that wants to know whether their wipe or delete actually had any effect has to follow up with `GET /history`.

This PR returns a small JSON body:

```json
{"cleared": <int>, "deleted": <int>}
```

`cleared` is the previous size of the history dict (what `clear: true` removed). `deleted` is the count of `id`s that were present and removed from the `delete: [...]` list.

### Implementation

`PromptQueue.wipe_history()` now returns the previous size; `delete_history_item()` returns `True` if the id was present and `False` otherwise. Both are inside the existing mutex acquisition so the counts are accurate without a second lock.

### Backwards compatibility

Response shape changes from "empty 200" to "200 with JSON body". Existing clients that ignored the body keep working. New clients can read the counts.

### Risk

Trivial. Two-line return-value additions to mutex-guarded helpers; the route handler computes counts inline.