### PR TITLE
fix: centralize upload and view path validation

### DIFF
--- a/comfy/path_validation.py
+++ b/comfy/path_validation.py
@@ -1,22 +1,23 @@
 from pathlib import Path, PureWindowsPath
 
 
-def resolve_safe_path(base_dir: str | Path, user_path: str | Path) -> Path | None:
-    """Return the resolved path if user_path stays inside base_dir."""
-    raw_path = str(user_path)
-    if "\0" in raw_path:
-        return None
+def resolve_safe_path(base_dir: str | Path, *user_paths: str | Path) -> Path | None:
+    """Return the resolved path if user path segments stay inside base_dir."""
+    raw_paths = [str(user_path) for user_path in user_paths]
+    for raw_path in raw_paths:
+        if "\0" in raw_path:
+            return None
 
-    if ".." in Path(raw_path).parts or ".." in PureWindowsPath(raw_path).parts:
-        return None
+        if ".." in Path(raw_path).parts or ".." in PureWindowsPath(raw_path).parts:
+            return None
 
-    windows_path = PureWindowsPath(raw_path)
-    if windows_path.is_absolute() or windows_path.drive:
-        return None
+        windows_path = PureWindowsPath(raw_path)
+        if Path(raw_path).is_absolute() or windows_path.is_absolute() or windows_path.drive:
+            return None
 
     try:
         base = Path(base_dir).resolve(strict=False)
-        candidate = (base / raw_path).resolve(strict=False)
+        candidate = base.joinpath(*raw_paths).resolve(strict=False)
     except (OSError, RuntimeError, ValueError):
         return None
 

--- a/comfy/path_validation.py
+++ b/comfy/path_validation.py
@@ -1,0 +1,26 @@
+from pathlib import Path, PureWindowsPath
+
+
+def resolve_safe_path(base_dir: str | Path, user_path: str | Path) -> Path | None:
+    """Return the resolved path if user_path stays inside base_dir."""
+    raw_path = str(user_path)
+    if "\0" in raw_path:
+        return None
+
+    if ".." in Path(raw_path).parts or ".." in PureWindowsPath(raw_path).parts:
+        return None
+
+    windows_path = PureWindowsPath(raw_path)
+    if windows_path.is_absolute() or windows_path.drive:
+        return None
+
+    try:
+        base = Path(base_dir).resolve(strict=False)
+        candidate = (base / raw_path).resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+    if not candidate.is_relative_to(base):
+        return None
+
+    return candidate

--- a/server.py
+++ b/server.py
@@ -28,6 +28,7 @@ import logging
 import mimetypes
 from comfy.cli_args import args
 import comfy.utils
+from comfy.path_validation import resolve_safe_path
 import comfy.model_management
 from comfy_api import feature_flags
 import node_helpers
@@ -396,14 +397,18 @@ class PromptServer():
                     return web.Response(status=400)
 
                 subfolder = post.get("subfolder", "")
-                full_output_folder = os.path.join(upload_dir, os.path.normpath(subfolder))
-                filepath = os.path.abspath(os.path.join(full_output_folder, filename))
-
-                if os.path.commonpath((upload_dir, filepath)) != upload_dir:
+                full_output_folder = resolve_safe_path(upload_dir, subfolder)
+                filepath = (
+                    resolve_safe_path(full_output_folder, filename)
+                    if full_output_folder is not None
+                    else None
+                )
+                if filepath is None:
                     return web.Response(status=400)
+                full_output_folder = str(full_output_folder)
+                filepath = str(filepath)
 
-                if not os.path.exists(full_output_folder):
-                    os.makedirs(full_output_folder)
+                os.makedirs(full_output_folder, exist_ok=True)
 
                 split = os.path.splitext(filename)
 
@@ -464,10 +469,6 @@ class PromptServer():
                 if not filename:
                     return web.Response(status=400)
 
