### PR TITLE
Fix SaveAudioMP3 avcodec_open2 EINVAL crashes

### DIFF
--- a/comfy_api/latest/_ui.py
+++ b/comfy_api/latest/_ui.py
@@ -260,6 +260,7 @@ class ImageSaveHelper:
 class AudioSaveHelper:
     """A helper class with static methods to handle audio saving and metadata."""
     _OPUS_RATES = [8000, 12000, 16000, 24000, 48000]
+    _MP3_RATES = [8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000]
 
     @staticmethod
     def save_audio(
@@ -303,12 +304,15 @@ class AudioSaveHelper:
                             break
                     if sample_rate not in AudioSaveHelper._OPUS_RATES:  # Fallback if still not supported
                         sample_rate = 48000
+            elif format == "mp3" and sample_rate not in AudioSaveHelper._MP3_RATES:
+                # libmp3lame only accepts a fixed set of sample rates; remap to the closest one
+                sample_rate = min(AudioSaveHelper._MP3_RATES, key=lambda rate: abs(rate - sample_rate))
 
-                # Resample if necessary
-                if sample_rate != audio["sample_rate"]:
-                    if not TORCH_AUDIO_AVAILABLE:
-                        raise Exception("torchaudio is not available; cannot resample audio.")
-                    waveform = torchaudio.functional.resample(waveform, audio["sample_rate"], sample_rate)
+            # Resample if necessary
+            if sample_rate != audio["sample_rate"]:
+                if not TORCH_AUDIO_AVAILABLE:
+                    raise Exception("torchaudio is not available; cannot resample audio.")
+                waveform = torchaudio.functional.resample(waveform, audio["sample_rate"], sample_rate)
 
             # Create output with specified format
             output_buffer = BytesIO()
@@ -335,8 +339,10 @@ class AudioSaveHelper:
             elif format == "mp3":
                 out_stream = output_container.add_stream("libmp3lame", rate=sample_rate, layout=layout)
                 if quality == "V0":
-                    # TODO i would really love to support V3 and V5 but there doesn't seem to be a way to set the qscale level, the property below is a bool
-                    out_stream.codec_context.qscale = 1
+                    # PyAV exposes codec_context.qscale as a bool flag, not the int quality
+                    # scale libmp3lame expects, so assigning a level to it raises avcodec_open2
+                    # EINVAL. libmp3lame's default VBR mode is roughly equivalent to V0 quality.
+                    pass
                 elif quality == "128k":
                     out_stream.bit_rate = 128000
                 elif quality == "320k":


### PR DESCRIPTION
## Summary
`SaveAudioMP3` (`AudioSaveHelper.save_audio` in `comfy_api/latest/_ui.py`) fails with `av.error.ValueError: [Errno 22] Invalid argument: 'avcodec_open2(libmp3lame)'` due to two separate bugs:

1. **Invalid `qscale` assignment for "V0" quality** — PyAV exposes `codec_context.qscale` as a `bool` flag, not the integer quality scale libmp3lame expects (the existing TODO comment already noted this). Assigning `1` to it makes `avcodec_open2` reject the codec context with `EINVAL`. Since libmp3lame's default VBR mode is roughly equivalent to V0 quality anyway, the assignment is simply removed (`pass`).
2. **Unsupported sample rates rejected by libmp3lame** — `libmp3lame` only accepts `8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000` Hz. Audio sources outputting other rates (e.g. 40000 Hz, seen with some RVC voice-conversion models) were passed straight through, causing `avcodec_open2` to fail. MP3 output now remaps to the closest supported rate and resamples — mirroring the existing Opus rate-handling logic just above it (the shared resample step was hoisted out of the `if format == "opus"` block so both formats use it).

Fixes #13937

## Test plan
- [x] Reproduced both failures directly against PyAV (17.1.0) with the unpatched code:
  - `out_stream.codec_context.qscale = 1` — fails on some PyAV/libmp3lame builds with the exact `avcodec_open2(libmp3lame)` EINVAL from the report
  - encoding at 40000 Hz fails with `Invalid argument: 'avcodec_open2("libmp3lame", {})' returned 22` on every PyAV build tested
- [x] Confirmed the patched `AudioSaveHelper.save_audio` successfully encodes MP3 for: V0 quality at 44.1 kHz, V0 quality at 40 kHz (remap + resample + qscale fix together), and 320k quality at 40 kHz (remap + resample only)
- [x] Ran `pytest tests-unit/comfy_api_test/` — all 31 tests pass