### PR TITLE
docs(openapi): clarify internal files response items

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1468,13 +1468,15 @@ paths:
           description: Directory type (e.g. output, input, temp)
       responses:
         "200":
-          description: Array of filenames
+          description: Array of filenames with their directory type suffix
           content:
             application/json:
               schema:
                 type: array
                 items:
                   type: string
+                  description: Filename followed by its directory type suffix, for example `example.png [output]`.
+                  pattern: '^.+ \[(output|input|temp)\]$'
 
   # ---------------------------------------------------------------------------
   # Assets (x-feature-gate: enable-assets)


### PR DESCRIPTION
## Summary

Update the OpenAPI schema for `GET /internal/files/{directory_type}` so each array item documents the suffix that the route already returns, for example `example.png [output]`.

`api_server/routes/internal/internal_routes.py` formats every visible file as:

```py
f"{entry.name} [{directory_type}]"
```

The previous schema only said `array<string>`, which made generated clients miss the directory-type suffix contract.

## Validation

- `python3 - <<'PY' ... yaml.safe_load(open('openapi.yaml')) ... PY`
- `git diff --check`