### PR TITLE
Add colored logs

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -69,7 +69,7 @@ def on_flush(callback):
     if stderr_interceptor is not None:
         stderr_interceptor.on_flush(callback)
 
-def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool = False, color_logs: bool = False):
+def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool = False, color_logs: bool = True):
     global logs
     if logs:
         return

--- a/app/logger.py
+++ b/app/logger.py
@@ -5,13 +5,25 @@ import logging
 import sys
 import threading
 
-ANSI_LEVEL_COLORS = {
-    'DEBUG':    '\033[36m',   # cyan
-    'INFO':     '\033[32m',   # green
-    'WARNING':  '\033[33m',   # yellow
-    'ERROR':    '\033[31m',   # red
-    'CRITICAL': '\033[35m',   # magenta
+ANSI_NAMED_COLORS = {
+    'black':   '\033[30m',
+    'red':     '\033[31m',
+    'green':   '\033[32m',
+    'yellow':  '\033[33m',
+    'blue':    '\033[34m',
+    'magenta': '\033[35m',
+    'cyan':    '\033[36m',
+    'white':   '\033[37m',
 }
+
+ANSI_LEVEL_COLORS = {
+    'DEBUG':    ANSI_NAMED_COLORS['cyan'],
+    'INFO':     ANSI_NAMED_COLORS['green'],
+    'WARNING':  ANSI_NAMED_COLORS['yellow'],
+    'ERROR':    ANSI_NAMED_COLORS['red'],
+    'CRITICAL': ANSI_NAMED_COLORS['magenta'],
+}
+
 ANSI_RESET = '\033[0m'
 ANSI_BOLD  = '\033[1m'
 
@@ -21,7 +33,11 @@ class ColoredFormatter(logging.Formatter):
         color = ANSI_LEVEL_COLORS.get(record.levelname, '')
         bold  = ANSI_BOLD if record.levelno >= logging.WARNING else ''
         level_tag = f"{bold}{color}[{record.levelname}]{ANSI_RESET} "
-        return level_tag + super().format(record)
+        message = super().format(record)
+        line_color = ANSI_NAMED_COLORS.get(getattr(record, 'color', ''), '')
+        if line_color:
+            return f"{level_tag}{line_color}{message}{ANSI_RESET}"
+        return level_tag + message
 
 logs = None
 stdout_interceptor = None

--- a/app/logger.py
+++ b/app/logger.py
@@ -85,7 +85,7 @@ def on_flush(callback):
     if stderr_interceptor is not None:
         stderr_interceptor.on_flush(callback)
 
-def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool = False, color_logs: bool = True):
+def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool = False):
     global logs
     if logs:
         return
@@ -102,7 +102,7 @@ def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool 
     logger = logging.getLogger()
     logger.setLevel(log_level)
 
-    formatter = ColoredFormatter("%(message)s") if color_logs else logging.Formatter("%(message)s")
+    formatter = ColoredFormatter("%(message)s")
 
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)

--- a/app/logger.py
+++ b/app/logger.py
@@ -5,6 +5,24 @@ import logging
 import sys
 import threading
 
+ANSI_LEVEL_COLORS = {
+    'DEBUG':    '\033[36m',   # cyan
+    'INFO':     '\033[32m',   # green
+    'WARNING':  '\033[33m',   # yellow
+    'ERROR':    '\033[31m',   # red
+    'CRITICAL': '\033[35m',   # magenta
+}
+ANSI_RESET = '\033[0m'
+ANSI_BOLD  = '\033[1m'
+
+
+class ColoredFormatter(logging.Formatter):
+    def format(self, record):
+        color = ANSI_LEVEL_COLORS.get(record.levelname, '')
+        bold  = ANSI_BOLD if record.levelno >= logging.WARNING else ''
+        level_tag = f"{bold}{color}[{record.levelname}]{ANSI_RESET} "
+        return level_tag + super().format(record)
+
 logs = None
 stdout_interceptor = None
 stderr_interceptor = None
@@ -51,7 +69,7 @@ def on_flush(callback):
     if stderr_interceptor is not None:
         stderr_interceptor.on_flush(callback)
 
-def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool = False):
+def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool = False, color_logs: bool = False):
     global logs
     if logs:
         return
@@ -68,8 +86,10 @@ def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool 
     logger = logging.getLogger()
     logger.setLevel(log_level)
 
