### PR TITLE
fix: Add back apply_rotary_emb for Qwen Image

### DIFF
--- a/comfy/ldm/qwen_image/model.py
+++ b/comfy/ldm/qwen_image/model.py
@@ -51,7 +51,7 @@ class FeedForward(nn.Module):
         return hidden_states
 
 
-# This was added back because Nunchaku custom nodes rely on it, see comment here:
+# Addin this back because Nunchaku custom nodes rely on it, see comment here:
 # https://github.com/Comfy-Org/ComfyUI/pull/14178#issuecomment-4640475161
 # TODO: Eventually remove this once we natively support SVDQuants
 def apply_rotary_emb(x, freqs_cis):

--- a/comfy/ldm/qwen_image/model.py
+++ b/comfy/ldm/qwen_image/model.py
@@ -51,6 +51,18 @@ class FeedForward(nn.Module):
         return hidden_states
 
 
+# This was added back because Nunchaku custom nodes rely on it, see comment here:
+# https://github.com/Comfy-Org/ComfyUI/pull/14178#issuecomment-4640475161
+# TODO: Eventually remove this once we natively support SVDQuants
+def apply_rotary_emb(x, freqs_cis):
+    if x.shape[1] == 0:
+        return x
+
+    t_ = x.reshape(*x.shape[:-1], -1, 1, 2)
+    t_out = freqs_cis[..., 0] * t_[..., 0] + freqs_cis[..., 1] * t_[..., 1]
+    return t_out.reshape(*x.shape)
+
+
 class QwenTimestepProjEmbeddings(nn.Module):
     def __init__(self, embedding_dim, pooled_projection_dim, use_additional_t_cond=False, dtype=None, device=None, operations=None):
         super().__init__()


### PR DESCRIPTION
Adding this back to avoid breaking Nunchaku custom nodes. See comment:

https://github.com/Comfy-Org/ComfyUI/pull/14178#issuecomment-4640475161