### PR TITLE
feat: add Preview3DAdvanced node

### DIFF
--- a/comfy_api/latest/_ui.py
+++ b/comfy_api/latest/_ui.py
@@ -452,6 +452,16 @@ class PreviewUI3D(_UIOutput):
         return {"result": [self.model_file, self.camera_info, self.bg_image_path]}
 
 
+class PreviewUI3DAdvanced(_UIOutput):
+    def __init__(self, model_file, camera_info, model_3d_info):
+        self.model_file = model_file
+        self.camera_info = camera_info
+        self.model_3d_info = model_3d_info
+
+    def as_dict(self):
+        return {"result": [self.model_file, self.camera_info, self.model_3d_info]}
+
+
 class PreviewText(_UIOutput):
     def __init__(self, value: str, **kwargs):
         self.value = value
@@ -471,5 +481,6 @@ __all__ = [
     "PreviewAudio",
     "PreviewVideo",
     "PreviewUI3D",
+    "PreviewUI3DAdvanced",
     "PreviewText",
 ]

--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -124,12 +124,71 @@ class Preview3D(IO.ComfyNode):
     process = execute  # TODO: remove
 
 
+class Preview3DAdvanced(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="Preview3DAdvanced",
+            display_name="Preview 3D (Advanced)",
+            search_aliases=["preview 3d", "3d viewer", "view mesh", "frame 3d", "3d camera output"],
+            category="3d",
+            is_experimental=True,
+            is_output_node=True,
+            inputs=[
+                IO.MultiType.Input(
+                    "model_file",
+                    types=[
+                        IO.File3DGLB,
+                        IO.File3DGLTF,
+                        IO.File3DFBX,
+                        IO.File3DOBJ,
+                        IO.File3DSTL,
+                        IO.File3DUSDZ,
+                        IO.File3DAny,
+                    ],
+                    tooltip="3D model file from an upstream 3D node.",
+                ),
+                IO.Load3D.Input("image"),
+                IO.Load3DCamera.Input("camera_info", optional=True, advanced=True),
+                IO.Load3DModelInfo.Input("model_3d_info", optional=True, advanced=True),
+                IO.Int.Input("width", default=1024, min=1, max=4096, step=1),
+                IO.Int.Input("height", default=1024, min=1, max=4096, step=1),
+            ],
+            outputs=[
+                IO.File3DAny.Output(display_name="model_file"),
+                IO.Load3DCamera.Output(display_name="camera_info"),
+                IO.Load3DModelInfo.Output(display_name="model_3d_info"),
+                IO.Int.Output(display_name="width"),
+                IO.Int.Output(display_name="height"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, model_file: Types.File3D, image, width: int, height: int, **kwargs) -> IO.NodeOutput:
+        filename = f"preview3d_advanced_{uuid.uuid4().hex}.{model_file.format}"
+        model_file.save_to(os.path.join(folder_paths.get_output_directory(), filename))
+
+        camera_info_input = kwargs.get("camera_info", None)
+        camera_info = camera_info_input if camera_info_input is not None else image['camera_info']
+        model_3d_info_input = kwargs.get("model_3d_info", None)
+        model_3d_info = model_3d_info_input if model_3d_info_input is not None else image.get('model_3d_info', [])
+        return IO.NodeOutput(
+            model_file,
+            camera_info,
+            model_3d_info,
+            width,
+            height,
+            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info),
+        )
+
+
 class Load3DExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
         return [
             Load3D,
             Preview3D,
+            Preview3DAdvanced,
         ]
 
 


### PR DESCRIPTION
A new Preview3D that emits live viewport state as outputs: model_file, camera_info, model_info, width, height. Reuses the Load3D capture widget and the PreviewUI3D side effect. 
Input model_file is File3D-only (no String path) to keep the contract typed; width/height are pre-promoted to socket inputs. 

Inputs win when connected; otherwise the viewport's live framing & transform carries through. 
The same resolved values flow to the output (so chained Preview3DAdvanced nodes propagate in a single run, and headless execution still carries state) and to PreviewUI3DAdvanced (so the viewport applies the input when one is connected).

FE: https://github.com/Comfy-Org/ComfyUI_frontend/pull/12527

https://github.com/user-attachments/assets/815d78af-28c5-46e3-a538-69a38e81c5e5

