### PR TITLE
main: support fallback to aimdo 0.4.9

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,11 @@ if __name__ == "__main__" and args.debug_hang:
 import comfy_aimdo.control
 
 if enables_dynamic_vram():
-    comfy_aimdo.control.init(simple_vram_headroom=None if args.reserve_vram is None else int(args.reserve_vram * 1024 ** 3))
+    try:
+        comfy_aimdo.control.init(simple_vram_headroom=None if args.reserve_vram is None else int(args.reserve_vram * 1024 ** 3))
+    except TypeError:
+        # comfy-aimdo 0.4.9 protocol.
+        comfy_aimdo.control.init()
 
 if os.name == "nt":
     os.environ['MIMALLOC_PURGE_DELAY'] = '0'
@@ -231,23 +235,30 @@ import comfy.model_patcher
 if args.enable_dynamic_vram or (enables_dynamic_vram() and comfy.model_management.is_nvidia() and not comfy.model_management.is_wsl()):
     if (not args.enable_dynamic_vram) and (comfy.model_management.torch_version_numeric < (2, 8)):
         logging.warning("Unsupported Pytorch detected. DynamicVRAM support requires Pytorch version 2.8 or later. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
-    elif comfy_aimdo.control.init_devices((d.index, int(args.vram_headroom * 1024 ** 3)) for d in comfy.model_management.get_all_torch_devices()):
-        if args.verbose == 'DEBUG':
-            comfy_aimdo.control.set_log_debug()
-        elif args.verbose == 'CRITICAL':
-            comfy_aimdo.control.set_log_critical()
-        elif args.verbose == 'ERROR':
-            comfy_aimdo.control.set_log_error()
-        elif args.verbose == 'WARNING':
-            comfy_aimdo.control.set_log_warning()
-        else: #INFO
-            comfy_aimdo.control.set_log_info()
-
-        comfy.model_patcher.CoreModelPatcher = comfy.model_patcher.ModelPatcherDynamic
-        comfy.memory_management.aimdo_enabled = True
-        logging.info("DynamicVRAM support detected and enabled")
     else:
-        logging.warning("No working comfy-aimdo install detected. DynamicVRAM support disabled. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
+        try:
+            aimdo_initialized = comfy_aimdo.control.init_devices((d.index, int(args.vram_headroom * 1024 ** 3)) for d in comfy.model_management.get_all_torch_devices())
+        except TypeError:
+            # comfy-aimdo 0.4.9 protocol.
+            aimdo_initialized = comfy_aimdo.control.init_devices(d.index for d in comfy.model_management.get_all_torch_devices())
+
+        if aimdo_initialized:
+            if args.verbose == 'DEBUG':
+                comfy_aimdo.control.set_log_debug()
+            elif args.verbose == 'CRITICAL':
+                comfy_aimdo.control.set_log_critical()
+            elif args.verbose == 'ERROR':
+                comfy_aimdo.control.set_log_error()
+            elif args.verbose == 'WARNING':
+                comfy_aimdo.control.set_log_warning()
+            else: #INFO
+                comfy_aimdo.control.set_log_info()
+
+            comfy.model_patcher.CoreModelPatcher = comfy.model_patcher.ModelPatcherDynamic
+            comfy.memory_management.aimdo_enabled = True
+            logging.info("DynamicVRAM support detected and enabled")
+        else:
+            logging.warning("No working comfy-aimdo install detected. DynamicVRAM support disabled. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
 
 
 def cuda_malloc_warning():


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/14485
https://github.com/Comfy-Org/ComfyUI/issues/14486

The aimdo 0.4.10 protocol causing startup failure to be too early and before the aimdo version warning can happen. This causes user confusion. Limp on with 0.4.9 as it will work and users will see the version warning.

Example test conditions:

Linux, 5090, 96GB, LTX2.3
aimdo 0.4.9 downgrade

before:

```
+ /home/rattus/venv/bin/python /home/rattus/ComfyUI/main.py --listen 0.0.0.0 --base-directory /home/rattus/111-你好-comfy-básè
[INFO] setup plugin alembic.autogenerate.schemas
[INFO] setup plugin alembic.autogenerate.tables
[INFO] setup plugin alembic.autogenerate.types
[INFO] setup plugin alembic.autogenerate.constraints
[INFO] setup plugin alembic.autogenerate.defaults
[INFO] setup plugin alembic.autogenerate.comments
Traceback (most recent call last):
  File "/home/rattus/ComfyUI/main.py", line 58, in <module>
    comfy_aimdo.control.init(simple_vram_headroom=None if args.reserve_vram is None else int(args.reserve_vram * 1024 ** 3))
TypeError: init() got an unexpected keyword argument 'simple_vram_headroom'

```

after:

```
[WARNING] ________________________________________________________________________
WARNING WARNING WARNING WARNING WARNING

Installed comfy-aimdo version 0.4.9 is lower than the recommended version 0.4.10.

Please install the updated requirements.txt file by running:
/home/rattus/venv/bin/python -m pip install -r /home/rattus/ComfyUI/requirements.txt
If you are on the portable package you can run: update\update_comfyui.bat to solve this problem.
________________________________________________________________________

```

```
[INFO] Requested to load VideoVAE
[INFO] 0 models unloaded.
[INFO] Model VideoVAE prepared for dynamic VRAM loading. 1384MB Staged. 0 patches attached.
[INFO] Prompt executed in 24.26 seconds
```

regression tests:
ace-step turbo xl 1.5 ✅ 
LTX2.3 --vram-headroom 12 ✅ 
LTX2.3 --reserve-vram 12 ✅ 

whitspace diff:

```
--- a/main.py
+++ b/main.py
@@ -55,7 +55,11 @@ if __name__ == "__main__" and args.debug_hang:
 import comfy_aimdo.control
 
 if enables_dynamic_vram():
+    try:
         comfy_aimdo.control.init(simple_vram_headroom=None if args.reserve_vram is None else int(args.reserve_vram * 1024 ** 3))
+    except TypeError:
+        # comfy-aimdo 0.4.9 protocol.
+        comfy_aimdo.control.init()
 
 if os.name == "nt":
     os.environ['MIMALLOC_PURGE_DELAY'] = '0'
@@ -231,7 +235,14 @@ import comfy.model_patcher
 if args.enable_dynamic_vram or (enables_dynamic_vram() and comfy.model_management.is_nvidia() and not comfy.model_management.is_wsl()):
     if (not args.enable_dynamic_vram) and (comfy.model_management.torch_version_numeric < (2, 8)):
         logging.warning("Unsupported Pytorch detected. DynamicVRAM support requires Pytorch version 2.8 or later. Falling back to legacy ModelPatcher. VRAM estimates may be unreliable especially on Windows")
-    elif comfy_aimdo.control.init_devices((d.index, int(args.vram_headroom * 1024 ** 3)) for d in comfy.model_management.get_all_torch_devices()):
+    else:
+        try:
+            aimdo_initialized = comfy_aimdo.control.init_devices((d.index, int(args.vram_headroom * 1024 ** 3)) for d in comfy.model_management.get_all_torch_devices())
+        except TypeError:
+            # comfy-aimdo 0.4.9 protocol.
+            aimdo_initialized = comfy_aimdo.control.init_devices(d.index for d in comfy.model_management.get_all_torch_devices())
+
+        if aimdo_initialized:
             if args.verbose == 'DEBUG':
                 comfy_aimdo.control.set_log_debug()
             elif args.verbose == 'CRITICAL':

```
