### PR TITLE
[Experimental] Micro MVP

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -37,6 +37,7 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("--listen", type=str, default="127.0.0.1", metavar="IP", nargs="?", const="0.0.0.0,::", help="Specify the IP address to listen on (default: 127.0.0.1). You can give a list of ip addresses by separating them with a comma like: 127.2.2.2,127.3.3.3 If --listen is provided without an argument, it defaults to 0.0.0.0,:: (listens on all ipv4 and ipv6)")
 parser.add_argument("--port", type=int, default=8188, help="Set the listen port.")
+parser.add_argument("--micro-worker-url", type=str, default=None, help="Set the Micro Substrate worker endpoint. Defaults to this server's loopback /micro/execute route.")
 parser.add_argument("--tls-keyfile", type=str, help="Path to TLS (SSL) key file. Enables TLS, makes app accessible at https://... requires --tls-certfile to function")
 parser.add_argument("--tls-certfile", type=str, help="Path to TLS (SSL) certificate file. Enables TLS, makes app accessible at https://... requires --tls-keyfile to function")
 parser.add_argument("--enable-cors-header", type=str, default=None, metavar="ORIGIN", nargs="?", const="*", help="Enable CORS (Cross-Origin Resource Sharing) with optional origin or allow all with default '*'.")
@@ -266,6 +267,10 @@ if args.force_fp16:
 # '--enable-manager-legacy-ui' is meaningless unless the manager is enabled, so imply '--enable-manager'.
 if args.enable_manager_legacy_ui:
     args.enable_manager = True
+
+if args.micro_worker_url is None:
+    scheme = "https" if args.tls_keyfile and args.tls_certfile else "http"
+    args.micro_worker_url = f"{scheme}://127.0.0.1:{args.port}/micro/execute"
 
 
 # '--fast' is not provided, use an empty set

--- a/comfy/micro/__init__.py
+++ b/comfy/micro/__init__.py
@@ -1,0 +1,1 @@
+"""Micro substrate wire-format helpers."""

--- a/comfy/micro/codec.py
+++ b/comfy/micro/codec.py
@@ -1,0 +1,63 @@
+from io import BytesIO
+
+import numpy as np
+import torch
+
+
+SUPPORTED_TYPES = frozenset({"IMAGE", "MASK"})
+
+
+def _tensor_to_bytes(arr: torch.Tensor) -> bytes:
+    buffer = BytesIO()
+    np.save(buffer, arr.detach().cpu().numpy(), allow_pickle=False)
+    return buffer.getvalue()
+
+
+def _bytes_to_tensor(data: bytes) -> torch.Tensor:
+    buffer = BytesIO(data)
+    arr = np.load(buffer, allow_pickle=False)
+    return torch.from_numpy(arr)
+
+
+def encode_image(arr: torch.Tensor) -> bytes:
+    """Encode a ComfyUI IMAGE tensor [N,H,W,3] fp16/fp32 to bytes."""
+
+    return _tensor_to_bytes(arr)
+
+
+def decode_image(data: bytes) -> torch.Tensor:
+    """Inverse of encode_image."""
+
+    return _bytes_to_tensor(data)
+
+
+def encode_mask(arr: torch.Tensor) -> bytes:
+    """Encode a ComfyUI MASK tensor to bytes."""
+
+    return _tensor_to_bytes(arr)
+
+
+def decode_mask(data: bytes) -> torch.Tensor:
+    """Inverse of encode_mask."""
+
+    return _bytes_to_tensor(data)
+
+
+def supports_type(type_name: str) -> bool:
+    return type_name in SUPPORTED_TYPES
+
+
+def encode(type_name: str, value) -> bytes:
+    if type_name == "IMAGE":
+        return encode_image(value)
+    if type_name == "MASK":
+        return encode_mask(value)
+    raise ValueError(f"unsupported micro type {type_name!r}")
+
+
+def decode(type_name: str, data: bytes):
+    if type_name == "IMAGE":
+        return decode_image(data)
+    if type_name == "MASK":
+        return decode_mask(data)
+    raise ValueError(f"unsupported micro type {type_name!r}")

--- a/comfy/micro/demo_workflow.json
+++ b/comfy/micro/demo_workflow.json
@@ -1,0 +1,49 @@
+{
+  "1": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "micro_demo_input.png"
+    }
+  },
+  "2": {
+    "class_type": "ToMicro_IMAGE",
+    "inputs": {
+      "image": [
+        "1",
+        0
+      ]
+    }
+  },
+  "3": {
+    "class_type": "Micro_ScaleImage",
+    "inputs": {
+      "image": [
+        "2",
+        0
+      ],
+      "upscale_method": "lanczos",
+      "width": 48,
+      "height": 32,
+      "crop": "disabled"
+    }
+  },
+  "4": {
+    "class_type": "FromMicro_IMAGE",
+    "inputs": {
+      "value": [
+        "3",
+        0
+      ]
+    }
+  },
+  "5": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": [
+        "4",
+        0
+      ],
+      "filename_prefix": "micro_demo"
+    }
+  }
+}

