### PR TITLE
Add .onnx to supported model extensions

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -7,7 +7,7 @@ from collections.abc import Collection
 
 from comfy.cli_args import args
 
-supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft'}
+supported_pt_extensions: set[str] = {'.ckpt', '.pt', '.pt2', '.bin', '.pth', '.safetensors', '.pkl', '.sft', '.onnx'}
 
 folder_names_and_paths: dict[str, tuple[list[str], set[str]]] = {}
 


### PR DESCRIPTION
Adds `.onnx` to the shared supported model extension set used by model folders.

This lets ONNX model files appear in existing model folder searches for workflows and custom nodes that expect to select them through ComfyUI's folder path helpers. It does not add any new loader behavior or network access.

Verification:
- `python3 -m py_compile folder_paths.py`

Closes #14676

AI assistance was used to prepare this contribution, and the final change was reviewed before submission.
