### PR TITLE
Adaptive Projected Guidance: Running average size mismatch fix

### DIFF
--- a/comfy_extras/nodes_apg.py
+++ b/comfy_extras/nodes_apg.py
@@ -73,7 +73,7 @@ class APG(io.ComfyNode):
             guidance = cond - uncond
 
             if momentum != 0:
-                if not torch.is_tensor(running_avg):
+                if not torch.is_tensor(running_avg) or (running_avg.shape != guidance.shape):
                     running_avg = guidance
                 else:
                     running_avg = momentum * running_avg + guidance


### PR DESCRIPTION
I've encountered size mismatch error `The size of tensor a (SIZE_A) must match the size of tensor b (SIZE_B) at non-singleton dimension 4` with APG+momentum multiple times. This dirty fixes it.

# Breakdown

`running_avg` doesn't reset to 0 when queuing following prompt such, that `prev_sigma` bigger or equal to `sigma`:
https://github.com/Comfy-Org/ComfyUI/blob/c96fcddb8100d7d5358c33f5fb4fab33cb6a2da0/comfy_extras/nodes_apg.py#L69-L70

This can happen when user generate at high denoise, stops midway, then changing denoise to very low. In result, new `sigma` is low, but `prev_sigma` is high, which leads to previous `running_avg` being used. 

But in some cases `running_avg` and `guidance` tensor sizes differ (ex. latent resolution change in new prompt, checkpoint swap etc.), throwing size mismatch error here:
https://github.com/Comfy-Org/ComfyUI/blob/c96fcddb8100d7d5358c33f5fb4fab33cb6a2da0/comfy_extras/nodes_apg.py#L78-L79