### PR TITLE
feat(cache-provider): add on_set_prompt lifecycle hook (CORE-246)

### DIFF
--- a/comfy_api/latest/_caching.py
+++ b/comfy_api/latest/_caching.py
@@ -21,6 +21,10 @@ class CacheProvider(ABC):
     Exceptions from provider methods are caught by the caller and never break execution.
     """
 
+    async def on_set_prompt(self) -> None:
+        """Called after prompt cache keys are prepared. Dispatched via asyncio.create_task."""
+        pass
+
     @abstractmethod
     async def on_lookup(self, context: CacheContext) -> Optional[CacheValue]:
         """Called on local cache miss. Return CacheValue if found, None otherwise."""

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -164,6 +164,7 @@ class BasicCache:
         await self.cache_key_set.add_keys(node_ids)
         self.is_changed_cache = is_changed_cache
         self.initialized = True
+        await self._notify_providers_set_prompt()
 
     def all_node_ids(self):
         assert self.initialized
@@ -263,6 +264,24 @@ class BasicCache:
             except Exception as e:
                 _logger.warning(f"Cache provider {provider.__class__.__name__} error on store: {e}")
 
+    async def _notify_providers_set_prompt(self):
+        from comfy_execution.cache_provider import (
+            _has_cache_providers, _get_cache_providers, _logger
+        )
+
+        if not self.enable_providers:
+            return
+        if not _has_cache_providers():
+            return
+
+        for provider in _get_cache_providers():
+            try:
+                task = asyncio.create_task(self._safe_provider_set_prompt(provider))
+                self._pending_store_tasks.add(task)
+                task.add_done_callback(self._pending_store_tasks.discard)
+            except Exception as e:
+                _logger.warning(f"Cache provider {provider.__class__.__name__} error on set_prompt: {e}")
+
     @staticmethod
     async def _safe_provider_store(provider, context, cache_value):
         from comfy_execution.cache_provider import _logger
@@ -270,6 +289,14 @@ class BasicCache:
             await provider.on_store(context, cache_value)
         except Exception as e:
             _logger.warning(f"Cache provider {provider.__class__.__name__} async store error: {e}")
+
+    @staticmethod
+    async def _safe_provider_set_prompt(provider):
+        from comfy_execution.cache_provider import _logger
+        try:
+            await provider.on_set_prompt()
+        except Exception as e:
+            _logger.warning(f"Cache provider {provider.__class__.__name__} async set_prompt error: {e}")
 
     async def _check_providers_lookup(self, node_id, cache_key):
         from comfy_execution.cache_provider import (


### PR DESCRIPTION
## Summary

Adds a new `on_set_prompt()` lifecycle hook on the `CacheProvider` interface that fires after the cache key set is prepared for a new prompt. Dispatched as an async task with errors swallowed (same fail-safe pattern as `on_store` / `on_lookup` / `on_prompt_start` / `on_prompt_end`).

## Why

`BasicCache`'s lifecycle notifications to external providers are incomplete. `set_prompt` is a key per-prompt event — the moment the cache key set is prepared and the cache is ready to serve lookups — and providers currently get no signal for it. There's a clean completeness argument for surfacing this.

The immediate motivating use case: **cost-aware caching policies**. A provider can set `t = perf_counter()` in `on_set_prompt`, then measure `elapsed` at each `on_store` to estimate the compute that a future hit on this entry would save. That gives the provider a simple, accurate per-prompt clock without needing per-node timing exposed in the API.

## Implementation

```
comfy_api/latest/_caching.py
  CacheProvider gains async def on_set_prompt() with default no-op

comfy_execution/caching.py
  BasicCache.set_prompt(...) now awaits self._notify_providers_set_prompt()
  _notify_providers_set_prompt → asyncio.create_task per provider
  _safe_provider_set_prompt → swallows exceptions, same as _safe_provider_store
```

Only 31 lines, two files, fully additive.

## Backward compatibility

- New `on_set_prompt()` method has a `pass` default — existing providers compile and run unchanged.
- New `_notify_providers_set_prompt` is gated on `self.enable_providers` + `_has_cache_providers()`, so no-op when no providers are registered.
- Errors swallowed per existing pattern; provider faults never break execution.

## Lifecycle position

```
on_prompt_start(prompt_id)            — already exists, fires at exec start
   ↓
caches.set_prompt(...) initializes cache_key_set
   ↓
on_set_prompt()                       — NEW, fires here
   ↓
execution loop → on_lookup / on_store per node
   ↓
on_prompt_end(prompt_id)              — already exists, fires at exec end
```

## Test plan
- [ ] Existing CacheProvider tests still pass (`on_set_prompt` defaults to no-op preserves behavior)
- [ ] Manual: register a provider that overrides `on_set_prompt` and confirm it fires once per prompt, after cache keys are prepared