--- a/comfy/micro/envelope.py
+++ b/comfy/micro/envelope.py
@@ -1,0 +1,168 @@
+import base64
+from collections.abc import Mapping
+
+from . import codec
+from .wire import BytesPayload, MicroValue
+
+
+PROTOCOL_VERSION = 1
+
+
+class ProtocolError(ValueError):
+    pass
+
+
+def build_micro_payload(value: MicroValue) -> dict:
+    payload_bytes = value.payload.as_bytes()
+    return {
+        "kind": "bytes",
+        "compression": "none",
+        "data_b64": base64.b64encode(payload_bytes).decode("ascii"),
+    }
+
+
+def parse_micro_payload(d: Mapping) -> BytesPayload:
+    if not isinstance(d, Mapping):
+        raise ProtocolError("payload must be an object")
+
+    kind = d.get("kind")
+    if kind == "bytes":
+        return _parse_bytes_payload(d)
+    raise ProtocolError(f"unknown payload.kind {kind!r}")
+
+
+def _parse_bytes_payload(d: Mapping) -> BytesPayload:
+    compression = d.get("compression")
+    if compression == "none":
+        data_b64 = d.get("data_b64")
+        if not isinstance(data_b64, str):
+            raise ProtocolError("payload.data_b64 must be a string")
+        try:
+            return BytesPayload(base64.b64decode(data_b64.encode("ascii"), validate=True))
+        except Exception as exc:
+            raise ProtocolError("payload.data_b64 is not valid base64") from exc
+    raise ProtocolError(f"unknown payload.compression {compression!r}")
+
+
+def build_micro_value(value: MicroValue) -> dict:
+    return {
+        "_micro": True,
+        "type": value.type_name,
+        "payload": build_micro_payload(value),
+    }
+
+
+def parse_micro_value(d: Mapping) -> MicroValue:
+    if not isinstance(d, Mapping):
+        raise ProtocolError("micro value must be an object")
+    if d.get("_micro") is not True:
+        raise ProtocolError("micro value missing _micro discriminator")
+
+    type_name = d.get("type")
+    if not isinstance(type_name, str):
+        raise ProtocolError("micro value type must be a string")
+
+    payload = parse_micro_payload(d.get("payload"))
+    return MicroValue(type_name, payload)
+
+
+def materialize_micro_value(value: MicroValue):
+    try:
+        return codec.decode(value.type_name, value.payload.as_bytes())
+    except ValueError as exc:
+        raise ProtocolError(str(exc)) from exc
+
+
+def build_request(node_id: str, inputs: dict) -> dict:
+    if not isinstance(node_id, str) or not node_id:
+        raise ProtocolError("node_id must be a non-empty string")
+
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "node_id": node_id,
+        "inputs": {name: _build_value(value) for name, value in inputs.items()},
+    }
+
+
+def parse_request(body: Mapping, *, materialize: bool = False) -> dict:
+    _check_protocol_version(body)
+
+    inputs = body.get("inputs")
+    if not isinstance(inputs, Mapping):
+        raise ProtocolError("inputs must be an object")
+
+    return {name: _parse_value(value, materialize=materialize) for name, value in inputs.items()}
+
+
+def build_response(output_names, result, output_types=None) -> dict:
+    values = _normalize_result(result)
+    if len(output_names) != len(values):
+        raise ProtocolError("output name count does not match result count")
+    if output_types is not None and len(output_types) != len(values):
+        raise ProtocolError("output type count does not match result count")
+
+    outputs = {}
+    for index, name in enumerate(output_names):
+        output_type = None if output_types is None else output_types[index]
+        outputs[name] = _build_output_value(values[index], output_type)
+
+    return {"ok": True, "outputs": outputs}
+
+
+def parse_response(body: Mapping) -> dict:
+    if not isinstance(body, Mapping):
+        raise ProtocolError("response must be an object")
+    if body.get("ok") is not True:
+        raise ProtocolError("response is not an ok micro response")
+
+    outputs = body.get("outputs")
+    if not isinstance(outputs, Mapping):
+        raise ProtocolError("outputs must be an object")
+
+    return {name: _parse_value(value, materialize=False) for name, value in outputs.items()}
+
+
+def _check_protocol_version(body: Mapping) -> None:
+    if not isinstance(body, Mapping):
+        raise ProtocolError("request must be an object")
+    version = body.get("protocol_version")
+    if version != PROTOCOL_VERSION:
+        raise ProtocolError(f"unsupported protocol_version {version}")
+
+
+def _build_value(value):
+    if isinstance(value, MicroValue):
+        return build_micro_value(value)
+    return value
+
+
+def _parse_value(value, *, materialize: bool):
+    if isinstance(value, Mapping):
+        if value.get("_micro") is True:
+            micro_value = parse_micro_value(value)
+            if materialize:
+                return materialize_micro_value(micro_value)
+            return micro_value
+        raise ProtocolError("objects must use the _micro discriminator")
+    return value
+
+
+def _build_output_value(value, output_type):
+    if isinstance(value, MicroValue):
+        return build_micro_value(value)
+    if output_type is not None and codec.supports_type(output_type):
+        return build_micro_value(MicroValue(output_type, BytesPayload(codec.encode(output_type, value))))
+    return value
+
+
+def _normalize_result(result) -> tuple:
+    if isinstance(result, dict):
+        if "result" in result:
+            result = result["result"]
+        else:
+            raise ProtocolError("node result dict missing result key")
+    if isinstance(result, tuple):
+        return result
+    if isinstance(result, list):
+        return tuple(result)
+    return (result,)

