### PR TITLE
fix: enable XPU MultiGPU CFG Split on Windows (CFG > 1)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1723,6 +1723,13 @@ def is_device_xpu(device):
 def is_device_cuda(device):
     return is_device_type(device, 'cuda')
 
+def set_torch_device(device):
+    """Set the current device for the given torch device. Supports CUDA and XPU."""
+    if is_device_cuda(device):
+        torch.cuda.set_device(device)
+    elif is_device_xpu(device):
+        torch.xpu.set_device(device)
+
 def is_directml_enabled():
     global directml_enabled
     if directml_enabled:

--- a/comfy/multigpu.py
+++ b/comfy/multigpu.py
@@ -17,7 +17,7 @@ class MultiGPUThreadPool:
     """Persistent thread pool for multi-GPU work distribution.
 
     Maintains one worker thread per extra GPU device. Each thread calls
-    torch.cuda.set_device() once at startup so that compiled kernel caches
+    set_torch_device() once at startup so that compiled kernel caches
     (inductor/triton) stay warm across diffusion steps.
     """
 
@@ -37,7 +37,7 @@ class MultiGPUThreadPool:
 
     def _worker_loop(self, device: torch.device, work_q: queue.Queue, result_q: queue.Queue):
         try:
-            torch.cuda.set_device(device)
+            comfy.model_management.set_torch_device(device)
         except Exception as e:
             logging.error(f"MultiGPUThreadPool: failed to set device {device}: {e}")
             while True:

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -464,10 +464,7 @@ def _calc_cond_batch_multigpu(model: BaseModel, conds: list[list[dict]], x_in: t
 
     def _handle_batch(device: torch.device, batch_tuple: tuple[comfy.hooks.HookGroup, tuple], results: list[thread_result]):
         try:
-            # TODO: non-NVIDIA support -- guard with `if device.type == "cuda":` once
-            # we extend multigpu QA beyond CUDA. Unconditional call crashes on
-            # XPU/NPU/MPS/CPU/DirectML backends.
-            torch.cuda.set_device(device)
+            comfy.model_management.set_torch_device(device)
             model_current: BaseModel = model_options["multigpu_clones"][device].model
             # run every hooked_to_run separately
             with torch.no_grad():


### PR DESCRIPTION
## Intel GPU MultiGPU CFG Split for ComfyUI

Enables the MultiGPU CFG Split feature ([PR #7063](https://github.com/Comfy-Org/ComfyUI/pull/7063)) on Intel XPU devices under Windows by replacing hardcoded `torch.cuda.set_device()` calls with a device-agnostic `set_torch_device()` helper.

**Requires CFG > 1**: With CFG = 1 there is no negative condition (`total_conds = 1`), so the MultiGPU split has nothing to distribute across GPUs. Set CFG ≥ 2 to use both GPUs.

The fix also works with z-image Turbo models, though CFG > 1 is typically not used with those.

## Changes

- `comfy/model_management.py` — add `set_torch_device(device)` (dispatches to `torch.cuda.set_device` / `torch.xpu.set_device`)
- `comfy/multigpu.py` — use `set_torch_device()` in `MultiGPUThreadPool._worker_loop`
- `comfy/samplers.py` — use `set_torch_device()` in `_handle_batch` within `_calc_cond_batch_multigpu`

## Performance (2x Intel Arc A770, Windows 11 — driver 8737)

| Configuration | Steps | s/it (steady) | Total | Speedup |
|---|---|---|---|---|
| 1x A770 (no MultiGPU) | 20 | 1.73-2.00 | 45-50s | 1x (baseline) |
| 2x A770 (+ MultiGPU CFG Split) | 20 | **1.10** | **31-38s** | **~1.7x** |

Model: [SDXL base 1.0](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0), 2048x2048, CFG=7, 20 steps, Euler.

![MultiGPU benchmark log](https://github.com/savvadesogle/ComfyUI/raw/docs/xpu-multigpu-support/docs/xpu-multigpu-benchmark.png)

## Documentation

Full details, hardware requirements, and benchmark methodology are in [`docs/xpu-multigpu-support.md`](https://github.com/savvadesogle/ComfyUI/blob/docs/xpu-multigpu-support/docs/xpu-multigpu-support.md) (branch `docs/xpu-multigpu-support`).
