### PR TITLE
[Partner Nodes] additionally use Baidu to detect the accessibility of internet

### DIFF
--- a/comfy_api_nodes/util/client.py
+++ b/comfy_api_nodes/util/client.py
@@ -488,10 +488,30 @@ async def _diagnose_connectivity() -> dict[str, bool]:
         "api_accessible": False,
     }
     timeout = aiohttp.ClientTimeout(total=5.0)
+
+    # Probe Google and Baidu in parallel: Google is blocked by the GFW in mainland China, so a Baidu probe is required
+    # to correctly detect that Chinese users with working internet do have working internet.
+    internet_probe_urls = ("https://www.google.com", "https://www.baidu.com")
+
     async with aiohttp.ClientSession(timeout=timeout) as session:
-        with contextlib.suppress(ClientError, OSError):
-            async with session.get("https://www.google.com") as resp:
-                results["internet_accessible"] = resp.status < 500
+        async def _probe(url: str) -> bool:
+            try:
+                async with session.get(url) as resp:
+                    return resp.status < 500
+            except (ClientError, OSError, asyncio.TimeoutError):
+                return False
+
+        probe_tasks = [asyncio.create_task(_probe(u)) for u in internet_probe_urls]
+        try:
+            for fut in asyncio.as_completed(probe_tasks):
+                if await fut:
+                    results["internet_accessible"] = True
+                    break
+        finally:
+            for t in probe_tasks:
+                if not t.done():
+                    t.cancel()
+            await asyncio.gather(*probe_tasks, return_exceptions=True)
         if not results["internet_accessible"]:
             return results
 


### PR DESCRIPTION
Fix `_diagnose_connectivity()` misdiagnosing users in mainland China as offline. The function probed only `google.com` to determine whether the user's internet works, and `google.com` is GFW-blocked - so any transient API failure for Chinese users surfaced as a misleading `LocalNetworkError: "Unable to connect to the network. Please check your internet connection"`.


`_diagnose_connectivity()` now probes `google.com` and `baidu.com` in parallel via `asyncio.as_completed`, breaks on the first success, and cancels the loser in `finally`. `internet_accessible` is `True` if either probe succeeds. `asyncio.TimeoutError` is now explicitly caught (it isn't unified with `OSError` on Python 3.10)


Chinese users hitting transient errors now see `ApiServerError: "The remote service appears unreachable at this time."` instead of the old false `LocalNetworkError`.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [x] Informed **Kosinkadink**

