### PR TITLE
[Partner Nodes] fix: respect VideoSlice trim when resizing videos

### DIFF
--- a/comfy_api/latest/_input/video_types.py
+++ b/comfy_api/latest/_input/video_types.py
@@ -65,6 +65,12 @@ class VideoInput(ABC):
         buffer.seek(0)
         return buffer
 
+    def get_active_trim_window(self) -> tuple[float, float]:
+        """Return the active trim as ``(start_time, duration)`` in seconds (start_time normalized
+        to ``>= 0``; ``duration == 0`` means "until the end"). Default: no trim; trimmable subclasses override.
+        """
+        return 0.0, 0.0
+
     # Provide a default implementation, but subclasses can provide optimized versions
     # if possible.
     def get_dimensions(self) -> tuple[int, int]:

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -75,6 +75,12 @@ class VideoFromFile(VideoInput):
             self.__file.seek(0)
         return self.__file
 
+    def get_active_trim_window(self) -> tuple[float, float]:
+        start_time = self.__start_time
+        if start_time < 0:
+            start_time = max(self._get_raw_duration() + start_time, 0.0)
+        return float(start_time), float(self.__duration)
+
     def get_dimensions(self) -> tuple[int, int]:
         """
         Returns the dimensions of the video input.

--- a/comfy_api_nodes/util/conversions.py
+++ b/comfy_api_nodes/util/conversions.py
@@ -469,6 +469,11 @@ def _apply_video_scale(video: Input.Video, scale_dims: tuple[int, int]) -> Input
     input_container = None
     output_container = None
 
+    # get_stream_source() is untrimmed, so apply the trim window in this same pass.
+    # start_time is normalized (>= 0); duration == 0 means "until the end".
+    start_time, duration = video.get_active_trim_window()
+    trimming = bool(start_time or duration)
+
     try:
         input_source = video.get_stream_source()
         input_container = av.open(input_source, mode="r")
@@ -487,16 +492,45 @@ def _apply_video_scale(video: Input.Video, scale_dims: tuple[int, int]) -> Input
                 audio_stream.layout = stream.layout
                 break
 
+        in_video = input_container.streams.video[0]
+        start_pts = int(start_time / in_video.time_base) if trimming else 0
+        end_pts = int((start_time + duration) / in_video.time_base) if duration else None
+        if start_pts:
+            input_container.seek(start_pts, stream=in_video)
+
+        encoded = 0
         for frame in input_container.decode(video=0):
+            if trimming:
+                if frame.pts is None or frame.pts < start_pts:
+                    continue
+                if end_pts is not None and frame.pts >= end_pts:
+                    break
             frame = frame.reformat(width=out_w, height=out_h, format="yuv420p")
+            # Re-wrap as a fresh frame: dropping irregular source timestamps (VFR/AVI/GIF/...)
+            # lets the encoder assign clean ones and avoids mp4 muxer errors.
+            frame = av.VideoFrame.from_ndarray(frame.to_ndarray(format="yuv420p"), format="yuv420p")
             for packet in video_stream.encode(frame):
                 output_container.mux(packet)
+            encoded += 1
         for packet in video_stream.encode():
             output_container.mux(packet)
+
+        if encoded == 0:
+            raise ValueError(
+                f"resize produced no frames (start_time={start_time}, duration={duration} "
+                "selected nothing from the source)"
+            )
 
         if audio_stream is not None:
             input_container.seek(0)
             for audio_frame in input_container.decode(audio=0):
+                if trimming:
+                    if audio_frame.time is None or audio_frame.time < start_time:
+                        continue
+                    if duration and audio_frame.time > start_time + duration:
+                        break
+                # Carry odd audio time bases the mp4 muxer rejects; reset pts, encoder assigns clean ones (MP3-in-AVI)
+                audio_frame.pts = None
                 for packet in audio_stream.encode(audio_frame):
                     output_container.mux(packet)
             for packet in audio_stream.encode():


### PR DESCRIPTION
Fixes #14197

`VideoSlice` lets trim a clip (say, down to 4 seconds), but when that trimmed clip was fed into a node that auto-resizes videos before upload - **ByteDance Seedance** (`auto_downscale`/`auto_upscale`) and **Beeble SwitchX** - the trim was silently lost and the full original video was sent instead.

The cause is in `_apply_video_scale`: it reads `video.get_stream_source()`, which intentionally returns the untrimmed underlying stream, and never applied the start_time/duration that VideoSlice had set. So the resize step re-expanded the clip back to its full length.

While verifying this against a wide range of real uploads, I also hardened the same re-encode path so it stops crashing on perfectly valid files:

- Clean-frame rebuild - irregular source timestamps (variable frame rate, MP3-in-AVI, WMV, ...) were making the MP4 muxer throw `Invalid argument`. Have to nice to have it for future us. 
- Empty-trim guard - a trim that selects no frames now raises a clear error instead of producing a broken empty file.
- Audio is trimmed to match the video

**Alternatives considered and tested**

- The original community PR (#14196): `save_to(`) then re-decode + re-encode. This is the most obvious fix and it does respect the trim, but it encodes the video twice (generational quality loss) and materializes the whole clip in memory.
- Decode to a tensor --> scale with common_upscale (lanczos) --> re-encode. Cleanest code and the best raw scaling quality, but it has the same memory problem as above

---

**Changes in Core:**

`get_active_trim_window()` was added to the VideoInput base class (`comfy_api/latest/_input/video_types.py`). It reports the active trim as (`start_time`, `duration`) in seconds and defaults to (0.0, 0.0) - "no trim", so every existing video type (and any custom subclass) keeps its current behavior unless it opts in.

This was needed because `_apply_video_scale` re-decodes the untrimmed stream from `get_stream_source()`, so it needs a cheap, public way to learn the trim window - without materializing the clip (`get_components()`) or re-encoding it (`save_to()`), which would defeat the whole point.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

