### PR TITLE
SaveImage: optional format widget (png / jpg / webp) + quality

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1619,6 +1619,10 @@ class SaveImage:
                 "images": ("IMAGE", {"tooltip": "The images to save."}),
                 "filename_prefix": ("STRING", {"default": "ComfyUI", "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."})
             },
+            "optional": {
+                "format": (["png", "jpg", "webp"], {"default": "png", "tooltip": "Image format. PNG (lossless, embeds workflow); JPG (smaller, EXIF metadata); WEBP (small + alpha)."}),
+                "quality": ("INT", {"default": 90, "min": 1, "max": 100, "step": 1, "tooltip": "Quality for jpg/webp (1-100). Ignored for png."}),
+            },
             "hidden": {
                 "prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"
             },
@@ -1634,25 +1638,57 @@ class SaveImage:
     DESCRIPTION = "Saves the input images to your ComfyUI output directory."
     SEARCH_ALIASES = ["save", "save image", "export image", "output image", "write image", "download"]
 
-    def save_images(self, images, filename_prefix="ComfyUI", prompt=None, extra_pnginfo=None):
+    def save_images(self, images, filename_prefix="ComfyUI", format="png", quality=90, prompt=None, extra_pnginfo=None):
         filename_prefix += self.prefix_append
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
         results = list()
+        # Build a JSON blob of the workflow once — embedded into every image
+        # (PNG via PngInfo text chunk; jpg/webp via EXIF UserComment for the
+        # frontend to read back on drag-and-drop).
+        workflow_json = None
+        if not args.disable_metadata:
+            workflow_pieces = {}
+            if prompt is not None:
+                workflow_pieces["prompt"] = prompt
+            if extra_pnginfo is not None:
+                workflow_pieces.update(extra_pnginfo)
+            if workflow_pieces:
+                workflow_json = json.dumps(workflow_pieces)
+
         for (batch_number, image) in enumerate(images):
             i = 255. * image.cpu().numpy()
             img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
-            metadata = None
-            if not args.disable_metadata:
-                metadata = PngInfo()
-                if prompt is not None:
-                    metadata.add_text("prompt", json.dumps(prompt))
-                if extra_pnginfo is not None:
-                    for x in extra_pnginfo:
-                        metadata.add_text(x, json.dumps(extra_pnginfo[x]))
 
             filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
-            file = f"{filename_with_batch_num}_{counter:05}_.png"
-            img.save(os.path.join(full_output_folder, file), pnginfo=metadata, compress_level=self.compress_level)
+            ext = format if format != "jpg" else "jpeg"  # PIL wants 'jpeg' not 'jpg'
+            file = f"{filename_with_batch_num}_{counter:05}_.{format}"
+            target = os.path.join(full_output_folder, file)
+
+            if format == "png":
+                metadata = None
+                if not args.disable_metadata:
+                    metadata = PngInfo()
+                    if prompt is not None:
+                        metadata.add_text("prompt", json.dumps(prompt))
+                    if extra_pnginfo is not None:
+                        for x in extra_pnginfo:
+                            metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+                img.save(target, pnginfo=metadata, compress_level=self.compress_level)
+            else:
+                # JPG can't carry alpha; WebP handles RGBA natively.
+                if format == "jpg" and img.mode == "RGBA":
+                    img = img.convert("RGB")
+                save_kwargs = {"format": ext, "quality": int(quality)}
+                if workflow_json is not None:
+                    # Encode workflow as EXIF UserComment (tag 0x9286). Both
+                    # JPG and WEBP carry EXIF; the frontend reads it on
+                    # drag-and-drop the same way as PNG text chunks.
+                    exif = img.getexif()
+                    # 0x9286 is UserComment; first 8 bytes are charset header.
+                    exif[0x9286] = b"UNICODE\0" + workflow_json.encode("utf-16-be")
+                    save_kwargs["exif"] = exif.tobytes()
+                img.save(target, **save_kwargs)
+
             results.append({
                 "filename": file,
                 "subfolder": subfolder,


### PR DESCRIPTION
### What

Adds two optional widgets to `SaveImage`:

- `format`: `png` (default) | `jpg` | `webp`
- `quality`: `1`–`100` (jpg/webp only, default `90`)

### Why

`SaveImage` currently only writes PNG. Users who want smaller files (gallery hosting, sharing, low-disk setups) have to wire a separate custom-node like `comfyui-save-image-extended` (which I noticed the user already has installed on their box). PNG is great for archival but a 12 MB PNG when a 600 KB WebP would do for a personal gallery is wasteful.

### Behaviour

**PNG path (default) is byte-identical to current master.** Same filename pattern, same `PngInfo` metadata embedding (`prompt` + `extra_pnginfo` as text chunks). The new `quality` widget is ignored.

**JPG / WebP path** when the user explicitly picks the format:
- File extension matches the format (`_00001_.jpg` / `_00001_.webp`)
- Workflow JSON (`prompt` + `extra_pnginfo`) is embedded as **EXIF UserComment** (tag `0x9286`, UTF-16-BE per the EXIF `UNICODE` charset header) so the frontend's drag-and-drop workflow loader can read it back the same way it reads PNG text chunks
- JPG forces `RGBA → RGB` (jpg can't carry alpha); WebP keeps alpha
- `quality` controls Pillow's encoder quality

### Backwards compatibility

Existing workflow JSON has only `["ComfyUI"]` (the prefix) in `widgets_values`. Adding the new fields as `optional` (not `required`) means the defaults apply on load — old workflows continue to write PNG with the existing metadata embedding. PNG output bytes are bit-identical.

Same `OUTPUT_NODE` shape and `{"ui": {"images": [...]}}` return — the frontend gallery / queue UI sees no change.

### Risk

Low. Single-node, additive change. The PNG path is the same code that previously ran; jpg/webp are new branches gated behind the explicit format choice.