### PR TITLE
Remove the 'partner' prefix from all api nodes

### DIFF
--- a/comfy_api_nodes/nodes_anthropic.py
+++ b/comfy_api_nodes/nodes_anthropic.py
@@ -155,7 +155,7 @@ class ClaudeNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ClaudeNode",
             display_name="Anthropic Claude",
-            category="text/partner/Anthropic",
+            category="text/Anthropic",
             essentials_category="Text Generation",
             description="Generate text responses with Anthropic's Claude models. "
             "Provide a text prompt and optionally one or more images for multimodal context.",

--- a/comfy_api_nodes/nodes_beeble.py
+++ b/comfy_api_nodes/nodes_beeble.py
@@ -206,7 +206,7 @@ class BeebleSwitchXVideoEdit(IO.ComfyNode):
         return IO.Schema(
             node_id="BeebleSwitchXVideoEdit",
             display_name="Beeble SwitchX Video Edit",
-            category="video/partner/Beeble",
+            category="video/Beeble",
             description=(
                 "Edit a video with Beeble SwitchX. Switches anything in the scene (background, "
                 "lighting, costume) while preserving the original subject's pixels and motion. "
@@ -302,7 +302,7 @@ class BeebleSwitchXImageEdit(IO.ComfyNode):
         return IO.Schema(
             node_id="BeebleSwitchXImageEdit",
             display_name="Beeble SwitchX Image Edit",
-            category="image/partner/Beeble",
+            category="image/Beeble",
             description=(
                 "Edit a single image with Beeble SwitchX. Switches anything in the scene "
                 "(background, lighting, costume) while preserving the original subject's pixels. "

--- a/comfy_api_nodes/nodes_bfl.py
+++ b/comfy_api_nodes/nodes_bfl.py
@@ -37,7 +37,7 @@ class FluxProUltraImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="FluxProUltraImageNode",
             display_name="Flux 1.1 [pro] Ultra Image",
-            category="image/partner/BFL",
+            category="image/BFL",
             description="Generates images using Flux Pro 1.1 Ultra via api based on prompt and resolution.",
             inputs=[
                 IO.String.Input(
@@ -155,7 +155,7 @@ class FluxKontextProImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id=cls.NODE_ID,
             display_name=cls.DISPLAY_NAME,
-            category="image/partner/BFL",
+            category="image/BFL",
             description="Edits images using Flux.1 Kontext [pro] via api based on prompt and aspect ratio.",
             inputs=[
                 IO.String.Input(
@@ -277,7 +277,7 @@ class FluxProExpandNode(IO.ComfyNode):
         return IO.Schema(
             node_id="FluxProExpandNode",
             display_name="Flux.1 Expand Image",
-            category="image/partner/BFL",
+            category="image/BFL",
             description="Outpaints image based on prompt.",
             inputs=[
                 IO.Image.Input("image"),
@@ -414,7 +414,7 @@ class FluxProFillNode(IO.ComfyNode):
         return IO.Schema(
             node_id="FluxProFillNode",
             display_name="Flux.1 Fill Image",
-            category="image/partner/BFL",
+            category="image/BFL",
             description="Inpaints image based on mask and prompt.",
             inputs=[
                 IO.Image.Input("image"),
@@ -521,7 +521,7 @@ class FluxEraseNode(IO.ComfyNode):
         return IO.Schema(
             node_id="FluxEraseNode",
             display_name="Flux Erase Image",
-            category="image/partner/BFL",
+            category="image/BFL",
             description="Removes the masked object from an image and reconstructs the background. "
             "Paint the mask over what you want to erase.",
             inputs=[
@@ -597,7 +597,7 @@ class FluxVTONode(IO.ComfyNode):
         return IO.Schema(
             node_id="FluxVTONode",
             display_name="Flux Virtual Try-On",
-            category="image/partner/BFL",
+            category="image/BFL",
             description="Virtual try-on: dresses the person in the provided garment.",
             inputs=[
                 IO.Image.Input("person", tooltip="Image of the person to dress."),
@@ -697,7 +697,7 @@ class Flux2ProImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id=cls.NODE_ID,
             display_name=cls.DISPLAY_NAME,
-            category="image/partner/BFL",
+            category="image/BFL",
             description="Generates images synchronously based on prompt and resolution.",
             inputs=[
                 IO.String.Input(
@@ -868,7 +868,7 @@ class Flux2ImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Flux2ImageNode",
             display_name="Flux.2 Image",
-            category="image/partner/BFL",
+            category="image/BFL",
             description="Generate images via Flux.2 [pro] or Flux.2 [max] from a prompt and optional reference images.",
             inputs=[
                 IO.String.Input(

--- a/comfy_api_nodes/nodes_bria.py
+++ b/comfy_api_nodes/nodes_bria.py
@@ -31,7 +31,7 @@ class BriaImageEditNode(IO.ComfyNode):
         return IO.Schema(
             node_id="BriaImageEditNode",
             display_name="Bria FIBO Image Edit",
-            category="image/partner/Bria",
+            category="image/Bria",
             description="Edit images using Bria latest model",
             inputs=[
                 IO.Combo.Input("model", options=["FIBO"]),
@@ -169,7 +169,7 @@ class BriaRemoveImageBackground(IO.ComfyNode):
         return IO.Schema(
             node_id="BriaRemoveImageBackground",
             display_name="Bria Remove Image Background",
-            category="image/partner/Bria",
+            category="image/Bria",
             description="Remove the background from an image using Bria RMBG 2.0.",
             inputs=[
                 IO.Image.Input("image"),
@@ -245,7 +245,7 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
         return IO.Schema(
             node_id="BriaRemoveVideoBackground",
             display_name="Bria Remove Video Background",
-            category="video/partner/Bria",
+            category="video/Bria",
             description="Remove the background from a video using Bria. ",
             inputs=[
                 IO.Video.Input("video"),

--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -368,7 +368,7 @@ class ByteDanceImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceImageNode",
             display_name="ByteDance Image",
-            category="image/partner/ByteDance",
+            category="image/ByteDance",
             description="Generate images using ByteDance models via api based on prompt",
             inputs=[
                 IO.Combo.Input("model", options=["seedream-3-0-t2i-250415"]),
@@ -492,7 +492,7 @@ class ByteDanceSeedreamNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceSeedreamNode",
             display_name="ByteDance Seedream 4.5 & 5.0",
-            category="image/partner/ByteDance",
+            category="image/ByteDance",
             description="Unified text-to-image generation and precise single-sentence editing at up to 4K resolution.",
             inputs=[
                 IO.Combo.Input(
@@ -754,7 +754,7 @@ class ByteDanceSeedreamNodeV2(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceSeedreamNodeV2",
             display_name="ByteDance Seedream 4.5 & 5.0",
-            category="image/partner/ByteDance",
+            category="image/ByteDance",
             description="Unified text-to-image generation and precise single-sentence editing at up to 4K resolution.",
             inputs=[
                 IO.String.Input(
@@ -920,7 +920,7 @@ class ByteDanceTextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceTextToVideoNode",
             display_name="ByteDance Text to Video",
-            category="video/partner/ByteDance",
+            category="video/ByteDance",
             description="Generate video using ByteDance models via api based on prompt",
             inputs=[
                 IO.Combo.Input(
@@ -1048,7 +1048,7 @@ class ByteDanceImageToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceImageToVideoNode",
             display_name="ByteDance Image to Video",
-            category="video/partner/ByteDance",
+            category="video/ByteDance",
             description="Generate video using ByteDance models via api based on image and prompt",
             inputs=[
                 IO.Combo.Input(
@@ -1185,7 +1185,7 @@ class ByteDanceFirstLastFrameNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceFirstLastFrameNode",
             display_name="ByteDance First-Last-Frame to Video",
-            category="video/partner/ByteDance",
+            category="video/ByteDance",
             description="Generate video using prompt and first and last frames.",
             inputs=[
                 IO.Combo.Input(
@@ -1333,7 +1333,7 @@ class ByteDanceImageReferenceNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceImageReferenceNode",
             display_name="ByteDance Reference Images to Video",
-            category="video/partner/ByteDance",
+            category="video/ByteDance",
             description="Generate video using prompt and reference images.",
             inputs=[
                 IO.Combo.Input(
@@ -1576,7 +1576,7 @@ class ByteDance2TextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDance2TextToVideoNode",
             display_name="ByteDance Seedance 2.0 Text to Video",
-            category="video/partner/ByteDance",
+            category="video/ByteDance",
             description="Generate video using Seedance 2.0 models based on a text prompt.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1677,7 +1677,7 @@ class ByteDance2FirstLastFrameNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDance2FirstLastFrameNode",
             display_name="ByteDance Seedance 2.0 First-Last-Frame to Video",
-            category="video/partner/ByteDance",
+            category="video/ByteDance",
             description="Generate video using Seedance 2.0 from a first frame image and optional last frame image.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1944,7 +1944,7 @@ class ByteDance2ReferenceNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDance2ReferenceNode",
             display_name="ByteDance Seedance 2.0 Reference to Video",
-            category="video/partner/ByteDance",
+            category="video/ByteDance",
             description="Generate, edit, or extend video using Seedance 2.0 with reference images, "
             "videos, and audio. Supports multimodal reference, video editing, and video extension.",
             inputs=[
@@ -2241,7 +2241,7 @@ class ByteDanceCreateImageAsset(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceCreateImageAsset",
             display_name="ByteDance Create Image Asset",
-            category="image/partner/ByteDance",
+            category="image/ByteDance",
             description=(
                 "Create a Seedance 2.0 personal image asset. Uploads the input image and "
                 "registers it in the given asset group. If group_id is empty, runs a real-person "
@@ -2308,7 +2308,7 @@ class ByteDanceCreateVideoAsset(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceCreateVideoAsset",
             display_name="ByteDance Create Video Asset",
-            category="video/partner/ByteDance",
+            category="video/ByteDance",
             description=(
                 "Create a Seedance 2.0 personal video asset. Uploads the input video and "
                 "registers it in the given asset group. If group_id is empty, runs a real-person "

--- a/comfy_api_nodes/nodes_bytedance_llm.py
+++ b/comfy_api_nodes/nodes_bytedance_llm.py
@@ -144,7 +144,7 @@ class ByteDanceSeedNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ByteDanceSeedNode",
             display_name="ByteDance Seed",
-            category="text/partner/ByteDance",
+            category="text/ByteDance",
             essentials_category="Text Generation",
             description="Generate text responses with ByteDance's Seed 2.0 models. "
             "Provide a text prompt and optionally one or more images or videos for multimodal context.",

--- a/comfy_api_nodes/nodes_elevenlabs.py
+++ b/comfy_api_nodes/nodes_elevenlabs.py
@@ -69,7 +69,7 @@ class ElevenLabsSpeechToText(IO.ComfyNode):
         return IO.Schema(
             node_id="ElevenLabsSpeechToText",
             display_name="ElevenLabs Speech to Text",
-            category="audio/partner/ElevenLabs",
+            category="audio/ElevenLabs",
             description="Transcribe audio to text. "
             "Supports automatic language detection, speaker diarization, and audio event tagging.",
             inputs=[
@@ -210,7 +210,7 @@ class ElevenLabsVoiceSelector(IO.ComfyNode):
         return IO.Schema(
             node_id="ElevenLabsVoiceSelector",
             display_name="ElevenLabs Voice Selector",
-            category="audio/partner/ElevenLabs",
+            category="audio/ElevenLabs",
             description="Select a predefined ElevenLabs voice for text-to-speech generation.",
             inputs=[
                 IO.Combo.Input(
@@ -239,7 +239,7 @@ class ElevenLabsTextToSpeech(IO.ComfyNode):
         return IO.Schema(
             node_id="ElevenLabsTextToSpeech",
             display_name="ElevenLabs Text to Speech",
-            category="audio/partner/ElevenLabs",
+            category="audio/ElevenLabs",
             description="Convert text to speech.",
             inputs=[
                 IO.Custom(ELEVENLABS_VOICE).Input(
@@ -414,7 +414,7 @@ class ElevenLabsAudioIsolation(IO.ComfyNode):
         return IO.Schema(
             node_id="ElevenLabsAudioIsolation",
             display_name="ElevenLabs Voice Isolation",
-            category="audio/partner/ElevenLabs",
+            category="audio/ElevenLabs",
             description="Remove background noise from audio, isolating vocals or speech.",
             inputs=[
                 IO.Audio.Input(
@@ -459,7 +459,7 @@ class ElevenLabsTextToSoundEffects(IO.ComfyNode):
         return IO.Schema(
             node_id="ElevenLabsTextToSoundEffects",
             display_name="ElevenLabs Text to Sound Effects",
-            category="audio/partner/ElevenLabs",
+            category="audio/ElevenLabs",
             description="Generate sound effects from text descriptions.",
             inputs=[
                 IO.String.Input(
@@ -555,7 +555,7 @@ class ElevenLabsInstantVoiceClone(IO.ComfyNode):
         return IO.Schema(
             node_id="ElevenLabsInstantVoiceClone",
             display_name="ElevenLabs Instant Voice Clone",
-            category="audio/partner/ElevenLabs",
+            category="audio/ElevenLabs",
             description="Create a cloned voice from audio samples. "
             "Provide 1-8 audio recordings of the voice to clone.",
             inputs=[
@@ -658,7 +658,7 @@ class ElevenLabsSpeechToSpeech(IO.ComfyNode):
         return IO.Schema(
             node_id="ElevenLabsSpeechToSpeech",
             display_name="ElevenLabs Speech to Speech",
-            category="audio/partner/ElevenLabs",
+            category="audio/ElevenLabs",
             description="Transform speech from one voice to another while preserving the original content and emotion.",
             inputs=[
                 IO.Custom(ELEVENLABS_VOICE).Input(
@@ -793,7 +793,7 @@ class ElevenLabsTextToDialogue(IO.ComfyNode):
         return IO.Schema(
             node_id="ElevenLabsTextToDialogue",
             display_name="ElevenLabs Text to Dialogue",
-            category="audio/partner/ElevenLabs",
+            category="audio/ElevenLabs",
             description="Generate multi-speaker dialogue from text. Each dialogue entry has its own text and voice.",
             inputs=[
                 IO.Float.Input(

--- a/comfy_api_nodes/nodes_gemini.py
+++ b/comfy_api_nodes/nodes_gemini.py
@@ -300,7 +300,7 @@ class GeminiNode(IO.ComfyNode):
         return IO.Schema(
             node_id="GeminiNode",
             display_name="Google Gemini",
-            category="text/partner/Gemini",
+            category="text/Gemini",
             description="Generate text responses with Google's Gemini AI model. "
             "You can provide multiple types of inputs (text, images, audio, video) "
             "as context for generating more relevant and meaningful responses.",
@@ -541,7 +541,7 @@ class GeminiInputFiles(IO.ComfyNode):
         return IO.Schema(
             node_id="GeminiInputFiles",
             display_name="Gemini Input Files",
-            category="text/partner/Gemini",
+            category="text/Gemini",
             description="Loads and prepares input files to include as inputs for Gemini LLM nodes. "
             "The files will be read by the Gemini model when generating a response. "
             "The contents of the text file count toward the token limit. "
@@ -598,7 +598,7 @@ class GeminiImage(IO.ComfyNode):
         return IO.Schema(
             node_id="GeminiImageNode",
             display_name="Nano Banana (Google Gemini Image)",
-            category="image/partner/Gemini",
+            category="image/Gemini",
             description="Edit images synchronously via Google API.",
             inputs=[
                 IO.String.Input(
@@ -731,7 +731,7 @@ class GeminiImage2(IO.ComfyNode):
         return IO.Schema(
             node_id="GeminiImage2Node",
             display_name="Nano Banana Pro (Google Gemini Image)",
-            category="image/partner/Gemini",
+            category="image/Gemini",
             description="Generate or edit images synchronously via Google Vertex API.",
             inputs=[
                 IO.String.Input(
@@ -869,7 +869,7 @@ class GeminiNanoBanana2(IO.ComfyNode):
         return IO.Schema(
             node_id="GeminiNanoBanana2",
             display_name="Nano Banana 2",
-            category="image/partner/Gemini",
+            category="image/Gemini",
             description="Generate or edit images synchronously via Google Vertex API.",
             inputs=[
                 IO.String.Input(
@@ -1085,7 +1085,7 @@ class GeminiNanoBanana2V2(IO.ComfyNode):
         return IO.Schema(
             node_id="GeminiNanoBanana2V2",
             display_name="Nano Banana 2",
-            category="image/partner/Gemini",
+            category="image/Gemini",
             description="Generate or edit images synchronously via Google Vertex API.",
             inputs=[
                 IO.String.Input(

--- a/comfy_api_nodes/nodes_grok.py
+++ b/comfy_api_nodes/nodes_grok.py
@@ -54,7 +54,7 @@ class GrokImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="GrokImageNode",
             display_name="Grok Image",
-            category="image/partner/Grok",
+            category="image/Grok",
             description="Generate images using Grok based on a text prompt",
             inputs=[
                 IO.Combo.Input(
@@ -228,7 +228,7 @@ class GrokImageEditNode(IO.ComfyNode):
         return IO.Schema(
             node_id="GrokImageEditNode",
             display_name="Grok Image Edit",
-            category="image/partner/Grok",
+            category="image/Grok",
             description="Modify an existing image based on a text prompt",
             inputs=[
                 IO.Combo.Input(
@@ -369,7 +369,7 @@ class GrokImageEditNodeV2(IO.ComfyNode):
         return IO.Schema(
             node_id="GrokImageEditNodeV2",
             display_name="Grok Image Edit",
-            category="image/partner/Grok",
+            category="image/Grok",
             description="Modify an existing image based on a text prompt",
             inputs=[
                 IO.String.Input(
@@ -506,7 +506,7 @@ class GrokVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="GrokVideoNode",
             display_name="Grok Video",
-            category="video/partner/Grok",
+            category="video/Grok",
             description="Generate video from a prompt or an image",
             inputs=[
                 IO.Combo.Input(
@@ -630,7 +630,7 @@ class GrokVideoEditNode(IO.ComfyNode):
         return IO.Schema(
             node_id="GrokVideoEditNode",
             display_name="Grok Video Edit",
-            category="video/partner/Grok",
+            category="video/Grok",
             description="Edit an existing video based on a text prompt.",
             inputs=[
                 IO.Combo.Input("model", options=["grok-imagine-video"]),
@@ -708,7 +708,7 @@ class GrokVideoReferenceNode(IO.ComfyNode):
         return IO.Schema(
             node_id="GrokVideoReferenceNode",
             display_name="Grok Reference-to-Video",
-            category="video/partner/Grok",
+            category="video/Grok",
             description="Generate video guided by reference images as style and content references.",
             inputs=[
                 IO.String.Input(
@@ -841,7 +841,7 @@ class GrokVideoExtendNode(IO.ComfyNode):
         return IO.Schema(
             node_id="GrokVideoExtendNode",
             display_name="Grok Video Extend",
-            category="video/partner/Grok",
+            category="video/Grok",
             description="Extend an existing video with a seamless continuation based on a text prompt.",
             inputs=[
                 IO.String.Input(

--- a/comfy_api_nodes/nodes_hitpaw.py
+++ b/comfy_api_nodes/nodes_hitpaw.py
@@ -71,7 +71,7 @@ class HitPawGeneralImageEnhance(IO.ComfyNode):
         return IO.Schema(
             node_id="HitPawGeneralImageEnhance",
             display_name="HitPaw General Image Enhance",
-            category="image/partner/HitPaw",
+            category="image/HitPaw",
             description="Upscale low-resolution images to super-resolution, eliminate artifacts and noise. "
             f"Maximum output: {MAX_MP_GENERATIVE} megapixels.",
             inputs=[
@@ -201,7 +201,7 @@ class HitPawVideoEnhance(IO.ComfyNode):
         return IO.Schema(
             node_id="HitPawVideoEnhance",
             display_name="HitPaw Video Enhance",
-            category="video/partner/HitPaw",
+            category="video/HitPaw",
             description="Upscale low-resolution videos to high resolution, eliminate artifacts and noise. "
             "Prices shown are per second of video.",
             inputs=[

--- a/comfy_api_nodes/nodes_hunyuan3d.py
+++ b/comfy_api_nodes/nodes_hunyuan3d.py
@@ -123,7 +123,7 @@ class TencentTextToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TencentTextToModelNode",
             display_name="Hunyuan3D: Text to Model",
-            category="3d/partner/Tencent",
+            category="3d/Tencent",
             essentials_category="3D",
             inputs=[
                 IO.Combo.Input(
@@ -242,7 +242,7 @@ class TencentImageToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TencentImageToModelNode",
             display_name="Hunyuan3D: Image(s) to Model",
-            category="3d/partner/Tencent",
+            category="3d/Tencent",
             essentials_category="3D",
             inputs=[
                 IO.Combo.Input(
@@ -415,7 +415,7 @@ class TencentModelTo3DUVNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TencentModelTo3DUVNode",
             display_name="Hunyuan3D: Model to UV",
-            category="3d/partner/Tencent",
+            category="3d/Tencent",
             description="Perform UV unfolding on a 3D model to generate UV texture. "
             "Input model must have less than 30000 faces.",
             inputs=[
@@ -505,7 +505,7 @@ class Tencent3DTextureEditNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Tencent3DTextureEditNode",
             display_name="Hunyuan3D: 3D Texture Edit",
-            category="3d/partner/Tencent",
+            category="3d/Tencent",
             description="After inputting the 3D model, perform 3D model texture redrawing.",
             inputs=[
                 IO.MultiType.Input(
@@ -594,7 +594,7 @@ class Tencent3DPartNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Tencent3DPartNode",
             display_name="Hunyuan3D: 3D Part",
-            category="3d/partner/Tencent",
+            category="3d/Tencent",
             description="Automatically perform component identification and generation based on the model structure.",
             inputs=[
                 IO.MultiType.Input(
@@ -666,7 +666,7 @@ class TencentSmartTopologyNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TencentSmartTopologyNode",
             display_name="Hunyuan3D: Smart Topology",
-            category="3d/partner/Tencent",
+            category="3d/Tencent",
             description="Perform smart retopology on a 3D model. "
             "Supports GLB/OBJ formats; max 200MB; recommended for high-poly models.",
             inputs=[

--- a/comfy_api_nodes/nodes_ideogram.py
+++ b/comfy_api_nodes/nodes_ideogram.py
@@ -234,7 +234,7 @@ class IdeogramV1(IO.ComfyNode):
         return IO.Schema(
             node_id="IdeogramV1",
             display_name="Ideogram V1",
-            category="image/partner/Ideogram",
+            category="image/Ideogram",
             description="Generates images using the Ideogram V1 model.",
             inputs=[
                 IO.String.Input(
@@ -360,7 +360,7 @@ class IdeogramV2(IO.ComfyNode):
         return IO.Schema(
             node_id="IdeogramV2",
             display_name="Ideogram V2",
-            category="image/partner/Ideogram",
+            category="image/Ideogram",
             description="Generates images using the Ideogram V2 model.",
             inputs=[
                 IO.String.Input(
@@ -526,7 +526,7 @@ class IdeogramV3(IO.ComfyNode):
         return IO.Schema(
             node_id="IdeogramV3",
             display_name="Ideogram V3",
-            category="image/partner/Ideogram",
+            category="image/Ideogram",
             description="Generates images using the Ideogram V3 model. "
                         "Supports both regular image generation from text prompts and image editing with mask.",
             inputs=[

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -642,7 +642,7 @@ class KlingCameraControls(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingCameraControls",
             display_name="Kling Camera Controls",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Allows specifying configuration options for Kling Camera Controls and motion control effects.",
             inputs=[
                 IO.Combo.Input("camera_control_type", options=KlingCameraControlType),
@@ -762,7 +762,7 @@ class KlingTextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingTextToVideoNode",
             display_name="Kling Text to Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Kling Text to Video Node",
             inputs=[
                 IO.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
@@ -849,7 +849,7 @@ class OmniProTextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingOmniProTextToVideoNode",
             display_name="Kling 3.0 Omni Text to Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Use text prompts to generate videos with the latest Kling model.",
             inputs=[
                 IO.Combo.Input("model_name", options=["kling-v3-omni", "kling-video-o1"]),
@@ -998,7 +998,7 @@ class OmniProFirstLastFrameNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingOmniProFirstLastFrameNode",
             display_name="Kling 3.0 Omni First-Last-Frame to Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Use a start frame, an optional end frame, or reference images with the latest Kling model.",
             inputs=[
                 IO.Combo.Input("model_name", options=["kling-v3-omni", "kling-video-o1"]),
@@ -1205,7 +1205,7 @@ class OmniProImageToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingOmniProImageToVideoNode",
             display_name="Kling 3.0 Omni Image to Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Use up to 7 reference images to generate a video with the latest Kling model.",
             inputs=[
                 IO.Combo.Input("model_name", options=["kling-v3-omni", "kling-video-o1"]),
@@ -1374,7 +1374,7 @@ class OmniProVideoToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingOmniProVideoToVideoNode",
             display_name="Kling 3.0 Omni Video to Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Use a video and up to 4 reference images to generate a video with the latest Kling model.",
             inputs=[
                 IO.Combo.Input("model_name", options=["kling-v3-omni", "kling-video-o1"]),
@@ -1485,7 +1485,7 @@ class OmniProEditVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingOmniProEditVideoNode",
             display_name="Kling 3.0 Omni Edit Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             essentials_category="Video Generation",
             description="Edit an existing video with the latest model from Kling.",
             inputs=[
@@ -1593,7 +1593,7 @@ class OmniProImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingOmniProImageNode",
             display_name="Kling 3.0 Omni Image",
-            category="image/partner/Kling",
+            category="image/Kling",
             description="Create or edit images with the latest model from Kling.",
             inputs=[
                 IO.Combo.Input("model_name", options=["kling-v3-omni", "kling-image-o1"]),
@@ -1721,7 +1721,7 @@ class KlingCameraControlT2VNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingCameraControlT2VNode",
             display_name="Kling Text to Video (Camera Control)",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Transform text into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original text.",
             inputs=[
                 IO.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
@@ -1783,7 +1783,7 @@ class KlingImage2VideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingImage2VideoNode",
             display_name="Kling Image(First Frame) to Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             inputs=[
                 IO.Image.Input("start_frame", tooltip="The reference image used to generate the video."),
                 IO.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
@@ -1882,7 +1882,7 @@ class KlingCameraControlI2VNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingCameraControlI2VNode",
             display_name="Kling Image to Video (Camera Control)",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Transform still images into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original image.",
             inputs=[
                 IO.Image.Input(
@@ -1953,7 +1953,7 @@ class KlingStartEndFrameNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingStartEndFrameNode",
             display_name="Kling Start-End Frame to Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Generate a video sequence that transitions between your provided start and end images. The node creates all frames in between, producing a smooth transformation from the first frame to the last.",
             inputs=[
                 IO.Image.Input(
@@ -2047,7 +2047,7 @@ class KlingVideoExtendNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingVideoExtendNode",
             display_name="Kling Video Extend",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Kling Video Extend Node. Extend videos made by other Kling nodes. The video_id is created by using other Kling Nodes.",
             inputs=[
                 IO.String.Input(
@@ -2128,7 +2128,7 @@ class KlingDualCharacterVideoEffectNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingDualCharacterVideoEffectNode",
             display_name="Kling Dual Character Video Effects",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Achieve different special effects when generating a video based on the effect_scene. First image will be positioned on left side, second on right side of the composite.",
             inputs=[
                 IO.Image.Input("image_left", tooltip="Left side image"),
@@ -2218,7 +2218,7 @@ class KlingSingleImageVideoEffectNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingSingleImageVideoEffectNode",
             display_name="Kling Video Effects",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Achieve different special effects when generating a video based on the effect_scene.",
             inputs=[
                 IO.Image.Input(
@@ -2291,7 +2291,7 @@ class KlingLipSyncAudioToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingLipSyncAudioToVideoNode",
             display_name="Kling Lip Sync Video with Audio",
-            category="video/partner/Kling",
+            category="video/Kling",
             essentials_category="Video Generation",
             description="Kling Lip Sync Audio to Video Node. Syncs mouth movements in a video file to the audio content of an audio file. When using, ensure that the audio contains clearly distinguishable vocals and that the video contains a distinct face. The audio file should not be larger than 5MB. The video file should not be larger than 100MB, should have height/width between 720px and 1920px, and should be between 2s and 10s in length.",
             inputs=[
@@ -2343,7 +2343,7 @@ class KlingLipSyncTextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingLipSyncTextToVideoNode",
             display_name="Kling Lip Sync Video with Text",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Kling Lip Sync Text to Video Node. Syncs mouth movements in a video file to a text prompt. The video file should not be larger than 100MB, should have height/width between 720px and 1920px, and should be between 2s and 10s in length.",
             inputs=[
                 IO.Video.Input("video"),
@@ -2411,7 +2411,7 @@ class KlingVirtualTryOnNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingVirtualTryOnNode",
             display_name="Kling Virtual Try On",
-            category="image/partner/Kling",
+            category="image/Kling",
             description="Kling Virtual Try On Node. Input a human image and a cloth image to try on the cloth on the human. You can merge multiple clothing item pictures into one image with a white background.",
             inputs=[
                 IO.Image.Input("human_image"),
@@ -2478,7 +2478,7 @@ class KlingImageGenerationNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingImageGenerationNode",
             display_name="Kling 3.0 Image",
-            category="image/partner/Kling",
+            category="image/Kling",
             description="Kling Image Generation Node. Generate an image from a text prompt with an optional reference image.",
             inputs=[
                 IO.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
@@ -2615,7 +2615,7 @@ class TextToVideoWithAudio(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingTextToVideoWithAudio",
             display_name="Kling 2.6 Text to Video with Audio",
-            category="video/partner/Kling",
+            category="video/Kling",
             inputs=[
                 IO.Combo.Input("model_name", options=["kling-v2-6"]),
                 IO.String.Input("prompt", multiline=True, tooltip="Positive text prompt."),
@@ -2683,7 +2683,7 @@ class ImageToVideoWithAudio(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingImageToVideoWithAudio",
             display_name="Kling 2.6 Image(First Frame) to Video with Audio",
-            category="video/partner/Kling",
+            category="video/Kling",
             inputs=[
                 IO.Combo.Input("model_name", options=["kling-v2-6"]),
                 IO.Image.Input("start_frame"),
@@ -2753,7 +2753,7 @@ class MotionControl(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingMotionControl",
             display_name="Kling Motion Control",
-            category="video/partner/Kling",
+            category="video/Kling",
             inputs=[
                 IO.String.Input("prompt", multiline=True),
                 IO.Image.Input("reference_image"),
@@ -2854,7 +2854,7 @@ class KlingVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingVideoNode",
             display_name="Kling 3.0 Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Generate videos with Kling V3. "
             "Supports text-to-video and image-to-video with optional storyboard multi-prompt and audio generation.",
             inputs=[
@@ -3077,7 +3077,7 @@ class KlingFirstLastFrameNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingFirstLastFrameNode",
             display_name="Kling 3.0 First-Last-Frame to Video",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Generate videos with Kling V3 using first and last frames.",
             inputs=[
                 IO.String.Input("prompt", multiline=True, default=""),
@@ -3202,7 +3202,7 @@ class KlingAvatarNode(IO.ComfyNode):
         return IO.Schema(
             node_id="KlingAvatarNode",
             display_name="Kling Avatar 2.0",
-            category="video/partner/Kling",
+            category="video/Kling",
             description="Generate broadcast-style digital human videos from a single photo and an audio file.",
             inputs=[
                 IO.Image.Input(

--- a/comfy_api_nodes/nodes_krea.py
+++ b/comfy_api_nodes/nodes_krea.py
@@ -106,7 +106,7 @@ class Krea2ImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Krea2ImageNode",
             display_name="Krea 2 Image",
-            category="image/partner/Krea",
+            category="image/Krea",
             description=(
                 "Generate images via Krea 2 — pick Medium (expressive illustrations) or "
                 "Large (expressive photorealism). Supports an optional moodboard and up "
@@ -229,7 +229,7 @@ class Krea2StyleReferenceNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Krea2StyleReferenceNode",
             display_name="Krea 2 Style Reference",
-            category="image/partner/Krea",
+            category="image/Krea",
             description=(
                 "Add an image style reference to a Krea 2 generation. Chain multiple Krea 2 "
                 "Style Reference nodes (max 10) and feed the final `style_reference` output "

--- a/comfy_api_nodes/nodes_ltxv.py
+++ b/comfy_api_nodes/nodes_ltxv.py
@@ -50,7 +50,7 @@ class TextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LtxvApiTextToVideo",
             display_name="LTXV Text To Video",
-            category="video/partner/LTXV",
+            category="video/LTXV",
             description="Professional-quality videos with customizable duration and resolution.",
             inputs=[
                 IO.Combo.Input("model", options=list(MODELS_MAP.keys())),
@@ -127,7 +127,7 @@ class ImageToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LtxvApiImageToVideo",
             display_name="LTXV Image To Video",
-            category="video/partner/LTXV",
+            category="video/LTXV",
             description="Professional-quality videos with customizable duration and resolution based on start image.",
             inputs=[
                 IO.Image.Input("image", tooltip="First frame to be used for the video."),

--- a/comfy_api_nodes/nodes_luma.py
+++ b/comfy_api_nodes/nodes_luma.py
@@ -46,7 +46,7 @@ class LumaReferenceNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LumaReferenceNode",
             display_name="Luma Reference",
-            category="image/partner/Luma",
+            category="image/Luma",
             description="Holds an image and weight for use with Luma Generate Image node.",
             inputs=[
                 IO.Image.Input(
@@ -85,7 +85,7 @@ class LumaConceptsNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LumaConceptsNode",
             display_name="Luma Concepts",
-            category="video/partner/Luma",
+            category="video/Luma",
             description="Camera Concepts for use with Luma Text to Video and Luma Image to Video nodes.",
             inputs=[
                 IO.Combo.Input(
@@ -134,7 +134,7 @@ class LumaImageGenerationNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LumaImageNode",
             display_name="Luma Text to Image",
-            category="image/partner/Luma",
+            category="image/Luma",
             description="Generates images synchronously based on prompt and aspect ratio.",
             inputs=[
                 IO.String.Input(
@@ -278,7 +278,7 @@ class LumaImageModifyNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LumaImageModifyNode",
             display_name="Luma Image to Image",
-            category="image/partner/Luma",
+            category="image/Luma",
             description="Modifies images synchronously based on prompt and aspect ratio.",
             inputs=[
                 IO.Image.Input(
@@ -371,7 +371,7 @@ class LumaTextToVideoGenerationNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LumaVideoNode",
             display_name="Luma Text to Video",
-            category="video/partner/Luma",
+            category="video/Luma",
             description="Generates videos synchronously based on prompt and output_size.",
             inputs=[
                 IO.String.Input(
@@ -472,7 +472,7 @@ class LumaImageToVideoGenerationNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LumaImageToVideoNode",
             display_name="Luma Image to Video",
-            category="video/partner/Luma",
+            category="video/Luma",
             description="Generates videos synchronously based on prompt, input images, and output_size.",
             inputs=[
                 IO.String.Input(
@@ -724,7 +724,7 @@ class LumaImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LumaImageNode2",
             display_name="Luma UNI-1 Image",
-            category="image/partner/Luma",
+            category="image/Luma",
             description="Generate images from text using the Luma UNI-1 model.",
             inputs=[
                 IO.String.Input(
@@ -853,7 +853,7 @@ class LumaImageEditNode(IO.ComfyNode):
         return IO.Schema(
             node_id="LumaImageEditNode2",
             display_name="Luma UNI-1 Image Edit",
-            category="image/partner/Luma",
+            category="image/Luma",
             description="Edit an existing image with a text prompt using the Luma UNI-1 model.",
             inputs=[
                 IO.Image.Input(

--- a/comfy_api_nodes/nodes_magnific.py
+++ b/comfy_api_nodes/nodes_magnific.py
@@ -61,7 +61,7 @@ class MagnificImageUpscalerCreativeNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MagnificImageUpscalerCreativeNode",
             display_name="Magnific Image Upscale (Creative)",
-            category="image/partner/Magnific",
+            category="image/Magnific",
             description="Prompt‑guided enhancement, stylization, and 2x/4x/8x/16x upscaling. "
             "Maximum output: 25.3 megapixels.",
             inputs=[
@@ -240,7 +240,7 @@ class MagnificImageUpscalerPreciseV2Node(IO.ComfyNode):
         return IO.Schema(
             node_id="MagnificImageUpscalerPreciseV2Node",
             display_name="Magnific Image Upscale (Precise V2)",
-            category="image/partner/Magnific",
+            category="image/Magnific",
             description="High-fidelity upscaling with fine control over sharpness, grain, and detail. "
             "Maximum output: 10060×10060 pixels.",
             inputs=[
@@ -400,7 +400,7 @@ class MagnificImageStyleTransferNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MagnificImageStyleTransferNode",
             display_name="Magnific Image Style Transfer",
-            category="image/partner/Magnific",
+            category="image/Magnific",
             description="Transfer the style from a reference image to your input image.",
             inputs=[
                 IO.Image.Input("image", tooltip="The image to apply style transfer to."),
@@ -549,7 +549,7 @@ class MagnificImageRelightNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MagnificImageRelightNode",
             display_name="Magnific Image Relight",
-            category="image/partner/Magnific",
+            category="image/Magnific",
             description="Relight an image with lighting adjustments and optional reference-based light transfer.",
             inputs=[
                 IO.Image.Input("image", tooltip="The image to relight."),
@@ -789,7 +789,7 @@ class MagnificImageSkinEnhancerNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MagnificImageSkinEnhancerNode",
             display_name="Magnific Image Skin Enhancer",
-            category="image/partner/Magnific",
+            category="image/Magnific",
             description="Skin enhancement for portraits with multiple processing modes.",
             inputs=[
                 IO.Image.Input("image", tooltip="The portrait image to enhance."),

--- a/comfy_api_nodes/nodes_meshy.py
+++ b/comfy_api_nodes/nodes_meshy.py
@@ -33,7 +33,7 @@ class MeshyTextToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MeshyTextToModelNode",
             display_name="Meshy: Text to Model",
-            category="3d/partner/Meshy",
+            category="3d/Meshy",
             inputs=[
                 IO.Combo.Input("model", options=["latest"]),
                 IO.String.Input("prompt", multiline=True, default=""),
@@ -145,7 +145,7 @@ class MeshyRefineNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MeshyRefineNode",
             display_name="Meshy: Refine Draft Model",
-            category="3d/partner/Meshy",
+            category="3d/Meshy",
             description="Refine a previously created draft model.",
             inputs=[
                 IO.Combo.Input("model", options=["latest"]),
@@ -240,7 +240,7 @@ class MeshyImageToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MeshyImageToModelNode",
             display_name="Meshy: Image to Model",
-            category="3d/partner/Meshy",
+            category="3d/Meshy",
             inputs=[
                 IO.Combo.Input("model", options=["latest"]),
                 IO.Image.Input("image"),
@@ -405,7 +405,7 @@ class MeshyMultiImageToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MeshyMultiImageToModelNode",
             display_name="Meshy: Multi-Image to Model",
-            category="3d/partner/Meshy",
+            category="3d/Meshy",
             inputs=[
                 IO.Combo.Input("model", options=["latest"]),
                 IO.Autogrow.Input(
@@ -575,7 +575,7 @@ class MeshyRigModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MeshyRigModelNode",
             display_name="Meshy: Rig Model",
-            category="3d/partner/Meshy",
+            category="3d/Meshy",
             description="Provides a rigged character in standard formats. "
             "Auto-rigging is currently not suitable for untextured meshes, non-humanoid assets, "
             "or humanoid assets with unclear limb and body structure.",
@@ -656,7 +656,7 @@ class MeshyAnimateModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MeshyAnimateModelNode",
             display_name="Meshy: Animate Model",
-            category="3d/partner/Meshy",
+            category="3d/Meshy",
             description="Apply a specific animation action to a previously rigged character.",
             inputs=[
                 IO.Custom("MESHY_RIGGED_TASK_ID").Input("rig_task_id"),
@@ -722,7 +722,7 @@ class MeshyTextureNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MeshyTextureNode",
             display_name="Meshy: Texture Model",
-            category="3d/partner/Meshy",
+            category="3d/Meshy",
             inputs=[
                 IO.Combo.Input("model", options=["latest"]),
                 IO.Custom("MESHY_TASK_ID").Input("meshy_task_id"),

--- a/comfy_api_nodes/nodes_minimax.py
+++ b/comfy_api_nodes/nodes_minimax.py
@@ -101,7 +101,7 @@ class MinimaxTextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MinimaxTextToVideoNode",
             display_name="MiniMax Text to Video",
-            category="video/partner/MiniMax",
+            category="video/MiniMax",
             description="Generates videos synchronously based on a prompt, and optional parameters.",
             inputs=[
                 IO.String.Input(
@@ -163,7 +163,7 @@ class MinimaxImageToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MinimaxImageToVideoNode",
             display_name="MiniMax Image to Video",
-            category="video/partner/MiniMax",
+            category="video/MiniMax",
             description="Generates videos synchronously based on an image and prompt, and optional parameters.",
             inputs=[
                 IO.Image.Input(
@@ -230,7 +230,7 @@ class MinimaxSubjectToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MinimaxSubjectToVideoNode",
             display_name="MiniMax Subject to Video",
-            category="video/partner/MiniMax",
+            category="video/MiniMax",
             description="Generates videos synchronously based on an image and prompt, and optional parameters.",
             inputs=[
                 IO.Image.Input(
@@ -294,7 +294,7 @@ class MinimaxHailuoVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="MinimaxHailuoVideoNode",
             display_name="MiniMax Hailuo Video",
-            category="video/partner/MiniMax",
+            category="video/MiniMax",
             description="Generates videos from prompt, with optional start frame using the new MiniMax Hailuo-02 model.",
             inputs=[
                 IO.String.Input(

--- a/comfy_api_nodes/nodes_openai.py
+++ b/comfy_api_nodes/nodes_openai.py
@@ -99,7 +99,7 @@ class OpenAIDalle2(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenAIDalle2",
             display_name="OpenAI DALL·E 2",
-            category="image/partner/OpenAI",
+            category="image/OpenAI",
             description="Generates images synchronously via OpenAI's DALL·E 2 endpoint.",
             inputs=[
                 IO.String.Input(
@@ -249,7 +249,7 @@ class OpenAIDalle3(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenAIDalle3",
             display_name="OpenAI DALL·E 3",
-            category="image/partner/OpenAI",
+            category="image/OpenAI",
             description="Generates images synchronously via OpenAI's DALL·E 3 endpoint.",
             inputs=[
                 IO.String.Input(
@@ -371,7 +371,7 @@ class OpenAIGPTImage1(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenAIGPTImage1",
             display_name="OpenAI GPT Image 2",
-            category="image/partner/OpenAI",
+            category="image/OpenAI",
             description="Generates images synchronously via OpenAI's GPT Image endpoint.",
             is_deprecated=True,
             inputs=[
@@ -695,7 +695,7 @@ class OpenAIGPTImageNodeV2(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenAIGPTImageNodeV2",
             display_name="OpenAI GPT Image 2",
-            category="image/partner/OpenAI",
+            category="image/OpenAI",
             description="Generates images via OpenAI's GPT Image endpoint.",
             inputs=[
                 IO.String.Input(
@@ -962,7 +962,7 @@ class OpenAIChatNode(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenAIChatNode",
             display_name="OpenAI ChatGPT",
-            category="text/partner/OpenAI",
+            category="text/OpenAI",
             essentials_category="Text Generation",
             description="Generate text responses from an OpenAI model.",
             inputs=[
@@ -1201,7 +1201,7 @@ class OpenAIInputFiles(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenAIInputFiles",
             display_name="OpenAI ChatGPT Input Files",
-            category="text/partner/OpenAI",
+            category="text/OpenAI",
             description="Loads and prepares input files (text, pdf, etc.) to include as inputs for the OpenAI Chat Node. The files will be read by the OpenAI model when generating a response. 🛈 TIP: Can be chained together with other OpenAI Input File nodes.",
             inputs=[
                 IO.Combo.Input(
@@ -1248,7 +1248,7 @@ class OpenAIChatConfig(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenAIChatConfig",
             display_name="OpenAI ChatGPT Advanced Options",
-            category="text/partner/OpenAI",
+            category="text/OpenAI",
             description="Allows specifying advanced configuration options for the OpenAI Chat Nodes.",
             inputs=[
                 IO.Combo.Input(

--- a/comfy_api_nodes/nodes_openrouter.py
+++ b/comfy_api_nodes/nodes_openrouter.py
@@ -265,7 +265,7 @@ class OpenRouterLLMNode(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenRouterLLMNode",
             display_name="OpenRouter LLM",
-            category="text/partner/OpenRouter",
+            category="text/OpenRouter",
             essentials_category="Text Generation",
             description=(
                 "Generate text responses through OpenRouter. Routes to a curated set of popular "

--- a/comfy_api_nodes/nodes_pixverse.py
+++ b/comfy_api_nodes/nodes_pixverse.py
@@ -53,7 +53,7 @@ class PixverseTemplateNode(IO.ComfyNode):
         return IO.Schema(
             node_id="PixverseTemplateNode",
             display_name="PixVerse Template",
-            category="video/partner/PixVerse",
+            category="video/PixVerse",
             inputs=[
                 IO.Combo.Input("template", options=list(pixverse_templates.keys())),
             ],
@@ -74,7 +74,7 @@ class PixverseTextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="PixverseTextToVideoNode",
             display_name="PixVerse Text to Video",
-            category="video/partner/PixVerse",
+            category="video/PixVerse",
             description="Generates videos based on prompt and output_size.",
             inputs=[
                 IO.String.Input(
@@ -192,7 +192,7 @@ class PixverseImageToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="PixverseImageToVideoNode",
             display_name="PixVerse Image to Video",
-            category="video/partner/PixVerse",
+            category="video/PixVerse",
             description="Generates videos based on prompt and output_size.",
             inputs=[
                 IO.Image.Input("image"),
@@ -310,7 +310,7 @@ class PixverseTransitionVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="PixverseTransitionVideoNode",
             display_name="PixVerse Transition Video",
-            category="video/partner/PixVerse",
+            category="video/PixVerse",
             description="Generates videos based on prompt and output_size.",
             inputs=[
                 IO.Image.Input("first_frame"),

--- a/comfy_api_nodes/nodes_quiver.py
+++ b/comfy_api_nodes/nodes_quiver.py
@@ -62,7 +62,7 @@ class QuiverTextToSVGNode(IO.ComfyNode):
         return IO.Schema(
             node_id="QuiverTextToSVGNode",
             display_name="Quiver Text to SVG",
-            category="image/partner/Quiver",
+            category="image/Quiver",
             description="Generate an SVG from a text prompt using Quiver AI.",
             inputs=[
                 IO.String.Input(
@@ -177,7 +177,7 @@ class QuiverImageToSVGNode(IO.ComfyNode):
         return IO.Schema(
             node_id="QuiverImageToSVGNode",
             display_name="Quiver Image to SVG",
-            category="image/partner/Quiver",
+            category="image/Quiver",
             description="Vectorize a raster image into SVG using Quiver AI.",
             inputs=[
                 IO.Image.Input(

--- a/comfy_api_nodes/nodes_recraft.py
+++ b/comfy_api_nodes/nodes_recraft.py
@@ -178,7 +178,7 @@ class RecraftColorRGBNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftColorRGB",
             display_name="Recraft Color RGB",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Create Recraft Color by choosing specific RGB values.",
             inputs=[
                 IO.Int.Input("r", default=0, min=0, max=255, tooltip="Red value of color."),
@@ -204,7 +204,7 @@ class RecraftControlsNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftControls",
             display_name="Recraft Controls",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Create Recraft Controls for customizing Recraft generation.",
             inputs=[
                 IO.Custom(RecraftIO.COLOR).Input("colors", optional=True),
@@ -228,7 +228,7 @@ class RecraftStyleV3RealisticImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftStyleV3RealisticImage",
             display_name="Recraft Style - Realistic Image",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Select realistic_image style and optional substyle.",
             inputs=[
                 IO.Combo.Input("substyle", options=get_v3_substyles(cls.RECRAFT_STYLE)),
@@ -253,7 +253,7 @@ class RecraftStyleV3DigitalIllustrationNode(RecraftStyleV3RealisticImageNode):
         return IO.Schema(
             node_id="RecraftStyleV3DigitalIllustration",
             display_name="Recraft Style - Digital Illustration",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Select realistic_image style and optional substyle.",
             inputs=[
                 IO.Combo.Input("substyle", options=get_v3_substyles(cls.RECRAFT_STYLE)),
@@ -272,7 +272,7 @@ class RecraftStyleV3VectorIllustrationNode(RecraftStyleV3RealisticImageNode):
         return IO.Schema(
             node_id="RecraftStyleV3VectorIllustrationNode",
             display_name="Recraft Style - Realistic Image",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Select realistic_image style and optional substyle.",
             inputs=[
                 IO.Combo.Input("substyle", options=get_v3_substyles(cls.RECRAFT_STYLE)),
@@ -291,7 +291,7 @@ class RecraftStyleV3LogoRasterNode(RecraftStyleV3RealisticImageNode):
         return IO.Schema(
             node_id="RecraftStyleV3LogoRaster",
             display_name="Recraft Style - Logo Raster",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Select realistic_image style and optional substyle.",
             inputs=[
                 IO.Combo.Input("substyle", options=get_v3_substyles(cls.RECRAFT_STYLE, include_none=False)),
@@ -308,7 +308,7 @@ class RecraftStyleInfiniteStyleLibrary(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftStyleV3InfiniteStyleLibrary",
             display_name="Recraft Style - Infinite Style Library",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Choose style based on preexisting UUID from Recraft's Infinite Style Library.",
             inputs=[
                 IO.String.Input("style_id", default="", tooltip="UUID of style from Infinite Style Library."),
@@ -331,7 +331,7 @@ class RecraftCreateStyleNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftCreateStyleNode",
             display_name="Recraft Create Style",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Create a custom style from reference images. "
             "Upload 1-5 images to use as style references. "
             "Total size of all images is limited to 5 MB.",
@@ -400,7 +400,7 @@ class RecraftTextToImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftTextToImageNode",
             display_name="Recraft Text to Image",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Generates images synchronously based on prompt and resolution.",
             inputs=[
                 IO.String.Input("prompt", multiline=True, default="", tooltip="Prompt for the image generation."),
@@ -512,7 +512,7 @@ class RecraftImageToImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftImageToImageNode",
             display_name="Recraft Image to Image",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Modify image based on prompt and strength.",
             inputs=[
                 IO.Image.Input("image"),
@@ -630,7 +630,7 @@ class RecraftImageInpaintingNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftImageInpaintingNode",
             display_name="Recraft Image Inpainting",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Modify image based on prompt and mask.",
             inputs=[
                 IO.Image.Input("image"),
@@ -732,7 +732,7 @@ class RecraftTextToVectorNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftTextToVectorNode",
             display_name="Recraft Text to Vector",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Generates SVG synchronously based on prompt and resolution.",
             inputs=[
                 IO.String.Input("prompt", default="", tooltip="Prompt for the image generation.", multiline=True),
@@ -832,7 +832,7 @@ class RecraftVectorizeImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftVectorizeImageNode",
             display_name="Recraft Vectorize Image",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             essentials_category="Image Tools",
             description="Generates SVG synchronously from an input image.",
             inputs=[
@@ -876,7 +876,7 @@ class RecraftReplaceBackgroundNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftReplaceBackgroundNode",
             display_name="Recraft Replace Background",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Replace background on image, based on provided prompt.",
             inputs=[
                 IO.Image.Input("image"),
@@ -963,7 +963,7 @@ class RecraftRemoveBackgroundNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftRemoveBackgroundNode",
             display_name="Recraft Remove Background",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             essentials_category="Image Tools",
             description="Remove background from image, and return processed image and mask.",
             inputs=[
@@ -1012,7 +1012,7 @@ class RecraftCrispUpscaleNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftCrispUpscaleNode",
             display_name="Recraft Crisp Upscale Image",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Upscale image synchronously.\n"
             "Enhances a given raster image using ‘crisp upscale’ tool, "
             "increasing image resolution, making the image sharper and cleaner.",
@@ -1058,7 +1058,7 @@ class RecraftCreativeUpscaleNode(RecraftCrispUpscaleNode):
         return IO.Schema(
             node_id="RecraftCreativeUpscaleNode",
             display_name="Recraft Creative Upscale Image",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Upscale image synchronously.\n"
             "Enhances a given raster image using ‘creative upscale’ tool, "
             "boosting resolution with a focus on refining small details and faces.",
@@ -1086,7 +1086,7 @@ class RecraftV4TextToImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftV4TextToImageNode",
             display_name="Recraft V4 Text to Image",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Generates images using Recraft V4 or V4 Pro models.",
             inputs=[
                 IO.String.Input(
@@ -1210,7 +1210,7 @@ class RecraftV4TextToVectorNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RecraftV4TextToVectorNode",
             display_name="Recraft V4 Text to Vector",
-            category="image/partner/Recraft",
+            category="image/Recraft",
             description="Generates SVG using Recraft V4 or V4 Pro models.",
             inputs=[
                 IO.String.Input(

--- a/comfy_api_nodes/nodes_reve.py
+++ b/comfy_api_nodes/nodes_reve.py
@@ -109,7 +109,7 @@ class ReveImageCreateNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ReveImageCreateNode",
             display_name="Reve Image Create",
-            category="image/partner/Reve",
+            category="image/Reve",
             description="Generate images from text descriptions using Reve.",
             inputs=[
                 IO.String.Input(
@@ -200,7 +200,7 @@ class ReveImageEditNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ReveImageEditNode",
             display_name="Reve Image Edit",
-            category="image/partner/Reve",
+            category="image/Reve",
             description="Edit images using natural language instructions with Reve.",
             inputs=[
                 IO.Image.Input("image", tooltip="The image to edit."),
@@ -300,7 +300,7 @@ class ReveImageRemixNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ReveImageRemixNode",
             display_name="Reve Image Remix",
-            category="image/partner/Reve",
+            category="image/Reve",
             description="Combine reference images with text prompts to create new images using Reve.",
             inputs=[
                 IO.Autogrow.Input(

--- a/comfy_api_nodes/nodes_rodin.py
+++ b/comfy_api_nodes/nodes_rodin.py
@@ -230,7 +230,7 @@ class Rodin3D_Regular(IO.ComfyNode):
         return IO.Schema(
             node_id="Rodin3D_Regular",
             display_name="Rodin 3D Generate - Regular Generate",
-            category="3d/partner/Rodin",
+            category="3d/Rodin",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Image.Input("Images"),
@@ -289,7 +289,7 @@ class Rodin3D_Detail(IO.ComfyNode):
         return IO.Schema(
             node_id="Rodin3D_Detail",
             display_name="Rodin 3D Generate - Detail Generate",
-            category="3d/partner/Rodin",
+            category="3d/Rodin",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Image.Input("Images"),
@@ -348,7 +348,7 @@ class Rodin3D_Smooth(IO.ComfyNode):
         return IO.Schema(
             node_id="Rodin3D_Smooth",
             display_name="Rodin 3D Generate - Smooth Generate",
-            category="3d/partner/Rodin",
+            category="3d/Rodin",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Image.Input("Images"),
@@ -406,7 +406,7 @@ class Rodin3D_Sketch(IO.ComfyNode):
         return IO.Schema(
             node_id="Rodin3D_Sketch",
             display_name="Rodin 3D Generate - Sketch Generate",
-            category="3d/partner/Rodin",
+            category="3d/Rodin",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Image.Input("Images"),
@@ -468,7 +468,7 @@ class Rodin3D_Gen2(IO.ComfyNode):
         return IO.Schema(
             node_id="Rodin3D_Gen2",
             display_name="Rodin 3D Generate - Gen-2 Generate",
-            category="3d/partner/Rodin",
+            category="3d/Rodin",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Image.Input("Images"),
@@ -941,7 +941,7 @@ class Rodin3D_Gen25_Image(IO.ComfyNode):
         return IO.Schema(
             node_id="Rodin3D_Gen25_Image",
             display_name="Rodin 3D Gen-2.5 - Image to 3D",
-            category="3d/partner/Rodin",
+            category="3d/Rodin",
             description=(
                 "Generate a 3D model from 1-5 reference images via Rodin Gen-2.5. "
                 "Pick a mode (Fast / Regular / Extreme-High) to tune quality vs. cost."
@@ -1035,7 +1035,7 @@ class Rodin3D_Gen25_Text(IO.ComfyNode):
         return IO.Schema(
             node_id="Rodin3D_Gen25_Text",
             display_name="Rodin 3D Gen-2.5 - Text to 3D",
-            category="3d/partner/Rodin",
+            category="3d/Rodin",
             description=(
                 "Generate a 3D model from a text prompt via Rodin Gen-2.5. "
                 "Pick a mode (Fast / Regular / Extreme-High) to tune quality vs. cost."

--- a/comfy_api_nodes/nodes_runway.py
+++ b/comfy_api_nodes/nodes_runway.py
@@ -140,7 +140,7 @@ class RunwayImageToVideoNodeGen3a(IO.ComfyNode):
         return IO.Schema(
             node_id="RunwayImageToVideoNodeGen3a",
             display_name="Runway Image to Video (Gen3a Turbo)",
-            category="video/partner/Runway",
+            category="video/Runway",
             description="Generate a video from a single starting frame using Gen3a Turbo model. "
             "Before diving in, review these best practices to ensure that "
             "your input selections will set your generation up for success: "
@@ -234,7 +234,7 @@ class RunwayImageToVideoNodeGen4(IO.ComfyNode):
         return IO.Schema(
             node_id="RunwayImageToVideoNodeGen4",
             display_name="Runway Image to Video (Gen4 Turbo)",
-            category="video/partner/Runway",
+            category="video/Runway",
             description="Generate a video from a single starting frame using Gen4 Turbo model. "
             "Before diving in, review these best practices to ensure that "
             "your input selections will set your generation up for success: "
@@ -329,7 +329,7 @@ class RunwayFirstLastFrameNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RunwayFirstLastFrameNode",
             display_name="Runway First-Last-Frame to Video",
-            category="video/partner/Runway",
+            category="video/Runway",
             description="Upload first and last keyframes, draft a prompt, and generate a video. "
             "More complex transitions, such as cases where the Last frame is completely different "
             "from the First frame, may benefit from the longer 10s duration. "
@@ -440,7 +440,7 @@ class RunwayTextToImageNode(IO.ComfyNode):
         return IO.Schema(
             node_id="RunwayTextToImageNode",
             display_name="Runway Text to Image",
-            category="image/partner/Runway",
+            category="image/Runway",
             description="Generate an image from a text prompt using Runway's Gen 4 model. "
             "You can also include reference image to guide the generation.",
             inputs=[

--- a/comfy_api_nodes/nodes_sonilo.py
+++ b/comfy_api_nodes/nodes_sonilo.py
@@ -34,7 +34,7 @@ class SoniloVideoToMusic(IO.ComfyNode):
         return IO.Schema(
             node_id="SoniloVideoToMusic",
             display_name="Sonilo Video to Music",
-            category="audio/partner/Sonilo",
+            category="audio/Sonilo",
             description="Generate music from video content using Sonilo's AI model. "
             "Analyzes the video and creates matching music.",
             inputs=[
@@ -99,7 +99,7 @@ class SoniloTextToMusic(IO.ComfyNode):
         return IO.Schema(
             node_id="SoniloTextToMusic",
             display_name="Sonilo Text to Music",
-            category="audio/partner/Sonilo",
+            category="audio/Sonilo",
             description="Generate music from a text prompt using Sonilo's AI model. "
             "Leave duration at 0 to let the model infer it from the prompt.",
             inputs=[

--- a/comfy_api_nodes/nodes_sora.py
+++ b/comfy_api_nodes/nodes_sora.py
@@ -34,7 +34,7 @@ class OpenAIVideoSora2(IO.ComfyNode):
         return IO.Schema(
             node_id="OpenAIVideoSora2",
             display_name="OpenAI Sora - Video (DEPRECATED)",
-            category="video/partner/Sora",
+            category="video/Sora",
             description=(
                 "OpenAI video and audio generation.\n\n"
                 "DEPRECATION NOTICE: OpenAI will stop serving the Sora v2 API in September 2026. "

--- a/comfy_api_nodes/nodes_stability.py
+++ b/comfy_api_nodes/nodes_stability.py
@@ -62,7 +62,7 @@ class StabilityStableImageUltraNode(IO.ComfyNode):
         return IO.Schema(
             node_id="StabilityStableImageUltraNode",
             display_name="Stability AI Stable Image Ultra",
-            category="image/partner/Stability AI",
+            category="image/Stability AI",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.String.Input(
@@ -197,7 +197,7 @@ class StabilityStableImageSD_3_5Node(IO.ComfyNode):
         return IO.Schema(
             node_id="StabilityStableImageSD_3_5Node",
             display_name="Stability AI Stable Diffusion 3.5 Image",
-            category="image/partner/Stability AI",
+            category="image/Stability AI",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.String.Input(
@@ -354,7 +354,7 @@ class StabilityUpscaleConservativeNode(IO.ComfyNode):
         return IO.Schema(
             node_id="StabilityUpscaleConservativeNode",
             display_name="Stability AI Upscale Conservative",
-            category="image/partner/Stability AI",
+            category="image/Stability AI",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Image.Input("image"),
@@ -457,7 +457,7 @@ class StabilityUpscaleCreativeNode(IO.ComfyNode):
         return IO.Schema(
             node_id="StabilityUpscaleCreativeNode",
             display_name="Stability AI Upscale Creative",
-            category="image/partner/Stability AI",
+            category="image/Stability AI",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Image.Input("image"),
@@ -578,7 +578,7 @@ class StabilityUpscaleFastNode(IO.ComfyNode):
         return IO.Schema(
             node_id="StabilityUpscaleFastNode",
             display_name="Stability AI Upscale Fast",
-            category="image/partner/Stability AI",
+            category="image/Stability AI",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Image.Input("image"),
@@ -630,7 +630,7 @@ class StabilityTextToAudio(IO.ComfyNode):
         return IO.Schema(
             node_id="StabilityTextToAudio",
             display_name="Stability AI Text To Audio",
-            category="audio/partner/Stability AI",
+            category="audio/Stability AI",
             essentials_category="Audio",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
@@ -708,7 +708,7 @@ class StabilityAudioToAudio(IO.ComfyNode):
         return IO.Schema(
             node_id="StabilityAudioToAudio",
             display_name="Stability AI Audio To Audio",
-            category="audio/partner/Stability AI",
+            category="audio/Stability AI",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Combo.Input(
@@ -802,7 +802,7 @@ class StabilityAudioInpaint(IO.ComfyNode):
         return IO.Schema(
             node_id="StabilityAudioInpaint",
             display_name="Stability AI Audio Inpaint",
-            category="audio/partner/Stability AI",
+            category="audio/Stability AI",
             description=cleandoc(cls.__doc__ or ""),
             inputs=[
                 IO.Combo.Input(

--- a/comfy_api_nodes/nodes_topaz.py
+++ b/comfy_api_nodes/nodes_topaz.py
@@ -52,7 +52,7 @@ class TopazImageEnhance(IO.ComfyNode):
         return IO.Schema(
             node_id="TopazImageEnhance",
             display_name="Topaz Image Enhance",
-            category="image/partner/Topaz",
+            category="image/Topaz",
             description="Industry-standard upscaling and image enhancement.",
             inputs=[
                 IO.Combo.Input("model", options=["Reimagine"]),
@@ -235,7 +235,7 @@ class TopazVideoEnhance(IO.ComfyNode):
         return IO.Schema(
             node_id="TopazVideoEnhance",
             display_name="Topaz Video Enhance (Legacy)",
-            category="video/partner/Topaz",
+            category="video/Topaz",
             description="Breathe new life into video with powerful upscaling and recovery technology.",
             inputs=[
                 IO.Video.Input("video"),
@@ -475,7 +475,7 @@ class TopazVideoEnhanceV2(IO.ComfyNode):
         return IO.Schema(
             node_id="TopazVideoEnhanceV2",
             display_name="Topaz Video Enhance",
-            category="video/partner/Topaz",
+            category="video/Topaz",
             description="Breathe new life into video with powerful upscaling and recovery technology.",
             inputs=[
                 IO.Video.Input("video"),

--- a/comfy_api_nodes/nodes_tripo.py
+++ b/comfy_api_nodes/nodes_tripo.py
@@ -83,7 +83,7 @@ class TripoTextToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoTextToModelNode",
             display_name="Tripo: Text to Model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             inputs=[
                 IO.String.Input("prompt", multiline=True),
                 IO.String.Input("negative_prompt", multiline=True, optional=True),
@@ -210,7 +210,7 @@ class TripoImageToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoImageToModelNode",
             display_name="Tripo: Image to Model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             inputs=[
                 IO.Image.Input("image"),
                 IO.Combo.Input(
@@ -358,7 +358,7 @@ class TripoMultiviewToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoMultiviewToModelNode",
             display_name="Tripo: Multiview to Model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             inputs=[
                 IO.Image.Input("image"),
                 IO.Image.Input("image_left", optional=True),
@@ -518,7 +518,7 @@ class TripoTextureNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoTextureNode",
             display_name="Tripo: Texture model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             inputs=[
                 IO.Custom("MODEL_TASK_ID").Input("model_task_id"),
                 IO.Boolean.Input("texture", default=True, optional=True),
@@ -595,7 +595,7 @@ class TripoRefineNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoRefineNode",
             display_name="Tripo: Refine Draft model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             description="Refine a draft model created by v1.4 Tripo models only.",
             inputs=[
                 IO.Custom("MODEL_TASK_ID").Input("model_task_id", tooltip="Must be a v1.4 Tripo model"),
@@ -635,7 +635,7 @@ class TripoRigNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoRigNode",
             display_name="Tripo: Rig model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             inputs=[IO.Custom("MODEL_TASK_ID").Input("original_model_task_id")],
             outputs=[
                 IO.String.Output(display_name="model_file"),  # for backward compatibility only
@@ -672,7 +672,7 @@ class TripoRetargetNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoRetargetNode",
             display_name="Tripo: Retarget rigged model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             inputs=[
                 IO.Custom("RIG_TASK_ID").Input("original_model_task_id"),
                 IO.Combo.Input(
@@ -737,7 +737,7 @@ class TripoConversionNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoConversionNode",
             display_name="Tripo: Convert model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             inputs=[
                 IO.Custom("MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID").Input("original_model_task_id"),
                 IO.Combo.Input("format", options=["GLTF", "USDZ", "FBX", "OBJ", "STL", "3MF"]),
@@ -1051,7 +1051,7 @@ class TripoP1TextToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoP1TextToModelNode",
             display_name="Tripo P1: Text to Model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             description="Tripo P1 text-to-3D. Optimized for low-poly, game-ready meshes with stable topology.",
             inputs=[
                 IO.String.Input("prompt", multiline=True, tooltip="Up to 1024 characters."),
@@ -1122,7 +1122,7 @@ class TripoP1ImageToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoP1ImageToModelNode",
             display_name="Tripo P1: Image to Model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             description="Tripo P1 image-to-3D. Optimized for low-poly, game-ready meshes.",
             inputs=[
                 IO.Image.Input("image"),
@@ -1202,7 +1202,7 @@ class TripoP1MultiviewToModelNode(IO.ComfyNode):
         return IO.Schema(
             node_id="TripoP1MultiviewToModelNode",
             display_name="Tripo P1: Multiview to Model",
-            category="3d/partner/Tripo",
+            category="3d/Tripo",
             description="Tripo P1 multiview-to-3D from 2-4 reference images in [front, left, back, right] order. "
             "Front is required; any combination of the other three may be omitted.",
             inputs=[

--- a/comfy_api_nodes/nodes_veo2.py
+++ b/comfy_api_nodes/nodes_veo2.py
@@ -45,7 +45,7 @@ class VeoVideoGenerationNode(IO.ComfyNode):
         return IO.Schema(
             node_id="VeoVideoGenerationNode",
             display_name="Google Veo 2 Video Generation",
-            category="video/partner/Veo",
+            category="video/Veo",
             description="Generates videos from text prompts using Google's Veo 2 API",
             inputs=[
                 IO.String.Input(
@@ -256,7 +256,7 @@ class Veo3VideoGenerationNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Veo3VideoGenerationNode",
             display_name="Google Veo 3 Video Generation",
-            category="video/partner/Veo",
+            category="video/Veo",
             description="Generates videos from text prompts using Google's Veo 3 API",
             inputs=[
                 IO.String.Input(
@@ -468,7 +468,7 @@ class Veo3FirstLastFrameNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Veo3FirstLastFrameNode",
             display_name="Google Veo 3 First-Last-Frame to Video",
-            category="video/partner/Veo",
+            category="video/Veo",
             description="Generate video using prompt and first and last frames.",
             inputs=[
                 IO.String.Input(

--- a/comfy_api_nodes/nodes_vidu.py
+++ b/comfy_api_nodes/nodes_vidu.py
@@ -71,7 +71,7 @@ class ViduTextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ViduTextToVideoNode",
             display_name="Vidu Text To Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate video from a text prompt",
             inputs=[
                 IO.Combo.Input("model", options=["viduq1"], tooltip="Model name"),
@@ -169,7 +169,7 @@ class ViduImageToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ViduImageToVideoNode",
             display_name="Vidu Image To Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate video from image and optional prompt",
             inputs=[
                 IO.Combo.Input("model", options=["viduq1"], tooltip="Model name"),
@@ -273,7 +273,7 @@ class ViduReferenceVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ViduReferenceVideoNode",
             display_name="Vidu Reference To Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate video from multiple images and a prompt",
             inputs=[
                 IO.Combo.Input("model", options=["viduq1"], tooltip="Model name"),
@@ -388,7 +388,7 @@ class ViduStartEndToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ViduStartEndToVideoNode",
             display_name="Vidu Start End To Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate a video from start and end frames and a prompt",
             inputs=[
                 IO.Combo.Input("model", options=["viduq1"], tooltip="Model name"),
@@ -492,7 +492,7 @@ class Vidu2TextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Vidu2TextToVideoNode",
             display_name="Vidu2 Text-to-Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate video from a text prompt",
             inputs=[
                 IO.Combo.Input("model", options=["viduq2"]),
@@ -584,7 +584,7 @@ class Vidu2ImageToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Vidu2ImageToVideoNode",
             display_name="Vidu2 Image-to-Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate a video from an image and an optional prompt.",
             inputs=[
                 IO.Combo.Input("model", options=["viduq2-pro-fast", "viduq2-pro", "viduq2-turbo"]),
@@ -714,7 +714,7 @@ class Vidu2ReferenceVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Vidu2ReferenceVideoNode",
             display_name="Vidu2 Reference-to-Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate a video from multiple reference images and a prompt.",
             inputs=[
                 IO.Combo.Input("model", options=["viduq2"]),
@@ -849,7 +849,7 @@ class Vidu2StartEndToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Vidu2StartEndToVideoNode",
             display_name="Vidu2 Start/End Frame-to-Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate a video from a start frame, an end frame, and a prompt.",
             inputs=[
                 IO.Combo.Input("model", options=["viduq2-pro-fast", "viduq2-pro", "viduq2-turbo"]),
@@ -969,7 +969,7 @@ class ViduExtendVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ViduExtendVideoNode",
             display_name="Vidu Video Extension",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Extend an existing video by generating additional frames.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1138,7 +1138,7 @@ class ViduMultiFrameVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="ViduMultiFrameVideoNode",
             display_name="Vidu Multi-Frame Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate a video with multiple keyframe transitions.",
             inputs=[
                 IO.Combo.Input("model", options=["viduq2-pro", "viduq2-turbo"]),
@@ -1284,7 +1284,7 @@ class Vidu3TextToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Vidu3TextToVideoNode",
             display_name="Vidu Q3 Text-to-Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate video from a text prompt.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1429,7 +1429,7 @@ class Vidu3ImageToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Vidu3ImageToVideoNode",
             display_name="Vidu Q3 Image-to-Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate a video from an image and an optional prompt.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1571,7 +1571,7 @@ class Vidu3StartEndToVideoNode(IO.ComfyNode):
         return IO.Schema(
             node_id="Vidu3StartEndToVideoNode",
             display_name="Vidu Q3 Start/End Frame-to-Video Generation",
-            category="video/partner/Vidu",
+            category="video/Vidu",
             description="Generate a video from a start frame, an end frame, and a prompt.",
             inputs=[
                 IO.DynamicCombo.Input(

--- a/comfy_api_nodes/nodes_wan.py
+++ b/comfy_api_nodes/nodes_wan.py
@@ -61,7 +61,7 @@ class WanTextToImageApi(IO.ComfyNode):
         return IO.Schema(
             node_id="WanTextToImageApi",
             display_name="Wan Text to Image",
-            category="image/partner/Wan",
+            category="image/Wan",
             description="Generates an image based on a text prompt.",
             inputs=[
                 IO.Combo.Input(
@@ -184,7 +184,7 @@ class WanImageToImageApi(IO.ComfyNode):
         return IO.Schema(
             node_id="WanImageToImageApi",
             display_name="Wan Image to Image",
-            category="image/partner/Wan",
+            category="image/Wan",
             description="Generates an image from one or two input images and a text prompt. "
             "The output image is currently fixed at 1.6 MP, and its aspect ratio matches the input image(s).",
             inputs=[
@@ -312,7 +312,7 @@ class WanTextToVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="WanTextToVideoApi",
             display_name="Wan Text to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Generates a video based on a text prompt.",
             inputs=[
                 IO.Combo.Input(
@@ -495,7 +495,7 @@ class WanImageToVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="WanImageToVideoApi",
             display_name="Wan Image to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Generates a video from the first frame and a text prompt.",
             inputs=[
                 IO.Combo.Input(
@@ -674,7 +674,7 @@ class WanReferenceVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="WanReferenceVideoApi",
             display_name="Wan Reference to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Use the character and voice from input videos, combined with a prompt, "
             "to generate a new video that maintains character consistency.",
             inputs=[
@@ -828,7 +828,7 @@ class Wan2TextToVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="Wan2TextToVideoApi",
             display_name="Wan 2.7 Text to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Generates a video based on a text prompt using the Wan 2.7 model.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -981,7 +981,7 @@ class Wan2ImageToVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="Wan2ImageToVideoApi",
             display_name="Wan 2.7 Image to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Generate a video from a first-frame image, with optional last-frame image and audio.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1152,7 +1152,7 @@ class Wan2VideoContinuationApi(IO.ComfyNode):
         return IO.Schema(
             node_id="Wan2VideoContinuationApi",
             display_name="Wan 2.7 Video Continuation",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Continue a video from where it left off, with optional last-frame control.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1319,7 +1319,7 @@ class Wan2VideoEditApi(IO.ComfyNode):
         return IO.Schema(
             node_id="Wan2VideoEditApi",
             display_name="Wan 2.7 Video Edit",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Edit a video using text instructions, reference images, or style transfer.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1477,7 +1477,7 @@ class Wan2ReferenceVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="Wan2ReferenceVideoApi",
             display_name="Wan 2.7 Reference to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Generate a video featuring a person or object from reference materials. "
             "Supports single-character performances and multi-character interactions.",
             inputs=[
@@ -1651,7 +1651,7 @@ class HappyHorseTextToVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="HappyHorseTextToVideoApi",
             display_name="HappyHorse Text to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Generates a video based on a text prompt using the HappyHorse model.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1775,7 +1775,7 @@ class HappyHorseImageToVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="HappyHorseImageToVideoApi",
             display_name="HappyHorse Image to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Generate a video from a first-frame image using the HappyHorse model.",
             inputs=[
                 IO.DynamicCombo.Input(
@@ -1905,7 +1905,7 @@ class HappyHorseVideoEditApi(IO.ComfyNode):
         return IO.Schema(
             node_id="HappyHorseVideoEditApi",
             display_name="HappyHorse Video Edit",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Edit a video using text instructions or reference images with the HappyHorse model. "
             "Output duration is 3-15s and matches the input video; inputs longer than 15s are truncated.",
             inputs=[
@@ -2046,7 +2046,7 @@ class HappyHorseReferenceVideoApi(IO.ComfyNode):
         return IO.Schema(
             node_id="HappyHorseReferenceVideoApi",
             display_name="HappyHorse Reference to Video",
-            category="video/partner/Wan",
+            category="video/Wan",
             description="Generate a video featuring a person or object from reference materials with the HappyHorse "
             "model. Supports single-character performances and multi-character interactions.",
             inputs=[

--- a/comfy_api_nodes/nodes_wavespeed.py
+++ b/comfy_api_nodes/nodes_wavespeed.py
@@ -27,7 +27,7 @@ class WavespeedFlashVSRNode(IO.ComfyNode):
         return IO.Schema(
             node_id="WavespeedFlashVSRNode",
             display_name="FlashVSR Video Upscale",
-            category="video/partner/WaveSpeed",
+            category="video/WaveSpeed",
             description="Fast, high-quality video upscaler that "
             "boosts resolution and restores clarity for low-resolution or blurry footage.",
             inputs=[
@@ -98,7 +98,7 @@ class WavespeedImageUpscaleNode(IO.ComfyNode):
         return IO.Schema(
             node_id="WavespeedImageUpscaleNode",
             display_name="WaveSpeed Image Upscale",
-            category="image/partner/WaveSpeed",
+            category="image/WaveSpeed",
             description="Boost image resolution and quality, upscaling photos to 4K or 8K for sharp, detailed results.",
             inputs=[
                 IO.Combo.Input("model", options=["SeedVR2", "Ultimate"]),


### PR DESCRIPTION
There is an extra `partner` subcategory under each partner node type, which is a bit redundant, so I removed them

## Before
<img width="1404" height="1780" alt="image" src="https://github.com/user-attachments/assets/ce57703e-6cbc-4632-b1db-f34a22c19ba2" />


## After 

<img width="1406" height="1846" alt="image" src="https://github.com/user-attachments/assets/1afeef85-b34a-4699-87af-3271e969b278" />


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

