### PR TITLE
Propagate workflow_id via per-prompt metadata registry (FE-745)

### DIFF
--- a/app/prompt_metadata.py
+++ b/app/prompt_metadata.py
@@ -1,0 +1,44 @@
+"""Validation for client-supplied per-prompt metadata (extra_data.metadata)."""
+
+from typing import Optional
+
+
+MAX_METADATA_KEYS = 16
+MAX_METADATA_KEY_LEN = 64
+MAX_METADATA_VALUE_LEN = 256
+
+# Server-emitted top-level fields on prompt-scoped WebSocket events.
+# Client-supplied metadata may not shadow these — payload-wins-on-conflict
+# only protects keys present in each individual frame, so reserve them
+# at the submission boundary as defense in depth.
+RESERVED_METADATA_KEYS = frozenset({
+    "prompt_id", "node", "display_node", "output", "nodes", "node_id",
+    "node_type", "executed", "exception_message", "exception_type",
+    "traceback", "current_inputs", "current_outputs", "timestamp",
+    "sid", "status", "prompt", "value", "max",
+})
+
+
+def validate_client_metadata(raw) -> tuple[Optional[dict], Optional[str]]:
+    """Return ``(cleaned_metadata, error_message)``.
+
+    A missing field (``None``) is treated as empty metadata. Anything else
+    must be a flat ``dict[str, str]`` within the size caps and free of
+    reserved keys.
+    """
+    if raw is None:
+        return {}, None
+    if not isinstance(raw, dict):
+        return None, "extra_data.metadata must be an object"
+    if len(raw) > MAX_METADATA_KEYS:
+        return None, f"extra_data.metadata exceeds {MAX_METADATA_KEYS} keys"
+    cleaned: dict = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key or len(key) > MAX_METADATA_KEY_LEN:
+            return None, f"metadata key must be a non-empty string up to {MAX_METADATA_KEY_LEN} chars"
+        if key in RESERVED_METADATA_KEYS:
+            return None, f"metadata key '{key}' is reserved"
+        if not isinstance(value, str) or len(value) > MAX_METADATA_VALUE_LEN:
+            return None, f"metadata value for '{key}' must be a string up to {MAX_METADATA_VALUE_LEN} chars"
+        cleaned[key] = value
+    return cleaned, None

--- a/comfy_execution/jobs.py
+++ b/comfy_execution/jobs.py
@@ -93,6 +93,22 @@ def _create_text_preview(value: str) -> dict:
     }
 
 
+def extract_workflow_id(extra_data: Optional[dict]) -> Optional[str]:
+    """Return extra_data["extra_pnginfo"]["workflow"]["id"] when it is a non-empty string."""
+    if not isinstance(extra_data, dict):
+        return None
+    extra_pnginfo = extra_data.get('extra_pnginfo')
+    if not isinstance(extra_pnginfo, dict):
+        return None
+    workflow = extra_pnginfo.get('workflow')
+    if not isinstance(workflow, dict):
+        return None
+    workflow_id = workflow.get('id')
+    if isinstance(workflow_id, str) and workflow_id:
+        return workflow_id
+    return None
+
+
 def _extract_job_metadata(extra_data: dict) -> tuple[Optional[int], Optional[str]]:
     """Extract create_time and workflow_id from extra_data.
 
@@ -100,8 +116,7 @@ def _extract_job_metadata(extra_data: dict) -> tuple[Optional[int], Optional[str
         tuple: (create_time, workflow_id)
     """
     create_time = extra_data.get('create_time')
-    extra_pnginfo = extra_data.get('extra_pnginfo', {})
-    workflow_id = extra_pnginfo.get('workflow', {}).get('id')
+    workflow_id = extract_workflow_id(extra_data)
     return create_time, workflow_id
 
 

--- a/main.py
+++ b/main.py
@@ -317,20 +317,28 @@ def prompt_worker(q, server_instance):
             for k in sensitive:
                 extra_data[k] = sensitive[k]
 
+            metadata = item[6] if len(item) > 6 and isinstance(item[6], dict) else None
+            server_instance.active_prompt_metadata = metadata
+
             asset_seeder.pause()
-            e.execute(item[2], prompt_id, extra_data, item[4])
+            try:
+                e.execute(item[2], prompt_id, extra_data, item[4])
 
-            need_gc = True
+                need_gc = True
 
-            remove_sensitive = lambda prompt: prompt[:5] + prompt[6:]
-            q.task_done(item_id,
-                        e.history_result,
-                        status=execution.PromptQueue.ExecutionStatus(
-                            status_str='success' if e.success else 'error',
-                            completed=e.success,
-                            messages=e.status_messages), process_item=remove_sensitive)
-            if server_instance.client_id is not None:
-                server_instance.send_sync("executing", {"node": None, "prompt_id": prompt_id}, server_instance.client_id)
+                # Drop sensitive (index 5) and metadata (index 6); history keeps a 5-tuple.
+                remove_sensitive = lambda prompt: prompt[:5]
+                q.task_done(item_id,
+                            e.history_result,
+                            status=execution.PromptQueue.ExecutionStatus(
+                                status_str='success' if e.success else 'error',
+                                completed=e.success,
+                                messages=e.status_messages), process_item=remove_sensitive)
+                if server_instance.client_id is not None:
+                    server_instance.send_sync("executing", {"node": None, "prompt_id": prompt_id}, server_instance.client_id)
+            finally:
+                # Clear after the terminal send so that frame still carries metadata.
+                server_instance.active_prompt_metadata = None
 
             current_time = time.perf_counter()
             execution_time = current_time - execution_start_time

