### PR TITLE
Fix: add .onnx to supported_pt_extensions to allow loading ONNX models

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -7,7 +7,7 @@ from collections.abc import Collection
 
 from comfy.cli_args import args
 
-supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft'}
+supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft', '.onnx'}
 
 folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
 

--- a/tests-unit/folder_paths_test/misc_test.py
+++ b/tests-unit/folder_paths_test/misc_test.py
@@ -49,3 +49,8 @@ def test_empty_input_directory():
     with tempfile.TemporaryDirectory() as temp_dir:
         set_input_directory(temp_dir)
         assert get_input_subfolders() == []  # Empty since we don't include root
+
+
+def test_supported_pt_extensions():
+    from folder_paths import supported_pt_extensions
+    assert ".onnx" in supported_pt_extensions


### PR DESCRIPTION
Resolves #14676. Many custom nodes (e.g. WanAnimatePreprocess) load pre-trained ONNX models and look up files using ComfyUI's model path APIs. Since `.onnx` was missing from `supported_pt_extensions`, these files were silently ignored and failed to load. This PR adds `.onnx` to `supported_pt_extensions` and adds a corresponding unit test to ensure stability.