### PR TITLE
security: prevent path traversal in dataset nodes and use weights_only for torch.load

### DIFF
--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -13,6 +13,18 @@ from comfy_api.latest import ComfyExtension, io
 
 
 def _sanitize_folder_name(base_dir, folder_name):
+    """Sanitize a folder name to prevent path traversal attacks.
+
+    Args:
+        base_dir: The base directory that the folder must reside within.
+        folder_name: The name of the folder to resolve.
+
+    Returns:
+        str: The absolute path to the resolved folder.
+
+    Raises:
+        ValueError: If the resolved path escapes the base directory.
+    """
     resolved = os.path.abspath(os.path.join(base_dir, folder_name))
     if not resolved.startswith(os.path.abspath(base_dir)):
         raise ValueError("Path traversal detected in folder_name")

--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -12,6 +12,13 @@ import node_helpers
 from comfy_api.latest import ComfyExtension, io
 
 
+def _sanitize_folder_name(base_dir, folder_name):
+    resolved = os.path.abspath(os.path.join(base_dir, folder_name))
+    if not resolved.startswith(os.path.abspath(base_dir)):
+        raise ValueError("Path traversal detected in folder_name")
+    return resolved
+
+
 def load_and_process_images(image_files, input_dir):
     """Utility function to load and process a list of images.
 
@@ -241,7 +248,7 @@ class SaveImageDataSetToFolderNode(io.ComfyNode):
         folder_name = folder_name[0]
         filename_prefix = filename_prefix[0]
 
-        output_dir = os.path.join(folder_paths.get_output_directory(), folder_name)
+        output_dir = _sanitize_folder_name(folder_paths.get_output_directory(), folder_name)
         saved_files = save_images_to_folder(images, output_dir, filename_prefix)
 
         logging.info(f"Saved {len(saved_files)} images to {output_dir}.")
@@ -288,7 +295,7 @@ class SaveImageTextDataSetToFolderNode(io.ComfyNode):
         folder_name = folder_name[0]
         filename_prefix = filename_prefix[0]
 
-        output_dir = os.path.join(folder_paths.get_output_directory(), folder_name)
+        output_dir = _sanitize_folder_name(folder_paths.get_output_directory(), folder_name)
         saved_files = save_images_to_folder(images, output_dir, filename_prefix)
 
         # Save captions
@@ -1438,7 +1445,7 @@ class SaveTrainingDataset(io.ComfyNode):
             )
 
         # Create output directory
-        output_dir = os.path.join(folder_paths.get_output_directory(), folder_name)
+        output_dir = _sanitize_folder_name(folder_paths.get_output_directory(), folder_name)
         os.makedirs(output_dir, exist_ok=True)
 
         # Prepare data pairs
@@ -1520,7 +1527,7 @@ class LoadTrainingDataset(io.ComfyNode):
     @classmethod
     def execute(cls, folder_name):
         # Get dataset directory
-        dataset_dir = os.path.join(folder_paths.get_output_directory(), folder_name)
+        dataset_dir = _sanitize_folder_name(folder_paths.get_output_directory(), folder_name)
 
         if not os.path.exists(dataset_dir):
             raise ValueError(f"Dataset directory not found: {dataset_dir}")
@@ -1547,7 +1554,7 @@ class LoadTrainingDataset(io.ComfyNode):
             shard_path = os.path.join(dataset_dir, shard_file)
 
             with open(shard_path, "rb") as f:
-                shard_data = torch.load(f)
+                shard_data = torch.load(f, weights_only=True)
 
             all_latents.extend(shard_data["latents"])
             all_conditioning.extend(shard_data["conditioning"])


### PR DESCRIPTION
This PR addresses path traversal vulnerabilities in dataset loading nodes and switches `torch.load` to use `weights_only=True` for safer deserialization.