### PR TITLE
refactor: drop rotation from Load3DCamera

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -762,17 +762,17 @@ class Accumulation(ComfyTypeIO):
 @comfytype(io_type="LOAD3D_CAMERA")
 class Load3DCamera(ComfyTypeIO):
     class CameraInfo(TypedDict):
-        position: dict[str, float | int]
-        target: dict[str, float | int]
-        zoom: int
-        cameraType: str
-        quaternion: NotRequired[dict[str, float | int]]
-        rotation: NotRequired[dict[str, float | int | str]]
-        fov: NotRequired[float | int]
-        aspect: NotRequired[float | int]
-        near: NotRequired[float | int]
-        far: NotRequired[float | int]
-        frustum: NotRequired[dict[str, float | int]]
+        # Coordinate system: right-handed, Y-up, camera looks down -Z
+        position: dict[str, float | int]  # scene units
+        target: dict[str, float | int]  # scene units; OrbitControls focus point
+        zoom: float | int  # dimensionless, 1 = 100%
+        cameraType: str  # 'perspective' | 'orthographic'
+        quaternion: NotRequired[dict[str, float | int]]  # normalized, dimensionless; camera world rotation
+        fov: NotRequired[float | int]  # degrees, vertical FOV (perspective only)
+        aspect: NotRequired[float | int]  # width / height (perspective only)
+        near: NotRequired[float | int]  # scene units
+        far: NotRequired[float | int]  # scene units
+        frustum: NotRequired[dict[str, float | int]]  # orthographic only: {left, right, top, bottom} in scene units
 
     Type = CameraInfo
 


### PR DESCRIPTION
As discussed in slack, we would like to drop the rotation field from Load3DCamera.CameraInfo, redundant with quaternion.

Annotate the remaining fields with coordinate-system convention so headless / programmatic consumers: scene units, fov in degrees, quaternion normalized, etc. 
Promote zoom from int to float | int since it can be fractional.