### PR TITLE
feat: add enable_telemetry CLI feature flag

### DIFF
--- a/comfy_api/feature_flags.py
+++ b/comfy_api/feature_flags.py
@@ -25,6 +25,11 @@ CLI_FEATURE_FLAG_REGISTRY: dict[str, FeatureFlagInfo] = {
         "default": False,
         "description": "Show the sign-in button in the frontend even when not signed in",
     },
+    "enable_telemetry": {
+        "type": "bool",
+        "default": False,
+        "description": "Signal the frontend that telemetry collection is enabled",
+    },
 }
 
 


### PR DESCRIPTION
Adds an `enable_telemetry` flag to `CLI_FEATURE_FLAG_REGISTRY` (bool, default `False`), mirroring `show_signin_button`. Launchers can set it via `--feature-flag enable_telemetry=true` to signal the frontend that telemetry collection is enabled; it ships to the frontend over the WS capability handshake and is discoverable via `--list-feature-flags`. Default off means nothing changes unless a launcher opts in.

Paired with Comfy-Desktop launcher support (Comfy-Org/Comfy-Desktop) that only sets the flag for opted-in standalone installs.

Ref: Comfy-Org/Comfy-Desktop#1142