--- a/main.py
+++ b/main.py
@@ -318,7 +318,7 @@ def prompt_worker(q, server_instance):
                 extra_data[k] = sensitive[k]
 
             metadata = item[6] if len(item) > 6 and isinstance(item[6], dict) else None
-            server_instance.active_prompt_metadata = metadata
+            server_instance.active_prompt_metadata = (prompt_id, metadata) if metadata else None
 
             asset_seeder.pause()
             try:

--- a/server.py
+++ b/server.py
@@ -252,6 +252,9 @@ class PromptServer():
         self.last_node_id = None
         self.client_id = None
 
+        # Opaque tag dict pinned by main.py around each prompt; send_sync spreads it.
+        self.active_prompt_metadata: Optional[dict] = None
+
         self.on_prompt_handlers = []
 
         @routes.get('/ws')
@@ -275,7 +278,13 @@ class PromptServer():
                 await self.send("status", {"status": self.get_queue_info(), "sid": sid}, sid)
                 # On reconnect if we are the currently executing client send the current node
                 if self.client_id == sid and self.last_node_id is not None:
-                    await self.send("executing", { "node": self.last_node_id }, sid)
+                    payload = {"node": self.last_node_id}
+                    last_prompt_id = getattr(self, "last_prompt_id", None)
+                    if last_prompt_id:
+                        payload["prompt_id"] = last_prompt_id
+                    if self.active_prompt_metadata:
+                        payload = {**self.active_prompt_metadata, **payload}
+                    await self.send("executing", payload, sid)
 
                 # Flag to track if we've received the first message
                 first_message = True
@@ -955,7 +964,9 @@ class PromptServer():
                         if sensitive_val in extra_data:
                             sensitive[sensitive_val] = extra_data.pop(sensitive_val)
                     extra_data["create_time"] = int(time.time() * 1000)  # timestamp in milliseconds
-                    self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute, sensitive))
+                    raw_metadata = extra_data.pop("metadata", None)
+                    client_metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+                    self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute, sensitive, client_metadata))
                     response = {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}
                     return web.json_response(response)
                 else:
@@ -1217,6 +1228,9 @@ class PromptServer():
             await send_socket_catch_exception(self.sockets[sid].send_json, message)
 
     def send_sync(self, event, data, sid=None):
+        meta = self.active_prompt_metadata
+        if meta and isinstance(data, dict):
+            data = {**meta, **data}
         self.loop.call_soon_threadsafe(
             self.messages.put_nowait, (event, data, sid))
 

--- a/server.py
+++ b/server.py
@@ -44,6 +44,7 @@ from app.model_manager import ModelFileManager
 from app.custom_node_manager import CustomNodeManager
 from app.subgraph_manager import SubgraphManager
 from app.node_replace_manager import NodeReplaceManager
+from app.prompt_metadata import validate_client_metadata
 from typing import Optional, Union
 from api_server.routes.internal.internal_routes import InternalRoutes
 from protocol import BinaryEventTypes
@@ -252,8 +253,10 @@ class PromptServer():
         self.last_node_id = None
         self.client_id = None
 
-        # Opaque tag dict pinned by main.py around each prompt; send_sync spreads it.
-        self.active_prompt_metadata: Optional[dict] = None
+        # (prompt_id, opaque tag dict) pinned by main.py around each prompt.
+        # send_sync only spreads the dict onto payloads whose prompt_id matches,
+        # so concurrent queue/status broadcasts are not contaminated.
+        self.active_prompt_metadata: Optional[tuple[str, dict]] = None
 
         self.on_prompt_handlers = []
 
@@ -282,8 +285,11 @@ class PromptServer():
                     last_prompt_id = getattr(self, "last_prompt_id", None)
                     if last_prompt_id:
                         payload["prompt_id"] = last_prompt_id
-                    if self.active_prompt_metadata:
-                        payload = {**self.active_prompt_metadata, **payload}
+                    slot = self.active_prompt_metadata
+                    if slot is not None:
+                        active_prompt_id, meta = slot
+                        if meta and payload.get("prompt_id") == active_prompt_id:
+                            payload = {**meta, **payload}
                     await self.send("executing", payload, sid)
 
                 # Flag to track if we've received the first message
@@ -965,7 +971,12 @@ class PromptServer():
                             sensitive[sensitive_val] = extra_data.pop(sensitive_val)
                     extra_data["create_time"] = int(time.time() * 1000)  # timestamp in milliseconds
                     raw_metadata = extra_data.pop("metadata", None)
