### PR TITLE
nodes_lora_extract: bare except → except Exception (so Ctrl-C survives)

### DIFF
--- a/comfy_extras/nodes_lora_extract.py
+++ b/comfy_extras/nodes_lora_extract.py
@@ -75,7 +75,12 @@ def calc_lora_model(model_diff, rank, prefix_model, prefix_lora, output_sd, lora
                     out = extract_lora(weight_diff, rank)
                     output_sd["{}{}.lora_up.weight".format(prefix_lora, k[len(prefix_model):-7])] = out[0].contiguous().half().cpu()
                     output_sd["{}{}.lora_down.weight".format(prefix_lora, k[len(prefix_model):-7])] = out[1].contiguous().half().cpu()
-                except:
+                except Exception:
+                    # Bare `except:` would swallow KeyboardInterrupt and
+                    # SystemExit, making Ctrl-C uncancellable mid-extract on
+                    # large models. We only want to skip this one key on
+                    # arithmetic / shape failures, not on user-initiated
+                    # interrupts.
                     logging.warning("Could not generate lora weights for key {}, is the weight difference a zero?".format(k))
             elif lora_type == LORAType.FULL_DIFF:
                 output_sd["{}{}.diff".format(prefix_lora, k[len(prefix_model):-7])] = weight_diff.contiguous().half().cpu()


### PR DESCRIPTION
### What

The per-key `try/except` wrapping `extract_lora(weight_diff, rank)` in `nodes_lora_extract.py` uses a bare `except:` which catches `BaseException` — including `KeyboardInterrupt` and `SystemExit`. Switch to `except Exception:`.

### Why

The intent of the try is to log + skip on arithmetic / shape failures from `extract_lora` and continue with the next key. On a model with 1000+ keys, the bare except would swallow every Ctrl-C the user pressed mid-extract, making the operation uncancellable. SystemExit (from a `sys.exit()` call elsewhere) would also be silently consumed.

Same shape as the other `except Exception:` usages in `comfy_extras/`.

### Risk

Trivial. The new clause still catches every error the original did (every bug in `extract_lora` raises an `Exception` subclass) — it just lets `KeyboardInterrupt` and `SystemExit` propagate as the user expects.