### PR TITLE
fix: handle LTX audio VAE dtype/device boundaries with --bf16-vae

### DIFF
--- a/comfy/ldm/lightricks/vae/audio_vae.py
+++ b/comfy/ldm/lightricks/vae/audio_vae.py
@@ -135,6 +135,16 @@ class AudioVAE(torch.nn.Module):
             n_fft=autoencoder_config["n_fft"],
         )
 
+    @staticmethod
+    def _module_device_dtype(module: torch.nn.Module) -> tuple[torch.device, torch.dtype]:
+        for tensor in module.parameters():
+            if tensor.is_floating_point():
+                return tensor.device, tensor.dtype
+        for tensor in module.buffers():
+            if tensor.is_floating_point():
+                return tensor.device, tensor.dtype
+        return torch.device("cpu"), torch.float32
+
     def encode(self, audio, sample_rate=44100) -> torch.Tensor:
         """Encode a waveform dictionary into normalized latent tensors."""
 
@@ -154,6 +164,8 @@ class AudioVAE(torch.nn.Module):
             waveform, waveform_sample_rate, device=waveform.device
         )
 
+        autoencoder_device, autoencoder_dtype = self._module_device_dtype(self.autoencoder)
+        mel_spec = mel_spec.to(device=autoencoder_device, dtype=autoencoder_dtype)
         latents = self.autoencoder.encode(mel_spec)
         posterior = DiagonalGaussianDistribution(latents)
         latent_mode = posterior.mode()
@@ -165,6 +177,8 @@ class AudioVAE(torch.nn.Module):
         """Decode normalized latent tensors into an audio waveform."""
         original_shape = latents.shape
 
+        autoencoder_device, autoencoder_dtype = self._module_device_dtype(self.autoencoder)
+        latents = latents.to(device=autoencoder_device, dtype=autoencoder_dtype)
         latents = self.normalizer.denormalize(latents)
 
         target_shape = self.target_shape_from_latents(original_shape)
@@ -197,6 +211,8 @@ class AudioVAE(torch.nn.Module):
         elif audio_channels != 2:
             raise ValueError(f"Unsupported audio_channels: {audio_channels}")
 
+        vocoder_device, vocoder_dtype = self._module_device_dtype(self.vocoder)
+        vocoder_input = vocoder_input.to(device=vocoder_device, dtype=vocoder_dtype)
         return self.vocoder(vocoder_input)
 
     @property


### PR DESCRIPTION
## Summary

Fixes LTX audio VAE dtype mismatches when the generic VAE wrapper casts the model to BF16, for example when ComfyUI is launched with `--bf16-vae`.

The LTX audio preprocessing path creates a fresh mel spectrogram tensor, which can remain float32 even though the autoencoder has been cast to BF16. That causes encode to fail at the first convolution with:

```text
RuntimeError: Input type (float) and bias type (c10::BFloat16) should be the same
```

This change aligns tensors at the module boundaries by casting:

- generated mel spectrograms to the autoencoder device/dtype before encode
- decode latents to the autoencoder device/dtype before denormalization/decode
- vocoder inputs to the vocoder device/dtype before waveform synthesis

## Root cause

After the LTX audio VAE was routed through `comfy.sd.VAE`, explicit VAE dtype flags such as `--bf16-vae` can cast the composed AudioVAE module. The audio preprocessor still constructs new float tensors internally, so dtype alignment needs to happen inside the AudioVAE wrapper before entering the submodules.

## Validation

- `venv/bin/python -m py_compile comfy/ldm/lightricks/vae/audio_vae.py`