### PR TITLE
docs: add API entry points for local script examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Supports all operating systems and GPU types (NVIDIA, AMD, Intel, Apple Silicon,
 ## Examples
 See what ComfyUI can do with the [newer template workflows](https://comfy.org/workflows) or old [example workflows](https://comfyanonymous.github.io/ComfyUI_examples/).
 
+## API
+
+If you want to automate local ComfyUI runs or integrate it into another tool:
+
+- `openapi.yaml` documents the newer `/api/*` endpoints, including `POST /api/prompt`, `GET /api/queue`, and `GET /api/jobs/{job_id}`.
+- [`script_examples/`](script_examples/README.md) contains small Python examples for the local scripting endpoints and websocket flow.
+- In the UI, use `File -> Export (API)` to export the current workflow in API format before sending it to the backend.
+
 ## Features
 - Nodes/graph/flowchart interface to experiment and create complex Stable Diffusion workflows without needing to code anything.
 - NOTE: There are many more models supported than the list below, if you want to see what is supported see our templates list inside ComfyUI.

--- a/script_examples/README.md
+++ b/script_examples/README.md
@@ -1,0 +1,44 @@
+# API Script Examples
+
+This folder contains small Python examples for driving a local ComfyUI server from code.
+
+## Files
+
+- `basic_api_example.py`: submits a workflow exported from `File -> Export (API)`.
+- `websockets_api_example.py`: submits a workflow, waits for completion over websocket, and then fetches generated images from history.
+- `websockets_api_example_ws_images.py`: streams image bytes directly through the websocket with `SaveImageWebsocket` instead of saving files to disk first.
+
+## What These Examples Use
+
+These scripts target the local scripting routes exposed by `server.py`:
+
+- `POST /prompt`
+- `GET /history/{prompt_id}`
+- `GET /queue`
+- `GET /view`
+- `GET /ws`
+
+For the newer documented REST API, see [`openapi.yaml`](../openapi.yaml). In particular:
+
+- `POST /api/prompt`
+- `GET /api/queue`
+- `GET /api/jobs/{job_id}`
+
+## Usage Notes
+
+1. Start ComfyUI locally, which defaults to `127.0.0.1:8188`.
+2. Load or create a workflow in the UI.
+3. Export the workflow with `File -> Export (API)`.
+4. Replace the sample `prompt_text` in one of these scripts with the exported JSON if needed.
+5. Make sure the referenced models and nodes are available in your local ComfyUI install.
+
+## Dependencies
+
+- `basic_api_example.py` uses only the Python standard library.
+- The websocket examples also require `websocket-client`.
+
+Install it with:
+
+```bash
+pip install websocket-client
+```


### PR DESCRIPTION
## Summary

This PR adds a small API documentation entry point for local automation users.

## Motivation

While checking the repository, I noticed that the project already includes both an OpenAPI spec and local Python API examples, but there is no short guide connecting them from the main README. This change may help users discover the right documentation and examples more quickly.

## Changes

- add a short API section to the main README
- add `script_examples/README.md` to explain the local example scripts and their related endpoints

## Testing

- Not run: documentation-only change.

## Notes

This is intended as a small and focused contribution. I am happy to adjust the wording if needed.
