### PR TITLE
Fix reshaping lora application

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1613,6 +1613,16 @@ class ModelPatcherDynamic(ModelPatcher):
         #use all ModelPatcherDynamic this is ignored and its all done dynamically.
         return super().memory_required(input_shape=input_shape) * 1.3 + (1024 ** 3)
 
+    def restore_loaded_backups(self):
+        restored = self.model.model_loaded_weight_memory
+        for key in list(self.backup.keys()):
+            bk = self.backup.pop(key)
+            comfy.utils.set_attr_param(self.model, key, bk.weight)
+        for key in list(self.backup_buffers.keys()):
+            comfy.utils.set_attr_buffer(self.model, key, self.backup_buffers.pop(key))
+        self.model.model_loaded_weight_memory = 0
+        return restored
+
 
     def load(self, device_to=None, lowvram_model_memory=0, force_patch_weights=False, full_load=False, dirty=False):
 
@@ -1629,7 +1639,7 @@ class ModelPatcherDynamic(ModelPatcher):
 
         num_patches = 0
         allocated_size = 0
-        self.model.model_loaded_weight_memory = 0
+        self.restore_loaded_backups()
 
         with self.use_ejected():
             self.unpatch_hooks()
@@ -1776,13 +1786,7 @@ class ModelPatcherDynamic(ModelPatcher):
         freed = 0 if vbar is None else vbar.free_memory(memory_to_free)
 
         if freed < memory_to_free:
-            for key in list(self.backup.keys()):
-                bk = self.backup.pop(key)
-                comfy.utils.set_attr_param(self.model, key, bk.weight)
-            for key in list(self.backup_buffers.keys()):
-                comfy.utils.set_attr_buffer(self.model, key, self.backup_buffers.pop(key))
-            freed += self.model.model_loaded_weight_memory
-            self.model.model_loaded_weight_memory = 0
+            freed += self.restore_loaded_backups()
 
         return freed
 

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1716,6 +1716,9 @@ class ModelPatcherDynamic(ModelPatcher):
                         force_load=True
 
                     if force_load:
+                        if hasattr(m, "_v"):
+                            comfy_aimdo.model_vbar.vbar_unpin(m._v)
+                            delattr(m, "_v")
                         force_load_param(self, "weight", device_to)
                         force_load_param(self, "bias", device_to)
                     else:


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/13989

Two fixes to the reshaper lora application that affect users causing a crash or output corruption.

Example test conditions:

WAN 2.1 1.3B + tile control lora
Run (lora bypassed), Run (lora on), Run (lora bypassed w/ seed change)

<img width="1745" height="915" alt="image" src="https://github.com/user-attachments/assets/f1dcd1d8-81f9-4864-9b9b-942567e3d77c" />


Before:

```
...
  File "/home/rattus/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 606, in forward
    return self.forward_comfy_cast_weights(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 598, in forward_comfy_cast_weights
    weight, bias, offload_stream = cast_bias_weight(self, input, offloadable=True)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 367, in cast_bias_weight
    weight, bias = resolve_cast_module_with_vbar(s, dtype, device, bias_dtype, compute_dtype, want_requant)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/ops.py", line 266, in resolve_cast_module_with_vbar
    comfy.memory_management.interpret_gathered_like(prefetch["cast_geometry"], cast_dest)):
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rattus/ComfyUI/comfy/memory_management.py", line 148, in interpret_gathered_like
    raise ValueError(f"Buffer too small: needs {offset + size} bytes, but only has {gathered.numel()}. ")
ValueError: Buffer too small: needs 786432 bytes, but only has 399360. 
```

After:

```
Requested to load WAN21
Model WAN21 prepared for dynamic VRAM loading. 2705MB Staged. 0 patches attached. Force pre-loaded 180 weights: 543 KB.
100%|██████████| 12/12 [00:02<00:00,  4.28it/s]                                  
...
Prompt executed in 5.63 seconds
got prompt
Requested to load WAN21
Module diffusion_model.patch_embedding has resizing Lora - force loading
Model WAN21 prepared for dynamic VRAM loading. 2705MB Staged. 240 patches attached. Force pre-loaded 182 weights: 930 KB.
100%|██████████| 12/12 [00:02<00:00,  4.27it/s]                                  
...
Prompt executed in 3.68 seconds
got prompt
Requested to load WAN21
Model WAN21 prepared for dynamic VRAM loading. 2705MB Staged. 0 patches attached. Force pre-loaded 180 weights: 543 KB.
100%|██████████| 12/12 [00:02<00:00,  4.27it/s]                                  
...
Prompt executed in 3.65 seconds
```

Regression Tests:

Linux, RTX5090, ZiT+Lora :white_check_mark: 
Linux, RTX5090, Ace-step 1.5 turbo XL :white_check_mark:
Linux, RTX5090, stable cascade -> Flux2 :white_check_mark: 