### PR TITLE
Fix Content-Disposition header to comply with RFC 2183

### DIFF
--- a/server.py
+++ b/server.py
@@ -560,7 +560,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -580,7 +580,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -597,7 +597,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"attachment; filename=\"{filename}\""})
                     else:
                         # Use the content type from asset resolution if available,
                         # otherwise guess from the filename.
@@ -614,7 +614,7 @@ class PromptServer():
                         return web.FileResponse(
                             file,
                             headers={
-                                "Content-Disposition": f"filename=\"{filename}\"",
+                                "Content-Disposition": f"attachment; filename=\"{filename}\"",
                                 "Content-Type": content_type
                             }
                         )


### PR DESCRIPTION
## Summary
- The `/view` endpoint (`server.py`) sets the `Content-Disposition` response header to a bare `filename="..."` value, omitting the required disposition-type (e.g. `attachment` or `inline`).
- This violates the grammar defined in RFC 2183 / RFC 6266 (`disposition-type *( ";" disposition-parm )`). Strict header parsers — e.g. Go's `mime.ParseMediaType` — reject the header outright instead of extracting the filename, which breaks third-party download tools that fetch files from `/view`.
- This PR prefixes the header value with `attachment; ` at all four locations in `view_image` where it is set, making the header spec-compliant while preserving the existing filename behavior.

Fixes #8914

## Test plan
- [x] Confirmed `server.py` parses (`python3 -c "import ast; ast.parse(open('server.py').read())"`)
- [ ] Manually fetch an image via `/view?filename=...` and confirm the response header now reads `Content-Disposition: attachment; filename="..."` and that the browser/tooling still downloads/displays the file with the correct name