### PR TITLE
feat: Add optional attention_mask input to LTXVAddGuide (CORE-220)

### DIFF
--- a/comfy_extras/nodes_lt.py
+++ b/comfy_extras/nodes_lt.py
@@ -175,18 +175,6 @@ class LTXVImgToVideoInplace(io.ComfyNode):
     generate = execute  # TODO: remove
 
 
-def _reshape_attention_mask(mask):
-    """Reshape a ComfyUI MASK to (1, 1, F, H, W) for per-guide attention weighting.
-    """
-    if mask is None:
-        return None
-    if mask.dim() == 2:  # (H, W) -> single frame
-        return mask.unsqueeze(0).unsqueeze(0).unsqueeze(0)
-    if mask.dim() == 3:  # (F, H, W) -> video mask
-        return mask.unsqueeze(0).unsqueeze(0)
-    return mask
-
-
 def _append_guide_attention_entry(positive, negative, pre_filter_count, latent_shape, strength=1.0, attention_mask=None):
     """Append a guide_attention_entry to both positive and negative conditioning.
 
@@ -196,9 +184,10 @@ def _append_guide_attention_entry(positive, negative, pre_filter_count, latent_s
     new_entry = {
         "pre_filter_count": pre_filter_count,
         "strength": strength,
-        "pixel_mask": _reshape_attention_mask(attention_mask),
+        "pixel_mask": attention_mask.unsqueeze(0).unsqueeze(0) if attention_mask is not None else None,  # reshape to (1, 1, F, H, W)
         "latent_shape": latent_shape,
     }
+    
     results = []
     for cond in (positive, negative):
         # Read existing entries from this specific conditioning

--- a/comfy_extras/nodes_lt.py
+++ b/comfy_extras/nodes_lt.py
@@ -175,7 +175,19 @@ class LTXVImgToVideoInplace(io.ComfyNode):
     generate = execute  # TODO: remove
 
 
-def _append_guide_attention_entry(positive, negative, pre_filter_count, latent_shape, strength=1.0):
+def _reshape_attention_mask(mask):
+    """Reshape a ComfyUI MASK to (1, 1, F, H, W) for per-guide attention weighting.
+    """
+    if mask is None:
+        return None
+    if mask.dim() == 2:  # (H, W) -> single frame
+        return mask.unsqueeze(0).unsqueeze(0).unsqueeze(0)
+    if mask.dim() == 3:  # (F, H, W) -> video mask
+        return mask.unsqueeze(0).unsqueeze(0)
+    return mask
+
+
+def _append_guide_attention_entry(positive, negative, pre_filter_count, latent_shape, strength=1.0, attention_mask=None):
     """Append a guide_attention_entry to both positive and negative conditioning.
 
     Each entry tracks one guide reference for per-reference attention control.
