### PR TITLE
Fix nondeterministic video decode at unaligned widths (CORE-299)

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -324,6 +324,8 @@ class VideoFromFile(VideoInput):
 
                             checked_alpha = True
 
+                        # Fix non-deterministic video decode when the video width is not a multiple of 32
+                        # For non-yuvj pixel formats (all H.264/H.265 video)
                         if image_format in ('gbrpf32le', 'gbrapf32le') and frame.width % 32 != 0:
                             if align_graph is None:
                                 pad_w = ((frame.width + 31) // 32) * 32

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -257,6 +257,7 @@ class VideoFromFile(VideoInput):
 
         image_format = 'gbrpf32le'
         process_image_format = lambda a: a
+        align_graph = None
         audio = None
 
         streams = [video_stream]
@@ -310,7 +311,22 @@ class VideoFromFile(VideoInput):
 
                             checked_alpha = True
 
-                        img = frame.to_ndarray(format=image_format)  # shape: (H, W, 4)
+                        if image_format in ('gbrpf32le', 'gbrapf32le') and frame.width % 32 != 0:
+                            if align_graph is None:
+                                pad_w = ((frame.width + 31) // 32) * 32
+                                g = av.filter.Graph()
+                                g_src = g.add_buffer(width=frame.width, height=frame.height,
+                                                     format=frame.format.name, time_base=video_stream.time_base)
+                                g_pad = g.add('pad', f'{pad_w}:{frame.height}:0:0')
+                                g_sink = g.add('buffersink')
+                                g_src.link_to(g_pad)
+                                g_pad.link_to(g_sink)
+                                g.configure()
+                                align_graph = (g, g_src, g_sink)
+                            align_graph[1].push(frame)
+                            img = np.ascontiguousarray(align_graph[2].pull().to_ndarray(format=image_format)[:, :frame.width])
+                        else:
+                            img = frame.to_ndarray(format=image_format)
                         if frame.rotation != 0:
                             k = int(round(frame.rotation // 90))
                             img = np.rot90(img, k=k, axes=(0, 1)).copy()


### PR DESCRIPTION
## Why

`LoadVideo` decodes the same file differently in every process when the video width is not a multiple of 32. For non-`yuvj` pixel formats (`yuv420p` and friends, which covers essentially all H.264/H.265 video), `VideoFromFile.get_components_internal()` converts frames with `frame.to_ndarray(format="gbrpf32le")`, a float path introduced in 4304c15e (#13542). At non-32-aligned widths, libswscale's float YUV->GBR SIMD kernel reads uninitialized memory past the stride boundary and overwrites pixels in columns 0-3 with process-dependent garbage. The uint8 paths (`rgb24`/`rgba`/`pal8`, split off in d10fc2d6, #13626) and 32-aligned widths are unaffected.

## What changed

One file, 17 lines. When the conversion target is `gbrpf32le`/`gbrapf32le` and `frame.width % 32 != 0`, the frame is padded to the next multiple of 32 with libav's `pad` filter, converted, cropped back to the original width, and copied so the padded buffer is released. The filter graph is built lazily on the first affected frame and reused for the rest of the stream. Blast radius: 32-aligned widths and all uint8 paths run the identical `to_ndarray` call as before and are byte-identical to master; on affected frames only the previously corrupt edge columns change, to their correct values.

The 3-line alternative (switching the float branch to integer `rgb48le`) was rejected because it shifts decoded values by about 1/255 for every non-`yuvj` video, including the aligned majority that already decodes correctly.

## See it

[Test clip](https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/decode_white_316.mp4) (316x180 lossless `yuv420p` solid white, 29 frames; `make_clip.py` in the [gist](https://gist.github.com/pollockjj/371d827205dfeda90e58978299ed12ea) regenerates it) and [workflow](https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/decode_workflow.json), stock nodes only: LoadVideo -> GetVideoComponents -> crop of the left 32 columns -> nearest 3x -> Save Animated WEBP. Drop the clip in `input/`, run the workflow once on master and once on this branch. The animations below are that workflow's saved output, untouched.

<img src="https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/panel_run0.webp"/> <img src="https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/panel_run1.webp"/> <img src="https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/panel_run2.webp"/> <img src="https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/panel_run3.webp"/> &nbsp;&nbsp;&nbsp;&nbsp; <img src="https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/panel_fix0.webp"/> <img src="https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/panel_fix1.webp"/>

run 0 through run 3 are master: the same file decoded by four separate processes. The source is solid white, so every gray dash is corruption, and each process scatters it differently. Fix 0 and Fix 1 are this PR, two separate processes: solid white, still, and byte-identical to each other.

The numbers behind the panels: the four master runs produced four different output files (42,336 / 43,740 / 43,056 / 42,984 non-white pixels in the zoomed strip, four distinct hashes); the two runs on this PR (Fix 0, Fix 1) produced byte-identical output with zero non-white pixels. Full frames: [master](https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/master_full.webp) | [fixed](https://gist.githubusercontent.com/pollockjj/371d827205dfeda90e58978299ed12ea/raw/c3980fefba0f7b1f45c7b09afda4d4f20ee19a10/fixed_full.webp).

## Tracking

Linear: https://linear.app/comfyorg/issue/CORE-299/loadvideo-decodes-non-32-aligned-width-video-nondeterministically
