### PR TITLE
Suppress false-positive Spectral lint on WebSocket endpoint

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -89,3 +89,12 @@ rules:
     then:
       field: description
       function: truthy
+
+overrides:
+  # /ws uses HTTP 101 (Switching Protocols) — a legitimate response for a
+  # WebSocket upgrade, but not a 2xx, so operation-success-response fires
+  # as a false positive. OpenAPI 3.x has no native WebSocket support.
+  - files:
+      - "openapi.yaml#/paths/~1ws"
+    rules:
+      operation-success-response: off


### PR DESCRIPTION
The `/ws` path returns `101 Switching Protocols` — the correct HTTP response for a WebSocket upgrade — but the built-in `operation-success-response` rule requires at least one 2xx response per operation. Since OpenAPI 3.x has no native WebSocket support, this fires as a false positive on every lint run.

## Change

Adds a path-scoped `overrides` block to `.spectral.yaml` that disables `operation-success-response` for `/ws` only. All other operations remain covered by the rule.

```yaml
overrides:
  - files:
      - "openapi.yaml#/paths/~1ws"
    rules:
      operation-success-response: off
```

No functional changes — spec, handlers, and tests are untouched.