### PR TITLE
Add unreviewed merge detector for SOC 2 compliance

### DIFF
--- a/.github/workflows/detect-unreviewed-merge.yml
+++ b/.github/workflows/detect-unreviewed-merge.yml
@@ -1,0 +1,24 @@
+name: Detect Unreviewed Merge
+
+# SOC 2 compliance — reusable workflow lives in Comfy-Org/github-workflows,
+# tracking issues are filed in Comfy-Org/unreviewed-merges.
+
+on:
+  push:
+    branches: [master]
+
+concurrency:
+  group: detect-unreviewed-merge-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect:
+    uses: Comfy-Org/github-workflows/.github/workflows/detect-unreviewed-merge.yml@4d9cb6b87f953bb7cd69954280e1465fb9bd2040 # v1
+    with:
+      approval-mode: latest-per-reviewer
+    secrets:
+      UNREVIEWED_MERGES_TOKEN: ${{ secrets.UNREVIEWED_MERGES_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that detects PRs merged to `main` without an approving review
- Creates tracking issues in [`Comfy-Org/unreviewed-merges`](https://github.com/Comfy-Org/unreviewed-merges) (private) for SOC 2 audit purposes
- Supports inline justification via `Justification: <reason>` in PR body or comments

## How it works

Triggers on `push` to `main`. Uses the GitHub API to find the associated PR and check for approving reviews. If none found, creates a tracking issue with the `unreviewed-merge` label. No code checkout required — API calls only.

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Merge a test PR without approval and confirm issue creation in `unreviewed-merges` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)