### PR TITLE
Fix: Handle VRAM allocation failures in vbar_fault gracefully

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -125,7 +125,12 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
         return buffer
 
     for s in comfy_modules:
-        signature = comfy_aimdo.model_vbar.vbar_fault(s._v)
+        try:
+            signature = comfy_aimdo.model_vbar.vbar_fault(s._v)
+        except RuntimeError as e:
+            # VRAM allocation failure (e.g., "Fault failed: 2" on non-OOM conditions)
+            # Treat as not-resident and fall back to standard cast path instead of crashing
+            signature = None
         resident = comfy_aimdo.model_vbar.vbar_signature_compare(signature, s._v_signature)
         prefetch = {
             "signature": signature,


### PR DESCRIPTION
- Wrap vbar_fault() call in try/except to catch RuntimeError
- Treat allocation failures as non-resident (fall back to standard cast path)
- Prevents fatal exceptions during sampling when VRAM allocation fails
- Specifically handles 'Fault failed: 2' errors (non-OOM conditions)
- Allows model inference to continue with degraded performance (slower) instead of crashing

https://github.com/Comfy-Org/ComfyUI/issues/12943