### PR TITLE
Convert user-facing assert calls to ValueError (nodes_lt + nodes_lt_audio)

### DIFF
--- a/comfy_extras/nodes_lt.py
+++ b/comfy_extras/nodes_lt.py
@@ -318,7 +318,11 @@ class LTXVAddGuide(io.ComfyNode):
     @classmethod
     def replace_latent_frames(cls, latent_image, noise_mask, guiding_latent, latent_idx, strength):
         cond_length = guiding_latent.shape[2]
-        assert latent_image.shape[2] >= latent_idx + cond_length, "Conditioning frames exceed the length of the latent sequence."
+        if latent_image.shape[2] < latent_idx + cond_length:
+            raise ValueError(
+                "Conditioning frames exceed the length of the latent sequence "
+                "(latent length {} < latent_idx {} + cond_length {}).".format(
+                    latent_image.shape[2], latent_idx, cond_length))
 
         mask = torch.full(
             (noise_mask.shape[0], 1, cond_length, 1, 1),
@@ -345,7 +349,11 @@ class LTXVAddGuide(io.ComfyNode):
         image, t = cls.encode(vae, latent_width, latent_height, image, scale_factors)
 
         frame_idx, latent_idx = cls.get_latent_index(positive, latent_length, len(image), frame_idx, scale_factors)
-        assert latent_idx + t.shape[2] <= latent_length, "Conditioning frames exceed the length of the latent sequence."
+        if latent_idx + t.shape[2] > latent_length:
+            raise ValueError(
+                "Conditioning frames exceed the length of the latent sequence "
+                "(latent_idx {} + cond_length {} > latent_length {}).".format(
+                    latent_idx, t.shape[2], latent_length))
 
         positive, negative, latent_image, noise_mask = cls.append_keyframe(
             positive,

--- a/comfy_extras/nodes_lt_audio.py
+++ b/comfy_extras/nodes_lt_audio.py
@@ -143,7 +143,10 @@ class LTXVEmptyLatentAudio(io.ComfyNode):
     ) -> io.NodeOutput:
         """Generate empty audio latents matching the reference pipeline structure."""
 
-        assert audio_vae is not None, "Audio VAE model is required"
+        if audio_vae is None:
+            raise ValueError(
+                "Audio VAE model is required. Wire an Audio VAE loader (e.g. "
+                "VAELoader pointing at the LTX-V audio VAE) into the audio_vae input.")
 
         z_channels = audio_vae.latent_channels
         audio_freq = audio_vae.first_stage_model.latent_frequency_bins


### PR DESCRIPTION
### What

Three user-facing `assert ..., "<msg>"` call-sites in node-execute paths converted to `if ...: raise ValueError(...)`:

- `comfy_extras/nodes_lt.py:321` — `replace_latent_frames` length mismatch
- `comfy_extras/nodes_lt.py:348` — `append_keyframe` length mismatch
- `comfy_extras/nodes_lt_audio.py:146` — missing `audio_vae` input

### Why

Bare `assert` calls get silently stripped when running under `python -O` and produce raw `AssertionError` tracebacks that don't classify cleanly through the executor's exception path. `ValueError` survives optimisation and is the conventional shape for "wrong input value".

For the LTX length-mismatch cases, the new message also includes the **actual numbers** (`latent_length`, `latent_idx`, `cond_length`) so the user can see by how much they overshot rather than just "exceeded". For the `audio_vae` case, point at the loader node that satisfies the input.

### Out of scope

Asserts in model-construction code (`nodes_wanmove.py`, `nodes_photomaker.py`) are intentionally left alone — they're internal sanity checks not in the user's execute path. The `PorterDuffImageComposite` assert (already converted in #13775) and `LtxAudioLatent` audio_vae assert covered here are the user-facing ones.

### Risk

Trivial. Same triggering condition + abort behaviour, better error UX, and survives `-O`. No behaviour change for any successful-path call.

### Sibling PR

#13775 — same pattern applied to PorterDuffImageComposite.