### PR TITLE
Make --enable-manager-legacy-ui imply --enable-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ For models compatible with Iluvatar Extension for PyTorch. Here's a step-by-step
 | Flag | Description |
 |------|-------------|
 | `--enable-manager` | Enable ComfyUI-Manager |
-| `--enable-manager-legacy-ui` | Use the legacy manager UI instead of the new UI (requires `--enable-manager`) |
+| `--enable-manager-legacy-ui` | Use the legacy manager UI instead of the new UI (implies `--enable-manager`) |
 | `--disable-manager-ui` | Disable the manager UI and endpoints while keeping background features like security checks and scheduled installation completion (requires `--enable-manager`) |
 
 

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -258,6 +258,10 @@ if args.disable_auto_launch:
 if args.force_fp16:
     args.fp16_unet = True
 
+# '--enable-manager-legacy-ui' is meaningless unless the manager is enabled, so imply '--enable-manager'.
+if args.enable_manager_legacy_ui:
+    args.enable_manager = True
+
 
 # '--fast' is not provided, use an empty set
 if args.fast is None:

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -133,7 +133,7 @@ upcast.add_argument("--dont-upcast-attention", action="store_true", help="Disabl
 parser.add_argument("--enable-manager", action="store_true", help="Enable the ComfyUI-Manager feature.")
 manager_group = parser.add_mutually_exclusive_group()
 manager_group.add_argument("--disable-manager-ui", action="store_true", help="Disables only the ComfyUI-Manager UI and endpoints. Scheduled installations and similar background tasks will still operate.")
-manager_group.add_argument("--enable-manager-legacy-ui", action="store_true", help="Enables the legacy UI of ComfyUI-Manager")
+manager_group.add_argument("--enable-manager-legacy-ui", action="store_true", help="Enables the legacy UI of ComfyUI-Manager. Implies --enable-manager.")
 
 
 vram_group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
## Summary

Makes `--enable-manager-legacy-ui` imply `--enable-manager`.

Previously the legacy manager UI flag had no effect on its own: ComfyUI only
loads ComfyUI-Manager when `args.enable_manager` is set (the gate used in
`main.py`, `server.py`, and `nodes.py`). The `--enable-manager-legacy-ui` flag
is only read afterwards by the manager to pick which UI to serve, so passing it
alone silently did nothing — users had to remember to also pass
`--enable-manager`, which is unintuitive.

This change treats `--enable-manager-legacy-ui` as implying `--enable-manager`
in the post-parse section of `cli_args.py`, alongside the existing flag
implications (e.g. `--windows-standalone-build` → `--auto-launch`).

## Changes

- `comfy/cli_args.py`: set `args.enable_manager = True` when
  `args.enable_manager_legacy_ui` is set.
- `README.md`: update the flag description from "requires `--enable-manager`" to
  "implies `--enable-manager`".

## Notes

- `--enable-manager-legacy-ui` is not part of the mutually-exclusive group that
  contains `--enable-manager`, so forcing it on is safe (no argparse conflict).
- `--disable-manager-ui` is intentionally left unchanged — it is a no-op without
  the manager and is outside the scope of this issue.

## Testing

- `--enable-manager-legacy-ui` alone → `enable_manager` is now `True`.
- No manager flags → both remain `False` (unchanged behavior).
- `--enable-manager-legacy-ui --disable-manager-ui` → still rejected by the
  existing mutually-exclusive group.

Fixes Comfy-Org/ComfyUI-Desktop-2.0-Beta#1062
