### PR TITLE
Add show_version_updates CLI feature flag

### DIFF
--- a/comfy_api/feature_flags.py
+++ b/comfy_api/feature_flags.py
@@ -30,6 +30,11 @@ CLI_FEATURE_FLAG_REGISTRY: dict[str, FeatureFlagInfo] = {
         "default": False,
         "description": "Signal the frontend that telemetry collection is enabled",
     },
+    "show_version_updates": {
+        "type": "bool",
+        "default": True,
+        "description": "Default for whether the frontend shows new-release/version-update notifications (the user setting can still override it)",
+    },
 }
 
 

--- a/comfy_api/feature_flags.py
+++ b/comfy_api/feature_flags.py
@@ -32,7 +32,7 @@ CLI_FEATURE_FLAG_REGISTRY: dict[str, FeatureFlagInfo] = {
     },
     "show_version_updates": {
         "type": "bool",
-        "default": True,
+        "default": False,
         "description": "Default for whether the frontend shows new-release/version-update notifications (the user setting can still override it)",
     },
 }


### PR DESCRIPTION
Registers a `show_version_updates` bool feature flag (default `false`) in `CLI_FEATURE_FLAG_REGISTRY`.

This lets a launcher discover the flag via `--list-feature-flags` and set it via `--feature-flag show_version_updates=<bool>`, which propagates into `SERVER_FEATURE_FLAGS` and is sent to the frontend. The frontend uses it to seed the default of its `Comfy.Notification.ShowVersionUpdates` setting (the user setting still overrides).

Default `false`: a plain ComfyUI run advertises the flag as off, so the frontend's in-app new-release / version-update notifications stay off by default on local installs. A launcher (or `--feature-flag show_version_updates=true`) can turn them on.

Part of a 3-repo change for Comfy-Org/Comfy-Desktop#1194:
- Comfy-Org/ComfyUI (this PR) — register the flag
- Comfy-Org/ComfyUI_frontend#13171 — gate the notifications on the setting / read the flag as its default
- Comfy-Org/Comfy-Desktop#1205 — inject the flag from a settings toggle