### PR TITLE
Fix: text_encoder_initial_device() forces TE to CPU on high-RAM systems

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1123,8 +1123,7 @@ def text_encoder_initial_device(load_device, offload_device, model_size=0):
         return load_device
 
     mem_l = get_free_memory(load_device)
-    mem_o = get_free_memory(offload_device)
-    if mem_l > (mem_o * 0.5) and model_size * 1.2 < mem_l:
+    if model_size * 1.2 < mem_l:
         return load_device
     else:
         return offload_device


### PR DESCRIPTION
## Fix: text encoder forced to CPU when RAM >> VRAM
**Bug:** `text_encoder_initial_device()` compares free VRAM against half of free system RAM (`mem_l > mem_o * 0.5`). On any system where RAM exceeds VRAM by more than 2× — which is the vast majority of modern GPU workstations (e.g. 16 GB VRAM + 64+ GB RAM) — this check always evaluates to `False`, forcing all text encoders larger than 1 GB to the CPU even when VRAM is plentiful.
**Fix:** Remove the `mem_o` (free RAM) comparison entirely. The remaining guard `model_size * 1.2 < mem_l` already ensures the text encoder only loads on GPU when it fits with 20% headroom. When VRAM later becomes insufficient for the diffusion model, `load_models_gpu()` → `free_memory()` automatically offloads the text encoder — so there is no OOM risk.
```diff
 mem_l = get_free_memory(load_device)
- mem_o = get_free_memory(offload_device)
- if mem_l > (mem_o * 0.5) and model_size * 1.2 < mem_l:
+ if model_size * 1.2 < mem_l:
     return load_device
 else:
     return offload_device
```
**Example (16 GB VRAM + 128 GB RAM, Qwen3-4B fp16 = 7.6 GB):** Original: `15 GB VRAM > 100 GB RAM * 0.5 = 50 GB` → False → CPU. Fixed: `7.6 * 1.2 = 9.12 < 15` → True → GPU. After the diffusion model loads, `free_memory()` offloads the text encoder automatically — no OOM risk, but the cold start is faster.
### Testing
- **Simulation:** 15,624 combinations across 6 GPU vendors, 9 VRAM sizes, 7 RAM sizes, 6 model sizes, 12 VRAM states → 3,908 devices correctly changed from CPU→GPU, **zero regressions**.
- **Unit tests:** 26/26 pass (edge cases: OOM, low RAM, shared memory, multi-GPU, etc.).
- **Real hardware:** Tested on 2× Intel Arc A770 16 GB + 128 GB RAM using the [Z-Image Turbo text-to-image workflow](https://docs.comfy.org/tutorials/image/z-image/z-image-turbo#z-image-turbo-text-to-image-workflow) — original forces Qwen3-4B (7.6 GB) to CPU, fix correctly places it on GPU.
- **Scenario analysis (16 GB VRAM / 128 GB RAM):** [`scenario-16gb-vram-128gb-ram.md`](https://github.com/savvadesogle/ComfyUI/blob/docs/text-encoder-analysis/docs/scenario-16gb-vram-128gb-ram.md)
- **Full analysis & simulation:** [`analysis-text-encoder-vram.md`](https://github.com/savvadesogle/ComfyUI/blob/docs/text-encoder-analysis/docs/analysis-text-encoder-vram.md)
The fix has no effect on LOW_VRAM, NO_VRAM, DISABLED, or SHARED modes (those already return CPU from `text_encoder_device()` before `text_encoder_initial_device()` is called), and small CLIP models < 1 GB are unaffected by the early-return filter at line 1119.
Testing on real hardware from other GPU vendors (NVIDIA, AMD ROCm, Apple MPS) would be appreciated to confirm the fix works correctly across different platforms.