### PR TITLE
feat: add camera intrinsics fields to Load3DCamera info

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -766,6 +766,13 @@ class Load3DCamera(ComfyTypeIO):
         target: dict[str, float | int]
         zoom: int
         cameraType: str
+        quaternion: NotRequired[dict[str, float | int]]
+        rotation: NotRequired[dict[str, float | int | str]]
+        fov: NotRequired[float | int]
+        aspect: NotRequired[float | int]
+        near: NotRequired[float | int]
+        far: NotRequired[float | int]
+        frustum: NotRequired[dict[str, float | int]]
 
     Type = CameraInfo
 


### PR DESCRIPTION
Extend Load3DCamera.CameraInfo with quaternion, rotation, fov, aspect, near, far and frustum (orthographic left/right/top/bottom) so the Load3D camera_info carries enough information for downstream nodes to fully reconstruct the camera. 

Pairs with the frontend change that emits these fields. https://github.com/Comfy-Org/ComfyUI_frontend/pull/12492

<img width="1807" height="1333" alt="image" src="https://github.com/user-attachments/assets/1227137f-4cf7-41d8-ba03-0859e0dbe196" />
