### PR TITLE
Downgrade the template to 0.10.2 to bring the HH1.1 templates back

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.45.19
-comfyui-workflow-templates==0.10.3
+comfyui-workflow-templates==0.10.2
 comfyui-embedded-docs==0.5.5
 torch
 torchsde


### PR DESCRIPTION
In 0.10.3, I hid the HH1.1 templates. Since #14611 has already been merged, it’s safe to downgrade the template package back to 0.10.2 to restore the HH1.1 templates.

<img width="2560" height="1800" alt="image" src="https://github.com/user-attachments/assets/4c45101a-986a-4104-891d-0b58e39f3c6b" />
