### PR TITLE
fix (MultiGPU): prevent freeze on manual abort when using MultiGPU CFG Split

### DIFF
--- a/comfy/multigpu.py
+++ b/comfy/multigpu.py
@@ -37,7 +37,7 @@ class MultiGPUThreadPool:
 
     def _worker_loop(self, device: torch.device, work_q: queue.Queue, result_q: queue.Queue):
         try:
-            comfy.model_management.set_torch_device(device)
+            torch.cuda.set_device(device)
         except Exception as e:
             logging.error(f"MultiGPUThreadPool: failed to set device {device}: {e}")
             while True:
@@ -54,6 +54,8 @@ class MultiGPUThreadPool:
             try:
                 result = fn(*args, **kwargs)
                 result_q.put((result, None))
+            except comfy.model_management.InterruptProcessingException as e:
+                result_q.put((None, e))
             except Exception as e:
                 result_q.put((None, e))
 

--- a/comfy/multigpu.py
+++ b/comfy/multigpu.py
@@ -37,7 +37,7 @@ class MultiGPUThreadPool:
 
     def _worker_loop(self, device: torch.device, work_q: queue.Queue, result_q: queue.Queue):
         try:
-            torch.cuda.set_device(device)
+            comfy.model_management.set_torch_device(device)
         except Exception as e:
             logging.error(f"MultiGPUThreadPool: failed to set device {device}: {e}")
             while True:


### PR DESCRIPTION
**Problem:**
Freezes if generation manually aborted when using MultiGPU CFG Split https://github.com/Comfy-Org/ComfyUI/pull/7063

`InterruptProcessingException` inherits from `BaseException` https://github.com/Comfy-Org/ComfyUI/pull/13523 so it bypasses MultiGPU's worker error handling block causing the thread to die silently, leaving the main thread waiting forever for `result_q.get()`

**Fix:** 
Additionally catch `comfy.model_management.InterruptProcessingException` so it's passed back via `result_q` to unblock the main thread when manual abort signal fires.