### PR TITLE
chore: filter ck backend info

### DIFF
--- a/.github/workflows/test-launch.yml
+++ b/.github/workflows/test-launch.yml
@@ -32,7 +32,7 @@ jobs:
       working-directory: ComfyUI
     - name: Check for unhandled exceptions in server log
       run: |
-        grep -v "Found comfy_kitchen backend triton: {'available': False, 'disabled': True, 'unavailable_reason': \"ImportError: No module named 'triton'\", 'capabilities': \[\]}" console_output.log | grep -v "Found comfy_kitchen backend triton: {'available': False, 'disabled': False, 'unavailable_reason': \"ImportError: No module named 'triton'\", 'capabilities': \[\]}" > console_output_filtered.log
+        grep -v "Found comfy_kitchen backend triton: {'available': False, 'unavailable_reason': \"ImportError: No module named 'triton'\"}" console_output.log > console_output_filtered.log
         cat console_output_filtered.log
         if grep -qE "Exception|Error" console_output_filtered.log; then
           echo "Unhandled exception/error found in server log."

--- a/comfy/quant_ops.py
+++ b/comfy/quant_ops.py
@@ -33,7 +33,8 @@ try:
     else:
         ck.registry.disable("triton")
     for k, v in ck.list_backends().items():
-        logging.info(f"Found comfy_kitchen backend {k}: {v}")
+        filtered = {kk: vv for kk, vv in v.items() if (kk in ('disabled', 'capabilities') if v['available'] else kk in ('available', 'unavailable_reason'))}
+        logging.info(f"Found comfy_kitchen backend {k}: {filtered}")
 except ImportError as e:
     logging.error(f"Failed to import comfy_kitchen, Error: {e}, fp8 and fp4 support will not be available.")
     _CK_AVAILABLE = False


### PR DESCRIPTION
Current comfy_kitchen backend prints redundant information:

>Found comfy_kitchen backend triton: {'available': False, 'disabled': True, 'unavailable_reason': "ImportError: No module named 'triton'", 'capabilities': []}
Found comfy_kitchen backend eager: {'available': True, 'disabled': False, 'unavailable_reason': None, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_mxfp8', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_mxfp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8', 'scaled_mm_mxfp8', 'scaled_mm_nvfp4']}
Found comfy_kitchen backend cuda: {'available': True, 'disabled': True, 'unavailable_reason': None, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_mxfp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8']}

Filter to necessary info: when not available, indicate `available` status and `unavailable_reason`; when available, show if `disabled` and it's `capabilities`:

>Found comfy_kitchen backend triton: {'available': False, 'unavailable_reason': "ImportError: No module named 'triton'"}
Found comfy_kitchen backend eager: {'disabled': False, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_mxfp8', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_mxfp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8', 'scaled_mm_mxfp8', 'scaled_mm_nvfp4']}
Found comfy_kitchen backend cuda: {'disabled': True, 'capabilities': ['apply_rope', 'apply_rope1', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'quantize_mxfp8', 'quantize_nvfp4', 'quantize_per_tensor_fp8']}
