### PR TITLE
[Partner Nodes] feat(ByteDance): add Seedance 2.0 Mini model

### DIFF
--- a/comfy_api_nodes/apis/bytedance.py
+++ b/comfy_api_nodes/apis/bytedance.py
@@ -177,6 +177,10 @@ SEEDANCE2_PRICE_PER_1K_TOKENS = {
     ("dreamina-seedance-2-0-fast-260128", True, "480p"): 0.0033,
     ("dreamina-seedance-2-0-fast-260128", False, "720p"): 0.0056,
     ("dreamina-seedance-2-0-fast-260128", True, "720p"): 0.0033,
+    ("dreamina-seedance-2-0-mini", False, "480p"): 0.0035,
+    ("dreamina-seedance-2-0-mini", True, "480p"): 0.0019,
+    ("dreamina-seedance-2-0-mini", False, "720p"): 0.0035,
+    ("dreamina-seedance-2-0-mini", True, "720p"): 0.0019,
 }
 
 
@@ -275,6 +279,10 @@ SEEDANCE2_REF_VIDEO_PIXEL_LIMITS = {
         "1080p": {"min": 409_600, "max": 2_073_600},
     },
     "dreamina-seedance-2-0-fast-260128": {
+        "480p": {"min": 409_600, "max": 927_408},
+        "720p": {"min": 409_600, "max": 927_408},
+    },
+    "dreamina-seedance-2-0-mini": {
         "480p": {"min": 409_600, "max": 927_408},
         "720p": {"min": 409_600, "max": 927_408},
     },

--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -89,6 +89,7 @@ BYTEPLUS_SEEDANCE2_TASK_STATUS_ENDPOINT = "/proxy/byteplus-seedance2/api/v3/cont
 SEEDANCE_MODELS = {
     "Seedance 2.0": "dreamina-seedance-2-0-260128",
     "Seedance 2.0 Fast": "dreamina-seedance-2-0-fast-260128",
+    "Seedance 2.0 Mini": "dreamina-seedance-2-0-mini",
 }
 
 DEPRECATED_MODELS = {"seedance-1-0-lite-t2v-250428", "seedance-1-0-lite-i2v-250428"}
@@ -1623,8 +1624,10 @@ class ByteDance2TextToVideoNode(IO.ComfyNode):
                     options=[
                         IO.DynamicCombo.Option("Seedance 2.0", _seedance2_text_inputs(["480p", "720p", "1080p", "4k"])),
                         IO.DynamicCombo.Option("Seedance 2.0 Fast", _seedance2_text_inputs(["480p", "720p"])),
+                        IO.DynamicCombo.Option("Seedance 2.0 Mini", _seedance2_text_inputs(["480p", "720p"])),
                     ],
-                    tooltip="Seedance 2.0 for maximum quality; Seedance 2.0 Fast for speed optimization.",
+                    tooltip="Seedance 2.0 for maximum quality; Seedance 2.0 Fast for speed optimization; "
+                    "Seedance 2.0 Mini for the lowest cost.",
                 ),
                 IO.Int.Input(
                     "seed",
@@ -1664,7 +1667,8 @@ class ByteDance2TextToVideoNode(IO.ComfyNode):
                   $m := widgets.model;
                   $res := $lookup(widgets, "model.resolution");
                   $dur := $lookup(widgets, "model.duration");
-                  $pricePer1K := $res = "4k"    ? 0.00572 :
+                  $pricePer1K := $contains($m, "Mini") ? 0.005005 :
+                                 $res = "4k"    ? 0.00572 :
                                  $res = "1080p" ? 0.011011 :
                                  $contains($m, "fast") ? 0.008008 : 0.01001;
                   $rate := $res = "4k"    ? $rate4k :
@@ -1734,8 +1738,13 @@ class ByteDance2FirstLastFrameNode(IO.ComfyNode):
                             "Seedance 2.0 Fast",
                             _seedance2_text_inputs(["480p", "720p"], default_ratio="adaptive"),
                         ),
