### PR TITLE
Fix grayscale VideoFromFile decoding

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -52,6 +52,18 @@ def get_open_write_kwargs(
 
     return open_kwargs
 
+BYTE_NORMALIZED_VIDEO_FORMATS = ("yuvj420p", "yuvj422p", "yuvj444p", "rgb24", "rgba", "pal8")
+
+
+def should_decode_as_byte_rgb(format_name: str) -> bool:
+    # PyAV decodes grayscale PNGs as `gray`, which should be normalized like
+    # other byte-based image formats instead of going through the float GBR path.
+    # Keep float grayscale formats on the existing float path.
+    return format_name in BYTE_NORMALIZED_VIDEO_FORMATS or (
+        format_name.startswith("gray") and not format_name.startswith("grayf")
+    )
+
+
 
 class VideoFromFile(VideoInput):
     """
@@ -290,7 +302,7 @@ class VideoFromFile(VideoInput):
                                     alphas = []
                                     alpha_channel = True
                                     break
-                            if frame.format.name in ("yuvj420p", "yuvj422p", "yuvj444p", "rgb24", "rgba", "pal8") or frame.format.name.startswith("gray"):
+                            if should_decode_as_byte_rgb(frame.format.name):
                                 process_image_format = lambda a: a.float() / 255.0
                                 if alpha_channel:
                                     image_format = 'rgba'

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -290,7 +290,7 @@ class VideoFromFile(VideoInput):
                                     alphas = []
                                     alpha_channel = True
                                     break
-                            if frame.format.name in ("yuvj420p", "yuvj422p", "yuvj444p", "rgb24", "rgba", "pal8"):
+                            if frame.format.name in ("yuvj420p", "yuvj422p", "yuvj444p", "rgb24", "rgba", "pal8") or frame.format.name.startswith("gray"):
                                 process_image_format = lambda a: a.float() / 255.0
                                 if alpha_channel:
                                     image_format = 'rgba'

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -5,7 +5,11 @@ import os
 import av
 import io
 from fractions import Fraction
-from comfy_api.input_impl.video_types import VideoFromFile, VideoFromComponents
+from comfy_api.input_impl.video_types import (
+    VideoFromFile,
+    VideoFromComponents,
+    should_decode_as_byte_rgb,
+)
 from comfy_api.util.video_types import VideoComponents
 from comfy_api.input.basic_types import AudioInput
 from av.error import InvalidDataError
@@ -169,6 +173,16 @@ def test_video_from_file_invalid_file_error():
             video.get_dimensions()
     finally:
         os.unlink(tmp_name)
+
+
+@pytest.mark.parametrize("format_name", ["gray", "gray8", "gray16be", "gray16le"])
+def test_should_decode_grayscale_byte_formats_as_rgb(format_name):
+    assert should_decode_as_byte_rgb(format_name)
+
+
+@pytest.mark.parametrize("format_name", ["grayf32le", "gbrpf32le"])
+def test_should_not_byte_normalize_float_formats(format_name):
+    assert not should_decode_as_byte_rgb(format_name)
 
 
 def test_video_from_file_decodes_grayscale_pixels_as_rgb_range():

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -171,6 +171,42 @@ def test_video_from_file_invalid_file_error():
         os.unlink(tmp_name)
 
 
+
+def test_video_from_file_decodes_grayscale_pixels_as_rgb_range():
+    """Grayscale frames should keep 0.0-1.0 pixel values after RGB conversion."""
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+        tmp_name = tmp.name
+
+    try:
+        with av.open(tmp_name, mode="w", format="png_pipe") as container:
+            stream = container.add_stream("png")
+            frame = av.VideoFrame.from_ndarray(
+                torch.tensor([[0, 255], [128, 64]], dtype=torch.uint8).numpy(),
+                format="gray",
+            )
+            packet = stream.encode(frame)
+            container.mux(packet)
+            for packet in stream.encode(None):
+                container.mux(packet)
+
+        components = VideoFromFile(tmp_name).get_components()
+
+        assert components.images.shape == (1, 2, 2, 3)
+        expected = torch.tensor(
+            [[
+                [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+                [
+                    [128 / 255.0, 128 / 255.0, 128 / 255.0],
+                    [64 / 255.0, 64 / 255.0, 64 / 255.0],
+                ],
+            ]],
+            dtype=components.images.dtype,
+        )
+        assert torch.allclose(components.images.cpu(), expected, atol=EPSILON)
+    finally:
+        os.unlink(tmp_name)
+
+
 def test_video_from_file_audio_only_error():
     """ValueError raised for audio-only files"""
     with tempfile.NamedTemporaryFile(suffix=".m4a", delete=False) as tmp:

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -171,7 +171,6 @@ def test_video_from_file_invalid_file_error():
         os.unlink(tmp_name)
 
 
-
 def test_video_from_file_decodes_grayscale_pixels_as_rgb_range():
     """Grayscale frames should keep 0.0-1.0 pixel values after RGB conversion."""
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
@@ -191,7 +190,7 @@ def test_video_from_file_decodes_grayscale_pixels_as_rgb_range():
 
         with av.open(tmp_name) as container:
             decoded_frame = next(container.decode(video=0))
-            assert decoded_frame.format.name == "gray"
+            assert decoded_frame.format.name.startswith("gray")
 
         components = VideoFromFile(tmp_name).get_components()
 

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -189,6 +189,10 @@ def test_video_from_file_decodes_grayscale_pixels_as_rgb_range():
             for packet in stream.encode(None):
                 container.mux(packet)
 
+        with av.open(tmp_name) as container:
+            decoded_frame = next(container.decode(video=0))
+            assert decoded_frame.format.name == "gray"
+
         components = VideoFromFile(tmp_name).get_components()
 
         assert components.images.shape == (1, 2, 2, 3)


### PR DESCRIPTION
## Summary
- treat PyAV grayscale frame formats as byte-based frames before converting them to RGB
- add a regression test that verifies grayscale pixels keep their expected 0.0-1.0 values through `VideoFromFile`

Fixes #13749.

## Tests
- `git diff --check`
- `python3 -m py_compile comfy_api/latest/_input_impl/video_types.py tests-unit/comfy_api_test/video_types_test.py`
- `python3 -m pytest tests-unit/comfy_api_test/video_types_test.py -k grayscale -q` *(not run: this local environment is missing `torch`)*
