### PR TITLE
Revert deprecation of non-dynamic smart memory (CORE-152 (revert))

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -817,6 +817,10 @@ def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, pins
     for i in sorted(unloaded_model, reverse=True):
         unloaded_models.append(current_loaded_models.pop(i))
 
+    if not for_dynamic and pins_required > 0:
+        ensure_pin_budget(pins_required)
+        ensure_pin_registerable(pins_required)
+
     if len(unloaded_model) > 0:
         soft_empty_cache()
     elif device is not None:
@@ -879,15 +883,19 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
             model_to_unload.model_finalizer.detach()
 
     total_memory_required = {}
+    total_pins_required = {}
     for loaded_model in models_to_load:
         device = loaded_model.device
         total_memory_required[device] = total_memory_required.get(device, 0) + loaded_model.model_memory_required(device)
+        if not loaded_model.model.is_dynamic():
+            total_pins_required[device] = total_pins_required.get(device, 0) + loaded_model.model_memory()
 
     for device in total_memory_required:
         if device != torch.device("cpu"):
             free_memory(total_memory_required[device] * 1.1 + extra_mem,
                         device,
-                        for_dynamic=free_for_dynamic)
+                        for_dynamic=free_for_dynamic,
+                        pins_required=total_pins_required.get(device, 0))
 
     for device in total_memory_required:
         if device != torch.device("cpu"):

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -803,9 +803,9 @@ def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, pins
     for x in can_unload_sorted:
         i = x[-1]
         memory_to_free = 1e32
-        if current_loaded_models[i].model.is_dynamic() and (not DISABLE_SMART_MEMORY or device is None):
+        if not DISABLE_SMART_MEMORY or device is None:
             memory_to_free = 0 if device is None else memory_required - get_free_memory(device)
-            if for_dynamic:
+            if current_loaded_models[i].model.is_dynamic() and for_dynamic:
                 #don't actually unload dynamic models for the sake of other dynamic models
                 #as that works on-demand.
                 memory_required -= current_loaded_models[i].model.loaded_size()


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/14162
https://github.com/Comfy-Org/ComfyUI/issues/14081

By popular demand. We aren't quite ready for the deprecation as non-dynamic enabled GPUs and some high-vram custom model loader setup prefer the old full hands on.

Example test conditions:

Windows, RTX5090, SDXL
--disable-dynamic-vram
2x runs

<img width="1839" height="626" alt="scr" src="https://github.com/user-attachments/assets/e8b8aa20-33d4-4683-9df3-9420bc51bdc1" />


Before:

```
[INFO] got prompt
[INFO] model weight dtype torch.float16, manual cast: None
[INFO] model_type EPS
[INFO] Using pytorch attention in VAE
[INFO] Using pytorch attention in VAE
[INFO] VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
[INFO] CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
[INFO] Requested to load SDXLClipModel
[INFO] loaded completely; 29321.80 MB usable, 1560.80 MB loaded, full load: True
[INFO] Requested to load SDXL
[INFO] loaded completely; 29208.67 MB usable, 4897.05 MB loaded, full load: True
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:02<00:00,  9.49it/s]
[INFO] Requested to load AutoencoderKL
[INFO] loaded completely; 25669.88 MB usable, 159.56 MB loaded, full load: True
[INFO] Prompt executed in 10.97 seconds
[INFO] got prompt
[INFO] Requested to load SDXL
[INFO] loaded completely; 29206.67 MB usable, 4897.05 MB loaded, full load: True
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:01<00:00, 11.05it/s]
[INFO] Requested to load AutoencoderKL
[INFO] loaded completely; 25669.88 MB usable, 159.56 MB loaded, full load: True
[INFO] Prompt executed in 3.60 seconds
```

End of run load state:

<img width="343" height="345" alt="scr" src="https://github.com/user-attachments/assets/2699f3ec-407c-4d9d-b7e9-bc686c114f3b" />


After:

```
[INFO] got prompt
[INFO] model weight dtype torch.float16, manual cast: None
[INFO] model_type EPS
[INFO] Using pytorch attention in VAE
[INFO] Using pytorch attention in VAE
[INFO] VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
[INFO] CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
[INFO] Requested to load SDXLClipModel
[INFO] loaded completely; 29321.80 MB usable, 1560.80 MB loaded, full load: True
[INFO] Requested to load SDXL
[INFO] loaded completely; 27647.87 MB usable, 4897.05 MB loaded, full load: True
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:02<00:00,  9.85it/s]
[INFO] Requested to load AutoencoderKL
[INFO] loaded completely; 19211.98 MB usable, 159.56 MB loaded, full load: True
[INFO] Prompt executed in 9.19 seconds
[INFO] got prompt
100%|██████████████████████████████████████████████████████████████████████████████████| 20/20 [00:01<00:00, 10.41it/s]
[INFO] Prompt executed in 2.23 seconds
```

End of run load state:

<img width="339" height="429" alt="scr" src="https://github.com/user-attachments/assets/8446d70b-0200-456b-b5a1-4bd347ae3000" />

Regression Tests:
Windows, 96GB RTX5090, LTX2.3 FP16 x2 ✅
Windows, 96GB RTX5090, LTX2.3 FP8 x2 ✅
Linux, 96GB RTX5090, LTX2.3 FP16 x2 ✅
Linux, 96GB RTX5090, LTX2.3 FP8 x2 ✅
Linux, 96GB RTX5090, stable cascade -> flux2 ✅
Linux, 96GB RTX5090, ace-step 1.5 Turbo XL ✅
