### PR TITLE
Fix get_filename_list crash when a cached model folder is deleted

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -412,7 +412,12 @@ def cached_filename_list_(folder_name: str) -> tuple[list[str], dict[str, float]
     for x in out[1]:
         time_modified = out[1][x]
         folder = x
-        if os.path.getmtime(folder) != time_modified:
+        try:
+            if os.path.getmtime(folder) != time_modified:
+                return None
+        except OSError:
+            # A tracked folder was deleted or became inaccessible; treat the
+            # cache as stale so it gets rebuilt instead of raising.
             return None
 
     folders = folder_names_and_paths[folder_name]

--- a/tests-unit/folder_paths_test/cache_invalidation_test.py
+++ b/tests-unit/folder_paths_test/cache_invalidation_test.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+import tempfile
+
+import pytest
+
+import folder_paths
+
+
+@pytest.fixture
+def model_folder():
+    """Register a temporary model category with a tracked subfolder."""
+    folder_name = "cache_invalidation_test_cat"
+    with tempfile.TemporaryDirectory() as base:
+        category = os.path.join(base, "category")
+        subfolder = os.path.join(category, "sub")
+        os.makedirs(subfolder)
+        open(os.path.join(category, "a.safetensors"), "w").close()
+        open(os.path.join(subfolder, "b.safetensors"), "w").close()
+
+        folder_paths.folder_names_and_paths[folder_name] = (
+            [category],
+            {".safetensors"},
+        )
+        try:
+            yield folder_name, category, subfolder
+        finally:
+            folder_paths.folder_names_and_paths.pop(folder_name, None)
+            folder_paths.filename_list_cache.pop(folder_name, None)
+            folder_paths.cache_helper.clear()
+
+
+def test_rebuilds_when_tracked_subfolder_deleted(model_folder):
+    folder_name, _category, subfolder = model_folder
+
+    # Populate the filename cache, which records the mtime of every subfolder.
+    initial = folder_paths.get_filename_list(folder_name)
+    assert sorted(initial) == ["a.safetensors", "sub/b.safetensors"]
+
+    # Remove a tracked subfolder at runtime (e.g. user deletes a model folder).
+    shutil.rmtree(subfolder)
+
+    # The cache must be treated as stale and rebuilt, not crash with
+    # FileNotFoundError when probing the deleted folder's mtime.
+    refreshed = folder_paths.get_filename_list(folder_name)
+    assert refreshed == ["a.safetensors"]


### PR DESCRIPTION
### Bug

`get_filename_list()` crashes with `FileNotFoundError` when a model
folder that was present at cache-build time is deleted while ComfyUI is
running.

`cached_filename_list_()` validates the cache by comparing the stored
mtime of every directory recorded during the previous scan
(`recursive_search` records each subfolder's mtime, not just the
top-level roots). It does this with a bare `os.path.getmtime(folder)`.
If any tracked folder has since been removed, `getmtime()` raises
`FileNotFoundError`, which propagates out of `get_filename_list()` and
breaks model listing for that category — instead of just invalidating
the stale cache and rebuilding it.

Repro:

```python
import os, shutil, tempfile, folder_paths

base = tempfile.mkdtemp()
cat = os.path.join(base, "category"); sub = os.path.join(cat, "sub")
os.makedirs(sub)
open(os.path.join(cat, "a.safetensors"), "w").close()
open(os.path.join(sub, "b.safetensors"), "w").close()
folder_paths.folder_names_and_paths["demo"] = ([cat], {".safetensors"})

folder_paths.get_filename_list("demo")   # builds cache, records sub/ mtime
shutil.rmtree(sub)                         # folder removed at runtime
folder_paths.get_filename_list("demo")   # -> FileNotFoundError
```

### Fix

Treat an inaccessible tracked folder as a stale-cache signal: catch
`OSError` around the `getmtime` probe and return `None`, so the cache is
rebuilt rather than raising. This mirrors the existing behaviour when a
folder's mtime simply changed.

### Verification

```
$ python -m pytest tests-unit/folder_paths_test/ -v
...
35 passed in 0.14s
```

The suite includes a new regression test
(`tests-unit/folder_paths_test/cache_invalidation_test.py`) that builds
the cache, deletes a tracked subfolder, and asserts the next
`get_filename_list()` call rebuilds successfully instead of crashing. It
fails on `master` and passes with this change.
