### PR TITLE
Guard LogInterceptor flush against OSError

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -66,7 +66,10 @@ class LogInterceptor(io.TextIOWrapper):
         super().write(data)
 
     def flush(self):
-        super().flush()
+        try:
+            super().flush()
+        except OSError:
+            pass
         for cb in self._flush_callbacks:
             cb(self._logs_since_flush)
             self._logs_since_flush = []

--- a/tests-unit/app_test/logger_test.py
+++ b/tests-unit/app_test/logger_test.py
@@ -1,0 +1,26 @@
+import io
+
+from app.logger import LogInterceptor
+
+
+class FlushErrorBuffer(io.BytesIO):
+    def flush(self):
+        raise OSError(22, "Invalid argument")
+
+
+class FlushErrorStream:
+    buffer = FlushErrorBuffer()
+    encoding = "utf-8"
+    line_buffering = False
+
+
+def test_log_interceptor_flush_ignores_oserror_and_runs_callbacks():
+    interceptor = LogInterceptor(FlushErrorStream())
+    interceptor._logs_since_flush = [{"m": "message"}]
+    flushed_logs = []
+
+    interceptor.on_flush(lambda logs: flushed_logs.append(list(logs)))
+    interceptor.flush()
+
+    assert flushed_logs == [[{"m": "message"}]]
+    assert interceptor._logs_since_flush == []


### PR DESCRIPTION
## Summary
- ignore `OSError` raised by the wrapped stdout/stderr stream during `LogInterceptor.flush()`
- still run flush callbacks after the underlying flush fails
- add a focused unit test for the invalid-argument flush path

This only suppresses errors from the underlying stream flush. Callback exceptions still propagate as before.

Fixes #13906

## Tests
- `python3 -m pytest tests-unit/app_test/logger_test.py`
- `python3 -m py_compile app/logger.py`