### PR TITLE
[Trainer/bug] Avoid conditions become trainable in training node

### DIFF
--- a/comfy_extras/nodes_train.py
+++ b/comfy_extras/nodes_train.py
@@ -15,6 +15,7 @@ import comfy.sampler_helpers
 import comfy.sd
 import comfy.utils
 import comfy.model_management
+from comfy.conds import CONDRegular, CONDList
 from comfy.cli_args import args, PerformanceFeature
 import comfy_extras.nodes_custom_sampler
 import folder_paths
@@ -120,6 +121,11 @@ def process_cond_list(d, prefix=""):
                 process_cond_list(v, f"{prefix}.{k}")
             elif isinstance(v, torch.Tensor):
                 d[k] = v.clone()
+            elif isinstance(v, CONDList):
+                v.cond = [t.detach() if isinstance(t, torch.Tensor) else t for t in v.cond]
+            elif isinstance(v, CONDRegular):
+                if isinstance(v.cond, torch.Tensor):
+                    v.cond = v.cond.detach()
             elif isinstance(v, (list, tuple)):
                 for index, item in enumerate(v):
                     process_cond_list(item, f"{prefix}.{k}.{index}")


### PR DESCRIPTION
As title, this PR fixes in some model setup that the conditions become trainable in training node.

As we pre-computed all the conditions (text emb or things like that), in training node they will get .backward() multiple time and make pytorch unhappy.

As in our training node we only wrap the backbone model, all the other model or tensor should not receive gradients, I directly detach all the tensors in conditions.

NOTE, with this PR and https://github.com/Comfy-Org/ComfyUI/pull/13400
Stable Audio also can be trained as well. (altho we lack audio related dataset nodes for now)