### PR TITLE
fix: Stop LTXVImgToVideoInplace from mutating input latents and dropping noise_mask (CORE-183)

### DIFF
--- a/comfy_extras/nodes_lt.py
+++ b/comfy_extras/nodes_lt.py
@@ -106,12 +106,12 @@ class LTXVImgToVideoInplace(io.ComfyNode):
         if bypass:
             return (latent,)
 
-        samples = latent["samples"]
+        samples = latent["samples"].clone()
         _, height_scale_factor, width_scale_factor = (
             vae.downscale_index_formula
         )
 
-        batch, _, latent_frames, latent_height, latent_width = samples.shape
+        _, _, _, latent_height, latent_width = samples.shape
         width = latent_width * width_scale_factor
         height = latent_height * height_scale_factor
 
@@ -124,11 +124,7 @@ class LTXVImgToVideoInplace(io.ComfyNode):
 
         samples[:, :, :t.shape[2]] = t
 
-        conditioning_latent_frames_mask = torch.ones(
-            (batch, 1, latent_frames, 1, 1),
-            dtype=torch.float32,
-            device=samples.device,
-        )
+        conditioning_latent_frames_mask = get_noise_mask(latent)
         conditioning_latent_frames_mask[:, :, :t.shape[2]] = 1.0 - strength
 
         return io.NodeOutput({"samples": samples, "noise_mask": conditioning_latent_frames_mask})


### PR DESCRIPTION
`LTXVImgToVideoInplace` usually works, but has two issues. Fix mirrors KJNodes' `LTXVImgToVideoInplaceKJ` (`custom_nodes/comfyui-kjnodes/nodes/ltxv_nodes.py:1077, 1086-1093`).

**1. It mutates the input latent in place, changing the upstream latent line.** Not common to see because the noise mask is still recreated and often hides the fact that the latent has changed. But it's a real thing and violates the statefulness of the graph and it's an easy fix. Below is a screenshot showing the original latent mutated after adding the latent image using the node:

<img width="862" height="623" alt="image" src="https://github.com/user-attachments/assets/86af7205-8416-468d-bc43-40e4a3c3d0c8" />

**2. It overwrites any existing `noise_mask` in the input latent.** Breaks `LTXVAddGuide` when placed afterwards, since AddGuide's keyframe-anchoring mask values get wiped. Much more commonly hit in practice.

This should also address #11948

WF used for testing and validation:
[droz_test_ltxvinplacebug.json](https://github.com/user-attachments/files/27524882/droz_test_ltxvinplacebug.json)
