### PR TITLE
model_patcher: Fix safetensors saving of fp8 (CORE-160)

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -242,6 +242,37 @@ class LazyCastingParam(torch.nn.Parameter):
         return self.model.patch_weight_to_device(self.key, device_to=self.model.load_device, return_weight=True).to("cpu")
 
 
+class LazyCastingQuantizedParam:
+    def __init__(self, model, key):
+        self.model = model
+        self.key = key
+        self.cpu_state_dict = None
+
+    def state_dict_tensor(self, state_dict_key):
+        if self.cpu_state_dict is None:
+            weight = self.model.patch_weight_to_device(self.key, device_to=self.model.load_device, return_weight=True)
+            self.cpu_state_dict = {k: v.to("cpu") for k, v in weight.state_dict(self.key).items()}
+        return self.cpu_state_dict[state_dict_key]
+
+
+class LazyCastingParamPiece(torch.nn.Parameter):
+    def __new__(cls, caster, state_dict_key, tensor):
+        return super().__new__(cls, tensor)
+
+    def __init__(self, caster, state_dict_key, tensor):
+        self.caster = caster
+        self.state_dict_key = state_dict_key
+
+    @property
+    def device(self):
+        return CustomTorchDevice
+
+    def to(self, *args, **kwargs):
+        caster = self.caster
+        del self.caster
+        return caster.state_dict_tensor(self.state_dict_key)
+
+
 class ModelPatcher:
     def __init__(self, model, load_device, offload_device, size=0, weight_inplace_update=False):
         self.size = size
@@ -1463,20 +1494,37 @@ class ModelPatcher:
         self.clear_cached_hook_weights()
 
     def state_dict_for_saving(self, clip_state_dict=None, vae_state_dict=None, clip_vision_state_dict=None):
-        unet_state_dict = self.model.diffusion_model.state_dict()
-        for k, v in unet_state_dict.items():
+        original_state_dict = self.model.diffusion_model.state_dict()
+        unet_state_dict = {}
+        keys = list(original_state_dict)
+        while len(keys) > 0:
+            k = keys.pop(0)
+            v = original_state_dict[k]
             op_keys = k.rsplit('.', 1)
             if (len(op_keys) < 2) or op_keys[1] not in ["weight", "bias"]:
+                unet_state_dict[k] = v
                 continue
             try:
                 op = comfy.utils.get_attr(self.model.diffusion_model, op_keys[0])
             except:
+                unet_state_dict[k] = v
                 continue
             if not op or not hasattr(op, "comfy_cast_weights") or \
                 (hasattr(op, "comfy_patched_weights") and op.comfy_patched_weights == True):
+                unet_state_dict[k] = v
                 continue
             key = "diffusion_model." + k
-            unet_state_dict[k] = LazyCastingParam(self, key, comfy.utils.get_attr(self.model, key))
+            weight = comfy.utils.get_attr(self.model, key)
+            if isinstance(weight, QuantizedTensor) and k in original_state_dict:
+                qt_state_dict = weight.state_dict(k)
+                caster = LazyCastingQuantizedParam(self, key)
+                for group_key in (x for x in qt_state_dict if x in original_state_dict):
+                    if group_key in keys:
+                        keys.remove(group_key)
+                    unet_state_dict.pop(group_key, "")
+                    unet_state_dict[group_key] = LazyCastingParamPiece(caster, "diffusion_model." + group_key, original_state_dict[group_key])
+                continue
+            unet_state_dict[k] = LazyCastingParam(self, key, weight)
         return self.model.state_dict_for_saving(unet_state_dict, clip_state_dict=clip_state_dict, vae_state_dict=vae_state_dict, clip_vision_state_dict=clip_vision_state_dict)
 
     def __del__(self):


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/13650
https://github.com/Comfy-Org/ComfyUI/issues/13637

This was missing proper weight scale casting in the saving path.

Example test conditons:

Load Flux2 fp8-mixed -> lora -> save Model

<img width="1340" height="318" alt="image" src="https://github.com/user-attachments/assets/c8798c98-4a2d-4b4d-b2d5-39b46715f7f4" />

Before:

```
got prompt
Found quantization metadata version 1
Detected mixed precision quantization
Using mixed precision operations
model weight dtype torch.bfloat16, manual cast: torch.bfloat16
model_type FLUX
Requested to load Flux2
Model Flux2 prepared for dynamic VRAM loading. 33813MB Staged. 138 patches attached. Force pre-loaded 128 weights: 39 KB.
/home/rattus/venv/lib/python3.12/site-packages/comfy_kitchen/tensor/base.py:268: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  return self._qdata.storage()
Fatal Python error: Segmentation fault

Stack (most recent call first):
  File "/home/rattus/venv/lib/python3.12/site-packages/safetensors/torch.py", line 545 in _tobytes
  File "/home/rattus/venv/lib/python3.12/site-packages/safetensors/torch.py", line 589 in _flatten
  File "/home/rattus/venv/lib/python3.12/site-packages/safetensors/torch.py", line 352 in save_file
  File "/home/rattus/ComfyUI/comfy/utils.py", line 171 in save_torch_file
  File "/home/rattus/ComfyUI/comfy/sd.py", line 1924 in save_checkpoint
  File "/home/rattus/ComfyUI/comfy_extras/nodes_model_merging.py", line 227 in save_checkpoint
  File "/home/rattus/ComfyUI/comfy_extras/nodes_model_merging.py", line 359 in save
  File "/home/rattus/ComfyUI/execution.py", line 297 in process_inputs
  File "/home/rattus/ComfyUI/execution.py", line 309 in _async_map_node_over_list
  File "/home/rattus/ComfyUI/execution.py", line 335 in get_output_data
  File "/home/rattus/ComfyUI/execution.py", line 535 in execute
  File "/home/rattus/ComfyUI/execution.py", line 772 in execute_async
  File "/usr/lib/python3.12/asyncio/events.py", line 88 in _run
  File "/usr/lib/python3.12/asyncio/base_events.py", line 1987 in _run_once
  File "/usr/lib/python3.12/asyncio/base_events.py", line 641 in run_forever
  File "/usr/lib/python3.12/asyncio/base_events.py", line 674 in run_until_complete
  File "/usr/lib/python3.12/asyncio/runners.py", line 118 in run
  File "/usr/lib/python3.12/asyncio/runners.py", line 194 in run
  File "/home/rattus/ComfyUI/execution.py", line 713 in execute
  File "/home/rattus/ComfyUI/main.py", line 321 in prompt_worker
  File "/usr/lib/python3.12/threading.py", line 1010 in run
  File "/usr/lib/python3.12/threading.py", line 1073 in _bootstrap_inner
  File "/usr/lib/python3.12/threading.py", line 1030 in _bootstrap
```

After:

```
got prompt
Found quantization metadata version 1
Detected mixed precision quantization
Using mixed precision operations
model weight dtype torch.bfloat16, manual cast: torch.bfloat16
model_type FLUX
Requested to load Flux2
Model Flux2 prepared for dynamic VRAM loading. 33813MB Staged. 138 patches attached. Force pre-loaded 128 weights: 39 KB.
Prompt executed in 23.92 seconds
```

Outputs checked :white_check_mark: 

There are very small differences in output compared to unfolded lora. These have been traced to dtype discrepency in the caster and in theory the saver path is actually the one in the right. Independent issue to this one though.