### PR TITLE
feat: make asset hashing opt-in via --enable-asset-hashing (off by default)

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -240,6 +240,7 @@ database_default_path = os.path.abspath(
 )
 parser.add_argument("--database-url", type=str, default=f"sqlite:///{database_default_path}", help="Specify the database URL, e.g. for an in-memory database you can use 'sqlite:///:memory:'.")
 parser.add_argument("--enable-assets", action="store_true", help="Enable the assets system (API routes, database synchronization, and background scanning).")
+parser.add_argument("--enable-asset-hashing", action="store_true", help="Compute blake3 content hashes when scanning assets. Hashing enables future asset-portability features (deduplication, cross-machine model resolution) but adds startup cost and per-output cost on large models directories. Off by default; enable to opt in.")
 parser.add_argument("--feature-flag", type=str, action='append', default=[], metavar="KEY[=VALUE]", help="Set a server feature flag. Use KEY=VALUE to set an explicit value, or bare KEY to set it to true. Can be specified multiple times. Boolean values (true/false) and numbers are auto-converted. Examples: --feature-flag show_signin_button=true  or  --feature-flag show_signin_button")
 parser.add_argument("--list-feature-flags", action="store_true", help="Print the registry of known CLI-settable feature flags as JSON and exit.")
 

--- a/main.py
+++ b/main.py
@@ -403,7 +403,7 @@ def prompt_worker(q, server_instance):
                 hook_breaker_ac10a0.restore_functions()
 
                 if not asset_seeder.is_disabled():
-                    asset_seeder.enqueue_enrich(roots=("output",), compute_hashes=True)
+                    asset_seeder.enqueue_enrich(roots=("output",), compute_hashes=args.enable_asset_hashing)
                 asset_seeder.resume()
 
 
@@ -458,7 +458,7 @@ def setup_database():
         if dependencies_available():
             init_db()
             if args.enable_assets:
-                if asset_seeder.start(roots=("models", "input", "output"), prune_first=True, compute_hashes=True):
+                if asset_seeder.start(roots=("models", "input", "output"), prune_first=True, compute_hashes=args.enable_asset_hashing):
                     logging.info("Background asset scan initiated for models, input, output")
     except Exception as e:
         if "database is locked" in str(e):


### PR DESCRIPTION
## ELI-5

ComfyUI can fingerprint ("hash") every model and output file so it can later tell when two files are really the same. That hashing reads every byte of every file with blake3, which is slow the first time you start up with a big `models/` folder. This PR makes that hashing **optional and off by default** when you run locally: nothing gets hashed unless you ask for it with a new `--enable-asset-hashing` flag. Asset registration still happens — only the expensive hashing step is gated.

## What changed

- Added `--enable-asset-hashing` to `comfy/cli_args.py` (`action="store_true"`, default `False`). The help text explains the trade-off: hashing enables future asset-portability features (dedup, cross-machine model resolution) but adds startup + per-output cost on large models directories.
- Plumbed the flag into the two call sites in `main.py` that previously hardcoded `compute_hashes=True`:
  - the startup scan (`asset_seeder.start(...)`)
  - the post-job output enqueue (`asset_seeder.enqueue_enrich(...)`)

Both now pass `compute_hashes=args.enable_asset_hashing`. No other behavior changes — this is purely the toggle. The `compute_hashes` parameter already existed throughout `app/assets/seeder.py` (defaults `False`); this PR only adds the user-facing switch and the right default.

## Why

A comprehensive blake3 pass over a user's `models/` directory can feel like a UX regression on slower machines. The decision was to ship registration without hashing locally and let users opt in. This ships only the *mechanism*, off by default; whether to ever flip the local default to on is a separate, later decision.

## Verification

- `--enable-asset-hashing` parses to `True`; absence parses to `False` (default) — confirmed against the argparse parser.
- `--help` renders the new flag with its description.
- `ruff check` passes on both changed files.
- **Note:** the full Python test suite could not be executed in this environment (only Python 3.9 was available, but the repo requires 3.10+ for `X | None` annotations, and torch/sqlalchemy deps were absent). The change is mechanical (one `store_true` flag + swapping a hardcoded `True` for the flag at two sites) and there are no existing tests covering `main.py`'s startup wiring or `cli_args`; `seeder.py` itself is untouched.

## Judgment calls

- **Flag naming:** the source ticket left open whether to call this `--enable-asset-hashing` or `--enable-hashing`. I used **`--enable-asset-hashing`** to stay consistent with the companion PR already in review that uses that exact name. If the team prefers `--enable-hashing`, both sides should be renamed together before merge.
- **`--enable-assets` left untouched:** removing that flag is tracked separately; this PR is scoped strictly to the hashing toggle.

## Merge dependency

The companion cloud-side launch-config wiring must be in flight before this merges — otherwise cloud silently stops hashing the moment this default takes effect (breaking dedup and cross-pod model resolution). Do not merge ahead of it.
