### PR TITLE
openapi: remove unused PUT /api/hub/profiles/me (updateMyHubProfile)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3696,40 +3696,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /api/hub/profiles/{username}:
-    get:
-      operationId: getHubProfile
-      tags: [hub]
-      summary: Get a hub profile by username
-      description: "[cloud-only] Returns the public hub profile for the given username."
-      x-runtime: [cloud]
-      parameters:
-        - name: username
-          in: path
-          required: true
-          schema:
-            type: string
-          description: Hub username
-      responses:
-        "200":
-          description: Profile
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HubProfile"
-        "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CloudError"
-
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
   /api/hub/profiles/check:
     get:
       operationId: checkHubUsername
@@ -3807,59 +3773,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-    put:
-      operationId: updateMyHubProfile
-      tags: [hub]
-      summary: Update the authenticated user's hub profile
-      description: "[cloud-only] Updates the hub profile of the currently authenticated user."
-      x-runtime: [cloud]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                username:
-                  type: string
-                display_name:
-                  type: string
-                bio:
-                  type: string
-                avatar_url:
-                  type: string
-                  format: uri
-                links:
-                  type: array
-                  items:
-                    type: string
-                    format: uri
-      responses:
-        "200":
-          description: Updated profile
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HubProfile"
-        "400":
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CloudError"
-        "401":
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CloudError"
-        "409":
-          description: Conflict
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CloudError"
-
   /api/hub/workflows:
     get:
       operationId: listHubWorkflows

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3696,6 +3696,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/hub/profiles/{username}:
+    get:
+      operationId: getHubProfile
+      tags: [hub]
+      summary: Get a hub profile by username
+      description: "[cloud-only] Returns the public hub profile for the given username."
+      x-runtime: [cloud]
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Hub username
+      responses:
+        "200":
+          description: Profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HubProfile"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CloudError"
+
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/hub/profiles/check:
     get:
       operationId: checkHubUsername


### PR DESCRIPTION
## What
Removes `PUT /api/hub/profiles/me` (`updateMyHubProfile`) from `openapi.yaml`.

## Why
It was never implemented (no handler in core or cloud) and has **zero traffic** in the last 30 days (Datadog, `comfy-ingest`). A phantom declaration — remove it from the shared contract.

## Explicitly kept
- `GET /api/hub/profiles/{username}` (`getHubProfile`) — **~37k requests/30d**, actively used. Earlier draft of this PR deleted it by mistake; restored.
- `GET /api/hub/profiles/me` (`getMyHubProfile`) — in use.

## Notes
- Draft. Part of cloud spec cleanup (BE-1150). The unused cloud-only `PATCH /{username}` is removed separately on the cloud side (not in OSS).