### PR TITLE
Add node SaveAudioWAV with bit_depth

### DIFF
--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -242,6 +242,75 @@ class SaveAudioOpus(IO.ComfyNode):
 
     save_opus = execute  # TODO: remove
 
+class SaveAudioWAV(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="SaveAudioWAV",
+            search_aliases=["export wav", "export wave"],
+            display_name="Save Audio (WAV)",
+            category="audio",
+            essentials_category="Audio",
+            inputs=[
+                IO.Audio.Input("audio"),
+                IO.String.Input("filename_prefix", default="audio/ComfyUI"),
+                IO.Combo.Input(
+                    "bit_depth",
+                    options=["pcm_16", "pcm_24", "pcm_32", "pcm_f32"],
+                    default="pcm_16",
+                    tooltip="Bit depth: pcm_16 = CD quality, pcm_24 = studio, pcm_32 = mastering, pcm_f32 = float 32-bit.",
+                ),
+            ],
+            hidden=[IO.Hidden.prompt, IO.Hidden.extra_pnginfo],
+            is_output_node=True,
+        )
+
+    @classmethod
+    def execute(cls, audio, filename_prefix="ComfyUI", bit_depth="pcm_16") -> IO.NodeOutput:
+        if audio is None:
+            raise ValueError("SaveAudioWAV: input audio is None.")
+
+        waveform = audio["waveform"].squeeze(0)  # [channels, samples]
+        sample_rate = audio["sample_rate"]
+
+        codec_map = {
+            "pcm_16":  ("pcm_s16le", "s16p"),
+            "pcm_24":  ("pcm_s24le", "s32p"),
+            "pcm_32":  ("pcm_s32le", "s32p"),
+            "pcm_f32": ("pcm_f32le", "fltp"),
+        }
+
+        codec_name, av_format = codec_map[bit_depth]
+
+        full_output_folder, filename, counter, subfolder, _ = \
+            folder_paths.get_save_image_path(filename_prefix, folder_paths.get_output_directory())
+
+        file = f"{filename}_{counter:05}_.wav"
+        filepath = os.path.join(full_output_folder, file)
+
+        with av.open(filepath, "w", format="wav") as container:
+            n_channels = waveform.shape[0]
+            stream = container.add_stream(codec_name, rate=sample_rate, layout="stereo" if n_channels == 2 else "mono")
+
+            # convert tensor → numpy right format
+            if av_format == "s16p":
+                data = (waveform * 32767).clamp(-32768, 32767).to(torch.int16).numpy()
+            elif av_format == "s32p":
+                data = (waveform * 2147483647).clamp(-2147483648, 2147483647).to(torch.int32).numpy()
+            else:  # fltp
+                data = waveform.numpy()
+
+            frame = av.AudioFrame.from_ndarray(data, format=av_format, layout="stereo" if n_channels == 2 else "mono")
+
+            frame.sample_rate = sample_rate
+            for packet in stream.encode(frame):
+                container.mux(packet)
+            for packet in stream.encode(None):  # flush
+                container.mux(packet)
+
+        return IO.NodeOutput(ui={"audio": [{"filename": file, "subfolder": subfolder, "type": "output"}]})
+
+    save_wav = execute  # TODO: remove
 
 class PreviewAudio(IO.ComfyNode):
     @classmethod
@@ -823,6 +892,7 @@ class AudioExtension(ComfyExtension):
             SaveAudio,
             SaveAudioMP3,
             SaveAudioOpus,
+            SaveAudioWAV,
             LoadAudio,
             PreviewAudio,
             ConditioningStableAudio,


### PR DESCRIPTION
## Add WAV export node (`SaveAudioWAV`) with selectable bit depth

### Summary

Adds a new `SaveAudioWAV` node to `comfy_extras/nodes_audio.py` that exports audio in uncompressed PCM WAV format with four selectable bit depths: `pcm_16`, `pcm_24`, `pcm_32`, and `pcm_f32`.

---

### Motivation

ComfyUI currently offers FLAC, MP3, and Opus export nodes, but no WAV export. WAV (uncompressed PCM) is a standard requirement for audio post-production workflows, DAW integration, and any pipeline that cannot accept lossy or lossless-compressed formats.

---

### Implementation approach and rejected alternatives

**Attempt 1 — Reusing `AudioSaveHelper` with `format="wav"`**
The first approach followed the same pattern as `SaveAudioMP3` and `SaveAudioOpus`, passing `format="wav"` to `UI.AudioSaveHelper.get_save_audio_ui()`. This failed silently: the helper ignored the format parameter and always encoded to FLAC regardless of the extension. ffprobe confirmed the output files were FLAC-encoded despite the `.wav` extension. The `quality`/bit depth parameter was also ignored, all four variants producing identical file sizes.

**Attempt 2 — `torchaudio.save()`**
The second approach used `torchaudio.save()` directly with explicit `format="wav"`, `encoding`, and `bits_per_sample` parameters. This failed at runtime because the installed torchaudio version delegates to `torchcodec`, which is not bundled with ComfyUI's portable Python environment (`ModuleNotFoundError: No module named 'torchcodec'`).

**Final approach — PyAV (direct)**
PyAV is already a hard dependency of ComfyUI (used in the `load()` function of the same file), so it is always available. The node writes WAV files directly via `av.open()` using the appropriate PCM codec (`pcm_s16le`, `pcm_s24le`, `pcm_s32le`, `pcm_f32le`) and planar sample formats (`s16p`, `s32p`, `fltp`) required by `av.AudioFrame.from_ndarray()` for multi-channel audio.

Two additional PyAV-specific constraints were resolved during development:
- `stream.channels` is read-only; channel count must be passed via the `layout` parameter at stream creation (`"stereo"` / `"mono"`).
- `av.AudioFrame.from_ndarray()` requires planar formats (e.g. `s16p`) for multi-channel audio, not packed formats (`s16`), matching the `[channels, samples]` shape of the waveform tensor after `squeeze(0)`.

---

### Validation

All four bit depth variants were verified with ffprobe on a stereo 44100 Hz source:

```
Audio: pcm_s16le ([1][0][0][0] / 0x0001), 44100 Hz, 2 channels, s16,       1411 kb/s
Audio: pcm_s24le ([1][0][0][0] / 0x0001), 44100 Hz, stereo, s32 (24 bit),  2116 kb/s
Audio: pcm_s32le ([1][0][0][0] / 0x0001), 44100 Hz, stereo, s32,           2822 kb/s
Audio: pcm_f32le ([3][0][0][0] / 0x0003), 44100 Hz, 2 channels, flt,       2822 kb/s
```

File sizes scale as expected (16-bit < 24-bit < 32-bit = f32), and all files are valid uncompressed PCM WAV.

---

### Changes

- `comfy_extras/nodes_audio.py`: added `SaveAudioWAV` class and registered it in `AudioExtension.get_node_list()`.
- No new dependencies introduced.

Close #7737 