### PR TITLE
Fix interoperation with external source of pinned memory pressure

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -651,8 +651,7 @@ def ensure_pin_budget(size, evict_active=False):
     to_free = shortfall + PIN_PRESSURE_HYSTERESIS
     return free_pins(to_free, evict_active=evict_active) >= shortfall
 
-def ensure_pin_registerable(size, evict_active=True):
-    shortfall = TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY
+def free_registrations(shortfall, evict_active=True):
     if MAX_PINNED_MEMORY <= 0:
         return False
     if shortfall <= 0:
@@ -673,6 +672,9 @@ def ensure_pin_registerable(size, evict_active=True):
                 if shortfall <= 0:
                     return True
     return shortfall <= REGISTERABLE_PIN_HYSTERESIS
+
+def ensure_pin_registerable(size, evict_active=True):
+    return free_registrations(TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY, evict_active=evict_active)
 
 class LoadedModel:
     def __init__(self, model: ModelPatcher):

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -96,6 +96,7 @@ def pin_memory(module, subset="weights", size=None):
         pin = comfy_aimdo.torch.hostbuf_to_tensor(hostbuf)[offset:offset + size]
         pin.untyped_storage()._comfy_hostbuf = hostbuf
         if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
+                comfy.model_management.discard_cuda_async_error()
                 del pin
                 hostbuf.truncate(offset, do_unregister=False)
                 return _steal_pin(module, stack, buckets, size, priority)

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -96,6 +96,9 @@ def pin_memory(module, subset="weights", size=None):
         pin = comfy_aimdo.torch.hostbuf_to_tensor(hostbuf)[offset:offset + size]
         pin.untyped_storage()._comfy_hostbuf = hostbuf
         if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
+            comfy.model_management.discard_cuda_async_error()
+            comfy.model_management.free_registrations(size)
+            if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
                 comfy.model_management.discard_cuda_async_error()
                 del pin
                 hostbuf.truncate(offset, do_unregister=False)

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -95,7 +95,7 @@ def pin_memory(module, subset="weights", size=None):
         extended = True
         pin = comfy_aimdo.torch.hostbuf_to_tensor(hostbuf)[offset:offset + size]
         pin.untyped_storage()._comfy_hostbuf = hostbuf
-        if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 0) != 0:
+        if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
                 del pin
                 hostbuf.truncate(offset, do_unregister=False)
                 return _steal_pin(module, stack, buckets, size, priority)

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -89,13 +89,22 @@ def pin_memory(module, subset="weights", size=None):
         not comfy.model_management.ensure_pin_registerable(registerable_size)):
         return _steal_pin(module, stack, buckets, size, priority)
 
+    extended = False
     try:
-        hostbuf.extend(size=size)
+        hostbuf.extend(size=size, register=False)
+        extended = True
+        pin = comfy_aimdo.torch.hostbuf_to_tensor(hostbuf)[offset:offset + size]
+        pin.untyped_storage()._comfy_hostbuf = hostbuf
+        if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 0) != 0:
+                del pin
+                hostbuf.truncate(offset, do_unregister=False)
+                return _steal_pin(module, stack, buckets, size, priority)
     except RuntimeError:
+        if extended:
+            hostbuf.truncate(offset, do_unregister=False)
         return _steal_pin(module, stack, buckets, size, priority)
 
-    module._pin = comfy_aimdo.torch.hostbuf_to_tensor(hostbuf)[offset:offset + size]
-    module._pin.untyped_storage()._comfy_hostbuf = hostbuf
+    module._pin = pin
     stack.append((module, offset))
     module._pin_registered = True
     module._pin_stack_index = len(stack) - 1


### PR DESCRIPTION
Info for the people with the reported crash:

We have multiple users reporting "HostBuffer.read_file_slice failed". This hopefully fixes it.

https://github.com/Comfy-Org/ComfyUI/issues/14126
https://github.com/Comfy-Org/ComfyUI/issues/14250