--- a/comfy/micro/runtime.py
+++ b/comfy/micro/runtime.py
@@ -1,0 +1,46 @@
+import json
+import logging
+import urllib.error
+import urllib.request
+
+from comfy.cli_args import args
+
+from . import envelope
+
+
+class MicroExecutionError(RuntimeError):
+    pass
+
+
+def call_micro_node(node_id: str, inputs: dict) -> dict:
+    """Invoke a registered Micro node body via the configured worker."""
+
+    request_body = envelope.build_request(node_id, inputs)
+    logging.info("[micro] POST %s node_id=%s", args.micro_worker_url, node_id)
+    response_body = _post_json(args.micro_worker_url, request_body)
+
+    if response_body.get("ok") is False:
+        error = response_body.get("error", {})
+        kind = error.get("kind", "micro_error")
+        message = error.get("message", "micro worker returned an error")
+        raise MicroExecutionError(f"{kind}: {message}")
+
+    return envelope.parse_response(response_body)
+
+
+def _post_json(url: str, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise MicroExecutionError(f"micro worker HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise MicroExecutionError(f"micro worker request failed: {exc}") from exc

--- a/comfy/micro/server.py
+++ b/comfy/micro/server.py
@@ -1,0 +1,94 @@
+import logging
+import traceback
+
+from aiohttp import web
+
+from . import envelope
+
+
+_MICRO_TO_NATIVE = {}
+_REGISTERED_ROUTE_TABLES = set()
+
+
+def register_micro_nodes(mapping: dict[str, str]) -> None:
+    _MICRO_TO_NATIVE.update(mapping)
+
+
+def register_routes(prompt_server=None) -> bool:
+    if prompt_server is None:
+        import server
+
+        prompt_server = getattr(server.PromptServer, "instance", None)
+        if prompt_server is None:
+            return False
+
+    route_table_id = id(prompt_server.routes)
+    if route_table_id in _REGISTERED_ROUTE_TABLES:
+        return False
+
+    prompt_server.routes.post("/micro/execute")(micro_execute)
+    _REGISTERED_ROUTE_TABLES.add(route_table_id)
+    logging.info("[micro] registered POST /micro/execute")
+    return True
+
+
+async def micro_execute(request):
+    try:
+        body = await request.json()
+    except Exception as exc:
+        return _error_response("protocol_error", f"invalid JSON body: {exc}")
+
+    try:
+        inputs = envelope.parse_request(body, materialize=True)
+        node_id = _parse_node_id(body)
+    except envelope.ProtocolError as exc:
+        return _error_response("protocol_error", str(exc))
+
+    logging.info("[micro] handling /micro/execute node_id=%s", node_id)
+    node_cls = _get_node_class(node_id)
+    if node_cls is None:
+        return _error_response("unknown_node", f"no registered node for {node_id}")
+
+    try:
+        instance = node_cls()
+        result = getattr(instance, node_cls.FUNCTION)(**inputs)
+        response = _build_success_response(node_id, node_cls, result)
+        return web.json_response(response)
+    except Exception as exc:
+        return _error_response("node_error", str(exc), traceback.format_exc())
+
+
+def _parse_node_id(body) -> str:
+    node_id = body.get("node_id")
+    if not isinstance(node_id, str) or not node_id:
+        raise envelope.ProtocolError("node_id must be a non-empty string")
+    return node_id
+
+
+def _get_node_class(node_id: str):
+    import nodes
+
+    native_node_id = _MICRO_TO_NATIVE.get(node_id, node_id)
+    return nodes.NODE_CLASS_MAPPINGS.get(native_node_id)
+
+
+def _build_success_response(node_id: str, node_cls, result) -> dict:
+    import nodes
+
+    wire_node_cls = nodes.NODE_CLASS_MAPPINGS.get(node_id)
+    output_names = getattr(wire_node_cls, "RETURN_NAMES", None) if wire_node_cls is not None else None
+    if output_names is None:
+        output_names = getattr(node_cls, "RETURN_NAMES", node_cls.RETURN_TYPES)
+
+    return envelope.build_response(output_names, result, output_types=node_cls.RETURN_TYPES)
+
+
+def _error_response(kind: str, message: str, tb: str = ""):
+    return web.json_response({
+        "ok": False,
+        "error": {
+            "kind": kind,
+            "message": message,
+            "traceback": tb,
+        },
+    })

--- a/comfy/micro/wire.py
+++ b/comfy/micro/wire.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MicroPayload(Protocol):
+    """A wire payload that can materialize itself as bytes."""
+
+    def as_bytes(self) -> bytes:
+        ...
+
+
+@dataclass(frozen=True)
+class BytesPayload:
+    """The only payload implementation in v1."""
+
+    data: bytes
+
+    def as_bytes(self) -> bytes:
+        return self.data
+
+
+@dataclass(frozen=True)
+class MicroValue:
+    """A graph value in wire form."""
+
+    type_name: str
+    payload: MicroPayload

--- a/comfy_extras/nodes_micro.py
+++ b/comfy_extras/nodes_micro.py
@@ -1,0 +1,113 @@
+import nodes
+
+from comfy.micro import codec
+from comfy.micro.runtime import call_micro_node
+from comfy.micro.server import register_micro_nodes, register_routes
+from comfy.micro.wire import BytesPayload, MicroValue
+
+
+class ToMicro_IMAGE:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"image": ("IMAGE",)}}
+
+    RETURN_TYPES = ("Micro_IMAGE",)
+    RETURN_NAMES = ("value",)
+    FUNCTION = "to_micro"
+    CATEGORY = "micro"
+
+    def to_micro(self, image):
+        return (MicroValue("IMAGE", BytesPayload(codec.encode_image(image))),)
+
+
+class FromMicro_IMAGE:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("Micro_IMAGE",)}}
+
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("image",)
+    FUNCTION = "from_micro"
+    CATEGORY = "micro"
+
+    def from_micro(self, value):
+        if value.type_name != "IMAGE":
+            raise ValueError(f"expected MicroValue type IMAGE, got {value.type_name!r}")
+        return (codec.decode_image(value.payload.as_bytes()),)
+
+
+class ToMicro_MASK:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"mask": ("MASK",)}}
+
+    RETURN_TYPES = ("Micro_MASK",)
+    RETURN_NAMES = ("value",)
+    FUNCTION = "to_micro"
+    CATEGORY = "micro"
+
+    def to_micro(self, mask):
+        return (MicroValue("MASK", BytesPayload(codec.encode_mask(mask))),)
+
+
+class FromMicro_MASK:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("Micro_MASK",)}}
+
+    RETURN_TYPES = ("MASK",)
+    RETURN_NAMES = ("mask",)
+    FUNCTION = "from_micro"
+    CATEGORY = "micro"
+
+    def from_micro(self, value):
+        if value.type_name != "MASK":
+            raise ValueError(f"expected MicroValue type MASK, got {value.type_name!r}")
+        return (codec.decode_mask(value.payload.as_bytes()),)
+
+
+class Micro_ScaleImage:
+    @classmethod
+    def INPUT_TYPES(cls):
+        required = dict(nodes.ImageScale.INPUT_TYPES()["required"])
+        required["image"] = ("Micro_IMAGE",)
+        return {"required": required}
+
+    RETURN_TYPES = ("Micro_IMAGE",)
+    RETURN_NAMES = ("image",)
+    FUNCTION = "scale"
+    CATEGORY = "micro/image"
+
+    def scale(self, image, upscale_method, width, height, crop):
+        result = call_micro_node("Micro_ScaleImage", {
+            "image": image,
+            "upscale_method": upscale_method,
+            "width": width,
+            "height": height,
+            "crop": crop,
+        })
+        return (result["image"],)
+
+
+MICRO_TO_NATIVE = {
+    "Micro_ScaleImage": "ImageScale",
+}
+
+NODE_CLASS_MAPPINGS = {
+    "ToMicro_IMAGE": ToMicro_IMAGE,
+    "FromMicro_IMAGE": FromMicro_IMAGE,
+    "ToMicro_MASK": ToMicro_MASK,
+    "FromMicro_MASK": FromMicro_MASK,
+    "Micro_ScaleImage": Micro_ScaleImage,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "ToMicro_IMAGE": "To Micro Image",
+    "FromMicro_IMAGE": "From Micro Image",
+    "ToMicro_MASK": "To Micro Mask",
+    "FromMicro_MASK": "From Micro Mask",
+    "Micro_ScaleImage": "Micro Scale Image",
+}
+
+register_micro_nodes(MICRO_TO_NATIVE)
+register_routes()

