### PR TITLE
Fix FP8 activation quantization for >2D activations in mixed_precision_ops

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -1235,7 +1235,7 @@ def mixed_precision_ops(quant_config={}, compute_dtype=torch.bfloat16, full_prec
                 run_every_op()
 
                 input_shape = input.shape
-                reshaped_3d = False
+                reshaped_nd = False
                 #If cast needs to apply lora, it should be done in the compute dtype
                 compute_dtype = input.dtype
 
@@ -1272,12 +1272,12 @@ def mixed_precision_ops(quant_config={}, compute_dtype=torch.bfloat16, full_prec
                 # Inference path (unchanged)
                 if _use_quantized and quantize_input:
 
-                    # Reshape 3D tensors to 2D for quantization (needed for NVFP4 and others)
-                    input_reshaped = input.reshape(-1, input_shape[2]) if input.ndim == 3 else input
+                    # Reshape >=3D tensors to 2D for quantization (needed for NVFP4 and others)
+                    input_reshaped = input.reshape(-1, input_shape[-1]) if input.ndim >= 3 else input
 
                     # Fall back to non-quantized for non-2D tensors
                     if input_reshaped.ndim == 2:
-                        reshaped_3d = input.ndim == 3
+                        reshaped_nd = input.ndim >= 3
                         # dtype is now implicit in the layout class
                         scale = getattr(self, 'input_scale', None)
                         if scale is not None:
@@ -1292,9 +1292,9 @@ def mixed_precision_ops(quant_config={}, compute_dtype=torch.bfloat16, full_prec
                     weight_only_quant=weight_only_quant,
                 )
 
-                # Reshape output back to 3D if input was 3D
-                if reshaped_3d:
-                    output = output.reshape((input_shape[0], input_shape[1], self.weight.shape[0]))
+                # Reshape output back to original rank if input was >2D
+                if reshaped_nd:
+                    output = output.reshape((*input_shape[:-1], self.weight.shape[0]))
 
                 return output
 


### PR DESCRIPTION
## Fix FP8 activation quantization fall-through for >2D activations in `mixed_precision_ops`

### Problem
With a fully-quantized FP8 checkpoint and `--fast fp8_matrix_mult`, only the
attention GEMMs (QKV / output proj) run in FP8 while the MLP GEMMs (up / down
proj) fall back to bf16. Since MLP is roughly half of the compute, the measured
FP8 speedup is far below expectation (~15%). Reported and root-caused by @TaihoC
in #14595 (Anima checkpoint).

### Root cause
In `mixed_precision_ops(...)` `Linear.forward` (`comfy/ops.py`), input activations
are only quantized when they are 2D, or 3D (reshaped to 2D):

```python
input_reshaped = input.reshape(-1, input_shape[2]) if input.ndim == 3 else input
if input_reshaped.ndim == 2:
    ...
    input = QuantizedTensor.from_float(input_reshaped, self.layout_type, scale=scale)
```

Models whose Linear inputs have rank >= 4 (e.g. Anima's MLP activations, which are
not reshaped to 3D the way the attention path is) never enter the `ndim == 2`
branch, so `QuantizedTensor.from_float` is never called. The activation reaches
`scaled_mm` as bf16 and a bf16 kernel is dispatched silently (`reshaped_3d` is
pre-initialised to `False`, so there is no error — just a silent fallback).

### Fix
Generalize the existing 3D->2D reshape to any rank >= 3 (flatten all leading dims,
keep the contraction dim), and reshape the output back to the original leading
dims:

- `input.ndim == 3` -> `input.ndim >= 3`, `input_shape[2]` -> `input_shape[-1]`
- output reshape `(input_shape[0], input_shape[1], out)` -> `(*input_shape[:-1], out)`

Backward compatible: 2D and 3D inputs are handled exactly as before; only rank >= 4
inputs change behavior (now quantized instead of silently skipped).

### Notes on quantization semantics
Flattening leading dims is the same operation the code already performs for 3D
(it flattens `B,T`). For per-tensor FP8 and the block formats currently in use
(MXFP8 / NVFP4 block along the last / contraction dim, which the reshape
preserves), the meaning of quantization is unchanged. This matches the safer,
more general of the two directions discussed in the issue.

### Verification
The shape logic was verified with a standalone script (no FP8 hardware required):
4D inputs now take the quantize branch and the output shape/values round-trip
correctly, while 2D/3D behavior is unchanged. I do not have an FP8 GPU to measure
end-to-end kernel dispatch; reviewers with an FP8 device can confirm the MLP GEMMs
now dispatch as FP8 using the trace method in the issue.

Closes #14595.