### PR TITLE
fix: create input directory if missing in LoadAudio define_schema

### DIFF
--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -297,6 +297,7 @@ class LoadAudio(IO.ComfyNode):
     @classmethod
     def define_schema(cls):
         input_dir = folder_paths.get_input_directory()
+        os.makedirs(input_dir, exist_ok=True)
         files = folder_paths.filter_files_content_types(os.listdir(input_dir), ["audio", "video"])
         return IO.Schema(
             node_id="LoadAudio",


### PR DESCRIPTION
Fixes #13688

## Problem

`LoadAudio.define_schema` runs at module-import time and immediately calls `os.listdir(folder_paths.get_input_directory())`. When ComfyUI is launched with `--input-directory` pointing to a path that does not yet exist (e.g. a fresh project directory), the `listdir` call raises `FileNotFoundError`, and `comfy_extras/nodes_audio.py` fails to import.

The user-visible result is a misleading log message that points at dependencies rather than the missing directory:

```
Error while calling comfy_entrypoint in ...\comfy_extras\nodes_audio.py:
  [WinError 3] The system cannot find the path specified: 'M:\\somewhere\\input'

IMPORT FAILED: nodes_audio.py
This issue might be caused by new missing dependencies added the last time you updated ComfyUI.
Please do a: pip install -r requirements.txt
```

## Fix

Create the input directory if it does not exist before listing it. This matches the existing pattern already used in [`comfy_extras/nodes_load_3d.py`](https://github.com/Comfy-Org/ComfyUI/blob/master/comfy_extras/nodes_load_3d.py#L20):

```python
input_dir = os.path.join(folder_paths.get_input_directory(), "3d")
os.makedirs(input_dir, exist_ok=True)
```

## Test plan

- [ ] Launch with `--input-directory <nonexistent path>`; confirm `nodes_audio.py` imports successfully and the path is created.
- [ ] Launch with `--input-directory <existing path>`; confirm no behavior change.
- [ ] Launch with the default input directory; confirm no behavior change.