### PR TITLE
[Partner Nodes] fix Opus 4.7 sending deprecated temperature parameter

### DIFF
--- a/comfy_api_nodes/nodes_anthropic.py
+++ b/comfy_api_nodes/nodes_anthropic.py
@@ -49,7 +49,7 @@ def _claude_model_inputs():
             min=0.0,
             max=1.0,
             step=0.01,
-            tooltip="Controls randomness. 0.0 is deterministic, 1.0 is most random.",
+            tooltip="Controls randomness. 0.0 is deterministic, 1.0 is most random. Ignored for Opus 4.7.",
             advanced=True,
         ),
     ]
@@ -208,7 +208,7 @@ class ClaudeNode(IO.ComfyNode):
         validate_string(prompt, strip_whitespace=True, min_length=1)
         model_label = model["model"]
         max_tokens = model["max_tokens"]
-        temperature = model["temperature"]
+        temperature = None if model_label == "Opus 4.7" else model["temperature"]
 
         image_tensors: list[Input.Image] = [t for t in (images or {}).values() if t is not None]
         if sum(get_number_of_images(t) for t in image_tensors) > CLAUDE_MAX_IMAGES:


### PR DESCRIPTION
1. Thanks to @qwqgong-ui for the thorough bug report in #13923 - the traceback, root-cause analysis, link to Anthropic's "sampling parameters removed" docs, and the suggested one-liner made this trivial to fix.
2. Thanks to @YUHAO-corn for #13930, which proposed a similar fix with a dedicated helper and unit tests. We went with a minimal inline check here to keep the diff to a single line, but the analysis and direction were the same.

Closes #13923
Supersedes #13930

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [x] Informed **Kosinkadink**

