### PR TITLE
docs: add Linux production deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,12 @@ Use `--tls-keyfile key.pem --tls-certfile cert.pem` to enable TLS/SSL, the app w
 > Note: Windows users can use [alexisrolland/docker-openssl](https://github.com/alexisrolland/docker-openssl) or one of the [3rd party binary distributions](https://wiki.openssl.org/index.php/Binaries) to run the command example above.
 <br/><br/>If you use a container, note that the volume mount `-v` can be a relative path so `... -v ".\:/openssl-certs" ...` would create the key & cert files in the current directory of your command prompt or powershell terminal.
 
+## Community Guides
+
+Practical deployment guides from the community:
+
+- [ComfyUI on Linux: Production Setup with systemd and HTTPS (2026)](https://runaihome.com/blog/comfyui-linux-production-setup-2026/) — Covers running ComfyUI as a systemd service, setting up an Nginx reverse proxy with Let's Encrypt TLS, and hardening the setup for always-on use
+
 ## Support and dev channel
 
 [Discord](https://comfy.org/discord): Try the #help or #feedback channels.


### PR DESCRIPTION
## What this adds

A new **Community Guides** section in `README.md` (placed before "Support and dev channel") with one external guide:

> [ComfyUI on Linux: Production Setup with systemd and HTTPS (2026)](https://runaihome.com/blog/comfyui-linux-production-setup-2026/)

## Why it's useful

The existing README covers installation on Windows and Linux, but stops at `python main.py`. There's a big gap between "it runs in my terminal" and "it runs reliably as a background service with a real URL."

This community article fills that gap: running ComfyUI as a systemd unit (auto-restart on crash/reboot), putting Nginx in front of it, and wiring up Let's Encrypt TLS so it's accessible over HTTPS. These are the steps users in the Discord #help channel ask about most when moving from a dev setup to something they leave running.

## Change scope

- One file edited: `README.md`
- 6 lines added, 0 deleted
- No code or dependency changes