### PR TITLE
main: force cudnn.benchmark to false (CORE-284)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -534,8 +534,10 @@ try:
 except:
     pass
 
-if torch.cuda.is_available() and torch.backends.cudnn.is_available() and PerformanceFeature.AutoTune in args.fast:
-    torch.backends.cudnn.benchmark = True
+
+def set_cudnn_benchmark():
+    if torch.cuda.is_available() and torch.backends.cudnn.is_available():
+        torch.backends.cudnn.benchmark = PerformanceFeature.AutoTune in args.fast
 
 try:
     if torch_version_numeric >= (2, 5):

--- a/main.py
+++ b/main.py
@@ -490,6 +490,11 @@ def start_comfyui(asyncio_loop=None):
         init_custom_nodes=(not args.disable_all_custom_nodes) or len(args.whitelist_custom_nodes) > 0,
         init_api_nodes=not args.disable_api_nodes
     ))
+
+    # Re-apply Comfy's cuDNN benchmark policy after custom-node imports. Benchmark
+    # mode can request near-card-sized autotune workspaces, and some custom nodes set it at import time.
+    comfy.model_management.set_cudnn_benchmark()
+
     hook_breaker_ac10a0.restore_functions()
 
     cuda_malloc_warning()


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/14378

Some custom nodes try to set this =true globally. It messes with dynamic VRAM with one-off spikes that can OOM but this is also very high risk for windows where such allocations might get serviced by shared memory fallback.

Trump it.

Example test conditions:

Linux, RTX5090, 96GB
Install ComfyUI-MiniCPM (rogue global settings actor)
qwen 3.5 text generate

<img width="1389" height="626" alt="image" src="https://github.com/user-attachments/assets/c9d8406d-039e-4652-b409-f72806a894a0" />

Before:

```
[INFO] got prompt
[INFO] CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
[INFO] Requested to load Qwen35TEModel_
[INFO] Model Qwen35TEModel_ prepared for dynamic VRAM loading. 8657MB Staged. 0 patches attached. Force pre-loaded 203 weights: 535 KB.
⚠️  GGUF functionality unavailable - install llama-cpp-python for GGUF support
📖 Installation guide: https://github.com/1038lab/ComfyUI-MiniCPM/tree/main/llama_cpp_install
✅ MiniCPM loaded: 2 nodes from 1 modules
⏭️  Skipped: AILab_MiniCPM_GGUF

Initializing ControlAltAI Nodes
Generating tokens: 100%|██████████| 256/256 [00:45<00:00,  5.59it/s]
[INFO] Prompt executed in 47.19 seconds
```

<img width="316" height="380" alt="image" src="https://github.com/user-attachments/assets/67f188bd-793e-4640-9e70-aab76d402a7f" />


After:

```
[INFO] got prompt
[INFO] CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
[INFO] Requested to load Qwen35TEModel_
[INFO] Model Qwen35TEModel_ prepared for dynamic VRAM loading. 8657MB Staged. 0 patches attached. Force pre-loaded 203 weights: 535 KB.
⚠️  GGUF functionality unavailable - install llama-cpp-python for GGUF support
📖 Installation guide: https://github.com/1038lab/ComfyUI-MiniCPM/tree/main/llama_cpp_install
✅ MiniCPM loaded: 2 nodes from 1 modules
⏭️  Skipped: AILab_MiniCPM_GGUF

Initializing ControlAltAI Nodes
Generating tokens: 100%|██████████| 256/256 [00:04<00:00, 53.98it/s]
[INFO] Prompt executed in 5.63 seconds
```

<img width="316" height="380" alt="image" src="https://github.com/user-attachments/assets/4f97a59c-871f-4b32-9eea-e8d5ef0e1b6e" />