-                    client_metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+                    client_metadata, meta_error = validate_client_metadata(raw_metadata)
+                    if meta_error is not None:
+                        return web.json_response(
+                            {"error": {"type": "invalid_metadata", "message": meta_error}},
+                            status=400,
+                        )
                     self.prompt_queue.put((number, prompt_id, prompt, extra_data, outputs_to_execute, sensitive, client_metadata))
                     response = {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}
                     return web.json_response(response)
@@ -1228,9 +1239,11 @@ class PromptServer():
             await send_socket_catch_exception(self.sockets[sid].send_json, message)
 
     def send_sync(self, event, data, sid=None):
-        meta = self.active_prompt_metadata
-        if meta and isinstance(data, dict):
-            data = {**meta, **data}
+        slot = self.active_prompt_metadata
+        if slot is not None and isinstance(data, dict):
+            active_prompt_id, meta = slot
+            if meta and data.get("prompt_id") == active_prompt_id:
+                data = {**meta, **data}
         self.loop.call_soon_threadsafe(
             self.messages.put_nowait, (event, data, sid))
 

--- a/tests-unit/server_test/test_prompt_metadata.py
+++ b/tests-unit/server_test/test_prompt_metadata.py
@@ -1,0 +1,162 @@
+"""Tests for the opaque per-prompt metadata mechanism on PromptServer."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from comfy_execution.jobs import extract_workflow_id
+
+
+class TestExtractWorkflowId:
+
+    def test_returns_id_when_present(self):
+        assert extract_workflow_id({"extra_pnginfo": {"workflow": {"id": "wf-1"}}}) == "wf-1"
+
+    def test_returns_none_when_missing(self):
+        assert extract_workflow_id({}) is None
+        assert extract_workflow_id({"extra_pnginfo": {}}) is None
+        assert extract_workflow_id({"extra_pnginfo": {"workflow": {}}}) is None
+
+    def test_returns_none_for_empty_or_wrong_type(self):
+        assert extract_workflow_id({"extra_pnginfo": {"workflow": {"id": ""}}}) is None
+        assert extract_workflow_id({"extra_pnginfo": {"workflow": {"id": 42}}}) is None
+        assert extract_workflow_id({"extra_pnginfo": {"workflow": {"id": None}}}) is None
+
+    def test_returns_none_for_non_dict_input(self):
+        assert extract_workflow_id(None) is None
+        assert extract_workflow_id("not a dict") is None
+        assert extract_workflow_id({"extra_pnginfo": "not a dict"}) is None
+        assert extract_workflow_id({"extra_pnginfo": {"workflow": "not a dict"}}) is None
+
+
+class _FakeServer:
+    """Minimal PromptServer stand-in mirroring send_sync verbatim."""
+
+    def __init__(self):
+        self.active_prompt_metadata = None
+        self.captured = []
+        self.loop = MagicMock()
+        self.loop.call_soon_threadsafe.side_effect = (
+            lambda fn, msg: self.captured.append(msg)
+        )
+        self.messages = MagicMock()
+        self.messages.put_nowait = MagicMock()
+
+    def send_sync(self, event, data, sid=None):
+        meta = self.active_prompt_metadata
+        if meta and isinstance(data, dict):
+            data = {**meta, **data}
+        self.loop.call_soon_threadsafe(
+            self.messages.put_nowait, (event, data, sid)
+        )
+
+
+@pytest.fixture
+def server():
+    return _FakeServer()
+
+
+class TestSendSyncMerge:
+    def test_spreads_active_metadata_onto_dict_payload(self, server):
+        server.active_prompt_metadata = {"workflow_id": "wf-1"}
+
+        server.send_sync(
+            "executing", {"node": "n1", "prompt_id": "p1"}, "client-1"
+        )
+
+        event, data, sid = server.captured[0]
+        assert event == "executing"
+        assert data == {
+            "workflow_id": "wf-1",
+            "node": "n1",
+            "prompt_id": "p1",
+        }
+        assert sid == "client-1"
+
+    def test_passthrough_when_no_active_metadata(self, server):
+        server.active_prompt_metadata = None
+
+        server.send_sync("executing", {"node": "n1", "prompt_id": "p1"})
+
+        _, data, _ = server.captured[0]
+        assert data == {"node": "n1", "prompt_id": "p1"}
+
+    def test_passthrough_when_metadata_is_empty_dict(self, server):
+        server.active_prompt_metadata = {}
+
+        server.send_sync("executing", {"node": "n1", "prompt_id": "p1"})
+
+        _, data, _ = server.captured[0]
+        assert data == {"node": "n1", "prompt_id": "p1"}
+
+    def test_event_payload_wins_on_key_conflict(self, server):
+        server.active_prompt_metadata = {"workflow_id": "wf-1", "prompt_id": "from-meta"}
+
+        server.send_sync("executing", {"node": "n1", "prompt_id": "from-frame"}, "c1")
+
+        _, data, _ = server.captured[0]
+        assert data["prompt_id"] == "from-frame"
+        assert data["workflow_id"] == "wf-1"
+
+    def test_non_dict_payload_passes_through_untouched(self, server):
+        # BinaryEventTypes.TEXT byte frames must not be merged.
+        server.active_prompt_metadata = {"workflow_id": "wf-1"}
+
+        server.send_sync("text", b"\x00\x00\x00\x03foobar", "c1")
+
+        _, data, _ = server.captured[0]
+        assert data == b"\x00\x00\x00\x03foobar"
+
+    def test_terminal_executing_frame_includes_metadata(self, server):
+        # Slot is cleared after this send in main.py so the reset still carries metadata (#13684 race).
+        server.active_prompt_metadata = {"workflow_id": "wf-1"}
+
+        server.send_sync(
+            "executing", {"node": None, "prompt_id": "p1"}, "client-1"
+        )
+
+        _, data, _ = server.captured[0]
+        assert data == {
+            "workflow_id": "wf-1",
+            "node": None,
+            "prompt_id": "p1",
+        }
+
+    def test_opaque_dict_supports_arbitrary_keys(self, server):
+        server.active_prompt_metadata = {
+            "workflow_id": "wf-1",
+            "trace_id": "trace-123",
+            "tenant": "acme",
+        }
+
+        server.send_sync("executing", {"node": "n1", "prompt_id": "p1"})
+
+        _, data, _ = server.captured[0]
+        assert data["workflow_id"] == "wf-1"
+        assert data["trace_id"] == "trace-123"
+        assert data["tenant"] == "acme"
+
+
+class TestWorkerSerializationIsolatesMetadata:
+    def test_two_prompts_sharing_prompt_id_get_correct_metadata(self, server):
+        # Prompt A
+        server.active_prompt_metadata = {"workflow_id": "wf-AAA"}
+        server.send_sync("execution_start", {"prompt_id": "P-shared"})
+        server.send_sync("executing", {"node": "n1", "prompt_id": "P-shared"})
+        server.send_sync("executing", {"node": None, "prompt_id": "P-shared"})
+        server.active_prompt_metadata = None
+
+        # Prompt B — same prompt_id, different workflow
+        server.active_prompt_metadata = {"workflow_id": "wf-BBB"}
+        server.send_sync("execution_start", {"prompt_id": "P-shared"})
+        server.send_sync("executing", {"node": "n2", "prompt_id": "P-shared"})
+        server.send_sync("executing", {"node": None, "prompt_id": "P-shared"})
+        server.active_prompt_metadata = None
+
+        frames = [d for (_, d, _) in server.captured]
+        a_frames = frames[:3]
+        b_frames = frames[3:]
+
+        assert all(f["workflow_id"] == "wf-AAA" for f in a_frames)
+        assert all(f["workflow_id"] == "wf-BBB" for f in b_frames)
+        assert all(f["prompt_id"] == "P-shared" for f in frames)

--- a/tests-unit/server_test/test_prompt_metadata.py
+++ b/tests-unit/server_test/test_prompt_metadata.py
@@ -4,6 +4,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from app.prompt_metadata import (
+    MAX_METADATA_KEY_LEN,
+    MAX_METADATA_KEYS,
+    MAX_METADATA_VALUE_LEN,
+    RESERVED_METADATA_KEYS,
+    validate_client_metadata,
+)
 from comfy_execution.jobs import extract_workflow_id
 
 
@@ -30,7 +37,13 @@ class TestExtractWorkflowId:
 
 
 class _FakeServer:
-    """Minimal PromptServer stand-in mirroring send_sync verbatim."""
+    """Minimal PromptServer stand-in mirroring send_sync verbatim.
+
+    ``active_prompt_metadata`` is ``Optional[tuple[str, dict]]`` — the
+    ``prompt_id`` it belongs to plus the opaque dict. send_sync only merges
+    when the outgoing payload's ``prompt_id`` matches the active one, so
+    unrelated queue/status broadcasts are not contaminated.
+    """
 
     def __init__(self):
         self.active_prompt_metadata = None
@@ -43,9 +56,11 @@ class _FakeServer:
         self.messages.put_nowait = MagicMock()
 
     def send_sync(self, event, data, sid=None):
-        meta = self.active_prompt_metadata
-        if meta and isinstance(data, dict):
-            data = {**meta, **data}
+        slot = self.active_prompt_metadata
+        if slot is not None and isinstance(data, dict):
+            active_prompt_id, meta = slot
+            if meta and data.get("prompt_id") == active_prompt_id:
+                data = {**meta, **data}
         self.loop.call_soon_threadsafe(
             self.messages.put_nowait, (event, data, sid)
         )
@@ -58,7 +73,7 @@ def server():
 
 class TestSendSyncMerge:
     def test_spreads_active_metadata_onto_dict_payload(self, server):
-        server.active_prompt_metadata = {"workflow_id": "wf-1"}
+        server.active_prompt_metadata = ("p1", {"workflow_id": "wf-1"})
 
         server.send_sync(
             "executing", {"node": "n1", "prompt_id": "p1"}, "client-1"
@@ -82,7 +97,7 @@ class TestSendSyncMerge:
         assert data == {"node": "n1", "prompt_id": "p1"}
 
     def test_passthrough_when_metadata_is_empty_dict(self, server):
-        server.active_prompt_metadata = {}
+        server.active_prompt_metadata = ("p1", {})
 
         server.send_sync("executing", {"node": "n1", "prompt_id": "p1"})
 
@@ -90,17 +105,19 @@ class TestSendSyncMerge:
         assert data == {"node": "n1", "prompt_id": "p1"}
 
     def test_event_payload_wins_on_key_conflict(self, server):
-        server.active_prompt_metadata = {"workflow_id": "wf-1", "prompt_id": "from-meta"}
+        server.active_prompt_metadata = (
+            "p1",
+            {"workflow_id": "wf-1", "prompt_id": "from-meta"},
+        )
 
-        server.send_sync("executing", {"node": "n1", "prompt_id": "from-frame"}, "c1")
+        server.send_sync("executing", {"node": "n1", "prompt_id": "p1"}, "c1")
 
         _, data, _ = server.captured[0]
-        assert data["prompt_id"] == "from-frame"
+        assert data["prompt_id"] == "p1"
         assert data["workflow_id"] == "wf-1"
 
     def test_non_dict_payload_passes_through_untouched(self, server):
-        # BinaryEventTypes.TEXT byte frames must not be merged.
-        server.active_prompt_metadata = {"workflow_id": "wf-1"}
+        server.active_prompt_metadata = ("p1", {"workflow_id": "wf-1"})
 
         server.send_sync("text", b"\x00\x00\x00\x03foobar", "c1")
 
@@ -108,8 +125,7 @@ class TestSendSyncMerge:
         assert data == b"\x00\x00\x00\x03foobar"
 
     def test_terminal_executing_frame_includes_metadata(self, server):
-        # Slot is cleared after this send in main.py so the reset still carries metadata (#13684 race).
-        server.active_prompt_metadata = {"workflow_id": "wf-1"}
+        server.active_prompt_metadata = ("p1", {"workflow_id": "wf-1"})
 
         server.send_sync(
             "executing", {"node": None, "prompt_id": "p1"}, "client-1"
@@ -123,11 +139,10 @@ class TestSendSyncMerge:
         }
 
     def test_opaque_dict_supports_arbitrary_keys(self, server):
-        server.active_prompt_metadata = {
-            "workflow_id": "wf-1",
-            "trace_id": "trace-123",
-            "tenant": "acme",
-        }
+        server.active_prompt_metadata = (
+            "p1",
+            {"workflow_id": "wf-1", "trace_id": "trace-123", "tenant": "acme"},
+        )
 
         server.send_sync("executing", {"node": "n1", "prompt_id": "p1"})
 
@@ -137,17 +152,54 @@ class TestSendSyncMerge:
         assert data["tenant"] == "acme"
 
 
+class TestStatusBroadcastsAreNotContaminated:
+    """Regression tests for the contamination bug:
+
+    ``send_sync`` previously spread metadata onto any dict payload, so a
+    status broadcast fired while a prompt was running picked up that
+    prompt's metadata even though it had nothing to do with that prompt.
+    """
+
+    def test_status_payload_without_prompt_id_is_untouched(self, server):
+        server.active_prompt_metadata = ("p-running", {"workflow_id": "wf-1"})
+
+        server.send_sync("status", {"status": {"exec_info": {"queue_remaining": 1}}})
+
+        _, data, _ = server.captured[0]
+        assert data == {"status": {"exec_info": {"queue_remaining": 1}}}
+        assert "workflow_id" not in data
+
+    def test_payload_for_different_prompt_is_untouched(self, server):
+        # Active prompt is p-running; we send a frame for p-other (e.g. another
+        # client's queued item). The merge must not leak across prompts.
+        server.active_prompt_metadata = ("p-running", {"workflow_id": "wf-1"})
+
+        server.send_sync("executing", {"node": "n1", "prompt_id": "p-other"})
+
+        _, data, _ = server.captured[0]
+        assert data == {"node": "n1", "prompt_id": "p-other"}
+        assert "workflow_id" not in data
+
+    def test_queue_updated_frame_during_active_prompt_is_clean(self, server):
+        server.active_prompt_metadata = ("p-running", {"workflow_id": "wf-1"})
+
+        server.send_sync("status", {"status": {"exec_info": {"queue_remaining": 0}}})
+
+        _, data, _ = server.captured[0]
+        assert "workflow_id" not in data
+
+
 class TestWorkerSerializationIsolatesMetadata:
     def test_two_prompts_sharing_prompt_id_get_correct_metadata(self, server):
         # Prompt A
-        server.active_prompt_metadata = {"workflow_id": "wf-AAA"}
+        server.active_prompt_metadata = ("P-shared", {"workflow_id": "wf-AAA"})
         server.send_sync("execution_start", {"prompt_id": "P-shared"})
         server.send_sync("executing", {"node": "n1", "prompt_id": "P-shared"})
         server.send_sync("executing", {"node": None, "prompt_id": "P-shared"})
         server.active_prompt_metadata = None
 
         # Prompt B — same prompt_id, different workflow
-        server.active_prompt_metadata = {"workflow_id": "wf-BBB"}
+        server.active_prompt_metadata = ("P-shared", {"workflow_id": "wf-BBB"})
         server.send_sync("execution_start", {"prompt_id": "P-shared"})
         server.send_sync("executing", {"node": "n2", "prompt_id": "P-shared"})
         server.send_sync("executing", {"node": None, "prompt_id": "P-shared"})
@@ -160,3 +212,77 @@ class TestWorkerSerializationIsolatesMetadata:
         assert all(f["workflow_id"] == "wf-AAA" for f in a_frames)
         assert all(f["workflow_id"] == "wf-BBB" for f in b_frames)
         assert all(f["prompt_id"] == "P-shared" for f in frames)
+
+
+class TestValidateClientMetadata:
+    def test_none_returns_empty_dict(self):
+        cleaned, error = validate_client_metadata(None)
+        assert cleaned == {}
+        assert error is None
+
+    def test_flat_string_dict_is_accepted(self):
+        cleaned, error = validate_client_metadata(
+            {"workflow_id": "wf-1", "trace_id": "trace-abc"}
+        )
+        assert cleaned == {"workflow_id": "wf-1", "trace_id": "trace-abc"}
+        assert error is None
+
+    def test_non_dict_is_rejected(self):
+        _, error = validate_client_metadata("not a dict")
+        assert error is not None
+        assert "object" in error
+
+    def test_list_is_rejected(self):
+        _, error = validate_client_metadata([("workflow_id", "wf-1")])
+        assert error is not None
+
+    def test_nested_dict_value_is_rejected(self):
+        _, error = validate_client_metadata({"workflow": {"id": "wf-1"}})
+        assert error is not None
+        assert "string" in error
+
+    def test_non_string_value_is_rejected(self):
+        _, error = validate_client_metadata({"workflow_id": 42})
+        assert error is not None
+
+    def test_non_string_key_is_rejected(self):
+        _, error = validate_client_metadata({123: "wf-1"})
+        assert error is not None
+
+    def test_empty_key_is_rejected(self):
+        _, error = validate_client_metadata({"": "wf-1"})
+        assert error is not None
+
+    def test_key_exceeding_limit_is_rejected(self):
+        _, error = validate_client_metadata({"k" * (MAX_METADATA_KEY_LEN + 1): "v"})
+        assert error is not None
+        assert str(MAX_METADATA_KEY_LEN) in error
+
+    def test_value_exceeding_limit_is_rejected(self):
+        _, error = validate_client_metadata({"workflow_id": "v" * (MAX_METADATA_VALUE_LEN + 1)})
+        assert error is not None
+        assert str(MAX_METADATA_VALUE_LEN) in error
+
+    def test_too_many_keys_is_rejected(self):
+        raw = {f"k{i}": "v" for i in range(MAX_METADATA_KEYS + 1)}
+        _, error = validate_client_metadata(raw)
+        assert error is not None
+        assert str(MAX_METADATA_KEYS) in error
+
+    def test_max_size_dict_is_accepted(self):
+        raw = {f"k{i}": "v" for i in range(MAX_METADATA_KEYS)}
+        cleaned, error = validate_client_metadata(raw)
+        assert error is None
+        assert len(cleaned) == MAX_METADATA_KEYS
+
+    def test_max_length_strings_are_accepted(self):
+        raw = {"k" * MAX_METADATA_KEY_LEN: "v" * MAX_METADATA_VALUE_LEN}
+        cleaned, error = validate_client_metadata(raw)
+        assert error is None
+        assert cleaned == raw
+
+    @pytest.mark.parametrize("reserved_key", sorted(RESERVED_METADATA_KEYS))
+    def test_reserved_keys_are_rejected(self, reserved_key):
+        _, error = validate_client_metadata({reserved_key: "anything"})
+        assert error is not None
+        assert reserved_key in error


### PR DESCRIPTION
## Summary

This PR reapplies the reverted workflow_id propagation (#13684) without re-triggering  "two ids in core" objection — the frontend's prompt_id → workflow_id map raced with execution_start, causing cross-tab state leakage, and the maintainer demanded a generic opaque dict instead of a first-class workflow_id field in core.

  It solves this by letting the client attach an opaque extra_data.metadata dict on POST /prompt, which server.py pins to a per-prompt slot and send_sync spreads onto every outgoing WS dict frame — so execution.py never names workflow_id, the FE reads it straight off each WS event, and the racy in-memory mapping (and its leak) goes away.

`server.py` is a pure relay — it takes an opaque dict the client supplied on the request and pins it on `PromptServer.active_prompt_metadata` while `main.py`'s worker drives the prompt. `send_sync` spreads its key/value pairs onto outgoing dict payloads. The transport layer never inspects the dict's contents; the execution layer never sees it at all.

Implements [FE-745](https://linear.app/comfyorg/issue/FE-745/implement-refactor-workflow-id-propagation-to-use-metadata-structure). Reapplies the wire-shape intent of #13684 (reverted) without the layering and surface-area issues called out in that revert thread.

## Wire contract — client supplies the dict

Clients (typically the frontend) include an opaque dict at `extra_data.metadata` on `POST /prompt`:

```json
{
  "prompt": { ... },
  "extra_data": {
    "extra_pnginfo": { "workflow": { ... } },
    "metadata": { "workflow_id": "wf-uuid-AAA" }
  }
}
```

`server.py` pops the dict, validates it's a dict (else uses `{}`), and attaches it to the queue item. The keys inside are not interpreted anywhere in core — `workflow_id` is just one example a client might send. Adding a new propagated tag (`trace_id`, tenant, etc.) requires **zero** changes on the server side; the client just adds another key to its `metadata` dict.

While a prompt is executing, every outbound WebSocket frame whose payload is a dict gets the metadata's keys merged at the top level. Event-payload keys win on conflict. `BinaryEventTypes.TEXT` byte frames pass through untouched.

```js
Request (POST /prompt):
  {
    "prompt": {...},
    "extra_data": {
      "metadata": {
        "workflow_id": "wf-abc"
      }
    }
  }

  Response (WebSocket frames during execution):
  {"type":"executing", "data":{"workflow_id":"wf-abc", "node":"n1", "prompt_id":"p1"}}
  {"type":"executed",  "data":{"workflow_id":"wf-abc", "output":..., "prompt_id":"p1"}}
  {"type":"execution_success", "data":{"workflow_id":"wf-abc", "prompt_id":"p1", "timestamp":...}}

```


## screenshot / test

| scenario | screenshot |
| --- | --- |
| metadata - workflow_id | <img width="749" height="311" alt="Screenshot 2026-05-20 at 10 05 22 PM" src="https://github.com/user-attachments/assets/56383e51-c71c-45a0-ab6a-2b753d1efa9b" /> <img width="1935" height="998" alt="Screenshot 2026-05-20 at 9 58 15 PM" src="https://github.com/user-attachments/assets/9bb8cb99-76c0-42c6-9370-94c0d0281192" /> | 

## What changed

| File | Change |
| --- | --- |
| `app/prompt_metadata.py` (new) | `validate_client_metadata` helper with caps (`MAX_METADATA_KEYS=16`, `MAX_METADATA_KEY_LEN=64`, `MAX_METADATA_VALUE_LEN=256`) and `RESERVED_METADATA_KEYS` covering every top-level field the server emits on prompt-scoped WS events (`prompt_id`, `node`, `display_node`, `output`, `nodes`, `node_id`, `node_type`, `executed`, `exception_*`, `traceback`, `current_inputs`, `current_outputs`, `timestamp`, `sid`, `status`, `prompt`, `value`, `max`). Pulled out of `server.py` so unit tests can import it without dragging server's import-time side effects. |
| `server.py` | `self.active_prompt_metadata: Optional[tuple[str, dict]] = None` — slot now carries `(prompt_id, metadata)` so injection is prompt-scoped. `post_prompt` calls `validate_client_metadata`; on violation returns `400 invalid_metadata` and never enqueues. `send_sync` spreads the dict **only when** the payload's `prompt_id` matches the active prompt's id, so unrelated `status`/`queue` broadcasts are not contaminated. WS reconnect `executing` frame applies the same match condition. |
| `main.py` | Worker reads `metadata = item[6]`, stores `(prompt_id, metadata)` in `server_instance.active_prompt_metadata` around `e.execute(...)`, clears in `finally` after the terminal `executing: {node: None}` send so that frame still carries the metadata. `remove_sensitive` drops index 6 so history stays at 5-element tuples (`normalize_history_item`'s contract). |
| `comfy_execution/jobs.py` | Public `extract_workflow_id(extra_data)` helper for the jobs REST API path (unchanged behavior). `server.py` does **not** import or call this — exclusively used by `_extract_job_metadata` for `/api/jobs` filtering, matching @comfyanonymous's *"only the job api has it"* carve-out. |
| `tests-unit/server_test/test_prompt_metadata.py` | **47 tests** (was 12): existing merge/serialization tests plus `TestStatusBroadcastsAreNotContaminated` (regression for prompt_id-scoped injection) and `TestValidateClientMetadata` (size caps, type checks, parametrized reserved-key rejection across all 19 reserved keys). |

`execution.py`: **0 line changes.** `comfy_execution/progress.py`: **0 line changes.**

## `server.py`'s `workflow_id` footprint is unchanged from master

The three remaining `workflow_id` references in `server.py` (`GET /api/jobs` handler — query param parsing and forwarding to `get_all_jobs`) were introduced by #11054 in December 2025, long before this work. They are part of the jobs REST API carve-out, not the transport/queue machinery. The metadata mechanism added by this PR introduces **zero new `workflow_id` references** in `server.py` — the transport-layer code that handles per-prompt metadata never names `workflow_id`. So `server.py`'s knowledge of `workflow_id` is identical to what it has been on `master` for the last ~5 months.

## How this answers the revert thread

Re-reading the [revert thread](https://comfy-organization.slack.com/archives/C08J80JST8C/p1778797797711489):

| Objection from #13684's revert | How this PR responds |
| --- | --- |
| *"Two different ids to represent the same thing in core"* | The transport layer here has no named `workflow_id` field. It spreads an opaque dict. Whether the dict happens to contain `workflow_id` is a client decision. |
| *"backend doesn't care about workflow tags like the workflow id"* | Core's transport and execution layers have zero knowledge of `workflow_id`. The only place that names it is the existing `/api/jobs` REST handler — the carved-out exception, unchanged from master. |
| *"the code itself is bad"* (state duplication, finally race, 9 dict literals to keep in sync, AST guard) | One state slot **scoped by `prompt_id` so unrelated `status`/`queue` broadcasts are never tagged**. One merge chokepoint. No race window (slot cleared in worker's `finally` after the terminal frame is queued). **Submission-boundary validation rejects shape violations and reserved-key collisions with 400**, so a misbehaving client cannot force unbounded data onto every WS frame or shadow server-emitted top-level fields. Adding a new propagated key is a one-line client-side change with zero server-side touches. |
| *"make it a dict that the keys/values will be sent back on the websocket and that get_jobs or whatever can filter the keys/values"* | The dict goes back on the websocket exactly as specified. `get_jobs` filtering uses the independent `extra_pnginfo.workflow.id` path that already existed pre-#13684. |

## Adversarial-review evidence

Same scenario (two prompts queued back-to-back with distinct `workflow_id`s, `status` broadcasts triggered during execution), with the prompt_id match condition in `send_sync` toggled on/off:

|                          | With fix | Without fix |
|--------------------------|----------|-------------|
| `status` frames captured | 7        | 7           |
| `status` frames carrying `workflow_id` (contamination) | **0** | **3** (2 × wf-AAA, 1 × wf-BBB) |
| Cross-prompt `workflow_id` leakage | 0 | 0 |

Confirms the prompt_id-scoped injection prevents the exact contamination flagged in adversarial review, with no other code-path differences.

## Prompt id collision safety

Worker dequeues prompts one at a time and rewrites the active slot per prompt. Even when two submissions share the same client-supplied `prompt_id`, each one's frames receive its own metadata — there's no shared lookup keyed by `prompt_id` to collide on, and no registry to mis-attribute from. Covered by `TestWorkerSerializationIsolatesMetadata::test_two_prompts_sharing_prompt_id_get_correct_metadata`.

## Backward compatibility

Clients that do not send `extra_data.metadata` get the master behavior unchanged: `extra_data.pop("metadata", None)` returns `None`, `validate_client_metadata` returns `({}, None)`, the `send_sync` merge condition is falsy on empty dict, and frames are emitted without any decoration. This means the backend can ship independently of the frontend update — until the frontend starts sending `metadata`, frames will simply lack `workflow_id`, identical to current `main`.

**Breaking-ish edge**: previously, malformed metadata (non-dict, oversize value, reserved key, non-string value) was silently coerced to `{}`. It now returns `400 invalid_metadata` with a specific reason. No known client sends malformed metadata — the cloud frontend hasn't started sending the field yet, and the FE follow-up will use the well-typed shape — so this is fail-fast hardening at the trust boundary, not a regression for any live client.

Side-effect audit (no changes to existing contracts):
- `extra_data` going to nodes via `get_input_data`: the popped `metadata` key is removed before `e.execute(...)` so custom nodes never see it.
- `history[prompt_id]['prompt']` tuple: `remove_sensitive = lambda prompt: prompt[:5]` ensures history stays as a 5-element tuple, matching `normalize_history_item`'s destructure contract.
- `GET /queue`, `GET /api/jobs`: `_remove_sensitive_from_queue` slices to `[:5]`, so the metadata at index 6 is never exposed via these REST surfaces.
- `comfy_execution/jobs.py` REST paths: unchanged — `workflow_id` still extracted from `extra_pnginfo.workflow.id` for the existing `workflow_id` column / filter / response.

## Test plan

- [x] `./venv/bin/python -m pytest tests-unit/server_test/test_prompt_metadata.py` — **47 tests pass**
- [x] `./venv/bin/python -m pytest tests/execution/test_jobs.py` — 48 tests pass (helper + delegation non-breaking)
- [x] `./venv/bin/python -m pytest tests-unit -q --ignore=tests-unit/execution_test/preview_method_override_test.py --ignore=tests-unit/prompt_server_test` — 740+ passed, 0 failures (2 errors pre-existing aiohttp_client fixture env issue, present on master)
- [x] `./venv/bin/python -m ruff check server.py main.py comfy_execution/jobs.py app/prompt_metadata.py tests-unit/server_test/test_prompt_metadata.py` — clean
- [x] Manual contamination check via live server + WebSocket tap (see *Adversarial-review evidence* above): 0 contaminated `status` frames with fix on, 3 reproducible without.

## Frontend follow-up (separate PR, ComfyUI_frontend)

The frontend needs to start sending `extra_data.metadata = { workflow_id: workflow.id }` on `POST /prompt` for `workflow_id` to be echoed on WS frames. Until that ships, frames carry no decoration — same as current master — so this PR is safe to ship independently and is not blocked on the frontend change.

## Out of scope

- `BinaryEventTypes.TEXT` wire-format inclusion of metadata (requires a feature-flag negotiation).
- Any changes to `comfy_execution/jobs.py`'s REST surface (`GET /api/jobs`, `GET /api/jobs/{id}`, `workflow_id` filter) — that path is unchanged.

Reserved-key set is intentionally conservative: `sid` and `prompt` don't currently appear top-level on any `send_sync` path — they're future-proofing and can be trimmed if reviewers prefer a tighter list.

Linear: FE-745. Previous reverted attempt: #13684. Alternative explored: #13905.