+                        IO.DynamicCombo.Option(
+                            "Seedance 2.0 Mini",
+                            _seedance2_text_inputs(["480p", "720p"], default_ratio="adaptive"),
+                        ),
                     ],
-                    tooltip="Seedance 2.0 for maximum quality; Seedance 2.0 Fast for speed optimization.",
+                    tooltip="Seedance 2.0 for maximum quality; Seedance 2.0 Fast for speed optimization; "
+                    "Seedance 2.0 Mini for the lowest cost.",
                 ),
                 IO.Image.Input(
                     "first_frame",
@@ -1799,7 +1808,8 @@ class ByteDance2FirstLastFrameNode(IO.ComfyNode):
                   $m := widgets.model;
                   $res := $lookup(widgets, "model.resolution");
                   $dur := $lookup(widgets, "model.duration");
-                  $pricePer1K := $res = "4k"    ? 0.00572 :
+                  $pricePer1K := $contains($m, "Mini") ? 0.005005 :
+                                 $res = "4k"    ? 0.00572 :
                                  $res = "1080p" ? 0.011011 :
                                  $contains($m, "fast") ? 0.008008 : 0.01001;
                   $rate := $res = "4k"    ? $rate4k :
@@ -2024,8 +2034,13 @@ class ByteDance2ReferenceNode(IO.ComfyNode):
                             "Seedance 2.0 Fast",
                             _seedance2_reference_inputs(["480p", "720p"], default_ratio="adaptive"),
                         ),
+                        IO.DynamicCombo.Option(
+                            "Seedance 2.0 Mini",
+                            _seedance2_reference_inputs(["480p", "720p"], default_ratio="adaptive"),
+                        ),
                     ],
-                    tooltip="Seedance 2.0 for maximum quality; Seedance 2.0 Fast for speed optimization.",
+                    tooltip="Seedance 2.0 for maximum quality; Seedance 2.0 Fast for speed optimization; "
+                    "Seedance 2.0 Mini for the lowest cost.",
                 ),
                 IO.Int.Input(
                     "seed",
@@ -2069,10 +2084,12 @@ class ByteDance2ReferenceNode(IO.ComfyNode):
                   $hasVideo := $lookup(inputGroups, "model.reference_videos") > 0;
                   $res := $lookup(widgets, "model.resolution");
                   $dur := $lookup(widgets, "model.duration");
-                  $noVideoPricePer1K := $res = "4k"    ? 0.00572 :
+                  $noVideoPricePer1K := $contains($m, "Mini") ? 0.005005 :
+                                        $res = "4k"    ? 0.00572 :
                                         $res = "1080p" ? 0.011011 :
                                         $contains($m, "fast") ? 0.008008 : 0.01001;
-                  $videoPricePer1K := $res = "4k"    ? 0.003432 :
+                  $videoPricePer1K := $contains($m, "Mini") ? 0.002717 :
+                                      $res = "4k"    ? 0.003432 :
                                       $res = "1080p" ? 0.006721 :
                                       $contains($m, "fast") ? 0.004719 : 0.006149;
                   $rate := $res = "4k"    ? $rate4k :
@@ -2080,7 +2097,7 @@ class ByteDance2ReferenceNode(IO.ComfyNode):
                            $res = "720p"  ? $rate720 :
                                             $rate480;
                   $noVideoCost := $dur * $rate * $noVideoPricePer1K / 1000;
-                  $minVideoFactor := $ceil($dur * 5 / 3);
+                  $minVideoFactor := $contains($m, "Mini") ? (3 + $dur) : $ceil($dur * 5 / 3);
                   $minVideoCost := $minVideoFactor * $rate * $videoPricePer1K / 1000;
                   $maxVideoCost := (15 + $dur) * $rate * $videoPricePer1K / 1000;
                   $hasVideo


### PR DESCRIPTION
Adds **Seedance 2.0 Mini** (`dreamina-seedance-2-0-mini`) as a model option on the Seedance 2.0 Text-to-Video, First-Last-Frame, and Reference nodes. Mini supports 480p and 720p.

Closing this PR; superseded.


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

