### PR TITLE
openapi: add Cloud-runtime fields (workflow_id, execution_error) to JobEntry

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3095,18 +3095,34 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - asset_ids
               properties:
+                job_ids:
+                  type: array
+                  items:
+                    type: string
+                  description: Job IDs whose associated assets should all be included in the ZIP bundle.
                 asset_ids:
                   type: array
                   items:
                     type: string
                     format: uuid
-                  description: IDs of assets to export
+                  description: Asset IDs to include in the ZIP bundle. Additive to assets associated with provided job IDs.
                 export_name:
                   type: string
                   description: Name for the export archive
+                naming_strategy:
+                  type: string
+                  enum: [group_by_job_id, preserve, asset_id, group_by_job_time]
+                  default: group_by_job_time
+                  description: "Strategy for naming files in the ZIP: group by job ID, preserve original names, use the asset ID, or group by job creation time."
+                job_asset_name_filters:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    minItems: 1
+                    items:
+                      type: string
+                  description: Optional per-job asset name filters. When provided for a job ID, only assets whose name matches one of the listed names are included.
       responses:
         "202":
           description: Export task accepted

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7565,6 +7565,16 @@ components:
         outputs_count:
           type: integer
           description: Total number of output files
+        workflow_id:
+          type: string
+          nullable: true
+          x-runtime: [cloud]
+          description: "[cloud-only] UUID of the Cloud workflow entity this job is associated with. Local ComfyUI returns null."
+        execution_error:
+          x-runtime: [cloud]
+          description: "[cloud-only] Detailed execution error from ComfyUI for failed jobs. Absent on local ComfyUI."
+          allOf:
+            - $ref: "#/components/schemas/ExecutionError"
 
     JobDetailResponse:
       type: object


### PR DESCRIPTION
## Summary

The Cloud runtime returns two fields on `JobEntry` (the `GET /api/jobs` list item) that the spec doesn't currently declare, so generated clients can't see them:

- `workflow_id` — UUID of the Cloud workflow entity the job is associated with
- `execution_error` — structured ComfyUI execution error for failed jobs (reuses the existing `ExecutionError` schema)

## Runtime tagging

Both tagged `x-runtime: [cloud]` with `[cloud-only]` descriptions; local ComfyUI does not populate them (`workflow_id` is `nullable`). Spec-only; matches what the runtime already returns.