### PR TITLE
feat(openapi): add optional description field to workspace API key schemas

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7687,6 +7687,7 @@ components:
           type: string
         description:
           type: string
+          nullable: true
           description: User-provided description
         prefix:
           type: string
@@ -7716,6 +7717,7 @@ components:
           type: string
         description:
           type: string
+          nullable: true
           description: User-provided description
         key:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4160,6 +4160,9 @@ paths:
                 name:
                   type: string
                   description: Display name for the API key
+                description:
+                  type: string
+                  description: User-provided description for the key
       responses:
         "201":
           description: API key created
@@ -7682,6 +7685,9 @@ components:
           type: string
         name:
           type: string
+        description:
+          type: string
+          description: User-provided description
         prefix:
           type: string
           description: First few characters of the key for identification
@@ -7708,6 +7714,9 @@ components:
           type: string
         name:
           type: string
+        description:
+          type: string
+          description: User-provided description
         key:
           type: string
           description: Full API key value (only returned on creation)


### PR DESCRIPTION
## Summary

Adds an optional `description` property (type: string, nullable) to three workspace API key schemas in `openapi.yaml`. This is a pure schema change — no implementation code is modified.

## Changes

Three schemas now include an optional `description` field:

1. **Inline request body** of `createWorkspaceApiKey` (POST `/api/workspace/api-keys`) — allows clients to send a description when creating a key
2. **`WorkspaceApiKey`** — surfaces the description in list/info responses (nullable to match storage)
3. **`WorkspaceApiKeyCreated`** — surfaces the description in the creation response (nullable to match storage)

## Why

The `workspace_api_keys.description` column already exists in the runtime database (nullable varchar, default `''`). Adding this field to the OSS-owned API contract unblocks downstream consumers that want to preserve a description column with zero UX regression.

## Constraints satisfied

- All additions are **optional** — no `required:` arrays were modified
- No new tags, schemas, or operations added
- No reformatting of surrounding YAML
- Spectral lint passes with 0 errors