### PR TITLE
Fix Claude Opus 4.7 temperature request parameter

### DIFF
--- a/comfy_api_nodes/apis/anthropic.py
+++ b/comfy_api_nodes/apis/anthropic.py
@@ -46,6 +46,13 @@ class AnthropicMessagesRequest(BaseModel):
     stop_sequences: list[str] | None = Field(None)
 
 
+ANTHROPIC_MODELS_WITHOUT_TEMPERATURE = {"claude-opus-4-7"}
+
+
+def get_supported_temperature(model: str, temperature: float) -> float | None:
+    return None if model in ANTHROPIC_MODELS_WITHOUT_TEMPERATURE else temperature
+
+
 class AnthropicResponseTextBlock(BaseModel):
     type: Literal["text"] = "text"
     text: str = Field(...)

--- a/comfy_api_nodes/nodes_anthropic.py
+++ b/comfy_api_nodes/nodes_anthropic.py
@@ -11,6 +11,7 @@ from comfy_api_nodes.apis.anthropic import (
     AnthropicMessagesResponse,
     AnthropicRole,
     AnthropicTextContent,
+    get_supported_temperature,
 )
 from comfy_api_nodes.util import (
     ApiEndpoint,
@@ -207,8 +208,9 @@ class ClaudeNode(IO.ComfyNode):
     ) -> IO.NodeOutput:
         validate_string(prompt, strip_whitespace=True, min_length=1)
         model_label = model["model"]
+        model_id = CLAUDE_MODELS[model_label]
         max_tokens = model["max_tokens"]
-        temperature = model["temperature"]
+        temperature = get_supported_temperature(model_id, model["temperature"])
 
         image_tensors: list[Input.Image] = [t for t in (images or {}).values() if t is not None]
         if sum(get_number_of_images(t) for t in image_tensors) > CLAUDE_MAX_IMAGES:
@@ -224,7 +226,7 @@ class ClaudeNode(IO.ComfyNode):
             ApiEndpoint(path=ANTHROPIC_MESSAGES_ENDPOINT, method="POST"),
             response_model=AnthropicMessagesResponse,
             data=AnthropicMessagesRequest(
-                model=CLAUDE_MODELS[model_label],
+                model=model_id,
                 max_tokens=max_tokens,
                 messages=[AnthropicMessage(role=AnthropicRole.user, content=content)],
                 system=system_prompt or None,

--- a/tests-unit/comfy_api_nodes_test/test_nodes_anthropic.py
+++ b/tests-unit/comfy_api_nodes_test/test_nodes_anthropic.py
@@ -1,0 +1,33 @@
+from comfy_api_nodes.apis.anthropic import (
+    AnthropicMessage,
+    AnthropicMessagesRequest,
+    AnthropicRole,
+    AnthropicTextContent,
+    get_supported_temperature,
+)
+
+
+def test_claude_opus_47_omits_temperature():
+    request = AnthropicMessagesRequest(
+        model="claude-opus-4-7",
+        max_tokens=128,
+        messages=[AnthropicMessage(role=AnthropicRole.user, content=[AnthropicTextContent(text="Hello")])],
+        temperature=get_supported_temperature("claude-opus-4-7", 0.25),
+    )
+
+    assert request.model == "claude-opus-4-7"
+    assert request.temperature is None
+    assert "temperature" not in request.model_dump(exclude_none=True)
+
+
+def test_claude_models_that_support_sampling_keep_temperature():
+    request = AnthropicMessagesRequest(
+        model="claude-sonnet-4-6",
+        max_tokens=128,
+        messages=[AnthropicMessage(role=AnthropicRole.user, content=[AnthropicTextContent(text="Hello")])],
+        temperature=get_supported_temperature("claude-sonnet-4-6", 0.25),
+    )
+
+    assert request.model == "claude-sonnet-4-6"
+    assert request.temperature == 0.25
+    assert request.model_dump(exclude_none=True)["temperature"] == 0.25


### PR DESCRIPTION
## Summary
- omit the Anthropic `temperature` field for `claude-opus-4-7` requests
- keep existing temperature behavior for other Claude models
- add unit coverage for request serialization with and without temperature

This is intentionally a request serialization fix only. The UI still shows the temperature control, but its value is ignored for Opus 4.7 so the outgoing request does not include the deprecated field.

Fixes #13923

## Tests
- `python3 -m pytest tests-unit/comfy_api_nodes_test/test_nodes_anthropic.py`
- `python3 -m py_compile comfy_api_nodes/apis/anthropic.py comfy_api_nodes/nodes_anthropic.py`

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto-billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**
