### PR TITLE
docs: mention Python bz2 and lzma requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Python 3.14 works but some custom nodes may have issues. The free threaded varia
 
 Python 3.13 is very well supported. If you have trouble with some custom node dependencies on 3.13 you can try 3.12
 
+Linux users who install Python through a version manager or build it from source should make sure the Python interpreter includes the `_bz2` and `_lzma` standard library modules. Install the system development packages before building or reinstalling Python, for example `sudo apt install libbz2-dev liblzma-dev` on Debian/Ubuntu, or `sudo dnf install bzip2-devel xz-devel` on Fedora/RHEL.
+
 torch 2.4 and above is supported but some features and optimizations might only work on newer versions. We generally recommend using the latest major version of pytorch with the latest cuda version unless it is less than 2 weeks old.
 
 ### Instructions:


### PR DESCRIPTION
## Summary
- document that Linux source/version-manager Python installs need _bz2 and _lzma support
- mention common Debian/Ubuntu and Fedora/RHEL development packages to install before rebuilding Python

Fixes #3219

## Tests
- git diff --check