### PR TITLE
docs(openapi): tighten workspace API key description field (BE-1004)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4162,7 +4162,8 @@ paths:
                   description: Display name for the API key
                 description:
                   type: string
-                  description: User-provided description for the key
+                  description: User-provided description of the key's purpose
+                  maxLength: 5000
       responses:
         "201":
           description: API key created
@@ -7680,6 +7681,7 @@ components:
       required:
         - id
         - name
+        - description
       properties:
         id:
           type: string
@@ -7687,8 +7689,8 @@ components:
           type: string
         description:
           type: string
-          nullable: true
-          description: User-provided description
+          maxLength: 5000
+          description: User-provided description of the key's purpose. Always present in responses; empty string when no description was supplied on create.
         prefix:
           type: string
           description: First few characters of the key for identification
@@ -7709,6 +7711,7 @@ components:
       required:
         - id
         - name
+        - description
         - key
       properties:
         id:
@@ -7717,8 +7720,8 @@ components:
           type: string
         description:
           type: string
-          nullable: true
-          description: User-provided description
+          maxLength: 5000
+          description: User-provided description of the key's purpose. Always present in responses; empty string when no description was supplied on create.
         key:
           type: string
           description: Full API key value (only returned on creation)


### PR DESCRIPTION
## Summary

Aligns the OSS spec for the workspace API key endpoints with cloud's runtime contract from BE-1004.

Three small changes to `openapi.yaml`:

- **`createWorkspaceApiKey` request body** — add `maxLength: 5000` to the description property (matches cloud's `hub_profile.description` Ent `MaxLen(5000)` convention; enforced cloud-side via handler check + Ent validator).
- **`WorkspaceApiKey` + `WorkspaceApiKeyCreated` response schemas** — mark `description` as required (cloud's handler always populates the field, defaulting to empty string when not supplied on create), drop `nullable: true`, add `maxLength: 5000` for symmetry, and clarify the doc string ("Always present in responses; empty string when no description was supplied on create").

## Why

The workspace API keys schemas are tagged `x-runtime: [cloud]` — they document a cloud-only endpoint surface that OSS doesn't implement. Cloud's hand-written spec (`services/ingest/openapi.yaml` in `Comfy-Org/cloud`) was tightened in https://github.com/Comfy-Org/cloud/pull/3747 to reflect actual runtime behavior; this PR brings the upstream OSS contract in line so the daily vendor-sync bot can propagate the tightening back to cloud's vendor copy without drift.

## Scope

Spec-only. No generated code or handlers in OSS to touch — OSS has no implementation of these endpoints.

## Related

- Cloud PR: Comfy-Org/cloud#3747
- Linear: BE-1004