### PR TITLE
fix: catch OSError in websocket send to prevent server crash send_soc…

### DIFF
--- a/server.py
+++ b/server.py
@@ -64,7 +64,7 @@ def _remove_sensitive_from_queue(queue: list) -> list:
 async def send_socket_catch_exception(function, message):
     try:
         await function(message)
-    except (aiohttp.ClientError, aiohttp.ClientPayloadError, ConnectionResetError, BrokenPipeError, ConnectionError) as err:
+    except (aiohttp.ClientError, aiohttp.ClientPayloadError, OSError) as err:
         logging.warning("send error: {}".format(err))
 
 # Track deprecated paths that have been warned about to only warn once per file

--- a/tests-unit/server_test/test_send_socket_catch_exception.py
+++ b/tests-unit/server_test/test_send_socket_catch_exception.py
@@ -1,0 +1,38 @@
+"""Tests for server.send_socket_catch_exception.
+"""
+
+import pytest
+import utils.install_util  # noqa: F401
+from server import send_socket_catch_exception
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSendSocketCatchException:
+    """The send helper must swallow client-disconnect errors, never propagate them."""
+
+    async def test_swallows_no_route_to_host(self, caplog):
+
+        async def failing_send(_message):
+            raise OSError(113, "No route to host")
+
+        await send_socket_catch_exception(failing_send, b"payload")
+        assert "send error" in caplog.text
+
+    async def test_swallows_connection_reset(self):
+        """Existing behaviour preserved: ConnectionResetError is still caught."""
+
+        async def failing_send(_message):
+            raise ConnectionResetError("peer reset the connection")
+
+        await send_socket_catch_exception(failing_send, b"payload")
+
+    async def test_successful_send_delivers_message(self):
+        """When the send succeeds the message is passed through and nothing is logged."""
+        received = []
+
+        async def ok_send(message):
+            received.append(message)
+
+        await send_socket_catch_exception(ok_send, b"hello")
+        assert received == [b"hello"]


### PR DESCRIPTION
fix: catch OSError in websocket send to prevent server crash

  ## Summary

  Fixes #1442. A websocket client that becomes unreachable mid-generation
  could crash the entire ComfyUI server with an uncaught `OSError`.

  ## When it happens

  While a generation is running, the server pushes progress updates to
  connected clients over the websocket. If a client disappears abruptly —
  laptop sleeps, drops off WiFi/VPN, remote route breaks — the OS raises
  `OSError: [Errno 113] No route to host` (`EHOSTUNREACH`) on the next send.

  ## Root cause

  `send_socket_catch_exception` (server.py) only caught `ConnectionError`
  and its subclasses:

  ```python
  except (aiohttp.ClientError, aiohttp.ClientPayloadError,
          ConnectionResetError, BrokenPipeError, ConnectionError) as err:

  EHOSTUNREACH is raised as a plain OSError, which is the parent of
  ConnectionError and a sibling of the connection errors listed  and not a
  subclass. It therefore escaped the handler, propagated up through
  publish_loop, and took the whole server down over a single dead client.

  Fix

  Catch OSError directly. As the parent of the connection errors already
  handled, it subsumes them and additionally covers EHOSTUNREACH:

  except (aiohttp.ClientError, aiohttp.ClientPayloadError, OSError) as err:

  Testing

  Added tests-unit/server_test/test_send_socket_catch_exception.py:

  - test_swallows_no_route_to_host — reproduces #1442 (OSError(EHOSTUNREACH));
  fails before this change, passes after.
  - test_swallows_connection_reset — regression guard for the existing
  ConnectionResetError behaviour.
  - test_successful_send_delivers_message — confirms normal messages are
  still delivered (errors are swallowed, valid sends are not).

  $ python -m pytest tests-unit/server_test/test_send_socket_catch_exception.py
  3 passed

  $ python -m pytest tests-unit
  900 passed, 10 skipped