### PR TITLE
ops: tolerate already force casted dynamic weight (CORE-288)

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -299,21 +299,21 @@ def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None, of
 
     non_blocking = comfy.model_management.device_supports_non_blocking(device)
 
-    if hasattr(s, "_v"):
+    if hasattr(s, "_v") and comfy.model_management.is_device_cpu(device):
 
         #vbar doesn't support CPU weights, but some custom nodes have weird paths
         #that might switch the layer to the CPU and expect it to work. We have to take
         #a clone conservatively as we are mmapped and some SFT files are packed misaligned
         #If you are a custom node author reading this, please move your layer to the GPU
         #or declare your ModelPatcher as CPU in the first place.
-        if comfy.model_management.is_device_cpu(device):
-            materialize_meta_param(s, ["weight", "bias"])
-            weight = s.weight.to(dtype=dtype, copy=True)
-            if isinstance(weight, QuantizedTensor):
-                weight = weight.dequantize()
-            bias = s.bias.to(dtype=bias_dtype, copy=True) if s.bias is not None else None
-            return format_return((weight, bias, (None, None, None)), offloadable)
+        materialize_meta_param(s, ["weight", "bias"])
+        weight = s.weight.to(dtype=dtype, copy=True)
+        if isinstance(weight, QuantizedTensor):
+            weight = weight.dequantize()
+        bias = s.bias.to(dtype=bias_dtype, copy=True) if s.bias is not None else None
+        return format_return((weight, bias, (None, None, None)), offloadable)
 
+    elif hasattr(s, "_v") and s.weight.device != device:
         prefetched = hasattr(s, "_prefetch")
         offload_stream = None
         offload_device = None


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/14383

Some custom nodes .to weights completely out of load context which can wreak havoc if its for a model that is not active. Detect this condition and just let it fall-through to the non-dynamic loader straight up.

Example test conditions:

Windows, RTX5060, 16GB
LTX2.3 with KJNodes LTX2_NAG
Run once with NAG bypassed, cancel after first step of diff model
Unbypass, Run again

<img width="1362" height="673" alt="scr" src="https://github.com/user-attachments/assets/842712a2-96b1-4294-8543-5655076e08bc" />


Before:

```
[INFO] got prompt
[ERROR] !!! Exception during processing !!! HostBuffer.truncate failed
[ERROR] Traceback (most recent call last):
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\pinned_memory.py", line 104, in pin_memory
    hostbuf.truncate(offset, do_unregister=False)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\comfy_aimdo\host_buffer.py", line 122, in truncate
    raise RuntimeError("HostBuffer.truncate failed")
RuntimeError: HostBuffer.truncate failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\execution.py", line 538, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\execution.py", line 337, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\execution.py", line 311, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\execution.py", line 299, in process_inputs
    result = f(**inputs)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy_api\internal\__init__.py", line 149, in wrapped_func
    return method(locked_class, **inputs)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy_api\latest\_io.py", line 1892, in EXECUTE_NORMALIZED
    to_return = cls.execute(*args, **kwargs)
  File "C:\Users\rattus\comfy-base\custom_nodes\ComfyUI-KJNodes\nodes\ltxv_nodes.py", line 523, in execute
    context_video = diffusion_model.video_embeddings_connector(context_video)[0]
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ldm\lightricks\embeddings_connector.py", line 297, in forward
    hidden_states = block(
        hidden_states, attention_mask=attention_mask, pe=freqs_cis
    )
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ldm\lightricks\embeddings_connector.py", line 93, in forward
    attn_output = self.attn1(norm_hidden_states, mask=attention_mask, pe=pe)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ldm\lightricks\model.py", line 456, in forward
    q = self.to_q(x)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ops.py", line 1244, in forward
    output = self.forward_comfy_cast_weights(input, compute_dtype, want_requant=isinstance(input, QuantizedTensor))
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ops.py", line 1187, in forward_comfy_cast_weights
    weight, bias, offload_stream = cast_bias_weight(self, input, offloadable=True, compute_dtype=compute_dtype, want_requant=want_requant)
                                   ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ops.py", line 321, in cast_bias_weight
    offload_stream = cast_modules_with_vbar([s], dtype, device, bias_dtype, non_blocking)
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ops.py", line 188, in cast_modules_with_vbar
    handle_pin(s, pin, xfer_source, xfer_dest, size=dest_size)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\ops.py", line 184, in handle_pin
    comfy.pinned_memory.pin_memory(m, subset=subset, size=size)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\comfy\pinned_memory.py", line 108, in pin_memory
    hostbuf.truncate(offset, do_unregister=False)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\comfy_aimdo\host_buffer.py", line 122, in truncate
    raise RuntimeError("HostBuffer.truncate failed")
RuntimeError: HostBuffer.truncate failed

[INFO] Prompt executed in 6.60 seconds
```

After:

```
 12%|██████▏                                          | 1/8 [00:46<05:28, 46.93s/it,  Model Initialization complete!  ][INFO] Interrupting prompt 3047c902-eab9-400e-b0fd-f5ce43a022bc
 12%|██████▏                                          | 1/8 [00:56<06:34, 56.31s/it,  Model Initialization complete!  ]
[INFO] Processing interrupted
[INFO] Prompt executed in 119.01 seconds
[INFO] got prompt
[INFO] Requested to load LTXAV
[INFO] Model LTXAV prepared for dynamic VRAM loading. 23835MB Staged. 1660 patches attached. Force pre-loaded 2104 weights: 3308 KB.
100%|████████████████████████████████████████████████████████████████████████████████████| 8/8 [03:36<00:00, 27.00s/it]
[INFO] Model LTXAV prepared for dynamic VRAM loading. 23835MB Staged. 1660 patches attached. Force pre-loaded 2104 weights: 3308 KB.
100%|████████████████████████████████████████████████████████████████████████████████████| 3/3 [01:40<00:00, 33.53s/it]
[INFO] Requested to load AudioVAE
[INFO] loaded completely;  693.46 MB loaded, full load: True
[INFO] Requested to load VideoVAE
[INFO] 0 models unloaded.
[INFO] Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
[INFO] Prompt executed in 365.79 seconds
```

Regression tests:

Linux, 5090, 96GB qwen 3.5 text generate ✅ 
Linux, 5090, 96GB stable cascade -> Flux 2 ✅ 
Linux, 5090, 96GB LTX2.3 ✅ 
