### PR TITLE
openapi: document Cloud-runtime request fields on POST /api/assets/export

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3095,18 +3095,34 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - asset_ids
               properties:
+                job_ids:
+                  type: array
+                  items:
+                    type: string
+                  description: Job IDs whose associated assets should all be included in the ZIP bundle.
                 asset_ids:
                   type: array
                   items:
                     type: string
                     format: uuid
-                  description: IDs of assets to export
+                  description: Asset IDs to include in the ZIP bundle. Additive to assets associated with provided job IDs.
                 export_name:
                   type: string
                   description: Name for the export archive
+                naming_strategy:
+                  type: string
+                  enum: [group_by_job_id, preserve, asset_id, group_by_job_time]
+                  default: group_by_job_time
+                  description: "Strategy for naming files in the ZIP: group by job ID, preserve original names, use the asset ID, or group by job creation time."
+                job_asset_name_filters:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    minItems: 1
+                    items:
+                      type: string
+                  description: Optional per-job asset name filters. When provided for a job ID, only assets whose name matches one of the listed names are included.
       responses:
         "202":
           description: Export task accepted


### PR DESCRIPTION
## Summary

`POST /api/assets/export` is an `x-runtime: [cloud]` endpoint, but its request body only declared `asset_ids` + `export_name`. The Cloud runtime accepts three more fields that generated clients can't currently express:

- `job_ids` — include all assets associated with the given jobs
- `naming_strategy` — how files are named in the ZIP (enum: `group_by_job_id` / `preserve` / `asset_id` / `group_by_job_time`, default `group_by_job_time`)
- `job_asset_name_filters` — optional per-job asset-name allowlist

Also drops `asset_ids` from `required`: the runtime supports exporting by `job_ids` alone, so neither is individually required.

These are plain field additions under the existing endpoint-level `x-runtime: [cloud]` tag (no per-field tags needed). Spec-only.