### PR TITLE
Fix unhandled ValueError in /view and /upload/mask for cross-drive subfolder paths

### DIFF
--- a/server.py
+++ b/server.py
@@ -200,6 +200,20 @@ def create_block_external_middleware():
     return block_external_middleware
 
 
+def is_path_within_directory(path, directory):
+    """Returns True if `path` resolves to a location inside `directory`.
+
+    os.path.commonpath raises ValueError when the two paths don't share a
+    drive (e.g. on Windows when one is on C: and the other on D:). That case
+    simply means `path` cannot be inside `directory`, so it is treated as such
+    rather than letting the exception bubble up as an unhandled error.
+    """
+    try:
+        return os.path.commonpath((os.path.abspath(path), directory)) == directory
+    except ValueError:
+        return False
+
+
 class PromptServer():
     def __init__(self, loop):
         PromptServer.instance = self
@@ -477,7 +491,7 @@ class PromptServer():
 
                 if original_ref.get("subfolder", "") != "":
                     full_output_dir = os.path.join(output_dir, original_ref["subfolder"])
-                    if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
+                    if not is_path_within_directory(full_output_dir, output_dir):
                         return web.Response(status=403)
                     output_dir = full_output_dir
 
@@ -534,7 +548,7 @@ class PromptServer():
 
                     if "subfolder" in request.rel_url.query:
                         full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
-                        if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
+                        if not is_path_within_directory(full_output_dir, output_dir):
                             return web.Response(status=403)
                         output_dir = full_output_dir
 

--- a/tests-unit/server_test/test_is_path_within_directory.py
+++ b/tests-unit/server_test/test_is_path_within_directory.py
@@ -1,0 +1,42 @@
+"""Tests for server.is_path_within_directory"""
+
+import os
+from unittest.mock import patch
+
+# Importing `nodes` (a transitive import of `server`) prepends the `comfy/`
+# directory to sys.path, which shadows the top-level `utils` package with
+# `comfy/utils.py`. Importing `utils` first caches the real package so later
+# `server` imports (e.g. app.frontend_management) resolve it correctly.
+import utils  # noqa: F401
+from server import is_path_within_directory
+
+
+def test_subpath_is_within_directory(tmp_path):
+    directory = str(tmp_path)
+    sub = os.path.join(directory, "subfolder")
+    assert is_path_within_directory(sub, directory) is True
+
+
+def test_directory_itself_is_within_directory(tmp_path):
+    directory = str(tmp_path)
+    assert is_path_within_directory(directory, directory) is True
+
+
+def test_sibling_path_is_not_within_directory(tmp_path):
+    directory = os.path.join(str(tmp_path), "output")
+    sibling = os.path.join(str(tmp_path), "other")
+    assert is_path_within_directory(sibling, directory) is False
+
+
+def test_parent_path_is_not_within_directory(tmp_path):
+    directory = os.path.join(str(tmp_path), "output")
+    parent = str(tmp_path)
+    assert is_path_within_directory(parent, directory) is False
+
+
+def test_different_drive_returns_false_instead_of_raising():
+    # On Windows, os.path.commonpath raises ValueError when the paths don't
+    # share a drive (e.g. comparing "C:\\output" with "D:\\secret"). That
+    # should be treated as "not within", not bubble up as an exception.
+    with patch("os.path.commonpath", side_effect=ValueError("Paths don't have the same drive")):
+        assert is_path_within_directory("D:\\secret", "C:\\output") is False


### PR DESCRIPTION
## Summary

Fixes #1488.

`os.path.commonpath` raises `ValueError: Paths don't have the same drive` when the two paths it compares don't share a common drive (this happens on Windows, e.g. comparing `C:\ComfyUI\output` with `D:\something`). 

The `/view` (`view_image`) and `/upload/mask` (`image_save_function`) handlers in [server.py](server.py) use `os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir` to validate that a user-supplied `subfolder` resolves inside the expected output directory. When the resolved path lands on a different drive than `output_dir`, `os.path.commonpath` raises instead of returning a value, so the handler crashes with an unhandled `ValueError` (HTTP 500) instead of cleanly returning the intended `403 Forbidden`.

## Changes

- Added a small helper `is_path_within_directory(path, directory)` in `server.py` that performs the same `commonpath` comparison but catches `ValueError` and returns `False` — a different drive obviously means the path isn't inside the directory, so it should be treated the same as any other "outside the directory" case (403).
- Replaced the two duplicated inline `commonpath` checks (`view_image` and `image_save_function` in `upload_mask`) with calls to the new helper.
- Added `tests-unit/server_test/test_is_path_within_directory.py` covering: subpaths, the directory itself, sibling/parent paths that should be rejected, and the cross-drive `ValueError` case (mocked, since it's Windows-specific behavior).

## Test plan

- [x] `python -m pytest tests-unit/server_test/test_is_path_within_directory.py -v` — 5/5 pass
- [x] `python -m pytest tests-unit/server_test/ tests-unit/prompt_server_test/` — 77/77 pass (no regressions)
- [x] Verified the new helper returns `False` (instead of raising) when `os.path.commonpath` raises `ValueError`, matching the previously-crashing cross-drive scenario described in #1488