### PR TITLE
Fix odd-height crash and edge bleed in unaligned-width image/video decode

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -325,21 +325,25 @@ class VideoFromFile(VideoInput):
                             checked_alpha = True
 
                         # Fix non-deterministic video decode when the video width is not a multiple of 32
-                        # For non-yuvj pixel formats (all H.264/H.265 video)
+                        # For non-yuvj pixel formats: most H.264/H.265 video and static images (e.g. lossy WebP via LoadImage)
+                        # Pad both axes to a multiple of 32 and smear the border so the alignment padding never bleeds into the cropped edges
                         if image_format in ('gbrpf32le', 'gbrapf32le') and frame.width % 32 != 0:
                             if align_graph is None:
                                 pad_w = ((frame.width + 31) // 32) * 32
+                                pad_h = ((frame.height + 31) // 32) * 32
                                 g = av.filter.Graph()
                                 g_src = g.add_buffer(width=frame.width, height=frame.height,
                                                      format=frame.format.name, time_base=video_stream.time_base)
-                                g_pad = g.add('pad', f'{pad_w}:{frame.height}:0:0')
+                                g_pad = g.add('pad', f'{pad_w}:{pad_h}:0:0')
+                                g_fill = g.add('fillborders', f'left=0:right={pad_w - frame.width}:top=0:bottom={pad_h - frame.height}:mode=smear')
                                 g_sink = g.add('buffersink')
                                 g_src.link_to(g_pad)
-                                g_pad.link_to(g_sink)
+                                g_pad.link_to(g_fill)
+                                g_fill.link_to(g_sink)
                                 g.configure()
                                 align_graph = (g, g_src, g_sink)
                             align_graph[1].push(frame)
-                            img = np.ascontiguousarray(align_graph[2].pull().to_ndarray(format=image_format)[:, :frame.width])
+                            img = np.ascontiguousarray(align_graph[2].pull().to_ndarray(format=image_format)[:frame.height, :frame.width])
                         else:
                             img = frame.to_ndarray(format=image_format)
                         if frame.rotation != 0:


### PR DESCRIPTION
## Summary

- `LoadImage`/`LoadVideo` crash when decoding a chroma-subsampled image whose width is not a multiple of 32 and whose height is odd (a lossy WebP, the common case).
- The same merged change also bleeds black into the right edge of every unaligned-width subsampled decode.
- Fix: pad both axes to a multiple of 32 and edge-replicate the padding (`fillborders` smear) before converting, then crop both axes back.

**Evidence and one-step reproduction**, the repro inputs, stock-node workflows, the before/after figure, the verbatim ComfyUI outputs, and the full crash traceback are all in [this gist](https://gist.github.com/pollockjj/f56712d0841c417800a78b8f6dfdc031).

## Why

The merged width-alignment change (#14438) fixed nondeterministic left-edge corruption at non-32-aligned widths by padding the width to the next multiple of 32 with libav's `pad` filter, converting, and cropping back. It leaves the pad target **height** equal to the source height. The `pad` filter requires the target height to be a multiple of the input's vertical chroma subsampling factor, so a chroma-subsampled input (`yuv420p`, the format the `gbrpf32le` float branch decodes) with an **odd height** makes the filter round the target below the input and fail to configure. `LoadImage` routes static images through `VideoFromFile(...).get_components()`, and a lossy WebP decodes to `yuv420p`, so a lossy WebP with unaligned width and odd height crashes the node. Reported as #14483.

Verbatim crash from a stock-node `Load Image` run on the merged code ([workflow_crash.json](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/workflow_crash.json) on [input_crash_200x199.webp](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/input_crash_200x199.webp)):

```
  File "comfy_api/latest/_input_impl/video_types.py", line 339, in get_components_internal
    g.configure()
av.error.ArgumentError: Invalid argument returned 22
[ERROR] Padded dimensions cannot be smaller than input dimensions.
```

Full traceback: [master_crash_traceback.txt](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/master_crash_traceback.txt).

## Solutions tried

| Approach | Result |
|---|---|
| **(1)** Round pad **height up to even**, crop both axes, the fix recommended in the bug report | Fixes `yuv420p`/`yuv422p`, but still **crashes `yuv410p`** (vertical subsampling factor 4): an even target is not a multiple of 4, so the filter still rounds below the input. |
| **(2)** Pad **both axes to a multiple of 32** with the default (black) `pad` fill | Fixes the crash for every format, but `pad` fills the border with black and chroma upsampling **bleeds black into the right and bottom edges** of the cropped output. |
| **(3), chosen** | Pad **both axes to a multiple of 32**, then `fillborders mode=smear`, crop both. 32 is a multiple of every real vertical subsampling factor (covers `yuv410p`); `fillborders` smear replicates the real edge into the alignment padding, so nothing bleeds. |

## Examples

Pixel-level zoom of the decoded right edge, verbatim ComfyUI output of [workflow_bleed.json](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/workflow_bleed.json) on [input_bleed_200x200.webp](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/input_bleed_200x200.webp) (rightmost 8x8 decoded pixels, nearest, each source pixel a 64px block). The merged code bleeds the rightmost column toward black `(64,162,207)`; the fix keeps it at the interior value `(39,170,230)`:

![before/after pixel zoom: merged right-edge bleed vs fix clean](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/bleed_before_after.png)

The odd-height input that crashes on the merged code decodes correctly on this branch:

<img src="https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/out_fix_crash_loaded.png" width="22%"/>

## What changed

One file (`comfy_api/latest/_input_impl/video_types.py`), the float-branch alignment path only:

```python
pad_w = ((frame.width + 31) // 32) * 32
pad_h = ((frame.height + 31) // 32) * 32
...
g_pad = g.add('pad', f'{pad_w}:{pad_h}:0:0')
g_fill = g.add('fillborders', f'left=0:right={pad_w - frame.width}:top=0:bottom={pad_h - frame.height}:mode=smear')
...
img = np.ascontiguousarray(align_graph[2].pull().to_ndarray(format=image_format)[:frame.height, :frame.width])
```

Blast radius: 32-aligned widths and all uint8 paths run the identical `to_ndarray` call as before and are byte-identical to master; only unaligned-width subsampled inputs take the new path, going from crash / corruption / edge-bleed to a clean, deterministic decode.

## Validation

Tri-state sweep across the 19 pixel formats that reach the `gbrpf32le`/`gbrapf32le` float branch x 15 diagonal cases (each N×N for N = 97..111, so every width residue 1-15 and every height parity / mod-4 residue), each state classified against an artifact-free ground truth (pad both axes to a multiple of 64, `fillborders` smear, crop).

**Per-state totals (285 cases = 19 formats x 15 cases):**

| State | fatal | corrupted | clean |
|---|---|---|---|
| pre-change (direct `to_ndarray`) | 0 | 192 | 93 |
| merged width-pad (black) | 52 | 48 | 185 |
| **this fix (smear)** | **0** | **0** | **285** |

**This fix, every case clean.** Column k (1-15) is the (96+k)×(96+k) diagonal case (so k=1 is 97×97 to k=15 is 111×111); ✅ means the decoded output is byte-identical to the artifact-free reference:

| format | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| `yuv420p` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv422p` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv444p` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv410p` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv411p` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv440p` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv420p10le` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv422p10le` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv444p10le` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv420p12le` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuv444p12le` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuva420p` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `yuva444p` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `gray` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `gray16le` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `gbrp` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `gbrap` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `gbrp10le` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| `gbrp16le` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

Aligned-width and uint8 paths byte-identical to master; output deterministic across separate processes; metamorphically stable (pad-32, pad-64, pad-128 byte-identical).

## Reproduce

[reproduce.py](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/reproduce.py) generates the two inputs; drop them in `input/` and run [workflow_bleed.json](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/workflow_bleed.json) and [workflow_crash.json](https://gist.githubusercontent.com/pollockjj/f56712d0841c417800a78b8f6dfdc031/raw/da016039af21cbcd210c26e92c02639e6bebdc72/workflow_crash.json) (stock nodes only: `LoadImage` -> `ImageCrop`/`ImageScale` -> `SaveImage`). On master the crash workflow fails with the traceback above and the bleed workflow's rightmost column is off-color; on this branch both decode cleanly. Everything is in [the gist](https://gist.github.com/pollockjj/f56712d0841c417800a78b8f6dfdc031).

## Tracking

Fixes #14483.

Linear: https://linear.app/comfyorg/issue/CORE-299/loadvideo-decodes-non-32-aligned-width-video-nondeterministically
