### PR TITLE
chore: Replace deprecated save audio nodes

### DIFF
--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -161,6 +161,7 @@ class SaveAudioAdvanced(IO.ComfyNode):
             display_name="Save Audio",
             description="Saves the input audio to your ComfyUI output directory.",
             category="audio",
+            essentials_category="Audio",
             inputs=[
                 IO.Audio.Input("audio", tooltip="The audio to save."),
                 IO.String.Input(

--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -152,105 +152,13 @@ class VAEDecodeAudioTiled(IO.ComfyNode):
         return IO.NodeOutput(vae_decode_audio(vae, samples, tile_size, overlap))
 
 
-class SaveAudio(IO.ComfyNode):
-    @classmethod
-    def define_schema(cls):
-        return IO.Schema(
-            node_id="SaveAudio",
-            search_aliases=["export flac"],
-            display_name="Save Audio (FLAC) (Deprecated)",
-            category="audio",
-            essentials_category="Audio",
-            inputs=[
-                IO.Audio.Input("audio"),
-                IO.String.Input("filename_prefix", default="audio/ComfyUI"),
-            ],
-            hidden=[IO.Hidden.prompt, IO.Hidden.extra_pnginfo],
-            is_output_node=True,
-            is_deprecated=True,
-        )
-
-    @classmethod
-    def execute(cls, audio, filename_prefix="ComfyUI", format="flac") -> IO.NodeOutput:
-        if audio is None:
-            raise ValueError("SaveAudio: input audio is None (source video may have no audio track).")
-        return IO.NodeOutput(
-            ui=UI.AudioSaveHelper.get_save_audio_ui(audio, filename_prefix=filename_prefix, cls=cls, format=format)
-        )
-
-    save_flac = execute  # TODO: remove
-
-
-class SaveAudioMP3(IO.ComfyNode):
-    @classmethod
-    def define_schema(cls):
-        return IO.Schema(
-            node_id="SaveAudioMP3",
-            search_aliases=["export mp3"],
-            display_name="Save Audio (MP3) (Deprecated)",
-            category="audio",
-            essentials_category="Audio",
-            inputs=[
-                IO.Audio.Input("audio"),
-                IO.String.Input("filename_prefix", default="audio/ComfyUI"),
-                IO.Combo.Input("quality", options=["V0", "128k", "320k"], default="V0"),
-            ],
-            hidden=[IO.Hidden.prompt, IO.Hidden.extra_pnginfo],
-            is_output_node=True,
-            is_deprecated=True,
-        )
-
-    @classmethod
-    def execute(cls, audio, filename_prefix="ComfyUI", format="mp3", quality="128k") -> IO.NodeOutput:
-        if audio is None:
-            raise ValueError("SaveAudioMP3: input audio is None (source video may have no audio track).")
-        return IO.NodeOutput(
-            ui=UI.AudioSaveHelper.get_save_audio_ui(
-                audio, filename_prefix=filename_prefix, cls=cls, format=format, quality=quality
-            )
-        )
-
-    save_mp3 = execute  # TODO: remove
-
-
-class SaveAudioOpus(IO.ComfyNode):
-    @classmethod
-    def define_schema(cls):
-        return IO.Schema(
-            node_id="SaveAudioOpus",
-            search_aliases=["export opus"],
-            display_name="Save Audio (Opus) (Deprecated)",
-            category="audio",
-            inputs=[
-                IO.Audio.Input("audio"),
-                IO.String.Input("filename_prefix", default="audio/ComfyUI"),
-                IO.Combo.Input("quality", options=["64k", "96k", "128k", "192k", "320k"], default="128k"),
-            ],
-            hidden=[IO.Hidden.prompt, IO.Hidden.extra_pnginfo],
-            is_output_node=True,
-            is_deprecated=True,
-        )
-
-    @classmethod
-    def execute(cls, audio, filename_prefix="ComfyUI", format="opus", quality="V3") -> IO.NodeOutput:
-        if audio is None:
-            raise ValueError("SaveAudioOpus: input audio is None (source video may have no audio track).")
-        return IO.NodeOutput(
-            ui=UI.AudioSaveHelper.get_save_audio_ui(
-                audio, filename_prefix=filename_prefix, cls=cls, format=format, quality=quality
-            )
-        )
-
-    save_opus = execute  # TODO: remove
-
-
 class SaveAudioAdvanced(IO.ComfyNode):
     @classmethod
     def define_schema(cls):
         return IO.Schema(
             node_id="SaveAudioAdvanced",
             search_aliases=["save audio", "export audio", "output audio", "write audio", "flac", "mp3", "opus"],
-            display_name="Save Audio (Advanced)",
+            display_name="Save Audio",
             description="Saves the input audio to your ComfyUI output directory.",
             category="audio",
             inputs=[
@@ -870,9 +778,6 @@ class AudioExtension(ComfyExtension):
             VAEEncodeAudio,
             VAEDecodeAudio,
             VAEDecodeAudioTiled,
-            SaveAudio,
-            SaveAudioMP3,
-            SaveAudioOpus,
             SaveAudioAdvanced,
             LoadAudio,
             PreviewAudio,

--- a/comfy_extras/nodes_replacements.py
+++ b/comfy_extras/nodes_replacements.py
@@ -5,14 +5,17 @@ api = ComfyAPI()
 
 async def register_replacements():
     """Register all built-in node replacements."""
-    await register_replacements_longeredge()
     await register_replacements_batchimages()
-    await register_replacements_upscaleimage()
+    await register_replacements_conditioningavg()
     await register_replacements_controlnet()
     await register_replacements_load3d()
+    await register_replacements_longeredge()
     await register_replacements_preview3d()
+    await register_replacements_saveaudio()
+    await register_replacements_saveaudiomp3()
+    await register_replacements_saveaudioopus()
     await register_replacements_svdimg2vid()
-    await register_replacements_conditioningavg()
+    await register_replacements_upscaleimage()
 
 async def register_replacements_longeredge():
     # No dynamic inputs here
@@ -90,6 +93,39 @@ async def register_replacements_conditioningavg():
     await api.node_replacement.register(io.NodeReplace(
             new_node_id="ConditioningAverage",
             old_node_id="ConditioningAverage ",
+        ))
+
+async def register_replacements_saveaudio():
+    # Replace deprecated node SaveAudio
+    await api.node_replacement.register(io.NodeReplace(
+            new_node_id="SaveAudioAdvanced",
+            old_node_id="SaveAudio",
+            input_mapping=[
+                {"new_id": "audio", "old_id": "audio"},
+                {"new_id": "format", "set_value": "flac"}
+            ]
+        ))
+
+async def register_replacements_saveaudiomp3():
+    # Replace deprecated node SaveAudioMP3
+    await api.node_replacement.register(io.NodeReplace(
+            new_node_id="SaveAudioAdvanced",
+            old_node_id="SaveAudioMP3",
+            input_mapping=[
+                {"new_id": "audio", "old_id": "audio"},
+                {"new_id": "format", "set_value": "mp3"}
+            ]
+        ))
+
+async def register_replacements_saveaudioopus():
+    # Replace deprecated node SaveAudioOpus
+    await api.node_replacement.register(io.NodeReplace(
+            new_node_id="SaveAudioAdvanced",
+            old_node_id="SaveAudioOpus",
+            input_mapping=[
+                {"new_id": "audio", "old_id": "audio"},
+                {"new_id": "format", "set_value": "opus"}
+            ]
         ))
 
 class NodeReplacementsExtension(ComfyExtension):


### PR DESCRIPTION
This PR does two things

- Replace the deprecated nodes `Save Audio (FLAC)`, `Save Audio (MP3)`, `Save Audio (Opus)` by the latest node `Save Audio (Advanced)`. 
- Rename `Save Audio (Advanced)` into `Save Audio`

Before replacement:

<img width="1726" height="925" alt="{DE8BFA20-4F26-4918-9355-A64154468A68}" src="https://github.com/user-attachments/assets/c7ec7517-5268-4d38-970d-edd4041da96e" />

After replacement:

<img width="1726" height="925" alt="{A8AB585A-8E47-44B8-ACA8-3C8B9D99F972}" src="https://github.com/user-attachments/assets/22e62316-8e04-4daa-b72b-9e41edeebb06" />
