### PR TITLE
fix: Fix bug when mask not on same device (CORE-181)

### DIFF
--- a/comfy/bg_removal_model.py
+++ b/comfy/bg_removal_model.py
@@ -47,7 +47,7 @@ class BackgroundRemovalModel():
         out = self.model(pixel_values=pixel_values)
         out = torch.nn.functional.interpolate(out, size=(H, W), mode="bicubic", antialias=False)
 
-        mask = out.sigmoid().float().cpu()
+        mask = out.sigmoid().to(device=comfy.model_management.intermediate_device(), dtype=comfy.model_management.intermediate_dtype())
         if mask.ndim == 3:
             mask = mask.unsqueeze(0)
         if mask.shape[1] != 1:

--- a/comfy/bg_removal_model.py
+++ b/comfy/bg_removal_model.py
@@ -47,7 +47,7 @@ class BackgroundRemovalModel():
         out = self.model(pixel_values=pixel_values)
         out = torch.nn.functional.interpolate(out, size=(H, W), mode="bicubic", antialias=False)
 
-        mask = out.sigmoid()
+        mask = out.sigmoid().float().cpu()
         if mask.ndim == 3:
             mask = mask.unsqueeze(0)
         if mask.shape[1] != 1:

--- a/comfy_extras/nodes_compositing.py
+++ b/comfy_extras/nodes_compositing.py
@@ -203,7 +203,7 @@ class JoinImageWithAlpha(io.ComfyNode):
     @classmethod
     def execute(cls, image: torch.Tensor, alpha: torch.Tensor) -> io.NodeOutput:
         batch_size = max(len(image), len(alpha))
-        alpha = 1.0 - resize_mask(alpha.to(image.device), image.shape[1:])
+        alpha = 1.0 - resize_mask(alpha.to(image), image.shape[1:])
         alpha = comfy.utils.repeat_to_batch_size(alpha, batch_size)
         image = comfy.utils.repeat_to_batch_size(image, batch_size)
         return io.NodeOutput(torch.cat((image[..., :3], alpha.unsqueeze(-1)), dim=-1))

--- a/comfy_extras/nodes_compositing.py
+++ b/comfy_extras/nodes_compositing.py
@@ -203,7 +203,7 @@ class JoinImageWithAlpha(io.ComfyNode):
     @classmethod
     def execute(cls, image: torch.Tensor, alpha: torch.Tensor) -> io.NodeOutput:
         batch_size = max(len(image), len(alpha))
-        alpha = 1.0 - resize_mask(alpha, image.shape[1:])
+        alpha = 1.0 - resize_mask(alpha.to(image.device), image.shape[1:])
         alpha = comfy.utils.repeat_to_batch_size(alpha, batch_size)
         image = comfy.utils.repeat_to_batch_size(image, batch_size)
         return io.NodeOutput(torch.cat((image[..., :3], alpha.unsqueeze(-1)), dim=-1))


### PR DESCRIPTION
Fix bug:

> Join Image with Alpha
> RuntimeError: Expected all tensors to be on the same device, but got tensors is on cuda:0, different from other tensors on cpu
> (when checking argument in method wrapper_CUDA_cat)

Before:

<img width="1920" height="1152" alt="{DE0E7E35-152A-4A95-82E3-9C069EAFDB10}" src="https://github.com/user-attachments/assets/9163dcc9-e012-49f0-9799-53d334220ab6" />

After:

<img width="1920" height="1152" alt="{D57588E5-7D21-4896-B0AC-79C62A9888E9}" src="https://github.com/user-attachments/assets/9f3d67e0-9852-4b94-895f-59a0d5035fb9" />
