### PR TITLE
fix: Make LTXVAddGuide center-crop guide images to match other LTXV nodes (CORE-182)

### DIFF
--- a/comfy_extras/nodes_lt.py
+++ b/comfy_extras/nodes_lt.py
@@ -236,7 +236,7 @@ class LTXVAddGuide(io.ComfyNode):
     def encode(cls, vae, latent_width, latent_height, images, scale_factors):
         time_scale_factor, width_scale_factor, height_scale_factor = scale_factors
         images = images[:(images.shape[0] - 1) // time_scale_factor * time_scale_factor + 1]
-        pixels = comfy.utils.common_upscale(images.movedim(-1, 1), latent_width * width_scale_factor, latent_height * height_scale_factor, "bilinear", crop="disabled").movedim(1, -1)
+        pixels = comfy.utils.common_upscale(images.movedim(-1, 1), latent_width * width_scale_factor, latent_height * height_scale_factor, "bilinear", crop="center").movedim(1, -1)
         encode_pixels = pixels[:, :, :, :3]
         t = vae.encode(encode_pixels)
         return encode_pixels, t


### PR DESCRIPTION
`LTXVAddGuide.encode()` uses `crop="disabled"` while every other LTX conditioning node, including its siblings `LTXVImgToVideo` and `LTXVImgToVideoInplace` in the same file, uses `crop="center"`. This looks like an accidental omission, not an intentional difference.

`crop="disabled"` doesn't really make sense as it will often distort images. Particularly affected are First-frame / last-frame workflows where `LTXVImgToVideoInplace` provides the first frame and `LTXVAddGuide` provides the last frame. Often the images are the same aspect ratio and the first-frame chain center-crops and the last-frame stretches, producing inconsistent framing across frames in the same output video.

This does change workflow outputs slightly when guide images don't already match the latent aspect, but having a single silent outlier in resize behavior is arguably worse. An alternative would be to expose `crop` as a node input on `LTXVAddGuide` defaulted to `"disabled"` so existing workflows produce byte-identical output, but that seems like unnecessary added node complexity.

Fixes #11924

### Examples
Base: Just look at what happens when you use two square images to generate a portrait video using LTXVImgToVideoInplace for the first frame and LTXVAddGuide for the last frame.

https://github.com/user-attachments/assets/1fea0904-2ee5-4e9f-9cfa-0d2cd322bd71

With fix:

https://github.com/user-attachments/assets/91a2398a-655d-4ea7-9a66-d873d69bd755

Workflow: 
[droz_20260507_ltxv_fflf_addguide_crop_test.json](https://github.com/user-attachments/files/27505052/droz_20260507_ltxv_fflf_addguide_crop_test.json)