I dont have a solid root cause theory for that just yet and cannot reproduce myself. My best theory is these users have external pin pressure, maybe from another application that causing the cudaHostRegister API to throw an unguarded error that that does the cuda async error that we dont appropriately handle. In this PR, ive added the missing async discard. Cuda is known to sometimes make pinning error async, I guess today they are not async for me, but maybe that are async for these unlucky users.

There is also a theory that multi-GPU has some context issues and the RAM is allocated on the wrong context and can be fixed with PORTABLE flag, but that is a weaker theory. But make that change anyway.

I have organized this PR into a bisectable set with all the smaller changes, so if this does fix the error for you, and you are handy with git or have a coding agent handy, please bisect this change set and let me which of the individual changes fixed it.

-------------------------------------------------
General change description:

Currently comfy assumes it has a monopoly on the GPU shared memory pool and is missing some case handling (including error handling) when this is not the case.

First bring the registration process into comfy for consistency with all other pinning paths. Having aimdo do this might be the wrong thing to do.

Then add the PORTABLE flag
Then add async error discarding

Even if that works though, that dooms the users to lock-step synchronous layer execution as that failure implies a cuda sync. So connect up this failure to do a hysteresis free of pins if and when it happens to give a similar UX to the normal case.

Example Test Conditions:

Windows, RTX5090, 64GB RAM
WAN2.2 2x14B FP16
A script on the side allocating and reserving 15GB of pinned memory

Before:

```
[INFO] got prompt
[INFO] Using pytorch attention in VAE
[INFO] Using pytorch attention in VAE
[INFO] VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
[INFO] Found quantization metadata version 1
[INFO] Using MixedPrecisionOps for text encoder
[INFO] CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
[INFO] Requested to load WanTEModel
[INFO] Model WanTEModel prepared for dynamic VRAM loading. 6419MB Staged. 0 patches attached. Force pre-loaded 73 weights: 488 KB.
[INFO] 0 models unloaded.
[INFO] Model WanTEModel prepared for dynamic VRAM loading. 6419MB Staged. 0 patches attached. Force pre-loaded 73 weights: 488 KB.
[INFO] model weight dtype torch.float16, manual cast: None
[INFO] model_type FLOW
[INFO] Requested to load WAN21
[INFO] 0 models unloaded.
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27249MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:16<00:00,  8.28s/it]
[INFO] model weight dtype torch.float16, manual cast: None
[INFO] model_type FLOW
[INFO] Requested to load WAN21
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27249MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:18<00:00,  9.31s/it]
[INFO] Requested to load WanVAE
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] Prompt executed in 48.06 seconds
```

The pins are wrong:

<img width="338" height="673" alt="scr" src="https://github.com/user-attachments/assets/875a8c54-1609-4b76-ae23-5805a6f5cdb6" />


After:

```
[INFO] got prompt
[INFO] Model WanTEModel prepared for dynamic VRAM loading. 6419MB Staged. 0 patches attached. Force pre-loaded 73 weights: 488 KB.
[INFO] 0 models unloaded.
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27249MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:16<00:00,  8.04s/it]
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27249MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:15<00:00,  7.91s/it]
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] Prompt executed in 47.12 seconds
```

<img width="334" height="685" alt="scr" src="https://github.com/user-attachments/assets/159a1670-9ad1-4557-98b8-b38d519f536f" />

Regressions combined with https://github.com/Comfy-Org/ComfyUI/pull/14300:

Windows, RTX5060, 64GB, PCIE5x4 wan 2.2 FP16 320x320 :white_check_mark: :white_check_mark: (benchmark slightly faster)
Windows, RTX5060, 64GB, PCIE5x4 wan 2.2 FP8 320x320 :white_check_mark: 
Windows, RTX5060, 64GB, LTX2.3 :white_check_mark: 
Windows, RTX5060, 64GB, zimage turbo :white_check_mark: 

Linux, RTX5090, 96GB, Stable cascade + Flux 2 :white_check_mark: 
Linux, RTX5090, 96GB, LTX2.3 :white_check_mark: 
Linux, RTX5090, 96GB, ace-step 1.5 XL :white_check_mark: 