-                # validation for security: prevent accessing arbitrary path
-                if filename[0] == '/' or '..' in filename:
-                    return web.Response(status=400)
-
                 if output_dir is None:
                     type = original_ref.get("type", "output")
                     output_dir = folder_paths.get_directory_by_type(type)
@@ -475,13 +476,10 @@ class PromptServer():
                 if output_dir is None:
                     return web.Response(status=400)
 
-                if original_ref.get("subfolder", "") != "":
-                    full_output_dir = os.path.join(output_dir, original_ref["subfolder"])
-                    if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
-                        return web.Response(status=403)
-                    output_dir = full_output_dir
-
-                file = os.path.join(output_dir, filename)
+                file = resolve_safe_path(output_dir, os.path.join(original_ref.get("subfolder", ""), filename))
+                if file is None:
+                    return web.Response(status=400)
+                file = str(file)
 
                 if os.path.isfile(file):
                     with Image.open(file) as original_pil:
@@ -521,10 +519,6 @@ class PromptServer():
                     if not filename:
                         return web.Response(status=400)
 
-                    # validation for security: prevent accessing arbitrary path
-                    if filename[0] == '/' or '..' in filename:
-                        return web.Response(status=400)
-
                     if output_dir is None:
                         type = request.rel_url.query.get("type", "output")
                         output_dir = folder_paths.get_directory_by_type(type)
@@ -532,14 +526,10 @@ class PromptServer():
                     if output_dir is None:
                         return web.Response(status=400)
 
-                    if "subfolder" in request.rel_url.query:
-                        full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
-                        if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
-                            return web.Response(status=403)
-                        output_dir = full_output_dir
-
-                    filename = os.path.basename(filename)
-                    file = os.path.join(output_dir, filename)
+                    file = resolve_safe_path(output_dir, os.path.join(request.rel_url.query.get("subfolder", ""), filename))
+                    if file is None:
+                        return web.Response(status=400)
+                    file = str(file)
 
                 if os.path.isfile(file):
                     if 'preview' in request.rel_url.query:

--- a/server.py
+++ b/server.py
@@ -476,7 +476,7 @@ class PromptServer():
                 if output_dir is None:
                     return web.Response(status=400)
 
-                file = resolve_safe_path(output_dir, os.path.join(original_ref.get("subfolder", ""), filename))
+                file = resolve_safe_path(output_dir, original_ref.get("subfolder", ""), filename)
                 if file is None:
                     return web.Response(status=400)
                 file = str(file)
@@ -526,7 +526,7 @@ class PromptServer():
                     if output_dir is None:
                         return web.Response(status=400)
 
-                    file = resolve_safe_path(output_dir, os.path.join(request.rel_url.query.get("subfolder", ""), filename))
+                    file = resolve_safe_path(output_dir, request.rel_url.query.get("subfolder", ""), filename)
                     if file is None:
                         return web.Response(status=400)
                     file = str(file)

