### PR TITLE
openapi: align response declarations with implementation (5 endpoints)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2342,16 +2342,27 @@ paths:
                     $ref: "#/components/schemas/AssetDownloadRequest"
                   description: Assets to download
       responses:
-        "200":
-          description: Download initiated
+        "202":
+          description: Download task accepted
           content:
             application/json:
               schema:
                 type: object
+                required:
+                  - task_id
+                  - status
                 properties:
                   task_id:
                     type: string
-                    description: Task ID for tracking progress via WebSocket
+                    format: uuid
+                    description: ID of the download task; use to poll status.
+                  status:
+                    type: string
+                    enum: [pending, running, completed, failed]
+                    description: Current task status (typically `pending` on initial creation).
+                  message:
+                    type: string
+                    description: Human-readable task message.
         "400":
           description: Bad request
           content:
@@ -2391,17 +2402,27 @@ paths:
                   type: string
                   description: Name for the export archive
       responses:
-        "200":
-          description: Export initiated
+        "202":
+          description: Export task accepted
           content:
             application/json:
               schema:
                 type: object
+                required:
+                  - task_id
+                  - status
                 properties:
                   task_id:
                     type: string
-                  export_name:
+                    format: uuid
+                    description: ID of the export task; use to poll status.
+                  status:
                     type: string
+                    enum: [pending, running, completed, failed]
+                    description: Current task status (typically `pending` on initial creation).
+                  message:
+                    type: string
+                    description: Human-readable task message.
         "400":
           description: Bad request
           content:
@@ -2476,8 +2497,8 @@ paths:
                     type: string
                   description: Tags to apply to the created assets
       responses:
-        "201":
-          description: Assets created
+        "200":
+          description: Assets created or referenced
           content:
             application/json:
               schema:
@@ -5056,7 +5077,7 @@ paths:
                   additionalProperties: true
                   description: Additional context metadata
       responses:
-        "200":
+        "201":
           description: Feedback submitted
           content:
             application/json:
@@ -6102,14 +6123,17 @@ components:
           type: string
           description: Current job status
         create_time:
-          type: number
-          description: Job creation timestamp
+          type: integer
+          format: int64
+          description: Job creation timestamp (Unix milliseconds).
         execution_start_time:
-          type: number
-          description: Workflow execution start timestamp
+          type: integer
+          format: int64
+          description: Workflow execution start timestamp (Unix milliseconds, terminal states only).
         execution_end_time:
-          type: number
-          description: Workflow execution end timestamp
+          type: integer
+          format: int64
+          description: Workflow execution end timestamp (Unix milliseconds, terminal states only).
         preview_output:
           type: object
           additionalProperties: true
@@ -6141,13 +6165,21 @@ components:
         execution_error:
           $ref: "#/components/schemas/ExecutionError"
         create_time:
-          type: number
+          type: integer
+          format: int64
+          description: Job creation timestamp (Unix milliseconds).
         update_time:
-          type: number
+          type: integer
+          format: int64
+          description: Last state-change timestamp (Unix milliseconds).
         execution_start_time:
-          type: number
+          type: integer
+          format: int64
+          description: Workflow execution start timestamp (Unix milliseconds, terminal states only).
         execution_end_time:
-          type: number
+          type: integer
+          format: int64
+          description: Workflow execution end timestamp (Unix milliseconds, terminal states only).
         preview_output:
           type: object
           additionalProperties: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2358,8 +2358,8 @@ paths:
                     description: ID of the download task; use to poll status.
                   status:
                     type: string
-                    enum: [pending, running, completed, failed]
-                    description: Current task status (typically `pending` on initial creation).
+                    enum: [created, running, completed, failed]
+                    description: Current task status (typically `created` on initial creation).
                   message:
                     type: string
                     description: Human-readable task message.
@@ -2418,8 +2418,8 @@ paths:
                     description: ID of the export task; use to poll status.
                   status:
                     type: string
-                    enum: [pending, running, completed, failed]
-                    description: Current task status (typically `pending` on initial creation).
+                    enum: [created, running, completed, failed]
+                    description: Current task status (typically `created` on initial creation).
                   message:
                     type: string
                     description: Human-readable task message.


### PR DESCRIPTION
Several endpoints in `openapi.yaml` declare response status codes or schema types that don't match what the API actually returns. This PR aligns the spec with observable behavior so generated clients see the correct types.

## Changes

### 1. `POST /api/assets/download` — replace `200` with `202 Accepted`

The endpoint kicks off an asynchronous download task. The handler returns `202 Accepted` with a tracking payload (`task_id`, `status`, `message`). The current spec declares `200` with only `{task_id}`, so generated clients receive an unmodeled response on the happy path.

### 2. `POST /api/assets/export` — replace `200` with `202 Accepted`

Same pattern: export is asynchronous, returns `202` with `{task_id, status, message}`. Spec declared `200` with `{task_id, export_name}` — `export_name` is supplied by the caller in the request, not returned in the response.

### 3. `POST /api/assets/from-workflow` — change `201` to `200`

The endpoint returns `200 OK` with the resolved asset list. It does not create new resources in a way that warrants `201 Created` (no `Location` header is emitted, and the response body lists existing or referenced assets rather than a single created resource).

### 4. `POST /api/feedback` — change `200` to `201 Created`

Submitting feedback creates a new feedback record on the server. `201 Created` is the correct status for that semantic. Response body schema (`{id, status}`) is unchanged.

### 5. Job timestamp types — `number` → `integer format: int64`

Job timestamp fields are Unix epoch milliseconds, returned as `int64`. The spec declared them as `number`, which causes generated clients (notably Go via `oapi-codegen`) to model them as `float64` — losing precision and producing the wrong type. Affected fields across `/api/jobs` and `/api/jobs/{job_id}` response schemas:

- `create_time`
- `update_time`
- `execution_start_time`
- `execution_end_time`

Each changes from:

```yaml
create_time:
  type: number
```

to:

```yaml
create_time:
  type: integer
  format: int64
  description: Job creation timestamp (Unix milliseconds).
```

## Backwards compatibility

- **Status code changes (#1–#4):** within the `2xx` family. Clients that check `status >= 200 && < 300` continue to work. Clients regenerated against the updated spec receive the canonical status code.
- **Timestamp type changes (#5):** `integer` is a strict subset of `number` for all values these endpoints emit. Existing clients parsing them as floats still work; newly generated clients get the more precise `int64` type.

## Verification

These fixes align the spec with what each endpoint observably returns. No handler changes are required.