### PR TITLE
Remove advanced flag from layers input in EmptyQwenImageLayeredLatent node

### DIFF
--- a/comfy_extras/nodes_qwen.py
+++ b/comfy_extras/nodes_qwen.py
@@ -116,7 +116,7 @@ class EmptyQwenImageLayeredLatentImage(io.ComfyNode):
             inputs=[
                 io.Int.Input("width", default=640, min=16, max=nodes.MAX_RESOLUTION, step=16),
                 io.Int.Input("height", default=640, min=16, max=nodes.MAX_RESOLUTION, step=16),
-                io.Int.Input("layers", default=3, min=0, max=nodes.MAX_RESOLUTION, step=1, advanced=True),
+                io.Int.Input("layers", default=3, min=0, max=nodes.MAX_RESOLUTION, step=1),
                 io.Int.Input("batch_size", default=1, min=1, max=4096),
             ],
             outputs=[


### PR DESCRIPTION
The `layers` setting is the key setting of the Qwen Image Layered workflow and shouldn't be hidden by default.

Hiding it by default will prevent users from controlling the output layers。

## Before
<img width="2052" height="922" alt="image" src="https://github.com/user-attachments/assets/3755868f-04b5-4897-8d69-a4a67d4cd0b6" />


## After
<img width="1102" height="726" alt="image" src="https://github.com/user-attachments/assets/2e9851ec-706a-4279-bb1a-fcc009dc15c0" />