### PR TITLE
docs(openapi): deprecate /api/upload/mask in favor of /api/upload/image

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -485,8 +485,15 @@ paths:
     post:
       operationId: uploadMask
       tags: [upload]
-      summary: Upload a mask image
-      description: Uploads a mask image associated with a previously-uploaded reference image.
+      deprecated: true
+      summary: Upload a mask image (deprecated)
+      description: |
+        Deprecated. Clients should composite the mask onto the source image
+        client-side and upload the resulting image via POST /api/upload/image
+        instead. This endpoint will continue to function for older clients,
+        but will not receive new features.
+
+        Uploads a mask image associated with a previously-uploaded reference image.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary

Mark `POST /api/upload/mask` as `deprecated: true` in `openapi.yaml` and document the migration to `POST /api/upload/image`.

No runtime behavior changes — the endpoint continues to function for older clients. Only the OpenAPI annotation and the operation description are updated.

## Why

The mask-compositing work `/api/upload/mask` performs server-side (alpha-compositing the supplied mask onto an `original_ref` image and writing the result to the input directory) is increasingly done client-side. With the composited result already in hand, clients can upload through the single unified `/api/upload/image` path, and no longer need the separate endpoint.

The first-party frontend has been updated to take this path:

- Companion PR (Comfy-Org/ComfyUI_frontend): https://github.com/Comfy-Org/ComfyUI_frontend/pull/12318
  - The mask editor's four output layers (masked, paint, painted, painted-masked) are now composited client-side and uploaded as plain images via `/api/upload/image`.
  - `/api/upload/mask` is no longer called from the frontend's save pipeline.

This spec change documents the resulting contract so other clients can migrate at their own pace.

## Behavior

- The endpoint remains live and functional. Marking it `deprecated` in OpenAPI is an annotation only — it does not affect routing, validation, or response shape.
- Older first-party frontend versions in the wild continue to work unchanged.
- Generated OpenAPI clients (TypeScript, Python, etc.) will surface a deprecation warning the next time they regenerate against this spec.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('openapi.yaml'))"` — spec still parses
- [x] No runtime code changed; existing server tests unaffected