### PR TITLE
Add ConditioningMultiply node to nodes.py as an addition to other adj…

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -159,6 +159,29 @@ class ConditioningConcat:
 
         return (out, )
 
+class ConditioningMultiply:
+    SEARCH_ALIASES = ["scale conditioning", "scale prompt", "multiply conditioning", "multiply prompt"]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"conditioning": ("CONDITIONING", ), 
+                            "multiplier": ("FLOAT", {"default": 1.0, "min": -100.0, "max": 100.0, "step": 0.01})
+                            }}
+    RETURN_TYPES = ("CONDITIONING",)
+    FUNCTION     = "multiply"
+    CATEGORY     = "model/conditioning/transform"
+
+    def multiply(self, conditioning, multiplier):
+        c = []
+        for t in conditioning:
+            values = {}
+            pooled_output = t[1].get("pooled_output", None)
+            if pooled_output is not None:
+                values["pooled_output"] = pooled_output * multiplier
+            scaled = node_helpers.conditioning_set_values([[t[0] * multiplier, t[1]]], values)[0]
+            c.append(scaled)
+        return (c,)
+
 class ConditioningSetArea:
     SEARCH_ALIASES = ["regional prompt", "area prompt", "spatial conditioning", "localized prompt"]
 
@@ -2050,6 +2073,7 @@ NODE_CLASS_MAPPINGS = {
     "ConditioningAverage": ConditioningAverage,
     "ConditioningCombine": ConditioningCombine,
     "ConditioningConcat": ConditioningConcat,
+    "ConditioningMultiply": ConditioningMultiply,
     "ConditioningSetArea": ConditioningSetArea,
     "ConditioningSetAreaPercentage": ConditioningSetAreaPercentage,
     "ConditioningSetAreaStrength": ConditioningSetAreaStrength,
@@ -2121,6 +2145,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ConditioningAverage ": "Conditioning (Average)",
     "ConditioningAverage": "Conditioning (Average)",
     "ConditioningConcat": "Conditioning (Concat)",
+    "ConditioningMultiply": "Conditioning (Multiply)",
     "ConditioningSetArea": "Conditioning (Set Area)",
     "ConditioningSetAreaPercentage": "Conditioning (Set Area with Percentage)",
     "ConditioningSetAreaStrength": "Conditioning (Set Area Strength)",

--- a/nodes.py
+++ b/nodes.py
@@ -164,7 +164,7 @@ class ConditioningMultiply:
 
     @classmethod
     def INPUT_TYPES(cls):
-        return {"required": {"conditioning": ("CONDITIONING", ), 
+        return {"required": {"conditioning": ("CONDITIONING", ),
                             "multiplier": ("FLOAT", {"default": 1.0, "min": -100.0, "max": 100.0, "step": 0.01})
                             }}
     RETURN_TYPES = ("CONDITIONING",)


### PR DESCRIPTION
…ascent nodes that modify conditioning. As modern models do not have any emphasis functionality such as prompt weighting and that Krea 2 in particular seem to be lacking in ability to prompt some concepts such as expressions or some fantasy scenes such as the one in example. I propose adding a node that allows for multiplying the conds tensors as alternative to old school prompt weighting. This can also play a role in other conditioning modifying nodes.

**Prompt used in example which is clearly not adhered to without multiplying:**

_Viewed from a straight-on, full-body angle, a small female green goblin stands in a snowy, pine-filled mountain forest atop a slain warthog with fur covered in blood. She has large, pointy ears with leathery membrane, bright yellow eyes, and long, straight black hair. In her left hand, she holds a blood smeared axe with a blackened blade and a splintered handle. She wears a bloody black fur vest, a brown scarf with dried blood stains, dark blood red leather pants, brown lace-up boots, and black gloves. She is laughing hysterically with her mouth wide open in joyous amusement._


**Example workflow:** 
[ConditioningMultiplyWF.json](https://github.com/user-attachments/files/29486621/ConditioningMultiplyWF.json)


**Example comparison image:**
<img width="4096" height="1152" alt="zTUNEbn5kC" src="https://github.com/user-attachments/assets/06564c52-7d64-4af1-a93c-5e474319baf2" />
