### PR TITLE
feat: server-side missing model downloads for remote web UI

### DIFF
--- a/app/model_manager.py
+++ b/app/model_manager.py
@@ -3,7 +3,9 @@ import base64
 import json
 import time
 import logging
+import asyncio
 import requests
+from threading import Lock
 from tqdm.auto import tqdm
 from urllib.parse import unquote, urlparse
 from typing import Callable
@@ -20,6 +22,8 @@ class ModelFileManager:
     def __init__(self, is_download_model_enabled: Callable[[], bool] = lambda: True) -> None:
         self.cache: dict[str, tuple[list[dict], dict[str, float], float]] = {}
         self.is_download_model_enabled = is_download_model_enabled
+        self._download_progress: dict[str, dict] = {}
+        self._download_lock = Lock()
 
     def get_cache(self, key: str, default=None) -> tuple[list[dict], dict[str, float], float] | None:
         return self.cache.get(key, default)
@@ -29,6 +33,39 @@ class ModelFileManager:
 
     def clear_cache(self):
         self.cache.clear()
+
+
+    def _download_progress_key(self, save_dir: str, filename: str) -> str:
+        return f"{save_dir}/{filename}"
+
+    def _set_download_progress(self, key: str, **fields) -> None:
+        with self._download_lock:
+            entry = dict(self._download_progress.get(key, {}))
+            entry.update(fields)
+            self._download_progress[key] = entry
+
+    def _download_file_sync(self, url: str, headers: dict, tmp_path: str, save_path: str, key: str) -> None:
+        with requests.get(url, headers=headers, stream=True, timeout=(30, 3600)) as r:
+            r.raise_for_status()
+            total_size = int(r.headers.get("content-length", 0) or 0)
+            os.makedirs(os.path.dirname(save_path), exist_ok=True)
+            self._set_download_progress(
+                key,
+                status="running",
+                bytes_downloaded=0,
+                bytes_total=total_size,
+                filename=os.path.basename(save_path),
+            )
+            with open(tmp_path, "wb") as f:
+                downloaded = 0
+                for chunk in r.iter_content(chunk_size=1024 * 1024):
+                    if not chunk:
+                        continue
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    self._set_download_progress(key, bytes_downloaded=downloaded, bytes_total=total_size or downloaded)
+        os.replace(tmp_path, save_path)
+
 
     def add_routes(self, routes):
         # NOTE: This is an experiment to replace `/models`
@@ -94,26 +131,59 @@ class ModelFileManager:
             token = json_data.get("token")
             headers = {"Authorization": f"Bearer {token}"} if token else {}
 
+            key = self._download_progress_key(save_dir, filename)
+            loop = asyncio.get_running_loop()
             try:
-                with requests.get(url, headers=headers, stream=True, timeout=60) as r:
-                    r.raise_for_status()
-                    total_size = int(r.headers.get("content-length", 0))
-                    os.makedirs(os.path.dirname(save_path), exist_ok=True)
-                    with open(tmp_path, "wb") as f:
-                        with tqdm(total=total_size, unit="iB", unit_scale=True, desc=filename) as pbar:
-                            for chunk in r.iter_content(chunk_size=1024 * 1024):
-                                if not chunk:
-                                    break
-                                size = f.write(chunk)
-                                pbar.update(size)
-                os.replace(tmp_path, save_path)
+                await loop.run_in_executor(
+                    None,
+                    self._download_file_sync,
+                    url,
+                    headers,
+                    tmp_path,
+                    save_path,
+                    key,
+                )
+                self._set_download_progress(key, status="completed")
                 logging.info("Downloaded model to %s", save_path)
                 return web.json_response({"ok": True, "path": save_path, "save_dir": save_dir, "filename": filename})
             except Exception as e:
                 logging.error("Failed to download model: %s", e)
+                self._set_download_progress(key, status="failed", error=str(e))
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
                 return web.json_response({"error": str(e)}, status=500)
