### PR TITLE
feat(io): add File3DPLY / File3DSPLAT / File3DSPZ / File3DKSPLAT types

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -727,6 +727,30 @@ class File3DUSDZ(ComfyTypeIO):
     Type = File3D
 
 
+@comfytype(io_type="FILE_3D_PLY")
+class File3DPLY(ComfyTypeIO):
+    """PLY format 3D file - point cloud or Gaussian splat."""
+    Type = File3D
+
+
+@comfytype(io_type="FILE_3D_SPLAT")
+class File3DSPLAT(ComfyTypeIO):
+    """SPLAT format 3D file - 3D Gaussian splat."""
+    Type = File3D
+
+
+@comfytype(io_type="FILE_3D_SPZ")
+class File3DSPZ(ComfyTypeIO):
+    """SPZ format 3D file - compressed 3D Gaussian splat."""
+    Type = File3D
+
+
+@comfytype(io_type="FILE_3D_KSPLAT")
+class File3DKSPLAT(ComfyTypeIO):
+    """KSPLAT format 3D file - 3D Gaussian splat."""
+    Type = File3D
+
+
 @comfytype(io_type="HOOKS")
 class Hooks(ComfyTypeIO):
     if TYPE_CHECKING:
@@ -2303,6 +2327,10 @@ __all__ = [
     "File3DOBJ",
     "File3DSTL",
     "File3DUSDZ",
+    "File3DPLY",
+    "File3DSPLAT",
+    "File3DSPZ",
+    "File3DKSPLAT",
     "Hooks",
     "HookKeyframes",
     "TimestepsRange",


### PR DESCRIPTION
Splat-specific File3D IO types alongside the existing mesh-format variants.
Lets downstream nodes type model sockets to point cloud and 3D Gaussian Splatting formats specifically, e.g. only accepting .ply / .spz / .splat / .ksplat inputs without falling back to File3DAny.

No call sites yet: this lands the types ahead of nodes that consume them (PreviewPointCloudGaussianSplat etc.) so the type layer can be reviewed independently of node UX.