### PR TITLE
fix: replace bare except in is_loopback() and fix DNS resolution logic

### DIFF
--- a/server.py
+++ b/server.py
@@ -119,6 +119,15 @@ def create_cors_middleware(allowed_origin: str):
     return cors_middleware
 
 def is_loopback(host):
+    """Check if a hostname resolves exclusively to loopback addresses.
+
+    Returns True only when:
+    - host is a loopback IP (127.0.0.1, ::1), OR
+    - host is a DNS name that resolves ONLY to loopback IPs (all families)
+
+    Returns False for None, empty strings, non-string input, public IPs,
+    and mixed-resolution hostnames.
+    """
     if host is None:
         return False
     if not isinstance(host, str) or not host:

--- a/server.py
+++ b/server.py
@@ -121,25 +121,28 @@ def create_cors_middleware(allowed_origin: str):
 def is_loopback(host):
     if host is None:
         return False
-    try:
-        if ipaddress.ip_address(host).is_loopback:
-            return True
-        else:
-            return False
-    except:
-        pass
+    if not isinstance(host, str) or not host:
+        return False
 
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        pass  # Not a raw IP — proceed to DNS resolution
+
+    # DNS resolution: ALL resolved addresses must be loopback
     loopback = False
     for family in (socket.AF_INET, socket.AF_INET6):
         try:
             r = socket.getaddrinfo(host, None, family, socket.SOCK_STREAM)
             for family, _, _, _, sockaddr in r:
-                if not ipaddress.ip_address(sockaddr[0]).is_loopback:
-                    return loopback
+                addr = ipaddress.ip_address(sockaddr[0])
+                if not addr.is_loopback:
+                    return False  # Found non-loopback — not exclusively loopback
                 else:
                     loopback = True
-        except socket.gaierror:
-            pass
+        except socket.gaierror as e:
+            logging.debug(f"DNS resolution failed for {host}: {e}")
+            continue
 
     return loopback
 

--- a/server.py
+++ b/server.py
@@ -144,11 +144,15 @@ def is_loopback(host):
         try:
             r = socket.getaddrinfo(host, None, family, socket.SOCK_STREAM)
             for family, _, _, _, sockaddr in r:
-                addr = ipaddress.ip_address(sockaddr[0])
+                try:
+                    addr = ipaddress.ip_address(sockaddr[0])
+                except ValueError:
+                    # Malformed address (e.g. IPv6 scope id) — fail-closed
+                    logging.debug(f"Unparseable address {sockaddr[0]!r} for {host}")
+                    return False
                 if not addr.is_loopback:
                     return False  # Found non-loopback — not exclusively loopback
-                else:
-                    loopback = True
+                loopback = True
         except socket.gaierror as e:
             logging.debug(f"DNS resolution failed for {host}: {e}")
             continue


### PR DESCRIPTION
## Summary

Fix three issues in is_loopback() (server.py:121-144).

## Issues

1. Bare 'except:' catches all exceptions silently
2. DNS resolution returns False on first non-loopback instead of requiring ALL loopback
3. No validation for None/empty/non-string input

## Fix

13 lines changed: replace bare except with except ValueError, enforce all-loopback DNS, add type validation, log DNS failures.

## Tests

Included in tests-unit/server_test/origin_csrf_test.py.