### PR TITLE
Fix /view Content-Disposition headers

### DIFF
--- a/api_server/utils/http_headers.py
+++ b/api_server/utils/http_headers.py
@@ -1,0 +1,19 @@
+import os
+from urllib.parse import quote
+
+
+def content_disposition_for_file(filename: str, disposition_type: str = "inline") -> str:
+    filename = filename.replace("\r", "_").replace("\n", "_")
+    if filename.isascii():
+        fallback_filename = filename
+    else:
+        _, ext = os.path.splitext(filename)
+        fallback_filename = f"download{ext}" if ext.isascii() else "download"
+
+    escaped_filename = fallback_filename.replace("\\", "\\\\").replace('"', '\\"')
+    header = f'{disposition_type}; filename="{escaped_filename}"'
+
+    if fallback_filename != filename:
+        header += f"; filename*=UTF-8''{quote(filename, safe='')}"
+
+    return header

--- a/server.py
+++ b/server.py
@@ -47,6 +47,7 @@ from app.subgraph_manager import SubgraphManager
 from app.node_replace_manager import NodeReplaceManager
 from typing import Optional, Union
 from api_server.routes.internal.internal_routes import InternalRoutes
+from api_server.utils.http_headers import content_disposition_for_file
 from protocol import BinaryEventTypes
 
 # Import cache control middleware
@@ -561,7 +562,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": content_disposition_for_file(filename, "inline")})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -581,7 +582,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": content_disposition_for_file(filename, "inline")})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -598,7 +599,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": content_disposition_for_file(filename, "inline")})
                     else:
                         # Use the content type from asset resolution if available,
                         # otherwise guess from the filename.
@@ -608,14 +609,17 @@ class PromptServer():
                             or 'application/octet-stream'
                         )
 
+                        disposition_type = "inline"
+
                         # For security, force certain mimetypes to download instead of display
                         if content_type in {'text/html', 'text/html-sandboxed', 'application/xhtml+xml', 'text/javascript', 'text/css'}:
                             content_type = 'application/octet-stream'  # Forces download
+                            disposition_type = "attachment"
 
                         return web.FileResponse(
                             file,
                             headers={
-                                "Content-Disposition": f"filename=\"{filename}\"",
+                                "Content-Disposition": content_disposition_for_file(filename, disposition_type),
                                 "Content-Type": content_type
                             }
                         )

--- a/tests-unit/server_test/test_http_headers.py
+++ b/tests-unit/server_test/test_http_headers.py
@@ -1,0 +1,32 @@
+from aiohttp.multipart import parse_content_disposition
+
+from api_server.utils.http_headers import content_disposition_for_file
+
+
+def test_content_disposition_for_file_adds_inline_type_by_default():
+    header = content_disposition_for_file("vace14b_00003.mp4")
+
+    disposition_type, params = parse_content_disposition(header)
+
+    assert header == 'inline; filename="vace14b_00003.mp4"'
+    assert disposition_type == "inline"
+    assert params == {"filename": "vace14b_00003.mp4"}
+
+
+def test_content_disposition_for_file_supports_attachment():
+    header = content_disposition_for_file("download me.png", "attachment")
+
+    disposition_type, params = parse_content_disposition(header)
+
+    assert disposition_type == "attachment"
+    assert params == {"filename": "download me.png"}
+
+
+def test_content_disposition_for_file_adds_utf8_filename_parameter():
+    header = content_disposition_for_file("八月のスーベニア.MP3")
+
+    disposition_type, params = parse_content_disposition(header)
+
+    assert disposition_type == "inline"
+    assert params["filename"] == "download.MP3"
+    assert params["filename*"] == "八月のスーベニア.MP3"


### PR DESCRIPTION
## Summary

Refs #8914.

`/view` currently returns `Content-Disposition` values like `filename="name.ext"`, which strict parsers reject because the disposition type is missing. This formats those headers as valid `inline; filename="..."` values by default so browser image-opening behavior is preserved, while keeping `attachment` for the mimetypes the endpoint already forces to download.

This intentionally avoids the `attachment`-for-every-response behavior from #13093, which was reverted in #13733 because it broke the existing Open Image workflow.

## Changes

- Add a shared formatter for valid `Content-Disposition` values, including quoted fallback filenames and `filename*` for UTF-8 filenames.
- Use it for all `/view` response branches.
- Add unit coverage for inline, attachment, and UTF-8 filename handling with `aiohttp`'s parser.

## Testing

- `uv run --with 'aiohttp>=3.11.8' python - <<'PY' ... PY`
- `uv run --with 'aiohttp>=3.11.8' --with pytest pytest tests-unit/server_test/test_http_headers.py -q`
- `uv run --with ruff ruff check api_server/utils/http_headers.py tests-unit/server_test/test_http_headers.py server.py`
- `python -m py_compile server.py api_server/utils/http_headers.py`
- `git diff --check`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.
