### PR TITLE
bump manager version to 4.2.2

### DIFF
--- a/manager_requirements.txt
+++ b/manager_requirements.txt
@@ -1,1 +1,1 @@
-comfyui_manager==4.2.1
+comfyui_manager==4.2.2


### PR DESCRIPTION
Adds dedicated install flags so `git_url`/`pip` installs are controlled independently of the global security level (Comfy-Org/ComfyUI-Manager#2962), and hardens the `pygit2` fallback path to prefer system git when available with follow-up fixes (Comfy-Org/ComfyUI-Manager#2972, Comfy-Org/ComfyUI-Manager#2974).

References:
- Diff: https://github.com/Comfy-Org/ComfyUI-Manager/compare/4.2.1...4.2.2
- PyPI: https://pypi.org/project/comfyui-manager/4.2.2