@@ -184,7 +196,7 @@ def _append_guide_attention_entry(positive, negative, pre_filter_count, latent_s
     new_entry = {
         "pre_filter_count": pre_filter_count,
         "strength": strength,
-        "pixel_mask": None,
+        "pixel_mask": _reshape_attention_mask(attention_mask),
         "latent_shape": latent_shape,
     }
     results = []
@@ -196,8 +208,7 @@ def _append_guide_attention_entry(positive, negative, pre_filter_count, latent_s
             if found is not None:
                 existing = found
                 break
-        # Shallow copy and append (no deepcopy needed — entries contain
-        # only scalars and None for pixel_mask at this call site).
+        # Shallow copy only and append (pixel_mask is never mutated).
         entries = [*existing, new_entry]
         results.append(node_helpers.conditioning_set_values(
             cond, {"guide_attention_entries": entries}
@@ -270,6 +281,12 @@ class LTXVAddGuide(io.ComfyNode):
                             "Used for adjusting guide processing as required by certain IC-LoRAs "
                             "(eg. those with a reference_downscale_factor > 1). "
                             "When chained, each LTXVAddGuide uses only the parameters connected to it.",
+                ),
+                io.Mask.Input(
+                    "attention_mask",
+                    optional=True,
+                    tooltip="Optional pixel-space spatial mask. Controls per-region "
+                            "conditioning influence via self-attention, multiplied by strength.",
                 ),
             ],
             outputs=[
@@ -410,7 +427,7 @@ class LTXVAddGuide(io.ComfyNode):
         return latent_image, noise_mask
 
     @classmethod
-    def execute(cls, positive, negative, vae, latent, image, frame_idx, strength, iclora_parameters=None) -> io.NodeOutput:
+    def execute(cls, positive, negative, vae, latent, image, frame_idx, strength, iclora_parameters=None, attention_mask=None) -> io.NodeOutput:
         scale_factors = vae.downscale_index_formula
         latent_image = latent["samples"]
         noise_mask = get_noise_mask(latent)
@@ -469,6 +486,7 @@ class LTXVAddGuide(io.ComfyNode):
         pre_filter_count = t.shape[2] * t.shape[3] * t.shape[4]
         positive, negative = _append_guide_attention_entry(
             positive, negative, pre_filter_count, guide_latent_shape, strength=strength,
+            attention_mask=attention_mask,
         )
 
         return io.NodeOutput(positive, negative, {"samples": latent_image, "noise_mask": noise_mask})

--- a/comfy_extras/nodes_lt.py
+++ b/comfy_extras/nodes_lt.py
@@ -274,6 +274,12 @@ class LTXVAddGuide(io.ComfyNode):
                             "down to the nearest multiple of 8. Negative values are counted from the end of the video.",
                 ),
                 io.Float.Input("strength", default=1.0, min=0.0, max=10.0, step=0.01),
+                io.Mask.Input(
+                    "attention_mask",
+                    optional=True,
+                    tooltip="Optional pixel-space spatial mask. Controls per-region "
+                            "conditioning influence via self-attention, multiplied by strength.",
+                ),
                 ICLoRAParameters.Input(
                     "iclora_parameters",
                     optional=True,
@@ -281,12 +287,6 @@ class LTXVAddGuide(io.ComfyNode):
                             "Used for adjusting guide processing as required by certain IC-LoRAs "
                             "(eg. those with a reference_downscale_factor > 1). "
                             "When chained, each LTXVAddGuide uses only the parameters connected to it.",
-                ),
-                io.Mask.Input(
-                    "attention_mask",
-                    optional=True,
-                    tooltip="Optional pixel-space spatial mask. Controls per-region "
-                            "conditioning influence via self-attention, multiplied by strength.",
                 ),
             ],
             outputs=[
@@ -427,7 +427,7 @@ class LTXVAddGuide(io.ComfyNode):
         return latent_image, noise_mask
 
     @classmethod
-    def execute(cls, positive, negative, vae, latent, image, frame_idx, strength, iclora_parameters=None, attention_mask=None) -> io.NodeOutput:
+    def execute(cls, positive, negative, vae, latent, image, frame_idx, strength, attention_mask=None, iclora_parameters=None) -> io.NodeOutput:
         scale_factors = vae.downscale_index_formula
         latent_image = latent["samples"]
         noise_mask = get_noise_mask(latent)

--- a/comfy_extras/nodes_lt.py
+++ b/comfy_extras/nodes_lt.py
@@ -187,7 +187,7 @@ def _append_guide_attention_entry(positive, negative, pre_filter_count, latent_s
         "pixel_mask": attention_mask.unsqueeze(0).unsqueeze(0) if attention_mask is not None else None,  # reshape to (1, 1, F, H, W)
         "latent_shape": latent_shape,
     }
-    
+
     results = []
     for cond in (positive, negative):
         # Read existing entries from this specific conditioning


### PR DESCRIPTION
`LTXVAddGuide` gets an optional `attention_mask` input, matching the `attention_mask` input on Lightricks's `LTXAddVideoICLoRAGuideAdvanced` custom node from ComfyUI-LTXVideo. It is a pixel-space mask that controls per-region conditioning influence, multiplied by the node's existing `strength`. With nothing connected, behavior is unchanged.

<img width="552" height="281" alt="image" src="https://github.com/user-attachments/assets/a0439390-e1d3-45e3-a10e-4cf6688f8931" />

The LTXV model code already reads each guide's `pixel_mask` and applies it when weighting that guide's self-attention.

### Workflow for testing:
This example shows using a temporally fading attention mask to allow smoother transitions for first and last frame inputs when combined with IC-lora control.
(Uses ComfyUI-KJNodes for Fade Mask)

[droz_LTX23_attention_mask_example_v1.json](https://github.com/user-attachments/files/27968468/droz_LTX23_attention_mask_example_v1.json)

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/edf3d4a0-6f9c-4d2e-80b5-50569fb6f601" />


### Expected output:

https://github.com/user-attachments/assets/447636cd-d742-4608-b8a2-e09a20824020


### Input assets for test workflow:
[input_assets.zip](https://github.com/user-attachments/files/27968492/input_assets.zip)