+    formatter = ColoredFormatter("%(message)s") if color_logs else logging.Formatter("%(message)s")
+
     stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(logging.Formatter("%(message)s"))
+    stream_handler.setFormatter(formatter)
 
     if use_stdout:
         # Only errors and critical to stderr
@@ -77,7 +97,7 @@ def setup_logger(log_level: str = 'INFO', capacity: int = 300, use_stdout: bool 
 
         # Lesser to stdout
         stdout_handler = logging.StreamHandler(sys.stdout)
-        stdout_handler.setFormatter(logging.Formatter("%(message)s"))
+        stdout_handler.setFormatter(formatter)
         stdout_handler.addFilter(lambda record: record.levelno < logging.ERROR)
         logger.addHandler(stdout_handler)
 

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -183,7 +183,7 @@ parser.add_argument("--multi-user", action="store_true", help="Enables per-user 
 
 parser.add_argument("--verbose", default='INFO', const='DEBUG', nargs="?", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], help='Set the logging level')
 parser.add_argument("--log-stdout", action="store_true", help="Send normal process output to stdout instead of stderr (default).")
-parser.add_argument("--color-logs", action="store_true", help="Enable ANSI colored log output in the terminal.")
+parser.add_argument("--color-logs", action=argparse.BooleanOptionalAction, default=True, help="Enable ANSI colored log output in the terminal (default: enabled, use --no-color-logs to disable).")
 
 
 # The default built-in provider hosted under web/

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -183,7 +183,6 @@ parser.add_argument("--multi-user", action="store_true", help="Enables per-user 
 
 parser.add_argument("--verbose", default='INFO', const='DEBUG', nargs="?", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], help='Set the logging level')
 parser.add_argument("--log-stdout", action="store_true", help="Send normal process output to stdout instead of stderr (default).")
-parser.add_argument("--color-logs", action=argparse.BooleanOptionalAction, default=True, help="Enable ANSI colored log output in the terminal (default: enabled, use --no-color-logs to disable).")
 
 
 # The default built-in provider hosted under web/

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -183,6 +183,7 @@ parser.add_argument("--multi-user", action="store_true", help="Enables per-user 
 
 parser.add_argument("--verbose", default='INFO', const='DEBUG', nargs="?", choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], help='Set the logging level')
 parser.add_argument("--log-stdout", action="store_true", help="Send normal process output to stdout instead of stderr (default).")
+parser.add_argument("--color-logs", action="store_true", help="Enable ANSI colored log output in the terminal.")
 
 
 # The default built-in provider hosted under web/

--- a/main.py
+++ b/main.py
@@ -344,9 +344,9 @@ def prompt_worker(q, server_instance):
             # Log Time in a more readable way after 10 minutes
             if execution_time > 600:
                 execution_time = time.strftime("%H:%M:%S", time.gmtime(execution_time))
-                logging.info(f"Prompt executed in {execution_time}")
+                logging.info(f"Prompt executed in {execution_time}", extra={'color': 'green'})
             else:
-                logging.info("Prompt executed in {:.2f} seconds".format(execution_time))
+                logging.info("Prompt executed in {:.2f} seconds".format(execution_time), extra={'color': 'green'})
 
             if not asset_seeder.is_disabled():
                 paths = _collect_output_absolute_paths(e.history_result)

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import folder_paths
 import time
 from comfy.cli_args import enables_dynamic_vram
 from app.logger import setup_logger
-setup_logger(log_level=args.verbose, use_stdout=args.log_stdout, color_logs=args.color_logs)
+setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
 
 from app.assets.seeder import asset_seeder
 from app.assets.services import register_output_files

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import folder_paths
 import time
 from comfy.cli_args import enables_dynamic_vram
 from app.logger import setup_logger
-setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
+setup_logger(log_level=args.verbose, use_stdout=args.log_stdout, color_logs=args.color_logs)
 
 from app.assets.seeder import asset_seeder
 from app.assets.services import register_output_files


### PR DESCRIPTION
Sometimes it's very hard to read the logs efficiently. This PR adds optional flag when starting comfyUI `python main.py --color-logs`

This colors all the infos green, warnings orange and errors red. See the image:
<img width="1727" height="453" alt="Screenshot 2026-05-21 at 21 59 04" src="https://github.com/user-attachments/assets/718b15e5-a852-46a4-87c3-c49bb697e0ee" />

I would personally set this as a default option.