### PR TITLE
Fix SIGPIPE false negative in Backport Release workflow validation

### DIFF
--- a/.github/workflows/backport_release.yaml
+++ b/.github/workflows/backport_release.yaml
@@ -110,15 +110,13 @@ jobs:
 
           source_sha="$(git rev-parse "refs/remotes/origin/${SOURCE_BRANCH}")"
 
-          # The source branch must be cut directly off the latest stable tag.
-          # "Cut directly off" means: walking first-parent from the source tip
-          # eventually reaches LATEST_TAG_SHA. This rejects branches that were
-          # cut from master after the tag (which would carry unrelated commits),
-          # while accepting a branch rooted at the tag with N backport commits
-          # on top (each of which may itself be a merge — first-parent walks
-          # through the mainline of the branch).
-          if ! git rev-list --first-parent "${source_sha}" \
-                | grep -qx "${LATEST_TAG_SHA}"; then
+          # Walking first-parent from the source tip must reach LATEST_TAG_SHA.
+          # We capture rev-list into a variable and grep against a here-string
+          # rather than piping `rev-list | grep -q`: under `set -o pipefail`,
+          # `grep -q` would exit on first match and SIGPIPE the still-streaming
+          # `rev-list`, propagating exit 141 as a spurious "not found".
+          first_parent_chain="$(git rev-list --first-parent "${source_sha}")"
+          if ! grep -Fxq "${LATEST_TAG_SHA}" <<< "${first_parent_chain}"; then
             echo "::error::Source branch '${SOURCE_BRANCH}' is not cut from '${LATEST_TAG}'."
             echo "::error::Its first-parent history does not include ${LATEST_TAG_SHA}."
             exit 1


### PR DESCRIPTION
The "Validate source branch is cut directly from the latest stable release" step in the Backport Release workflow fails with a spurious `not found` error even when the source branch is correctly cut from the latest stable tag. This blocked the first attempted run: https://github.com/Comfy-Org/ComfyUI/actions/runs/26257815677

### Root cause

The check uses:

`ash
set -euo pipefail
...
if ! git rev-list --first-parent "${source_sha}" \
      | grep -qx "${LATEST_TAG_SHA}"; then
`

On a real ComfyUI branch `git rev-list --first-parent` streams ~10k SHAs (~400 KB) — well beyond the 64 KB pipe buffer. `grep -q` finds the match on roughly line 4 and exits immediately, closing the read end of the pipe. `git rev-list` then receives `SIGPIPE` on its next write and exits 141. With `pipefail`, the pipeline's exit code becomes 141 (the leftmost non-zero), so `if !` interprets the result as "no match" and emits the error — even though the SHA was actually found.

### Fix

Capture the first-parent rev-list output into a variable, then `grep` against a here-string:

`ash
first_parent_chain="$(git rev-list --first-parent "${source_sha}")"
if ! grep -Fxq "${LATEST_TAG_SHA}" <<< "${first_parent_chain}"; then
  ...
fi
`

Why this form:

- **No live pipe between producer and consumer.** `git rev-list` runs to completion (its output is buffered into the shell variable) before `grep` ever sees the data, so SIGPIPE cannot occur regardless of `pipefail`.
- **Preserves the original semantics exactly** — it still asserts that `LATEST_TAG_SHA` is on the *first-parent chain* of the source branch, not merely a DAG-ancestor. (An earlier revision of this PR used `git merge-base --is-ancestor`, but that only checks DAG ancestry and would accept the edge case where `LATEST_TAG_SHA` is the second parent of a merge commit on the branch.)

The follow-up `all_added` vs `first_parent_added` check is unchanged. Both of its `rev-list | sort` pipelines are already SIGPIPE-safe because `sort` drains stdin to EOF.