### PR TITLE
Comfy Aimdo 0.4.10 + Dynamic --reserve-vram + --vram-headroom

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -145,6 +145,7 @@ vram_group.add_argument("--novram", action="store_true", help="When lowvram isn'
 vram_group.add_argument("--cpu", action="store_true", help="To use the CPU for everything (slow).")
 
 parser.add_argument("--reserve-vram", type=float, default=None, help="Set the amount of vram in GB you want to reserve for use by your OS/other software. By default some amount is reserved depending on your OS.")
+parser.add_argument("--vram-headroom", type=float, default=0, help="Set the amount of vram in GB for DynamicVRAM to maintain as extra headroom above default. ComfyUI will try and keep this much VRAM completely free and unused, even counting VRAM from other apps.")
 
 parser.add_argument("--async-offload", nargs='?', const=2, type=int, default=None, metavar="NUM_STREAMS", help="Use async weight offloading. An optional argument controls the amount of offload streams. Default is 2. Enabled by default on Nvidia.")
 parser.add_argument("--disable-async-offload", action="store_true", help="Disable async weight offloading.")

--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ if __name__ == "__main__" and args.debug_hang:
 import comfy_aimdo.control
 
 if enables_dynamic_vram():
-    comfy_aimdo.control.init()
+    comfy_aimdo.control.init(simple_vram_headroom=None if args.reserve_vram is None else int(args.reserve_vram * 1024 ** 3))
 
 if os.name == "nt":
     os.environ['MIMALLOC_PURGE_DELAY'] = '0'

--- a/main.py
+++ b/main.py
@@ -231,7 +231,7 @@ import comfy.model_patcher
 if args.enable_dynamic_vram or (enables_dynamic_vram() and comfy.model_management.is_nvidia() and not comfy.model_management.is_wsl()):
     if (not args.enable_dynamic_vram) and (comfy.model_management.torch_version_numeric < (2, 8)):
         logging.warning("Unsupported Pytorch detected. DynamicVRAM support requires Pytorch version 2.8 or later. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
-    elif comfy_aimdo.control.init_devices(d.index for d in comfy.model_management.get_all_torch_devices()):
+    elif comfy_aimdo.control.init_devices((d.index, int(args.vram_headroom * 1024 ** 3)) for d in comfy.model_management.get_all_torch_devices()):
         if args.verbose == 'DEBUG':
             comfy_aimdo.control.set_log_debug()
         elif args.verbose == 'CRITICAL':

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy>=2.0.0
 filelock
 av>=16.0.0
 comfy-kitchen==0.2.10
-comfy-aimdo==0.4.9
+comfy-aimdo==0.4.10
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/14396

comfy-aimdo 0.4.10 implements:

1: double sync on VBAR free operations. There are still hard-to-reproduce observable de-syncs between the cuda observed free memory and the real actuals. Syncing after the fact may help and this should be reasonably cheap given that is was already synced before the free operation.

2: Implement two VRAM headroom configuration mechanisms. --reserve-vram by popular demand, and a more dynamic form --vram-headroom.

Example Test Conditions:

Linux, 5090, 96GB, LTX2.3
8GB VRAM held in use by a script
--reserve-vram 12

Before:

<img width="313" height="570" alt="image" src="https://github.com/user-attachments/assets/a26ebb10-ceef-4f3f-98e1-a076657ad0e6" />

Comfy uses more than 32 - 12GB VRAM.

```
[INFO] Prompt executed in 26.13 seconds
```

After:

<img width="313" height="570" alt="image" src="https://github.com/user-attachments/assets/36fcc4a7-d49a-425a-982f-9d62f0b99a6c" />

The 12GB headroom is usable by the display driver and the 8GB background script so roughly 3GB is unused ✅ 

```
[INFO] Prompt executed in 26.59 seconds
```

`--vram-headroom 12` (instead of `--reserve-vram`):

<img width="313" height="570" alt="image" src="https://github.com/user-attachments/assets/7b604e30-f78d-4958-910b-090c8c08f3a2" />

The 12GB headroom is absolute ✅ 

```
[INFO] Prompt executed in 32.40 seconds
```

Regression Tests:

Linux, 5090, 96GB, Ace-step turbo XL ✅ 
Linux, 5090, 96GB, stable cascade -> flux 2 ✅ 
Windows, 5060, 16GB, wan 2x14B FP8 ✅ 
