### PR TITLE
Aimdo 0.4.5 + Cold marking of pins

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1217,7 +1217,7 @@ def get_aimdo_cast_buffer(offload_stream, device):
 def get_pin_buffer(offload_stream):
     pin_buffer = STREAM_PIN_BUFFERS.get(offload_stream, None)
     if pin_buffer is None:
-        pin_buffer = comfy_aimdo.host_buffer.HostBuffer(0, 0, pinned_hostbuf_size(8 * 1024**3))
+        pin_buffer = comfy_aimdo.host_buffer.HostBuffer(0, 0, pinned_hostbuf_size(8 * 1024**3), mark_cold=False)
         STREAM_PIN_BUFFERS[offload_stream] = pin_buffer
     elif offload_stream is not None:
         event = getattr(pin_buffer, "_comfy_event", None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy>=2.0.0
 filelock
 av>=14.2.0
 comfy-kitchen>=0.2.8
-comfy-aimdo==0.4.3
+comfy-aimdo==0.4.5
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/14076

comfy-aimdo 0.4.5 introduces a feature to mark a hostbuf as "cold". This is the default behavior. This does the posix_fadvise to kick the backing disk-cache copy out of the disk cache (to avoid a double copy in RAM). This saves uses from disk reloads as it kicks un-needed RAM, before the disk cache fills and pressures out all models due to LRU pattern.

Mark the stream pin buffer as warm, so those pages take priority in the linux disk cache, and the actual pinned model memory all defaults to cold.

This also flushes 0.4.4 which contains a bugfix for pinned memory and may fix some acendotal reports I have of pinned memory failure (along with the confirmed issue in the uncpoming multi-GPU work).

Very noticable for: slow disks + moderate VRAM + moderate RAM "just fits" when using the larger models (OPs  situation ^^)

Example Test conditions:

Linux, 5090 w/ 8GB truncation (approx 3090 emulation), 64GB RAM, NVME :red_circle: PCIe 1.0 :red_circle:  x4 (approx 800MB/s)
Wan 2.2 2x14B FP16
3 runs

<img width="1951" height="1074" alt="image" src="https://github.com/user-attachments/assets/43d95cbf-05bd-432e-97a9-e79943db5315" />

Before:

```
Prompt executed in 76.33 seconds
Prompt executed in 49.19 seconds
Prompt executed in 8.39 seconds
```

After:

```
Prompt executed in 76.31 seconds
Prompt executed in 7.66 seconds :white_check_mark: 
Prompt executed in 7.51 seconds
```