### PR TITLE
feat: add model_info output to Load3D node

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -779,19 +779,13 @@ class Load3DCamera(ComfyTypeIO):
 
 @comfytype(io_type="LOAD3D_MODEL_INFO")
 class Load3DModelInfo(ComfyTypeIO):
-    class ModelTransform(TypedDict):
-        uuid: str
-        name: str
-        type: str
-        position: dict[str, float | int]
-        rotation: dict[str, float | int | str]
-        quaternion: dict[str, float | int]
-        scale: dict[str, float | int]
-        up: dict[str, float | int]
-        visible: bool
-        matrix: list[float]
+    class Model3DTransform(TypedDict):
+        # Coordinate system: right-handed, Y-up, world space
+        position: dict[str, float | int]  # scene units
+        quaternion: dict[str, float | int]  # normalized, dimensionless; world rotation
+        scale: dict[str, float | int]  # dimensionless multiplier
 
-    Type = list[ModelTransform]
+    Type = list[Model3DTransform]
 
 
 @comfytype(io_type="LOAD_3D")
@@ -803,7 +797,7 @@ class Load3D(ComfyTypeIO):
         normal: str
         camera_info: Load3DCamera.CameraInfo
         recording: NotRequired[str]
-        model_info: NotRequired[list[Load3DModelInfo.ModelTransform]]
+        model_3d_info: NotRequired[list[Load3DModelInfo.Model3DTransform]]
 
     Type = Model3DDict
 

--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -777,6 +777,23 @@ class Load3DCamera(ComfyTypeIO):
     Type = CameraInfo
 
 
+@comfytype(io_type="LOAD3D_MODEL_INFO")
+class Load3DModelInfo(ComfyTypeIO):
+    class ModelTransform(TypedDict):
+        uuid: str
+        name: str
+        type: str
+        position: dict[str, float | int]
+        rotation: dict[str, float | int | str]
+        quaternion: dict[str, float | int]
+        scale: dict[str, float | int]
+        up: dict[str, float | int]
+        visible: bool
+        matrix: list[float]
+
+    Type = list[ModelTransform]
+
+
 @comfytype(io_type="LOAD_3D")
 class Load3D(ComfyTypeIO):
     """3D models are stored as a dictionary."""
@@ -786,6 +803,7 @@ class Load3D(ComfyTypeIO):
         normal: str
         camera_info: Load3DCamera.CameraInfo
         recording: NotRequired[str]
+        model_info: NotRequired[list[Load3DModelInfo.ModelTransform]]
 
     Type = Model3DDict
 
@@ -2298,6 +2316,7 @@ __all__ = [
     "FlowControl",
     "Accumulation",
     "Load3DCamera",
+    "Load3DModelInfo",
     "Load3D",
     "Load3DAnimation",
     "Photomaker",

--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -47,7 +47,7 @@ class Load3D(IO.ComfyNode):
                 IO.Load3DCamera.Output(display_name="camera_info"),
                 IO.Video.Output(display_name="recording_video"),
                 IO.File3DAny.Output(display_name="model_3d"),
-                IO.Load3DModelInfo.Output(display_name="model_info"),
+                IO.Load3DModelInfo.Output(display_name="model_3d_info"),
             ],
         )
 
@@ -74,8 +74,8 @@ class Load3D(IO.ComfyNode):
         if model_file and model_file != "none":
             file_3d = Types.File3D(folder_paths.get_annotated_filepath(model_file))
             mesh_path = model_file
-        model_info = image.get('model_info', [])
-        return IO.NodeOutput(output_image, output_mask, mesh_path, normal_image, image['camera_info'], video, file_3d, model_info)
+        model_3d_info = image.get('model_3d_info', [])
+        return IO.NodeOutput(output_image, output_mask, mesh_path, normal_image, image['camera_info'], video, file_3d, model_3d_info)
 
     process = execute  # TODO: remove
 

--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -47,6 +47,7 @@ class Load3D(IO.ComfyNode):
                 IO.Load3DCamera.Output(display_name="camera_info"),
                 IO.Video.Output(display_name="recording_video"),
                 IO.File3DAny.Output(display_name="model_3d"),
+                IO.Load3DModelInfo.Output(display_name="model_info"),
             ],
         )
 
@@ -73,7 +74,8 @@ class Load3D(IO.ComfyNode):
         if model_file and model_file != "none":
             file_3d = Types.File3D(folder_paths.get_annotated_filepath(model_file))
             mesh_path = model_file
-        return IO.NodeOutput(output_image, output_mask, mesh_path, normal_image, image['camera_info'], video, file_3d)
+        model_info = image.get('model_info', [])
+        return IO.NodeOutput(output_image, output_mask, mesh_path, normal_image, image['camera_info'], video, file_3d, model_info)
 
     process = execute  # TODO: remove
 


### PR DESCRIPTION
Add a `LOAD3D_MODEL_INFO` IO type and a `model_info` output on the `Load3D` node, carrying per-object transforms (uuid, name, type, position, rotation, quaternion, scale, up, visible, matrix).
https://github.com/Comfy-Org/ComfyUI_frontend/pull/12494
List-shaped to allow multiple objects in the future; the viewer currently renders a single main object, so the list has one entry.

please note, currently, data of **uuid, name, type** fileds are generated by threejs, we may change it to ours later

Pairs with the frontend PR (Comfy-Org/ComfyUI_frontend, branch `feat/load3d-model-info-output`) which serializes the gizmo transform into the node payload.
<img width="1915" height="1543" alt="image" src="https://github.com/user-attachments/assets/f13df39d-bac1-4912-83bb-12a749a17dd3" />