--- a/nodes.py
+++ b/nodes.py
@@ -2372,6 +2372,7 @@ async def init_builtin_extra_nodes():
         "nodes_model_advanced.py",
         "nodes_model_downscale.py",
         "nodes_images.py",
+        "nodes_micro.py",
         "nodes_video_model.py",
         "nodes_ideogram4.py",
         "nodes_bounding_boxes.py",

--- a/tests/run_demo.py
+++ b/tests/run_demo.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+import argparse
+import contextlib
+import hashlib
+import json
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from PIL import Image
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO_WORKFLOW = REPO_ROOT / "comfy" / "micro" / "demo_workflow.json"
+DEMO_INPUT_NAME = "micro_demo_input.png"
+
+
+class ServerProcess:
+    def __init__(self, name: str, port: int, input_dir: Path, output_dir: Path, temp_dir: Path, db_path: Path, log_path: Path, micro_worker_url: str | None = None):
+        self.name = name
+        self.port = port
+        self.input_dir = input_dir
+        self.output_dir = output_dir
+        self.temp_dir = temp_dir
+        self.db_path = db_path
+        self.log_path = log_path
+        self.micro_worker_url = micro_worker_url
+        self._log_file = None
+        self.proc = None
+
+    def start(self):
+        cmd = [
+            sys.executable,
+            "main.py",
+            "--listen",
+            "127.0.0.1",
+            "--port",
+            str(self.port),
+            "--input-directory",
+            str(self.input_dir),
+            "--output-directory",
+            str(self.output_dir),
+            "--temp-directory",
+            str(self.temp_dir),
+            "--database-url",
+            f"sqlite:///{self.db_path}",
+            "--disable-all-custom-nodes",
+            "--disable-api-nodes",
+            "--disable-auto-launch",
+            "--disable-metadata",
+            "--cpu",
+        ]
+        if self.micro_worker_url is not None:
+            cmd.extend(["--micro-worker-url", self.micro_worker_url])
+
+        self._log_file = self.log_path.open("w", encoding="utf-8")
+        self.proc = subprocess.Popen(
+            cmd,
+            cwd=REPO_ROOT,
+            stdout=self._log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        wait_for_ready(self.port, self.proc, self.log_path)
+        return self
+
+    def stop(self):
+        if self.proc is not None and self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait(timeout=10)
+        if self._log_file is not None:
+            self._log_file.close()
+
+    def __enter__(self):
+        return self.start()
+
+    def __exit__(self, exc_type, exc, tb):
+        self.stop()
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def wait_for_ready(port: int, proc: subprocess.Popen, log_path: Path, timeout: float = 120.0) -> None:
+    deadline = time.monotonic() + timeout
+    url = f"http://127.0.0.1:{port}/system_stats"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"server on port {port} exited early\n{tail_log(log_path)}")
+        try:
+            with urllib.request.urlopen(url, timeout=2) as response:
+                if response.status == 200:
+                    return
+        except Exception:
+            time.sleep(0.25)
+    raise RuntimeError(f"server on port {port} did not become ready\n{tail_log(log_path)}")
+
+
+def tail_log(log_path: Path, lines: int = 80) -> str:
+    if not log_path.exists():
+        return ""
+    content = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(content[-lines:])
+
+
+def write_demo_input(input_dir: Path) -> Path:
+    input_dir.mkdir(parents=True, exist_ok=True)
+    image = Image.new("RGB", (17, 13))
+    pixels = image.load()
+    for y in range(image.height):
+        for x in range(image.width):
+            pixels[x, y] = ((x * 17 + y * 3) % 256, (x * 5 + y * 19) % 256, (x * 11 + y * 7) % 256)
+    path = input_dir / DEMO_INPUT_NAME
+    image.save(path)
+    return path
+
+
+def load_demo_workflow(prefix: str) -> dict:
+    workflow = json.loads(DEMO_WORKFLOW.read_text(encoding="utf-8"))
+    workflow["5"]["inputs"]["filename_prefix"] = prefix
+    return workflow
+
+
+def build_reference_workflow(prefix: str) -> dict:
+    demo = load_demo_workflow(prefix)
+    scale_inputs = dict(demo["3"]["inputs"])
+    scale_inputs["image"] = ["1", 0]
+    return {
+        "1": demo["1"],
+        "2": {
+            "class_type": "ImageScale",
+            "inputs": scale_inputs,
+        },
+        "3": {
+            "class_type": "SaveImage",
+            "inputs": {
+                "images": ["2", 0],
+                "filename_prefix": prefix,
+            },
+        },
+    }
+
+
+def post_json(port: int, path: str, body: dict) -> dict:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"POST {path} failed with HTTP {exc.code}: {detail}") from exc
+
+
+def get_json(port: int, path: str) -> dict:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def run_prompt(port: int, workflow: dict, output_dir: Path, save_node_id: str, timeout: float = 120.0) -> bytes:
+    queued = post_json(port, "/prompt", {"prompt": workflow})
+    if "prompt_id" not in queued:
+        raise RuntimeError(f"prompt did not queue: {queued}")
+
+    prompt_id = queued["prompt_id"]
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        history = get_json(port, f"/history/{prompt_id}")
+        if prompt_id in history:
+            record = history[prompt_id]
+            status = record.get("status", {})
+            if status.get("status_str") != "success":
+                raise RuntimeError(f"prompt {prompt_id} failed: {status}")
+            outputs = record.get("outputs", {})
+            node_output = outputs.get(save_node_id, {})
+            images = node_output.get("images", [])
+            if not images:
+                raise RuntimeError(f"prompt {prompt_id} produced no saved images: {record}")
+            return read_output_image(output_dir, images[0])
+        time.sleep(0.25)
+
+    raise RuntimeError(f"prompt {prompt_id} did not finish within {timeout} seconds")
+
+
+def read_output_image(output_dir: Path, image_info: dict) -> bytes:
+    if image_info.get("type") != "output":
+        raise RuntimeError(f"expected output image, got {image_info}")
+    subfolder = image_info.get("subfolder", "")
+    filename = image_info["filename"]
+    path = output_dir / subfolder / filename
+    return path.read_bytes()
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def make_server(name: str, root: Path, port: int, micro_worker_url: str | None = None) -> ServerProcess:
+    return ServerProcess(
+        name=name,
+        port=port,
+        input_dir=root / name / "input",
+        output_dir=root / name / "output",
+        temp_dir=root / name / "tempbase",
+        db_path=root / name / "comfyui.db",
+        log_path=root / f"{name}.log",
+        micro_worker_url=micro_worker_url,
+    )
+
+
+def run_single(root: Path) -> tuple[str, bytes]:
+    port = find_free_port()
+    server = make_server("single", root, port)
+    write_demo_input(server.input_dir)
+
+    with server:
+        micro_bytes = run_prompt(port, load_demo_workflow("micro_single"), server.output_dir, "5")
+        reference_bytes = run_prompt(port, build_reference_workflow("micro_reference"), server.output_dir, "3")
+
+    if micro_bytes != reference_bytes:
+        raise RuntimeError(f"single-instance output mismatch: micro={sha256(micro_bytes)} reference={sha256(reference_bytes)}")
+
+    digest = sha256(micro_bytes)
+    print(f"single-instance sha256 {digest}")  # noqa: T201
+    return digest, reference_bytes
+
+
+def run_two_instance(root: Path, expected_reference: bytes | None = None) -> tuple[str, bytes]:
+    worker_port = find_free_port()
+    host_port = find_free_port()
+    worker = make_server("worker", root, worker_port)
+    host = make_server("host", root, host_port, micro_worker_url=f"http://127.0.0.1:{worker_port}/micro/execute")
+    write_demo_input(host.input_dir)
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(worker)
+        stack.enter_context(host)
+        micro_bytes = run_prompt(host_port, load_demo_workflow("micro_two_instance"), host.output_dir, "5")
+        if expected_reference is None:
+            expected_reference = run_prompt(host_port, build_reference_workflow("micro_reference_two"), host.output_dir, "3")
+
+    if micro_bytes != expected_reference:
+        raise RuntimeError(f"two-instance output mismatch: micro={sha256(micro_bytes)} reference={sha256(expected_reference)}")
+
+    digest = sha256(micro_bytes)
+    print(f"two-instance sha256 {digest}")  # noqa: T201
+    return digest, micro_bytes
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Run the Micro Substrate demo workflows end-to-end.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--single-only", action="store_true", help="Run only the single-instance loopback verification.")
+    mode.add_argument("--two-only", action="store_true", help="Run only the two-instance verification.")
+    parser.add_argument("--work-dir", type=Path, default=None, help="Directory for temporary server input/output/logs.")
+    args = parser.parse_args(argv)
+
+    if args.work_dir is None:
+        with tempfile.TemporaryDirectory(prefix="comfy-micro-demo-") as tmp:
+            return _main(args, Path(tmp))
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    return _main(args, args.work_dir)
+
+
+def _main(args, root: Path) -> int:
+    if args.single_only:
+        run_single(root)
+        return 0
+    if args.two_only:
+        run_two_instance(root)
+        return 0
+
+    digest, reference = run_single(root)
+    two_digest, _ = run_two_instance(root, reference)
+    if digest != two_digest:
+        raise RuntimeError(f"single and two-instance SHA-256 differ: {digest} != {two_digest}")
+    print(f"micro substrate demo verified sha256 {digest}")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_micro.py
+++ b/tests/test_micro.py
@@ -1,0 +1,180 @@
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from comfy.cli_args import args
+
+args.cpu = True
+
+import nodes  # noqa: E402
+from comfy.micro import codec, envelope, server as micro_server  # noqa: E402
+from comfy.micro.wire import BytesPayload, MicroValue  # noqa: E402
+
+
+def _load_micro_nodes():
+    module_path = Path(__file__).resolve().parents[1] / "comfy_extras" / "nodes_micro.py"
+    spec = importlib.util.spec_from_file_location("nodes_micro_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    nodes.NODE_CLASS_MAPPINGS.update(module.NODE_CLASS_MAPPINGS)
+    nodes.NODE_DISPLAY_NAME_MAPPINGS.update(module.NODE_DISPLAY_NAME_MAPPINGS)
+    return module
+
+
+def _load_run_demo():
+    module_path = Path(__file__).with_name("run_demo.py")
+    spec = importlib.util.spec_from_file_location("micro_run_demo_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MICRO_NODES = _load_micro_nodes()
+
+
+class DummyRequest:
+    def __init__(self, body):
+        self.body = body
+
+    async def json(self):
+        return self.body
+
+
+def _json_response_body(response):
+    return json.loads(response.text)
+
+
+def _micro_image(value: torch.Tensor) -> MicroValue:
+    return MicroValue("IMAGE", BytesPayload(codec.encode_image(value)))
+
+
+def test_image_codec_round_trips_bit_identically():
+    image = torch.rand((1, 64, 64, 3), dtype=torch.float32).to(torch.float16)
+
+    decoded = codec.decode_image(codec.encode_image(image))
+
+    assert torch.equal(decoded, image)
+
+
+def test_mask_codec_round_trips_bit_identically():
+    mask = torch.rand((1, 64, 64), dtype=torch.float32).to(torch.float16)
+
+    decoded = codec.decode_mask(codec.encode_mask(mask))
+
+    assert torch.equal(decoded, mask)
+
+
+def test_codec_unknown_type_raises():
+    with pytest.raises(ValueError):
+        codec.encode("LATENT", torch.zeros((1,)))
+
+
+def test_envelope_build_parse_request_round_trip():
+    value = MicroValue("IMAGE", BytesPayload(b"abc"))
+    request = envelope.build_request("Micro_ScaleImage", {"image": value, "width": 32})
+    parsed = envelope.parse_request(json.loads(json.dumps(request)))
+
+    assert parsed["image"].type_name == "IMAGE"
+    assert parsed["image"].payload.as_bytes() == b"abc"
+    assert parsed["width"] == 32
+
+
+def test_envelope_unknown_payload_kind_raises_protocol_error():
+    body = {
+        "protocol_version": envelope.PROTOCOL_VERSION,
+        "node_id": "Micro_ScaleImage",
+        "inputs": {
+            "image": {
+                "_micro": True,
+                "type": "IMAGE",
+                "payload": {"kind": "shmem"},
+            }
+        },
+    }
+
+    with pytest.raises(envelope.ProtocolError):
+        envelope.parse_request(body)
+
+
+def test_envelope_unknown_payload_compression_raises_protocol_error():
+    body = envelope.build_request("Micro_ScaleImage", {"image": MicroValue("IMAGE", BytesPayload(b"abc"))})
+    body["inputs"]["image"]["payload"]["compression"] = "zstd"
+
+    with pytest.raises(envelope.ProtocolError):
+        envelope.parse_request(body)
+
+
+def test_envelope_unsupported_protocol_version_raises_protocol_error():
+    body = {
+        "protocol_version": 999,
+        "node_id": "Micro_ScaleImage",
+        "inputs": {},
+    }
+
+    with pytest.raises(envelope.ProtocolError):
+        envelope.parse_request(body)
+
+
+def test_micro_execute_happy_path_matches_image_scale():
+    image = torch.linspace(0, 1, 1 * 7 * 5 * 3, dtype=torch.float32).reshape((1, 7, 5, 3))
+    body = envelope.build_request("Micro_ScaleImage", {
+        "image": _micro_image(image),
+        "upscale_method": "nearest-exact",
+        "width": 10,
+        "height": 14,
+        "crop": "disabled",
+    })
+
+    response = asyncio.run(micro_server.micro_execute(DummyRequest(body)))
+    response_body = _json_response_body(response)
+    parsed = envelope.parse_response(response_body)
+    decoded = codec.decode_image(parsed["image"].payload.as_bytes())
+    expected = nodes.ImageScale().upscale(image, "nearest-exact", 10, 14, "disabled")[0]
+
+    assert response_body["ok"] is True
+    assert torch.equal(decoded, expected)
+
+
+def test_micro_execute_unknown_node_returns_error():
+    body = {
+        "protocol_version": envelope.PROTOCOL_VERSION,
+        "node_id": "Micro_NonexistentNode",
+        "inputs": {},
+    }
+
+    response = asyncio.run(micro_server.micro_execute(DummyRequest(body)))
+    response_body = _json_response_body(response)
+
+    assert response_body["ok"] is False
+    assert response_body["error"]["kind"] == "unknown_node"
+
+
+def test_micro_execute_node_exception_returns_error():
+    image = torch.rand((1, 4, 4, 3), dtype=torch.float32)
+    body = envelope.build_request("Micro_ScaleImage", {
+        "image": _micro_image(image),
+        "upscale_method": "not-a-method",
+        "width": 8,
+        "height": 8,
+        "crop": "disabled",
+    })
+
+    response = asyncio.run(micro_server.micro_execute(DummyRequest(body)))
+    response_body = _json_response_body(response)
+
+    assert response_body["ok"] is False
+    assert response_body["error"]["kind"] == "node_error"
+    assert response_body["error"]["traceback"]
+
+
+def test_single_instance_demo_workflow(tmp_path):
+    run_demo = _load_run_demo()
+
+    digest, output = run_demo.run_single(tmp_path)
+
+    assert len(output) > 0
+    assert len(digest) == 64


### PR DESCRIPTION
## Summary

- Adds the `comfy.micro` substrate package: typed wire values, bytes payloads, numpy-based `IMAGE`/`MASK` codec, JSON envelope parsing/building, HTTP runtime dispatch, and `/micro/execute` server route.
- Adds built-in micro nodes: `ToMicro_IMAGE`, `FromMicro_IMAGE`, `ToMicro_MASK`, `FromMicro_MASK`, and `Micro_ScaleImage` delegating to native `ImageScale` over the HTTP wire path.
- Adds `--micro-worker-url` with a loopback default based on the resolved port.
- Adds `comfy/micro/demo_workflow.json`, `tests/test_micro.py`, and `tests/run_demo.py` for reproducible single-instance and two-instance verification.

## Validation

- `python3 -m compileall comfy/micro comfy_extras/nodes_micro.py tests/test_micro.py tests/run_demo.py`
- `git diff --cached --check`
- `ComfyUI/.venv/bin/python -m pytest tests/test_micro.py -q`
  - Result: `11 passed`
- `ComfyUI/.venv/bin/python tests/run_demo.py --work-dir /tmp/comfy-micro-demo-final`
  - Single-instance SHA-256: `ae7b492fc955068efa10c43d37677ed8bc60c855013cd7266f9a59600ecc8cac`
  - Two-instance SHA-256: `ae7b492fc955068efa10c43d37677ed8bc60c855013cd7266f9a59600ecc8cac`

## Notes

- ComfyUI built-in extras are registered through a static `extras_files` list in `nodes.py`, so this PR includes the minimal one-line `nodes_micro.py` registration there.
- The verifier starts temporary servers with `--disable-metadata`; otherwise `SaveImage` embeds the submitted prompt metadata, and the reference graph and micro graph cannot be byte-identical as PNG files even when image pixels match.