+
+
+
+        @routes.get("/download_model/progress")
+        async def get_download_model_progress(request):
+            save_dir = request.rel_url.query.get("save_dir")
+            filename = request.rel_url.query.get("filename")
+            if not save_dir or not filename:
+                return web.json_response({"error": "save_dir and filename required"}, status=400)
+            key = self._download_progress_key(save_dir, filename)
+            with self._download_lock:
+                entry = dict(self._download_progress.get(key, {}))
+            if not entry and save_dir in folder_paths.folder_names_and_paths:
+                root = folder_paths.folder_names_and_paths[save_dir][0][0]
+                tmp_path = os.path.join(root, filename + ".tmp")
+                final_path = os.path.join(root, filename)
+                if os.path.isfile(final_path):
+                    size = os.path.getsize(final_path)
+                    entry = {"status": "completed", "bytes_downloaded": size, "bytes_total": size}
+                elif os.path.isfile(tmp_path):
+                    size = os.path.getsize(tmp_path)
+                    entry = {"status": "running", "bytes_downloaded": size, "bytes_total": 0}
+            bytes_total = int(entry.get("bytes_total") or 0)
+            bytes_downloaded = int(entry.get("bytes_downloaded") or 0)
+            progress = (bytes_downloaded / bytes_total) if bytes_total > 0 else 0
+            return web.json_response({
+                "status": entry.get("status", "unknown"),
+                "bytes_downloaded": bytes_downloaded,
+                "bytes_total": bytes_total,
+                "progress": progress,
+                "error": entry.get("error"),
+            })
 
 
         @routes.get("/experiment/models/preview/{folder}/{path_index}/{filename:.*}")

--- a/app/model_manager.py
+++ b/app/model_manager.py
@@ -3,6 +3,10 @@ import base64
 import json
 import time
 import logging
+import requests
+from tqdm.auto import tqdm
+from urllib.parse import unquote, urlparse
+from typing import Callable
 import folder_paths
 import glob
 import comfy.utils
@@ -13,8 +17,9 @@ from folder_paths import map_legacy, filter_files_extensions, filter_files_conte
 
 
 class ModelFileManager:
-    def __init__(self) -> None:
+    def __init__(self, is_download_model_enabled: Callable[[], bool] = lambda: True) -> None:
         self.cache: dict[str, tuple[list[dict], dict[str, float], float]] = {}
+        self.is_download_model_enabled = is_download_model_enabled
 
     def get_cache(self, key: str, default=None) -> tuple[list[dict], dict[str, float], float] | None:
         return self.cache.get(key, default)
@@ -46,6 +51,70 @@ class ModelFileManager:
                 return web.Response(status=404)
             files = self.get_model_file_list(folder)
             return web.json_response(files)
+
+
+        @routes.post("/download_model")
+        async def post_download_model(request):
+            if not self.is_download_model_enabled():
+                logging.error("Download Model endpoint is disabled")
+                return web.Response(status=403)
+
+            json_data = await request.json()
+            url = json_data.get("url")
+            if not url:
+                return web.json_response({"error": "url required"}, status=400)
+
+            save_dir = json_data.get("save_dir")
+            if save_dir not in folder_paths.folder_names_and_paths:
+                return web.json_response({"error": "invalid save_dir"}, status=400)
+
+            default_filename = unquote(urlparse(url).path.split("/")[-1].split("?")[0])
+            filename = json_data.get("filename") or default_filename
+            if not filename or filename in (".", "..") or "/" in filename or "\\" in filename:
+                return web.json_response({"error": "invalid filename"}, status=400)
+
+            allowed_sources = (
+                "https://civitai.com/",
+                "https://civitai.red/",
+                "https://huggingface.co/",
+                "https://github.com/",
+                "http://localhost:",
+            )
+            if not any(url.startswith(src) for src in allowed_sources):
+                return web.json_response({"error": "url not allowed"}, status=400)
+
+            save_root = folder_paths.folder_names_and_paths[save_dir][0][0]
+            save_path = os.path.join(save_root, filename)
+            save_real = os.path.realpath(save_path)
+            root_real = os.path.realpath(save_root)
+            if not save_real.startswith(root_real + os.sep) and save_real != root_real:
+                return web.json_response({"error": "invalid path"}, status=400)
+
+            tmp_path = save_path + ".tmp"
+            token = json_data.get("token")
+            headers = {"Authorization": f"Bearer {token}"} if token else {}
+
+            try:
+                with requests.get(url, headers=headers, stream=True, timeout=60) as r:
+                    r.raise_for_status()
+                    total_size = int(r.headers.get("content-length", 0))
+                    os.makedirs(os.path.dirname(save_path), exist_ok=True)
+                    with open(tmp_path, "wb") as f:
+                        with tqdm(total=total_size, unit="iB", unit_scale=True, desc=filename) as pbar:
+                            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                                if not chunk:
+                                    break
+                                size = f.write(chunk)
+                                pbar.update(size)
+                os.replace(tmp_path, save_path)
+                logging.info("Downloaded model to %s", save_path)
+                return web.json_response({"ok": True, "path": save_path, "save_dir": save_dir, "filename": filename})
+            except Exception as e:
+                logging.error("Failed to download model: %s", e)
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+                return web.json_response({"error": str(e)}, status=500)
+
 
         @routes.get("/experiment/models/preview/{folder}/{path_index}/{filename:.*}")
         async def get_model_preview(request):

