### PR TITLE
openapi: fix invalid BillingStatus schema (object + enum hybrid)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9585,16 +9585,9 @@ components:
           description: List of plan features
 
     BillingStatus:
-      type: object
+      type: string
       x-runtime: [cloud]
-      description: "[cloud-only] Overall billing and subscription status."
-      properties:
-        subscription:
-          $ref: "#/components/schemas/BillingSubscription"
-        balance:
-          $ref: "#/components/schemas/BillingBalance"
-        has_payment_method:
-          type: boolean
+      description: "[cloud-only] Overall billing/payment lifecycle status."
       enum:
         - awaiting_payment_method
         - pending_payment


### PR DESCRIPTION
## Summary

Fixes a hybrid \`BillingStatus\` schema in vendor that ended up being both an \`object\` (with properties) AND a string \`enum\` — invalid in OpenAPI.

PR #14070 added the enum values to vendor's existing \`BillingStatus\` schema without recognizing that vendor's \`BillingStatus\` was originally an object (with \`subscription\`/\`balance\`/\`has_payment_method\` properties). The merged result was an invalid hybrid.

## Fix

Convert \`BillingStatus\` to a clean string enum matching cloud's runtime emission. The object's previous properties (\`subscription\`, \`balance\`, \`has_payment_method\`) were already duplicated in \`BillingStatusResponse\` — the only ref to \`BillingStatus\` (\`BillingStatusResponse.billing_status\`) is correctly a payment-lifecycle value, not the full response object.

## Verification

- \`spectral lint openapi.yaml --ruleset .spectral.yaml --fail-severity=error\` — 0 errors
- Closes the last remaining handler ref in Comfy-Org/cloud's \`TestCutoverSafe\` gate (BE-1106)

🤖 Generated with [Claude Code](https://claude.com/claude-code)