### PR TITLE
samplers: random-inpaint generator no longer mutates global torch RNG

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -736,7 +736,12 @@ class KSAMPLER(Sampler):
         model_k = KSamplerX0Inpaint(model_wrap, sigmas)
         model_k.latent_image = latent_image
         if self.inpaint_options.get("random", False): #TODO: Should this be the default?
-            generator = torch.manual_seed(extra_args.get("seed", 41) + 1)
+            # Use a per-call generator so seeding doesn't mutate the
+            # process-wide torch RNG. Same noise bytes for the same seed —
+            # torch.Generator uses the same Mersenne Twister as the default
+            # generator — but downstream torch.randn callers no longer
+            # inherit this seed via the global side effect.
+            generator = torch.Generator(device="cpu").manual_seed(extra_args.get("seed", 41) + 1)
             model_k.noise = torch.randn(noise.shape, generator=generator, device="cpu").to(noise.dtype).to(noise.device)
         else:
             model_k.noise = noise


### PR DESCRIPTION
### What

The `random` inpaint mode in `comfy/samplers.py` replaces the model's inpaint noise with a fresh `torch.randn` driven by `seed + 1`. The previous `torch.manual_seed(seed + 1)` call **replaced the default torch generator's state for the entire process** — leaking into any downstream `torch.randn` that doesn't pass an explicit generator argument.

Switch to `torch.Generator(device='cpu').manual_seed(...)` so the seed is local to this call.

### Behaviour

**Output bytes are identical to the old path.** `torch.Generator` and the default generator share the same Mersenne Twister implementation. Verified:

```python
g1 = torch.manual_seed(seed); out_old = torch.randn(shape, generator=g1, device='cpu')
g2 = torch.Generator(device='cpu').manual_seed(seed); out_new = torch.randn(shape, generator=g2, device='cpu')
assert torch.equal(out_old, out_new)  # passes
```

The only behaviour change is that subsequent `torch.randn` calls in the same process keep their previous seeding instead of being shifted to `seed + 1` via the global side effect.

### Sibling PR

Same fix as #13770 (ImageAddNoise). Three more callsites with the same antipattern remain:

- `comfy/sample.py:prepare_noise` — main KSampler noise generator
- `comfy/k_diffusion/sampling.py:1891` — block-noise after seeding
- `comfy/ldm/modules/diffusionmodules/upscaling.py:q_sample`

Those touch **reproducibility-load-bearing** paths that may warrant their own discussion — deliberately not changed in this PR. The `samplers.py` site is a strict subset (`self.inpaint_options.get("random")` is the gate, only entered for the random-inpaint mode) so the change is isolated.

### Risk

Trivial. One-line semantic equivalence, narrowly scoped to a single inpaint mode.