### PR TITLE
Improve error message when checkpoint file is missing

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -604,8 +604,26 @@ class CheckpointLoaderSimple:
     SEARCH_ALIASES = ["load model", "checkpoint", "model loader", "load checkpoint", "ckpt", "model"]
 
     def load_checkpoint(self, ckpt_name):
-        ckpt_path = folder_paths.get_full_path_or_raise("checkpoints", ckpt_name)
-        out = comfy.sd.load_checkpoint_guess_config(ckpt_path, output_vae=True, output_clip=True, embedding_directory=folder_paths.get_folder_paths("embeddings"))
+        try:
+            ckpt_path = folder_paths.get_full_path_or_raise("checkpoints", ckpt_name)
+        except FileNotFoundError:
+            available = folder_paths.get_filename_list("checkpoints")
+            available_models = "\n".join(f"- {name}" for name in available[:10])
+
+            raise FileNotFoundError(
+                f"Checkpoint '{ckpt_name}' was not found.\n\n"
+                f"Expected location:\n"
+                f"ComfyUI/models/checkpoints/\n\n"
+                f"Available checkpoints:\n"
+                f"{available_models if available_models else '(none found)'}"
+            )
+
+        out = comfy.sd.load_checkpoint_guess_config(
+            ckpt_path,
+            output_vae=True,
+            output_clip=True,
+            embedding_directory=folder_paths.get_folder_paths("embeddings")
+        )
         return out[:3]
 
 class DiffusersLoader:


### PR DESCRIPTION
## Summary

Improves the error message shown when a checkpoint file is missing in `CheckpointLoaderSimple`.

## Changes

* Shows the missing checkpoint filename
* Displays the expected directory: `ComfyUI/models/checkpoints/`
* Lists up to 10 available checkpoints

## Motivation

The previous `Value not in list` error did not clearly explain what was wrong or where users should place model files. This change provides actionable guidance and should reduce confusion and duplicate support issues.
