### PR TITLE
Adding in And, Or, and Not nodes.

### DIFF
--- a/comfy_extras/nodes_logic.py
+++ b/comfy_extras/nodes_logic.py
@@ -14,7 +14,7 @@ class NotNode(io.ComfyNode):
         return io.Schema(
             node_id="ComfyNotNode",
             display_name="Not",
-            category="logic",
+            category="utils/logic",
             description="Logical NOT operation. Returns true if the value is falsy. Uses Python's rules for truthiness.",
             search_aliases=["invert", "toggle", "negate", "flip boolean"],
             inputs=[
@@ -41,7 +41,7 @@ class AndNode(io.ComfyNode):
         return io.Schema(
             node_id="ComfyAndNode",
             display_name="And",
-            category="logic",
+            category="utils/logic",
             description="Logical AND operation. Returns true if all of the values are truthy. Uses Python's rules for truthiness.",
             search_aliases=["all", "every"],
             inputs=[
@@ -68,7 +68,7 @@ class OrNode(io.ComfyNode):
         return io.Schema(
             node_id="ComfyOrNode",
             display_name="Or",
-            category="logic",
+            category="utils/logic",
             description="Logical OR operation. Returns true if any of the values are truthy. Uses Python's rules for truthiness.",
             search_aliases=["any", "some"],
             inputs=[

--- a/comfy_extras/nodes_logic.py
+++ b/comfy_extras/nodes_logic.py
@@ -8,6 +8,82 @@ from comfy_api.latest import _io
 MISSING = object()
 
 
+class NotNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="ComfyNotNode",
+            display_name="Not",
+            category="logic",
+            description="Logical NOT operation. Returns true if the value is falsy. Uses Python's rules for truthiness.",
+            search_aliases=["invert", "toggle", "negate", "flip boolean"],
+            inputs=[
+                io.AnyType.Input("value"),
+            ],
+            outputs=[
+                io.Boolean.Output(),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, value) -> io.NodeOutput:
+        return io.NodeOutput(not value)
+
+
+class AndNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        template = io.Autogrow.TemplatePrefix(
+            input=io.AnyType.Input("value"),
+            prefix="value",
+            min=1,
+        )
+        return io.Schema(
+            node_id="ComfyAndNode",
+            display_name="And",
+            category="logic",
+            description="Logical AND operation. Returns true if all of the values are truthy. Uses Python's rules for truthiness.",
+            search_aliases=["all", "every"],
+            inputs=[
+                io.Autogrow.Input("values", template=template),
+            ],
+            outputs=[
+                io.Boolean.Output(),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, values: io.Autogrow.Type) -> io.NodeOutput:
+        return io.NodeOutput(all(values.values()))
+
+
+class OrNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        template = io.Autogrow.TemplatePrefix(
+            input=io.AnyType.Input("value"),
+            prefix="value",
+            min=1,
+        )
+        return io.Schema(
+            node_id="ComfyOrNode",
+            display_name="Or",
+            category="logic",
+            description="Logical OR operation. Returns true if any of the values are truthy. Uses Python's rules for truthiness.",
+            search_aliases=["any", "some"],
+            inputs=[
+                io.Autogrow.Input("values", template=template),
+            ],
+            outputs=[
+                io.Boolean.Output(),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, values: io.Autogrow.Type) -> io.NodeOutput:
+        return io.NodeOutput(any(values.values()))
+
+
 class SwitchNode(io.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -261,6 +337,9 @@ class LogicExtension(ComfyExtension):
         return [
             SwitchNode,
             CustomComboNode,
+            NotNode,
+            AndNode,
+            OrNode,
             # SoftSwitchNode,
             # ConvertStringToComboNode,
             # DCTestNode,


### PR DESCRIPTION
Adds in the logical AND, OR, and NOT operations.

They have the standard Python behavior for truthiness.

They accept any type, because every type in Python has a truthiness, and it's useful to convert arbitrary types into booleans.

AND and OR use autogrow, which avoids the need to chain multiple AND / OR.

AND and OR are eager... they always evaluate all of their inputs. Making them lazy might be a good idea, but the implementation is tricky, so it can wait for a future pull request.