### PR TITLE
Use torch.neg instead of unary minus in RoPE freqs computation

### DIFF
--- a/comfy/text_encoders/llama.py
+++ b/comfy/text_encoders/llama.py
@@ -437,7 +437,7 @@ def precompute_freqs_cis(head_dim, position_ids, theta, rope_scale=None, rope_di
                 cos = cos.unsqueeze(1)
                 sin = sin.unsqueeze(1)
         sin_split = sin.shape[-1] // 2
-        out.append((cos, sin[..., : sin_split], -sin[..., sin_split :]))
+        out.append((cos, sin[..., : sin_split], torch.neg(sin[..., sin_split :])))
 
     if len(out) == 1:
         return out[0]


### PR DESCRIPTION
## Summary
- On RTX 5090 (Blackwell) with PyTorch cu130, `precompute_freqs_cis` in `comfy/text_encoders/llama.py` crashes during RoPE computation for the Gemma3 12B text encoder used by LTX-AV workflows. Depending on driver version this surfaces as `torch.AcceleratorError: CUDA error: unknown error` or a Windows access-violation fatal exception — both originating from the unary-minus on a CUDA tensor slice at the line in question. The crash also cascades into DynamicVRAM/RAM exhaustion, which makes it easy to misdiagnose as a memory issue.
- The reporter root-caused it to the unary-minus operator dispatch on a CUDA tensor and found that replacing it with `torch.neg()` resolves the crash completely.
- `torch.neg(x)` is mathematically and numerically identical to `-x` — I verified the full `precompute_freqs_cis` output is bit-for-bit equal between the old and new code on CPU — so this is a pure no-op for every other platform while working around whatever Blackwell/cu130-specific issue exists in the unary-minus path.

Fixes #13977

## Test plan
- [x] Verified `torch.neg(x)` produces a bit-for-bit identical tensor to `-x` (same values and dtype)
- [x] Ran the full `precompute_freqs_cis` function before/after the change with sample position ids and confirmed `cos`, `sin[first half]`, and the negated `sin[second half]` outputs are all `torch.equal` and dtype-matching
- [ ] Reporter / RTX 5090 owners to confirm this resolves the crash on actual Blackwell hardware (I don't have access to that GPU to test directly)