### PR TITLE
Fix VOID failing with RuntimeError (CORE-205)

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -1164,12 +1164,18 @@ def tiled_scale_multidim(samples, function, tile=(64, 64), overlap=8, upscale_am
 
             o = out
             o_d = out_div
+            ps_view = ps
+            mask_view = mask
             for d in range(dims):
-                o = o.narrow(d + 2, upscaled[d], mask.shape[d + 2])
-                o_d = o_d.narrow(d + 2, upscaled[d], mask.shape[d + 2])
+                l = min(ps_view.shape[d + 2], o.shape[d + 2] - upscaled[d])
+                o = o.narrow(d + 2, upscaled[d], l)
+                o_d = o_d.narrow(d + 2, upscaled[d], l)
+                if l < ps_view.shape[d + 2]:
+                    ps_view = ps_view.narrow(d + 2, 0, l)
+                    mask_view = mask_view.narrow(d + 2, 0, l)
 
-            o.add_(ps * mask)
-            o_d.add_(mask)
+            o.add_(ps_view * mask_view)
+            o_d.add_(mask_view)
 
             if pbar is not None:
                 pbar.update(1)


### PR DESCRIPTION
`start (0) + length (464) exceeds dimension size (461).`

Some very short and long clips were failing within `tiled_scale_multidim` function.

**Root cause**: The output buffer is pre-allocated using `round(get_scale(dim, total_size))`, but when a callable index_formula is used (as the void 3D VAE does to handle non-linear temporal upscaling), the formula applied to an individual tile position + tile size can round up to 1-3 more pixels than what the total allocation computed. You got 464 but the buffer only had 461 slots.

**Fix**: Before narrowing into the output buffer o, clamp l to `o.shape[d+2] - upscaled[d]` — the actual remaining space. If a tile is trimmed, we narrow ps_view and mask_view from position 0 to the same l, so shapes stay consistent. Dropping the last 3 pixels of a tile that overlaps a border is harmless because those pixels are feathered to near-zero by the mask anyway.