--- a/tests-unit/server_test/test_path_validation.py
+++ b/tests-unit/server_test/test_path_validation.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from comfy.path_validation import resolve_safe_path
+
+
+def test_resolve_safe_path_allows_nested_relative_path(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+
+    resolved = resolve_safe_path(base, "subdir/image.png")
+
+    assert resolved == base / "subdir" / "image.png"
+
+
+def test_resolve_safe_path_rejects_parent_traversal(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+
+    assert resolve_safe_path(base, "../escape.png") is None
+
+
+def test_resolve_safe_path_rejects_windows_separator_parent_traversal(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+
+    assert resolve_safe_path(base, r"..\escape.png") is None
+
+
+def test_resolve_safe_path_rejects_posix_absolute_path(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+
+    assert resolve_safe_path(base, "/tmp/escape.png") is None
+
+
+def test_resolve_safe_path_rejects_windows_drive_path(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+
+    assert resolve_safe_path(base, r"C:\Users\public\escape.png") is None
+
+
+def test_resolve_safe_path_rejects_windows_unc_path(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+
+    assert resolve_safe_path(base, r"\\server\share\escape.png") is None
+
+
+def test_resolve_safe_path_rejects_null_bytes(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+
+    assert resolve_safe_path(base, "image.png\0.txt") is None
+
+
+def test_resolve_safe_path_rejects_symlink_escape(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    outside = tmp_path / "outside"
+    base.mkdir()
+    outside.mkdir()
+    (outside / "secret.png").write_text("secret")
+    (base / "linked").symlink_to(outside, target_is_directory=True)
+
+    assert resolve_safe_path(base, "linked/secret.png") is None

--- a/tests-unit/server_test/test_path_validation.py
+++ b/tests-unit/server_test/test_path_validation.py
@@ -3,6 +3,17 @@ from pathlib import Path
 from comfy.path_validation import resolve_safe_path
 
 
+def resolve_upload_image_path(upload_dir: Path, subfolder: str, filename: str) -> Path | None:
+    upload_folder = resolve_safe_path(upload_dir, subfolder)
+    if upload_folder is None:
+        return None
+    return resolve_safe_path(upload_folder, filename)
+
+
+def resolve_view_path(output_dir: Path, subfolder: str, filename: str) -> Path | None:
+    return resolve_safe_path(output_dir, subfolder, filename)
+
+
 def test_resolve_safe_path_allows_nested_relative_path(tmp_path: Path) -> None:
     base = tmp_path / "base"
     base.mkdir()
@@ -63,3 +74,42 @@ def test_resolve_safe_path_rejects_symlink_escape(tmp_path: Path) -> None:
     (base / "linked").symlink_to(outside, target_is_directory=True)
 
     assert resolve_safe_path(base, "linked/secret.png") is None
+
+
+def test_upload_image_path_allows_safe_subfolder_and_filename_with_dots(tmp_path: Path) -> None:
+    upload_dir = tmp_path / "input"
+    upload_dir.mkdir()
+
+    resolved = resolve_upload_image_path(upload_dir, "safe/subfolder", "foo..bar.png")
+
+    assert resolved == upload_dir / "safe" / "subfolder" / "foo..bar.png"
+
+
+def test_upload_image_path_rejects_bad_subfolder_or_filename(tmp_path: Path) -> None:
+    upload_dir = tmp_path / "input"
+    upload_dir.mkdir()
+
+    assert resolve_upload_image_path(upload_dir, "../escape", "image.png") is None
+    assert resolve_upload_image_path(upload_dir, "safe", "../escape.png") is None
+    assert resolve_upload_image_path(upload_dir, "safe", r"\\server\share\escape.png") is None
+    assert resolve_upload_image_path(upload_dir, "safe", "image.png\0.txt") is None
+
+
+def test_view_path_allows_annotated_base_dir_with_subfolder(tmp_path: Path) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    resolved = resolve_view_path(output_dir, "renders", "image.png")
+
+    assert resolved == output_dir / "renders" / "image.png"
+
+
+def test_view_path_rejects_traversal_absolute_unc_and_null_byte(tmp_path: Path) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    assert resolve_view_path(output_dir, "../escape", "image.png") is None
+    assert resolve_view_path(output_dir, "safe", "/tmp/escape.png") is None
+    assert resolve_view_path(output_dir, "safe", r"C:\Users\public\escape.png") is None
+    assert resolve_view_path(output_dir, "safe", r"\\server\share\escape.png") is None
+    assert resolve_view_path(output_dir, "safe", "image.png\0.txt") is None


### PR DESCRIPTION
## Summary
- add a reusable path validation helper for upload/view path containment
- apply it to image upload, mask upload original references, and /view file resolution
- add regression coverage for parent traversal, absolute paths, Windows drive/UNC paths, null bytes, and symlink escapes

Fixes #13742

## Tests
- python3 -m pytest tests-unit/server_test/test_path_validation.py
- python3 -m py_compile comfy/path_validation.py server.py tests-unit/server_test/test_path_validation.py
- git diff --check