### PR TITLE
feat: expose comfy-api/platform base URLs via /features

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -231,6 +231,13 @@ parser.add_argument(
     help="Set the base URL for the ComfyUI API.  (default: https://api.comfy.org)",
 )
 
+parser.add_argument(
+    "--comfy-platform-base",
+    type=str,
+    default="https://platform.comfy.org",
+    help="Set the base URL for the ComfyUI Platform.  (default: https://platform.comfy.org)",
+)
+
 database_default_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "user", "comfyui.db")
 )

--- a/comfy_api/feature_flags.py
+++ b/comfy_api/feature_flags.py
@@ -99,6 +99,8 @@ _CORE_FEATURE_FLAGS: dict[str, Any] = {
     "extension": {"manager": {"supports_v4": True}},
     "node_replacements": True,
     "assets": args.enable_assets,
+    "comfy_api_base_url": args.comfy_api_base,
+    "comfy_platform_base_url": args.comfy_platform_base,
 }
 
 # CLI-provided flags cannot overwrite core flags

--- a/tests-unit/feature_flags_test.py
+++ b/tests-unit/feature_flags_test.py
@@ -32,6 +32,17 @@ class TestFeatureFlags:
         assert "max_upload_size" in features
         assert isinstance(features["max_upload_size"], (int, float))
 
+    def test_get_server_features_exposes_comfy_api_base_urls(self):
+        """The frontend reads comfy_api_base_url / comfy_platform_base_url
+        from /features to learn which backend to talk to. The keys must be
+        present (with the CLI-provided or default URL) so an ephemeral or
+        self-hosted comfy-api can override them without a frontend rebuild."""
+        features = get_server_features()
+        assert isinstance(features.get("comfy_api_base_url"), str)
+        assert features["comfy_api_base_url"].startswith("http")
+        assert isinstance(features.get("comfy_platform_base_url"), str)
+        assert features["comfy_platform_base_url"].startswith("http")
+
     def test_get_connection_feature_with_missing_sid(self):
         """Test getting feature for non-existent session ID."""
         sockets_metadata = {}


### PR DESCRIPTION
This change is to allow for full end to end testing on private, temporary deployments of comfy api. Without this change (and a companion frontend change in https://github.com/Comfy-Org/ComfyUI_frontend/pull/12560), testing against such an environment requires a more complex and unnecessary development environment.

## Changes

- Adds `--comfy-platform-base` CLI flag mirroring the existing `--comfy-api-base`.
- Surfaces both URLs through the existing `/features` endpoint as `comfy_api_base_url` and `comfy_platform_base_url` so the frontend can discover the configured backend at runtime.
