### PR TITLE
[Partner Nodes] feat: add seed input to Flux Erase node

### DIFF
--- a/comfy_api_nodes/apis/bfl.py
+++ b/comfy_api_nodes/apis/bfl.py
@@ -43,6 +43,7 @@ class BFLFluxEraseRequest(BaseModel):
         "white (255) marks areas to remove, black (0) marks areas to preserve.",
     )
     dilate_pixels: int = Field(10)
+    seed: int | None = Field(None)
     output_format: str = Field("png")
 
 

--- a/comfy_api_nodes/nodes_bfl.py
+++ b/comfy_api_nodes/nodes_bfl.py
@@ -534,6 +534,15 @@ class FluxEraseNode(IO.ComfyNode):
                     max=25,
                     tooltip="Expands the mask boundaries to ensure clean coverage of the object's edges.",
                 ),
+                IO.Int.Input(
+                    "seed",
+                    default=0,
+                    min=0,
+                    max=2147483647,
+                    control_after_generate=True,
+                    tooltip="The random seed used for creating the noise.",
+                    optional=True,
+                ),
             ],
             outputs=[IO.Image.Output()],
             hidden=[
@@ -553,6 +562,7 @@ class FluxEraseNode(IO.ComfyNode):
         image: Input.Image,
         mask: Input.Image,
         dilate_pixels: int = 10,
+        seed: int = 0,
     ) -> IO.NodeOutput:
         validate_image_dimensions(image, min_width=256, min_height=256)
         mask = resize_mask_to_image(mask, image)
@@ -565,6 +575,7 @@ class FluxEraseNode(IO.ComfyNode):
                 image=tensor_to_base64_string(image[:, :, :, :3]),  # make sure image will have alpha channel removed
                 mask=mask,
                 dilate_pixels=dilate_pixels,
+                seed=seed,
             ),
         )
 


### PR DESCRIPTION
Forgot to add this initially.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

