### PR TITLE
harden: load training-dataset shards with weights_only=True

### DIFF
--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -1583,7 +1583,7 @@ class LoadTrainingDataset(io.ComfyNode):
             shard_path = os.path.join(dataset_dir, shard_file)
 
             with open(shard_path, "rb") as f:
-                shard_data = torch.load(f)
+                shard_data = torch.load(f, weights_only=True)
 
             all_latents.extend(shard_data["latents"])
             all_conditioning.extend(shard_data["conditioning"])


### PR DESCRIPTION
## What
`LoadTrainingDataset` loads dataset shards with `torch.load(f)` — the only `torch.load` call in the repo without `weights_only=True`. This adds the flag, matching every other call site (`comfy/utils.py:155`, `comfy/sd1_clip.py:455`).

## Why
Defense-in-depth: on PyTorch < 2.6 (where `weights_only` defaults to `False`) a crafted `.pkl` shard could execute pickle code on load. Recent PyTorch already defaults to `weights_only=True`, so current installs are protected — this just makes the safe behavior explicit and covers older pins, consistent with how every other `torch.load` in the codebase is already called.

## Compatibility
Verified a typical shard (latents + standard `[tensor, {"pooled_output": tensor}]` conditioning) round-trips cleanly under `weights_only=True`.
