### PR TITLE
Adding new StringFormat node

### DIFF
--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -1,8 +1,39 @@
 import re
 import json
+import string
 from typing_extensions import override
 
 from comfy_api.latest import ComfyExtension, io
+
+
+class StringFormat(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        autogrow = io.Autogrow.TemplateNames(
+            input=io.AnyType.Input("value"),
+            names=list(string.ascii_lowercase),
+            min=0,
+        )
+        return io.Schema(
+            node_id="StringFormat",
+            display_name="Text Format",
+            category="text",
+            search_aliases=["string", "format"],
+            description="Same as Python's string format method. Supports all of Python's format options and features.",
+            inputs=[
+                io.Autogrow.Input("values", template=autogrow),
+                io.String.Input("f_string", default="{a}", multiline=True),
+            ],
+            outputs=[
+                io.String.Output(),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls, values: io.Autogrow.Type, f_string: str
+    ) -> io.NodeOutput:
+        return io.NodeOutput(f_string.format(**values))
 
 
 class StringConcatenate(io.ComfyNode):
@@ -413,6 +444,7 @@ class StringExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[io.ComfyNode]]:
         return [
+            StringFormat,
             StringConcatenate,
             StringSubstring,
             StringLength,

--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -16,7 +16,7 @@ class StringFormat(io.ComfyNode):
         )
         return io.Schema(
             node_id="StringFormat",
-            display_name="Text Format",
+            display_name="Format Text",
             category="text",
             search_aliases=["string", "format"],
             description="Same as Python's string format method. Supports all of Python's format options and features.",


### PR DESCRIPTION
<img width="1455" height="528" alt="StringFormat node" src="https://github.com/user-attachments/assets/9c10b523-4a14-428b-a4bf-6073ef70ef84" />

This PR adds in a new StringFormat node that just uses Python's string format method.

Similar to the MathExpression node, it supports a maximum of 26 different arguments (a-z).

----

The Python [string format method](https://www.w3schools.com/python/ref_string_format.asp) is very useful:

* It can be used as an easy way to concatenate strings.
* It can be used to convert anything into a string.
* It can format items with padding and alignment.
* It can format numbers with zero-padding.
* It can format numbers with a specific number of decimals.
* And more!