### PR TITLE
fix(openapi): correct POST /api/assets/import to importPublishedAssets

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2514,37 +2514,25 @@ paths:
 
   /api/assets/import:
     post:
-      operationId: importAssets
+      operationId: importPublishedAssets
       tags: [assets]
-      summary: Import assets from external URLs
-      description: "[cloud-only] Imports one or more assets from external URLs into the cloud asset store."
+      summary: "[cloud-only] Import published assets into the caller's library"
+      description: |
+        [cloud-only] Imports the specified published assets into the caller's asset library. New DB records reference the same storage objects; no file copying occurs. Assets the caller already owns (by hash) are deduplicated. The `id` field on each returned `AssetInfo` is the caller's newly-created private asset ID, not the published asset ID supplied in the request.
       x-runtime: [cloud]
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - imports
-              properties:
-                imports:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/AssetImportRequest"
-                  description: Assets to import
+              $ref: "#/components/schemas/ImportPublishedAssetsRequest"
       responses:
         "200":
-          description: Import initiated
+          description: Successfully imported assets
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  assets:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Asset"
+                $ref: "#/components/schemas/ImportPublishedAssetsResponse"
         "400":
           description: Bad request
           content:
@@ -7090,24 +7078,35 @@ components:
           type: string
           description: Target path on the runtime filesystem
 
-    AssetImportRequest:
+    ImportPublishedAssetsRequest:
       type: object
       x-runtime: [cloud]
-      description: "[cloud-only] A single asset to import from an external URL."
+      description: "[cloud-only] Request body for importing published assets into the caller's library."
       required:
-        - url
+        - published_asset_ids
       properties:
-        url:
-          type: string
-          format: uri
-          description: URL of the asset to import
-        name:
-          type: string
-          description: Display name for the imported asset
-        tags:
+        published_asset_ids:
           type: array
+          description: IDs of published assets (inputs and models) to import.
           items:
             type: string
+        share_id:
+          type: string
+          nullable: true
+          description: |
+            Optional. Share ID of the published workflow these assets belong to. When provided (non-null, non-empty): all `published_asset_ids` must belong to this share's workflow version; returns 400 if the share is not found or any asset does not belong to it. When omitted, null, or empty string: no share-scoped validation is performed and the assets are validated only against global rules (preserved for clients that have not yet adopted `share_id`).
+
+    ImportPublishedAssetsResponse:
+      type: object
+      x-runtime: [cloud]
+      description: "[cloud-only] Response after importing published assets. Each returned `AssetInfo.id` is the caller's newly-created private asset ID, not the published asset ID supplied in the request."
+      required:
+        - assets
+      properties:
+        assets:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssetInfo"
 
     RemoteAssetMetadata:
       type: object


### PR DESCRIPTION
## Summary

The operation at \`POST /api/assets/import\` is currently defined as \`importAssets\` with a URL-list body shape — but no runtime actually serves that operation at this path. The cloud runtime serves a different operation here: \`importPublishedAssets\`, which imports published-workflow assets into the caller's library by ID, not by URL.

This PR corrects the spec to match what the runtime actually does.

## What changed

\`POST /api/assets/import\`:

- operationId: \`importAssets\` → \`importPublishedAssets\`
- Request body: \`{imports: AssetImportRequest[]}\` (URL list) → \`ImportPublishedAssetsRequest\` (\`published_asset_ids\` + optional \`share_id\`)
- Response: \`{assets: Asset[]}\` → \`ImportPublishedAssetsResponse\` (\`{assets: AssetInfo[]}\`)

Component schemas:

- Removed: \`AssetImportRequest\` (zero remaining references in the spec)
- Added: \`ImportPublishedAssetsRequest\`, \`ImportPublishedAssetsResponse\`

All new schemas + operation tagged \`x-runtime: [cloud]\` with \`[cloud-only]\` description prefix, matching the convention used by the other cloud-runtime-only operations on this spec.

## Why

Spec-drift correction. Cloud's URL-based asset ingestion is a separate concern and lives at separate paths (\`POST /assets/download\` + \`GET /assets/remote-metadata\`) tracked under different work; nothing in this PR affects that.

## Compatibility

No frontend consumer references \`AssetImportRequest\` today (verified by typechecking a frontend tree against types generated from this spec — \`AssetImportRequest\` was unreferenced). This is a spec-only correction.

## Validation

- \`spectral lint openapi.yaml --ruleset .spectral.yaml --fail-severity=error\` → 0 errors. The 2 hint / 3 warning findings are pre-existing on the spec, unrelated to this change.
- YAML parses; structural diff is +29 / −30, isolated to the operation and the swapped schema.

## Test plan

- [ ] Spectral CI passes (gated at \`error\` severity).
- [ ] No changes to local ComfyUI behavior expected — cloud-runtime-only operation.