### PR TITLE
Skip aimdo.so dlopen on WSL to mirror the init_device guard (refs #13458)

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,9 +39,31 @@ if __name__ == "__main__":
 
 faulthandler.enable(file=sys.stderr, all_threads=False)
 
+import platform
+
 import comfy_aimdo.control
 
-if enables_dynamic_vram():
+
+def _is_wsl_pre_torch():
+    """Mirror of `comfy.model_management.is_wsl()` for use before torch is
+    imported. The full implementation lives in `comfy.model_management`,
+    which transitively imports torch — and `aimdo.so` is loaded below in
+    non-WSL configurations *before* that import so its CUDA hooks are in
+    place when torch initializes its bindings."""
+    version = platform.uname().release
+    return version.endswith("-Microsoft") or version.endswith("microsoft-standard-WSL2")
+
+
+# Mirror the WSL exclusion from the `init_device` guard further down so
+# `aimdo.so` is not `dlopen`'d at all on WSL. The library is loaded with
+# `RTLD_NOW | RTLD_GLOBAL`, and its module-load side effects (CUDA hook
+# installation, allocator interposition) apply regardless of whether
+# `init_device()` is later called — which is why setting
+# `--disable-dynamic-vram` is currently the only thing that prevents the
+# regression reported in #13458 on WSL + NVIDIA. The explicit
+# `--enable-dynamic-vram` flag still forces the load through, matching
+# the override semantics of the `init_device` guard.
+if args.enable_dynamic_vram or (enables_dynamic_vram() and not _is_wsl_pre_torch()):
     comfy_aimdo.control.init()
 
 if os.name == "nt":


### PR DESCRIPTION
## Summary

Refs Comfy-Org/ComfyUI#13458.

The `comfy_aimdo.control.init()` call at the top of [`main.py`](https://github.com/comfyanonymous/ComfyUI/blob/master/main.py#L44-L45) is `ctypes.CDLL("aimdo.so", mode=RTLD_NOW | RTLD_GLOBAL)`. It's gated only on `enables_dynamic_vram()`. The downstream `init_device()` call at line ~218 has a stricter guard:

```python
if args.enable_dynamic_vram or (enables_dynamic_vram() and comfy.model_management.is_nvidia() and not comfy.model_management.is_wsl()):
```

By the time the line-218 guard kicks in, the library has already been loaded and any module-load side effects (CUDA hook installation, allocator interposition via `RTLD_GLOBAL` symbol replacement) are in place — regardless of whether `init_device()` is ever called or `aimdo_enabled` ever becomes `True`.

That asymmetry explains the regression in #13458: WSL + NVIDIA users on the auto-disable path still trip the bug at `loss.backward()` even though `aimdo_enabled` stays `False` and every `aimdo_enabled`-gated codepath in `ops.py`, `model_patcher.py`, `model_management.py`, `model_detection.py` and `utils.py` correctly falls through to legacy behaviour. The only thing `--disable-dynamic-vram` actually changes for those users is short-circuiting `enables_dynamic_vram()`, which prevents the `dlopen` from happening at all.

I traced this code-path-by-code-path in [an earlier triage comment on #13458](https://github.com/Comfy-Org/ComfyUI/issues/13458#issuecomment-4412349013) — the diagnosis matches what users in that thread describe (`uname -r` matches `is_wsl()`, comfy-aimdo 0.2.12, `--disable-dynamic-vram` is the only workaround).

## Fix

Mirror the WSL exclusion from the `init_device` guard at the `dlopen` site too:

```python
if args.enable_dynamic_vram or (enables_dynamic_vram() and not _is_wsl_pre_torch()):
    comfy_aimdo.control.init()
```

The helper `_is_wsl_pre_torch()` is a 2-line inline mirror of `comfy.model_management.is_wsl()` because the full implementation lives behind a torch import that intentionally happens *after* this load on non-WSL configurations. Logic is identical — `platform.uname().release.endswith("-Microsoft")` or `endswith("microsoft-standard-WSL2")`.

Override semantics match the `init_device` guard: `--enable-dynamic-vram` still forces the load through, even on WSL, for users who want to opt into dynamic-VRAM despite the auto-disable.

## Notes

- **Non-NVIDIA + non-WSL** users still load the library at this point (no change in behaviour). The `init_device` guard's `is_nvidia()` check still keeps the library dormant on those systems. If load-time side effects turn out to be problematic for non-NVIDIA users too, that's a follow-up — but it has not been reported as a regression so I've kept this PR scoped to the WSL case in #13458.
- I'd appreciate a sanity-check from @rattus128 here on whether the load-time hooks I'm describing are accurate to comfy-aimdo's actual constructor behaviour. From reading [`comfy_aimdo/control.py`](https://github.com/rattus128/comfy-aimdo/blob/main/comfy_aimdo/control.py) the Python wrapper's `init()` is just the `ctypes.CDLL` plus argtype binding — but the `aimdo.so` itself is what `RTLD_GLOBAL` would expose, and that's where the constructor-level side effects (if any) live.
- The reporter (@n0valis) confirmed in #13458 that their kernel matches `is_wsl()` and their comfy-aimdo version is 0.2.12. They have not yet tested commenting out the line-45 call directly to verify the dlopen is the trigger, but the gating analysis stands on its own — the asymmetry is a real bug regardless of whether it's the *only* bug they're hitting.

## Test plan

- [x] Confirmed the asymmetry on current `master` (line 44 has only `enables_dynamic_vram()`; line 218 has the full WSL+NVIDIA guard).
- [x] Confirmed `_is_wsl_pre_torch()` is logically equivalent to `comfy.model_management.is_wsl()` (same two `endswith` cases).
- [x] Python syntax-checked (`ast.parse`).
- [ ] Manual end-to-end on the reporter's exact workflow — I don't have a WSL + NVIDIA box with their LoRA-trainer setup; @n0valis or @rattus128 if you're around for the review, the canonical test is "run the LoRA training in #13458 *without* `--disable-dynamic-vram` and confirm it no longer panics in `loss.backward()`."

Credit @n0valis for the exhaustive repro in #13458 and @rattus128 for owning comfy-aimdo.