### PR TITLE
[Partner Nodes] fix(KlingTextToVideoNode): validation error for "kling-v2-master" model

### DIFF
--- a/comfy_api_nodes/apis/__init__.py
+++ b/comfy_api_nodes/apis/__init__.py
@@ -1310,13 +1310,6 @@ class KlingTaskStatus(str, Enum):
     failed = 'failed'
 
 
-class KlingTextToVideoModelName(str, Enum):
-    kling_v1 = 'kling-v1'
-    kling_v1_6 = 'kling-v1-6'
-    kling_v2_1_master = 'kling-v2-1-master'
-    kling_v2_5_turbo = 'kling-v2-5-turbo'
-
-
 class KlingVideoGenAspectRatio(str, Enum):
     field_16_9 = '16:9'
     field_9_16 = '9:16'
@@ -5179,7 +5172,7 @@ class KlingText2VideoRequest(BaseModel):
     duration: Optional[KlingVideoGenDuration] = '5'
     external_task_id: Optional[str] = Field(None, description='Customized Task ID')
     mode: Optional[KlingVideoGenMode] = 'std'
-    model_name: Optional[KlingTextToVideoModelName] = 'kling-v1'
+    model_name: Optional[str] = 'kling-v1'
     negative_prompt: Optional[str] = Field(
         None, description='Negative text prompt', max_length=2500
     )

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -436,7 +436,7 @@ async def execute_text2video(
             negative_prompt=negative_prompt if negative_prompt else None,
             duration=KlingVideoGenDuration(duration),
             mode=KlingVideoGenMode(model_mode),
-            model_name=KlingVideoGenModelName(model_name),
+            model_name=model_name,
             cfg_scale=cfg_scale,
             aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
             camera_control=camera_control,


### PR DESCRIPTION
The `model_name` **enum** on `KlingText2VideoRequest` went stale and was missing `kling-v2-master`.
Replaced it with a plain string per our Partner-nodes convention (the widget already constrains the values)

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

