### PR TITLE
Gate static pin_memory on pin budgets (fixes AMD/ROCm large-model load stall, #13730)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1574,7 +1574,8 @@ def pin_memory(tensor):
 
     size = tensor.nbytes
     comfy.memory_management.extra_ram_release(comfy.memory_management.RAM_CACHE_HEADROOM)
-    ensure_pin_registerable(size)
+    if not ensure_pin_budget(size) or not ensure_pin_registerable(size):
+        return False
 
     ptr = tensor.data_ptr()
     if ptr == 0:

--- a/tests-unit/comfy_test/model_management_test.py
+++ b/tests-unit/comfy_test/model_management_test.py
@@ -1,0 +1,85 @@
+from unittest import mock
+
+import pytest
+import torch
+
+import comfy.model_management as model_management
+
+
+class Tensor:
+    device = torch.device("cpu")
+    nbytes = 4096
+
+    def is_pinned(self):
+        return False
+
+    def is_contiguous(self):
+        return True
+
+    def data_ptr(self):
+        return 0x13730
+
+
+class CudaRuntime:
+    def __init__(self):
+        self.register_calls = []
+
+    def cudaHostRegister(self, ptr, size, flags):
+        self.register_calls.append((ptr, size, flags))
+        return 0
+
+
+def run_pin(budget, registerable):
+    runtime = CudaRuntime()
+    tensor = Tensor()
+    with (
+        mock.patch.object(model_management, "MAX_PINNED_MEMORY", 8192),
+        mock.patch.object(model_management, "PINNED_MEMORY", {}),
+        mock.patch.object(model_management, "TOTAL_PINNED_MEMORY", 0),
+        mock.patch.object(model_management, "ensure_pin_budget", return_value=budget) as budget_check,
+        mock.patch.object(model_management, "ensure_pin_registerable", return_value=registerable) as registerable_check,
+        mock.patch.object(model_management.comfy.memory_management, "extra_ram_release"),
+        mock.patch.object(torch.cuda, "cudart", return_value=runtime),
+    ):
+        result = model_management.pin_memory(tensor)
+        pinned = dict(model_management.PINNED_MEMORY)
+        total = model_management.TOTAL_PINNED_MEMORY
+    return result, runtime.register_calls, pinned, total, budget_check, registerable_check
+
+
+@pytest.mark.parametrize(
+    ("budget", "registerable", "expected_result", "expected_calls"),
+    [
+        (False, True, False, []),
+        (True, False, False, []),
+        (True, True, True, [(0x13730, Tensor.nbytes, 1)]),
+    ],
+)
+def test_static_pin_respects_budgets(budget, registerable, expected_result, expected_calls):
+    result, calls, pinned, total, budget_check, registerable_check = run_pin(budget, registerable)
+
+    assert result is expected_result
+    assert calls == expected_calls
+    assert pinned == ({0x13730: Tensor.nbytes} if expected_result else {})
+    assert total == (Tensor.nbytes if expected_result else 0)
+    budget_check.assert_called_once_with(Tensor.nbytes)
+    if budget:
+        registerable_check.assert_called_once_with(Tensor.nbytes)
+    else:
+        registerable_check.assert_not_called()
+
+
+def test_high_ram_only_bypasses_ram_pressure_budget():
+    with (
+        mock.patch.object(model_management.args, "high_ram", True),
+        mock.patch.object(model_management, "free_pins") as free_pins,
+    ):
+        assert model_management.ensure_pin_budget(Tensor.nbytes) is True
+        free_pins.assert_not_called()
+
+    result, calls, pinned, total, _, registerable_check = run_pin(True, False)
+    assert result is False
+    assert calls == []
+    assert pinned == {}
+    assert total == 0
+    registerable_check.assert_called_once_with(Tensor.nbytes)


### PR DESCRIPTION
## Overview

Fixes #13730. On AMD/ROCm, a clean LTX-2.3 launch can stall at `Requested to load LTXAV` while host
RAM and swap fill. This is host-side pinned-memory exhaustion, not VRAM pressure.

## Root cause

The static `pin_memory()` path calls `ensure_pin_registerable()` but ignores its return value, and it
does not call `ensure_pin_budget()` before `cudaHostRegister`. During partial model loading it can keep
registering offloaded weights after current host-RAM pressure says to stop.

## Change

Honor both existing budget helpers before registering. If either helper rejects the allocation,
`pin_memory()` returns `False` and the tensor remains in pageable RAM.

```python
-    ensure_pin_registerable(size)
+    if not ensure_pin_budget(size) or not ensure_pin_registerable(size):
+        return False
```

The product change is `+2/-1` in `comfy/model_management.py`. The second file adds focused regression
tests for RAM-budget rejection, registration-budget rejection, successful registration/accounting,
and the `--high-ram` contract.

## Validation

Validated on current `master` (`e651b7be`) with a digest-pinned ROCm 7.2.1 / PyTorch 2.9.1 container
on an RX 7900 GRE (gfx1100), 30 GiB host:

- focused regression on unmodified master: `4 failed`;
- focused regression with this change: `4 passed`;
- full candidate unit suite: `1117 passed, 10 skipped`;
- Ruff and `git diff --check`: pass.

For a clean default LTX-2.3 load, unmodified master reached the 1.2 GiB safety floor before LTX load
completion. The candidate crossed the LTX load boundary. Direct sampling of ComfyUI's own
`TOTAL_PINNED_MEMORY` measured a 2.860 GiB baseline peak versus 1.845 GiB for the candidate while it
completed the load.

An official-template-derived first-stage workflow (checkpoint + Gemma + distilled LoRA, AV nested
latents, and eight Euler denoise steps) completed for baseline and candidate at three loads:

| Video latent load | Result |
|---|---|
| 512x288x17 | both completed |
| 640x352x33 | both completed |
| 768x416x49 | both completed |

Each A/B pair produced byte-identical latent output. Across load sizes and reversed order there was no
consistent performance-regression direction; the static registration gate is not in the denoise loop.

## Parameter boundaries

- `--disable-pinned-memory` remains a no-op control for this change.
- `--fast-disk` uses the global pin cap instead of current host-RAM pressure.
- `--high-ram` intentionally bypasses the host-RAM pressure budget, but still honors the registration
    cap added by this gate.
- DynamicVRAM uses AIMDO's separate path; a valid DynamicVRAM A/B showed no static-gate effect.

This PR does not claim to fix separate long-running LoRA/VBAR lifecycle issues, AIMDO hook failures,
or unrelated DynamicVRAM segfault reports.

---

AI usage disclosure: this change was prepared with AI assistance; a human reviewed and verified it and
can explain every line.
