### PR TITLE
Security/Logic Fix: Autonomous Code Review

### DIFF
--- a/comfy/ldm/mmaudio/vae/vae_modules.py
+++ b/comfy/ldm/mmaudio/vae/vae_modules.py
@@ -17,7 +17,7 @@ def normalize(x, dim=None, eps=1e-4):
     if dim is None:
         dim = list(range(1, x.ndim))
     norm = torch.linalg.vector_norm(x, dim=dim, keepdim=True, dtype=torch.float32)
-    norm = torch.add(eps, norm, alpha=math.sqrt(norm.numel() / x.numel()))
+    norm = torch.add(norm, eps) / math.sqrt(norm.numel() / x.numel())
     return x / norm.to(x.dtype)
 
 class ResnetBlock1D(nn.Module):


### PR DESCRIPTION
## Autonomous Bug Report & Patch

This vulnerability and fix were autonomously discovered by the Lucy Red Team swarm.

The provided code snippet is part of a PyTorch implementation for a Variational Autoencoder (VAE) with attention mechanisms, specifically tailored for audio data processing. The code defines several modules like `ResnetBlock1D`, `AttnBlock1D`, `Upsample1D`, and `Downsample1D`. While the code looks well-structured and functional, there is a critical bug in the `normalize` function that could lead to incorrect behavior or numerical instability.

### Critical Bug in the `normalize` Function

The issue lies in the line where the normalization constant (`norm`) is calculated:
```python
norm = torch.add(eps, norm, alpha=math.sqrt(norm.numel() / x.numel()))
```

This line attempts to add a small value (`eps`) to the computed norm before dividing by it. However, this approach is problematic because:

1. **Incorrect Addition with Alpha**: The `alpha` parameter in `torch.add` is used for scaling the second input tensor, not adding a scalar value. This means that the addition operation is incorrect and does not add `eps` to each element of `norm`.

2. **Numerical Stability Issues**: Directly dividing by small norms can lead to numerical instability, even with a small `eps`. Properly handling numerical stability in normalization functions is crucial.

### Corrected `normalize` Function

To fix the bug, you should modify the `normalize` function as follows:
```python
def normalize