### PR TITLE
Fix MultiGPU scheduler capacity accounting

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -394,7 +394,7 @@ def _calc_cond_batch_multigpu(model: BaseModel, conds: list[list[dict]], x_in: t
     total_conds = 0
     for to_run in hooked_to_run.values():
         total_conds += len(to_run)
-    conds_per_device = max(1, math.ceil(total_conds//len(devices)))
+    conds_per_device = max(1, math.ceil(total_conds / len(devices)))
     index_device = 0
     current_device = devices[index_device]
     # run every hooked_to_run separately
@@ -406,13 +406,17 @@ def _calc_cond_batch_multigpu(model: BaseModel, conds: list[list[dict]], x_in: t
             batched_to_run_length = 0
             for btr in batched_to_run:
                 batched_to_run_length += len(btr[1])
+            remaining_capacity = conds_per_device - batched_to_run_length
+            if remaining_capacity <= 0:
+                index_device += 1
+                continue
 
             first = to_run[0]
             first_shape = first[0][0].shape
             to_batch_temp = []
             # make sure not over conds_per_device limit when creating temp batch
             for x in range(len(to_run)):
-                if can_concat_cond(to_run[x][0], first[0]) and len(to_batch_temp) < (conds_per_device - batched_to_run_length):
+                if can_concat_cond(to_run[x][0], first[0]) and len(to_batch_temp) < remaining_capacity:
                     to_batch_temp += [x]
 
             to_batch_temp.reverse()


### PR DESCRIPTION
Cherry-picks the fix from pollockjj/ComfyUI#64 by @pollockjj into `Comfy-Org/ComfyUI:worksplit-multigpu`.

## Summary

`_calc_cond_batch_multigpu` had two related bugs that could leave MultiGPU sampling stuck at `0/N` until timeout when `total_conds` was not evenly divisible by the number of devices (e.g. 3 conds on 2 GPUs, as produced by Omnigen2 image workflows).

## Bugs

**1. `conds_per_device` is computed with floor division before `ceil`:**

``python
conds_per_device = max(1, math.ceil(total_conds//len(devices)))
``

Python's `//` is integer floor division applied **before** `math.ceil`, so `ceil` is a no-op. For `total_conds=3, len(devices)=2` this yields `conds_per_device = 1` instead of `2`.

**2. The scheduling loop does not skip already-full devices.**

Once both devices reach capacity but `to_run` still has entries, `conds_per_device - batched_to_run_length` is `<= 0`. The inner filter produces an empty `to_batch_temp`, `to_batch = to_batch_temp[:1]` is empty, `to_run.pop` is never called, and an empty `(hooks, [])` group is appended. Because `batched_to_run_length >= conds_per_device` remains true, `index_device` is incremented and the next iteration repeats the same situation on the next device, looping forever and never advancing the sampler.

## Fix

``python
conds_per_device = max(1, math.ceil(total_conds / len(devices)))
...
remaining_capacity = conds_per_device - batched_to_run_length
if remaining_capacity <= 0:
    index_device += 1
    continue
``

For `total_conds=3, len(devices)=2` the scheduler now correctly assigns `conds_per_device=2` and splits work as `2 + 1` across the two devices, so sampling reaches `N/N`.

## Validation

- `python -m py_compile comfy/samplers.py`
- @pollockjj reports successful Omnigen2 worksplit runs on dual RTX 3090 and on RTX 5090 + RTX 4070 after this fix; see pollockjj/ComfyUI#64 for the full pre/post probe logs.

## Credit

Original fix authored by @pollockjj in pollockjj/ComfyUI#64.