### PR TITLE
Enable cfg1 optimization for DualModelGuider with CFGGuider

### DIFF
--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -1141,7 +1141,7 @@ class CFGOverride(io.ComfyNode):
         return io.Schema(
             node_id="CFGOverride",
             display_name="CFG Override",
-            description="Override cfg to a fixed value over a [start, end] percent slice of the steps. "
+            description="Override cfg to a fixed value over a [start, end] percent (sigma) range. "
                         "With multiple overrides, the one nearest the sampler wins on overlap.",
             category="sampling/custom_sampling",
             inputs=[

--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -933,9 +933,10 @@ class Guider_DualModel(comfy.samplers.CFGGuider):
 
     def predict_noise(self, x, timestep, model_options={}, seed=None):
         positive = self.conds.get("positive", None)
-        if self.uncond_inner is None:  # cfg == 1 or no negative -> single model, cond only
-            return comfy.samplers.calc_cond_batch(self.inner_model, [positive], x, timestep, model_options)[0]
         cond = comfy.samplers.calc_cond_batch(self.inner_model, [positive], x, timestep, model_options)[0]
+        # uncond model not loaded (base cfg==1/no negative), or cfg driven to 1.0 this step -> single model, cond only
+        if self.uncond_inner is None or (math.isclose(self.cfg, 1.0) and not model_options.get("disable_cfg1_optimization", False)):
+            return cond
 
         uncond_model_options = model_options
         if "multigpu_clones" in model_options: # TODO: support multigpu instead of just running uncond on a single GPU


### PR DESCRIPTION
When dropping cfg to 1.0 with the CFG Override (or other means) the negative pass wasn't being skipped, it should now honor the `disable_cfg1_optimization`.