### PR TITLE
model_management: guard None real_model in is_dead/cleanup_models

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -767,7 +767,8 @@ class LoadedModel:
             self._patcher_finalizer.detach()
 
     def is_dead(self):
-        return self.real_model() is not None and self.model is None
+        rm = self.real_model
+        return rm is not None and rm() is not None and self.model is None
 
 
 def use_more_memory(extra_memory, loaded_models, device):
@@ -990,12 +991,15 @@ def archive_model_dtypes(model):
 def cleanup_models():
     to_delete = []
     for i in range(len(current_loaded_models)):
-        if current_loaded_models[i].real_model() is None:
-            to_delete = [i] + to_delete
+        rm = current_loaded_models[i].real_model
+        if rm is not None and rm() is None:
+            to_delete.append(current_loaded_models[i])
 
-    for i in to_delete:
-        x = current_loaded_models.pop(i)
-        del x
+    for lm in to_delete:
+        for idx in range(len(current_loaded_models) - 1, -1, -1):
+            if current_loaded_models[idx] is lm:
+                current_loaded_models.pop(idx)
+                break
 
 def dtype_size(dtype):
     dtype_size = 4


### PR DESCRIPTION
### Summary
`LoadedModel.real_model` is the plain `None` from `__init__` and only becomes a `weakref`
after `model_load()`. `is_dead()` and `cleanup_models()` call `real_model()` unconditionally,
so an entry seen before/around `model_load()` makes `real_model()` a `None()` call.

### Tracebacks (unedited master)

```
File "comfy/model_management.py", in is_dead
    return self.real_model() is not None and self.model is None
TypeError: 'NoneType' object is not callable
```

```
File "comfy/model_management.py", in cleanup_models
    if current_loaded_models[i].real_model() is None:
TypeError: 'NoneType' object is not callable
```

`is_dead()` is reached from `cleanup_models_gc()` at the top of `free_memory()` /
`load_models_gpu()`; `cleanup_models()` also runs as a `weakref` finalizer.

### Change
Guard `real_model` before calling it in `is_dead()` and `cleanup_models()`, and in
`cleanup_models()` remove entries by identity over a snapshot so a reentrant finalizer pop
cannot stale the index.

### Test
Reproduced single-threaded against unedited `master`: a pre-`model_load` entry in
`current_loaded_models` makes `cleanup_models_gc()` / `is_dead()` and `cleanup_models()` raise
the `TypeError`; with this change both return cleanly, and reverting the hunk restores the crash.

> Companion to #14409 (the `free_memory` list race in the same issue). These
> `real_model is None` faces were reported by @j2gg0s alongside that race.

Relates to #14365

---

*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*
