### PR TITLE
docs(openapi): remove top-level width/height fields on Asset schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6344,14 +6344,6 @@ components:
           type: integer
           format: int64
           description: Size of the asset in bytes
-        width:
-          type: integer
-          nullable: true
-          description: "Original image width in pixels. Null for non-image assets or assets ingested before dimension extraction."
-        height:
-          type: integer
-          nullable: true
-          description: "Original image height in pixels. Null for non-image assets or assets ingested before dimension extraction."
         mime_type:
           type: string
           description: MIME type of the asset


### PR DESCRIPTION
## Summary

Remove the top-level `width` and `height` nullable integer fields from the `Asset` schema in `openapi.yaml`. These were added recently to expose original image dimensions to consumers that can't recover them via `naturalWidth`/`naturalHeight` (notably, clients that render server-side thumbnails). The implementation effort that consumes them subsequently converged on a different shape — dimensions nested under the existing free-form `metadata` field as `{kind: "image", width, height}` — to avoid introducing type-specific flat fields on the canonical Asset shape and to leave room for forward-compatible additions (video duration, fps, etc.) without further schema churn.

This removes the now-unused top-level fields so the spec reflects the agreed direction.

## What changes

Just the `Asset` schema definition. Two property blocks removed:

```yaml
        width:
          type: integer
          nullable: true
          description: "Original image width in pixels. Null for non-image assets or assets ingested before dimension extraction."
        height:
          type: integer
          nullable: true
          description: "Original image height in pixels. Null for non-image assets or assets ingested before dimension extraction."
```

No other schema definitions reference these fields directly — `AssetCreated`, `AssetUpdated`, etc. inherit `Asset` via `allOf` and don't redefine them. Generated OpenAPI clients (TypeScript, Python, etc.) will no longer surface these properties when they next regenerate against the spec.

## Behavior

- The endpoint surface is unchanged (this is annotation only).
- The runtime ingest implementation that would have populated these fields was not yet shipped, so no clients are relying on the top-level shape.
- Consumers that need dimensions in the future will read them from the nested-in-`metadata` location.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('openapi.yaml'))"` — spec still parses
- [x] No runtime code changed; existing server tests unaffected
- [x] `grep -E '^\s+(width|height):' openapi.yaml` returns no Asset-schema-scoped matches after the change