### PR TITLE
POST /interrupt: 404 when prompt_id doesn't match a running prompt

### DIFF
--- a/server.py
+++ b/server.py
@@ -1005,14 +1005,20 @@ class PromptServer():
 
                 if should_interrupt:
                     nodes.interrupt_processing()
+                    return web.json_response({"interrupted": True, "prompt_id": prompt_id})
                 else:
                     logging.info(f"Prompt {prompt_id} is not currently running, skipping interrupt")
+                    # Return 404 instead of silent 200 so callers (CLI scripts,
+                    # queue managers) can distinguish "wrong id" from "ok".
+                    return web.json_response(
+                        {"interrupted": False, "prompt_id": prompt_id,
+                         "reason": "prompt is not currently running"},
+                        status=404)
             else:
                 # No prompt_id provided, do a global interrupt
                 logging.info("Global interrupt (no prompt_id specified)")
                 nodes.interrupt_processing()
-
-            return web.Response(status=200)
+                return web.json_response({"interrupted": True})
 
         @routes.post("/free")
         async def post_free(request):


### PR DESCRIPTION
### What

`POST /interrupt` currently returns a bare `HTTP 200` in three cases:

1. **Global interrupt** (no `prompt_id`) — processing stops, 200 ✓
2. **Targeted interrupt** that matched — processing stops, 200 ✓
3. **Targeted interrupt** with a wrong/stale `prompt_id` — **silently 200, nothing happens** ✗

Case 3 is hostile to automation: a CLI script or queue manager that retries on transient errors thinks the interrupt landed when it didn't. Switch to:

- Match → `200 {"interrupted": true, "prompt_id": ...}`
- Mismatch → `404 {"interrupted": false, "prompt_id": ..., "reason": "prompt is not currently running"}`
- Global → `200 {"interrupted": true}`

### Backwards compatibility

The body shape is new but old clients that only read the status code keep working in cases 1 and 2. Case 3 changes from `200` to `404`; clients that treated the original endpoint as fire-and-forget need to ignore `404`s now. Worth the trade-off because silent failure is the worse default for an automation API.

### Risk

Trivial. Single-route addition of `web.json_response(..., status=404)` and explicit success bodies. The actual interrupt mechanism (`nodes.interrupt_processing()`) is unchanged.