### PR TITLE
Add validation for invalid HiDream input dimensions

### DIFF
--- a/comfy/ldm/hidream_o1/model.py
+++ b/comfy/ldm/hidream_o1/model.py
@@ -148,12 +148,13 @@ class HiDreamO1Transformer(nn.Module):
             raise ValueError("HiDreamO1Transformer requires input_ids and position_ids in conditioning")
 
         B, _, H, W = x.shape
-
-        if H % self.patch_size!=0 or W% self.patch_size!=0:
+        
+        if H % self.patch_size != 0 or W % self.patch_size != 0:
             raise ValueError(
-                f"Input dimensions ({H},{W}) must be divisible"
-                f"by patch size{self.patch_size}"
-            )
+        f"Input dimensions ({H}, {W}) must be divisible "
+        f"by patch size {self.patch_size}"
+    )
+
         h_p, w_p = H // self.patch_size, W // self.patch_size
         tgt_image_len = h_p * w_p
 

--- a/comfy/ldm/hidream_o1/model.py
+++ b/comfy/ldm/hidream_o1/model.py
@@ -148,6 +148,12 @@ class HiDreamO1Transformer(nn.Module):
             raise ValueError("HiDreamO1Transformer requires input_ids and position_ids in conditioning")
 
         B, _, H, W = x.shape
+
+        if H % self.patch_size!=0 or w% self.patch_size!=0:
+            raise ValueError(
+                f"Input dimensions ({H},{W}) must be divisible"
+                f"by patch size{self.patch_size}"
+            )
         h_p, w_p = H // self.patch_size, W // self.patch_size
         tgt_image_len = h_p * w_p
 

--- a/comfy/ldm/hidream_o1/model.py
+++ b/comfy/ldm/hidream_o1/model.py
@@ -149,7 +149,7 @@ class HiDreamO1Transformer(nn.Module):
 
         B, _, H, W = x.shape
 
-        if H % self.patch_size!=0 or w% self.patch_size!=0:
+        if H % self.patch_size!=0 or W% self.patch_size!=0:
             raise ValueError(
                 f"Input dimensions ({H},{W}) must be divisible"
                 f"by patch size{self.patch_size}"


### PR DESCRIPTION
## Problem
HiDream O1 crashes with an unclear EinopsError when image dimensions are not divisible by the patch size.

## Fix
Added explicit validation before the rearrange operation to provide a clearer error message.

## Result
Users now receive a more actionable error instead of a low-level shape mismatch traceback.