### PR TITLE
[Partner Nodes] chore(SoniloTextToMusic): reduce price by half

### DIFF
--- a/comfy_api_nodes/nodes_sonilo.py
+++ b/comfy_api_nodes/nodes_sonilo.py
@@ -100,8 +100,7 @@ class SoniloTextToMusic(IO.ComfyNode):
             node_id="SoniloTextToMusic",
             display_name="Sonilo Text to Music",
             category="partner/audio/Sonilo",
-            description="Generate music from a text prompt using Sonilo's AI model. "
-            "Leave duration at 0 to let the model infer it from the prompt.",
+            description="Generate music from a text prompt using Sonilo's AI model.",
             inputs=[
                 IO.String.Input(
                     "prompt",
@@ -135,13 +134,7 @@ class SoniloTextToMusic(IO.ComfyNode):
             is_api_node=True,
             price_badge=IO.PriceBadge(
                 depends_on=IO.PriceBadgeDepends(widgets=["duration"]),
-                expr="""
-                (
-                  widgets.duration > 0
-                    ? {"type":"usd","usd": 0.005 * widgets.duration}
-                    : {"type":"usd","usd": 0.005, "format":{"suffix":"/second"}}
-                )
-                """,
+                expr='{"type":"usd","usd": 0.0025 * widgets.duration}',
             ),
         )
 


### PR DESCRIPTION
Subj.  Lets cut the value in price badge in half. Also now we can simplify price badge as `duration` always have the `>0` value.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [x] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