--- a/server.py
+++ b/server.py
@@ -218,9 +218,6 @@ class PromptServer():
             return True
 
         self.model_file_manager = ModelFileManager(is_download_model_enabled=_is_model_download_enabled)
-            if hasattr(self.user_manager.settings, "get_settings")
-            else True
-        )
         self.custom_node_manager = CustomNodeManager()
         self.subgraph_manager = SubgraphManager()
         self.node_replace_manager = NodeReplaceManager()

--- a/server.py
+++ b/server.py
@@ -206,7 +206,21 @@ class PromptServer():
         PromptServer.instance = self
 
         self.user_manager = UserManager()
-        self.model_file_manager = ModelFileManager()
+        def _is_model_download_enabled():
+            settings_path = os.path.join(folder_paths.get_user_directory(), "default", "comfy.settings.json")
+            try:
+                if os.path.isfile(settings_path):
+                    with open(settings_path) as f:
+                        settings = json.load(f)
+                    return settings.get("Comfy.ModelDownloadEnabled", True)
+            except Exception:
+                pass
+            return True
+
+        self.model_file_manager = ModelFileManager(is_download_model_enabled=_is_model_download_enabled)
+            if hasattr(self.user_manager.settings, "get_settings")
+            else True
+        )
         self.custom_node_manager = CustomNodeManager()
         self.subgraph_manager = SubgraphManager()
         self.node_replace_manager = NodeReplaceManager()


### PR DESCRIPTION
## Summary

- Adds `POST /download_model` so the ComfyUI host fetches missing models (HuggingFace, Civitai, GitHub) into the correct `models/<folder>/` path instead of the client browser downloading them locally.
- Adds `GET /download_model/progress` with byte-level progress for long downloads.
- Gated by `Comfy.ModelDownloadEnabled` (defaults to enabled).

Fixes Comfy-Org/ComfyUI#13282

Related: Comfy-Org/ComfyUI#8826 — users hitting missing checkpoint validation when the model never lands on the server (e.g. remote UI sent the download to the laptop).

## Test plan

- [ ] Open ComfyUI in a browser against a remote host (Tailscale/LAN, not `localhost`).
- [ ] Load a workflow with a missing model and click **Download** / **Download All**.
- [ ] Confirm the file appears under `ComfyUI/models/<save_dir>/` on the server and **not** in the client Downloads folder.
- [ ] Confirm `/download_model/progress` reports increasing bytes for multi-GB files.
- [ ] Confirm disallowed URLs and path traversal attempts return HTTP 400.
- [ ] Confirm local Comfy Desktop sessions still use the desktop download path when appropriate.

Companion frontend PR: Comfy-Org/ComfyUI_frontend#12844