### PR TITLE
Support diffusers-format LoRAs for Anima

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -357,6 +357,17 @@ def model_lora_keys_unet(model, key_map={}):
                 key_lora = k[len("diffusion_model."):-len(".weight")]
                 key_map["transformer.{}".format(key_lora)] = k
 
+    if isinstance(model, comfy.model_base.Anima):
+        diffusers_keys = comfy.utils.anima_to_diffusers(model.model_config.unet_config, output_prefix="diffusion_model.")
+        for k in diffusers_keys:
+            if k.endswith(".weight"):
+                to = diffusers_keys[k]
+                key_lora = k[:-len(".weight")]
+                key_map["diffusion_model.{}".format(key_lora)] = to
+                key_map["transformer.{}".format(key_lora)] = to
+                key_map["lycoris_{}".format(key_lora.replace(".", "_"))] = to
+                key_map[key_lora] = to
+
     return key_map
 
 

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -818,6 +818,30 @@ def z_image_to_diffusers(mmdit_config, output_prefix=""):
 
     return key_map
 
+def anima_to_diffusers(mmdit_config, output_prefix=""):
+    num_blocks = mmdit_config.get("num_blocks", 0)
+    key_map = {}
+
+    for i in range(num_blocks):
+        prefix_from = "transformer_blocks.{}".format(i)
+        prefix_to = "{}blocks.{}".format(output_prefix, i)
+
+        # attn1 is self attention, attn2 is cross attention
+        for attn_from, attn_to in (("attn1", "self_attn"), ("attn2", "cross_attn")):
+            block_map = {
+                "{}.to_q.weight".format(attn_from): "{}.q_proj.weight".format(attn_to),
+                "{}.to_k.weight".format(attn_from): "{}.k_proj.weight".format(attn_to),
+                "{}.to_v.weight".format(attn_from): "{}.v_proj.weight".format(attn_to),
+                "{}.to_out.0.weight".format(attn_from): "{}.output_proj.weight".format(attn_to),
+            }
+            for k, v in block_map.items():
+                key_map["{}.{}".format(prefix_from, k)] = "{}.{}".format(prefix_to, v)
+
+        key_map["{}.ff.net.0.proj.weight".format(prefix_from)] = "{}.mlp.layer1.weight".format(prefix_to)
+        key_map["{}.ff.net.2.weight".format(prefix_from)] = "{}.mlp.layer2.weight".format(prefix_to)
+
+    return key_map
+
 def repeat_to_batch_size(tensor, batch_size, dim=0):
     if tensor.shape[dim] > batch_size:
         return tensor.narrow(dim, 0, batch_size)


### PR DESCRIPTION
`diffusers` have recently merged their Anima PR: https://github.com/huggingface/diffusers/pull/13732

This PR adds support for diffusers LoRAs with their keys. The template for this was the existing diffusers-LoRA support for Z-Image.
It was created with AI assistance, but manually checked.

Tested with a trained diffusers LoRA: all keys load with no unmatched keys, and it
applies correctly end-to-end on anima-preview3-base.
