### PR TITLE
Add careers link to README and startup log

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,8 @@ Use `--tls-keyfile key.pem --tls-certfile cert.pem` to enable TLS/SSL, the app w
 
 See also: [https://www.comfy.org/](https://www.comfy.org/)
 
+> _psst — we're hiring!_ Help build ComfyUI: [comfy.org/careers](https://www.comfy.org/careers)
+
 ## Frontend Development
 
 As of August 15, 2024, we have transitioned to a new frontend, which is now hosted in a separate repository: [ComfyUI Frontend](https://github.com/Comfy-Org/ComfyUI_frontend). This repository now hosts the compiled JS (from TS/Vue) under the `web/` directory.

--- a/server.py
+++ b/server.py
@@ -1266,6 +1266,9 @@ class PromptServer():
             if verbose:
                 logging.info("To see the GUI go to: {}://{}:{}".format(scheme, address_print, port))
 
+        if verbose:
+            logging.info("psst — we're hiring! https://www.comfy.org/careers")
+
         if call_on_start is not None:
             call_on_start(scheme, self.address, self.port)
 


### PR DESCRIPTION
Adds a small link to comfy.org/careers in the README and a one-line note in the server startup output.

<img width="752" height="172" alt="Screenshot 2026-05-14 at 10 10 06 AM" src="https://github.com/user-attachments/assets/953b91c0-d1f5-49a6-be46-10fc082ead2c" />
