### PR TITLE
fix: _apply_video_scale ignores VideoSlice trimming in ByteDance auto_downscale/auto_upscale

### DIFF
--- a/comfy_api_nodes/util/conversions.py
+++ b/comfy_api_nodes/util/conversions.py
@@ -470,8 +470,14 @@ def _apply_video_scale(video: Input.Video, scale_dims: tuple[int, int]) -> Input
     output_container = None
 
     try:
-        input_source = video.get_stream_source()
-        input_container = av.open(input_source, mode="r")
+        # Materialize the video to a buffer first so that any trimming
+        # (start_time / duration set by e.g. VideoSlice) is applied before
+        # we scale.  save_to() already handles trimming correctly.
+        materialized_buffer = BytesIO()
+        video.save_to(materialized_buffer)
+        materialized_buffer.seek(0)
+
+        input_container = av.open(materialized_buffer, mode="r")
         output_container = av.open(output_buffer, mode="w", format="mp4")
 
         video_stream = output_container.add_stream("h264", rate=video.get_frame_rate())


### PR DESCRIPTION
Fixes #14197

## Summary
- `_apply_video_scale()`, called by ByteDance Seedance 2.0 Reference to Video's `auto_downscale`/`auto_upscale`, ignores `start_time`/`duration` set by the VideoSlice node and re-encodes the full untrimmed video
- e.g. a video trimmed to 4s by VideoSlice reverts to its original 25s after `auto_downscale`, causing `ValueError: Total reference video duration is 25.1s. Maximum is 15.1 seconds`
- Root cause: `video.get_stream_source()` returns the raw file reference, discarding trimming metadata
- Fix: materialize via `save_to()` first so trimming is applied before the scale pass

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

### QA
- [x] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**