### PR TITLE
Add Slack notification on CI failure

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -97,3 +97,16 @@ jobs:
           torch_version: ${{ matrix.torch_version }}
           google_credentials: ${{ secrets.GCS_SERVICE_ACCOUNT_JSON }}
           comfyui_flags: ${{ matrix.flags }}
+
+  notify-failure:
+    needs: [test-stable, test-unix-nightly]
+    if: ${{ failure() && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack of CI failure
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.CI_ALERTS_SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":rotating_siren: ComfyUI CI failed on `${{ github.ref_name }}`\n*Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>\n*Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view logs>\n*Dashboard:* <https://ci.comfy.org/?branch=${{ github.ref_name }}|ci.comfy.org>"


### PR DESCRIPTION
Currently, when a `test-ci` run fails on `master`, GitHub only emails the commit author — nothing reaches the team, so a red master can go unnoticed.

This adds a `notify-failure` job to `test-ci.yml` that posts a single Slack message when any matrix leg fails.

## Behavior
- Fires when **any** job in `test-stable` or `test-unix-nightly` fails (the matrices use `fail-fast: false`, so all legs finish and one message summarizes the run — not one message per leg).
- Restricted to `push` events, so manual `workflow_dispatch` experiments don't post to the channel.
- Runs on `ubuntu-latest` (GitHub-hosted), so the notification still goes out if a self-hosted runner job fails mid-run.
- Message links the commit, the Actions run logs, and https://ci.comfy.org filtered to the branch.

## Setup required before merge
A repo admin needs to add a secret named `CI_ALERTS_SLACK_WEBHOOK` containing a Slack incoming-webhook URL for the channel that should receive alerts (Slack app → Incoming Webhooks → Add to channel).

If the secret is absent the notify job fails on its own, but test results are unaffected.

## Known limitation
If self-hosted runners are fully offline, jobs queue rather than fail, so no notification fires. Covering that needs a separate scheduled health-check — out of scope here.