### PR TITLE
fix(Video): don't crash on videos with undecodable audio streams

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -281,11 +281,18 @@ class VideoFromFile(VideoInput):
         video_done = False
         audio_done = True
 
-        if len(container.streams.audio):
-            audio_stream = container.streams.audio[-1]
+        # Use the last decodable audio stream. Streams FFmpeg has no decoder for have no codec context,
+        # and decoding their packets crashes the process. (e.g. APAC spatial-audio track in iPhone)
+        audio_stream = next(
+            (s for s in reversed(container.streams.audio) if s.codec_context is not None),
+            None,
+        )
+        if audio_stream is not None:
             streams += [audio_stream]
             resampler = av.audio.resampler.AudioResampler(format='fltp')
             audio_done = False
+        elif len(container.streams.audio):
+            logging.warning("No decodable audio stream found in video; ignoring audio.")
 
         for packet in container.demux(*streams):
             if video_done and audio_done:
@@ -457,10 +464,13 @@ class VideoFromFile(VideoInput):
                         else:
                             output_container.metadata[key] = json.dumps(value)
 
-                # Add streams to the new container
+                # Add streams to the new container. Streams with no codec context cannot be used as an output template.
                 stream_map = {}
                 for stream in streams:
                     if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream)):
+                        if stream.codec_context is None:
+                            logging.warning("Skipping %s stream %d with unsupported codec", stream.type, stream.index)
+                            continue
                         out_stream = output_container.add_stream_from_template(template=stream, opaque=True)
                         stream_map[stream] = out_stream
 

--- a/comfy_api_nodes/util/upload_helpers.py
+++ b/comfy_api_nodes/util/upload_helpers.py
@@ -158,7 +158,14 @@ async def upload_video_to_comfyapi(
 
     # Convert VideoInput to BytesIO using specified container/codec
     video_bytes_io = BytesIO()
-    video.save_to(video_bytes_io, format=container, codec=codec)
+    try:
+        video.save_to(video_bytes_io, format=container, codec=codec)
+    except Exception as e:
+        raise ValueError(
+            f"Could not convert the input video to {container.value.upper()} for upload; "
+            f"the file may be corrupt or use an unsupported codec. "
+            f"Try re-exporting it as MP4 (H.264). Original error: {e}"
+        ) from e
     video_bytes_io.seek(0)
 
     return await upload_file_to_comfyapi(cls, video_bytes_io, filename, upload_mime_type, wait_label)

--- a/comfy_api_nodes/util/upload_helpers.py
+++ b/comfy_api_nodes/util/upload_helpers.py
@@ -163,7 +163,7 @@ async def upload_video_to_comfyapi(
     except Exception as e:
         raise ValueError(
             f"Could not convert the input video to {container.value.upper()} for upload; "
-            f"the file may be corrupt or use an unsupported codec. "
+            f"the file may be corrupted or use an unsupported codec. "
             f"Try re-exporting it as MP4 (H.264). Original error: {e}"
         ) from e
     video_bytes_io.seek(0)


### PR DESCRIPTION
Videos recorded on recent iPhones with Spatial Audio carry two audio tracks: a stereo AAC fallback and Apple Positional Audio Codec(APAC)
FFmpeg usually has no APAC decoder, so PyAV exposes that stream with `codec_context = None`
`VideoFromFile` picked the last audio track - the APAC one. Decoding a packet on a stream without a codec context segfaults the whole process with such error:

```
Extension modules: numpy._core._multiarray_umath, numpy.linalg._umath_linalg, sqlalchemy.cyextension.collections,
...
scipy.signal._peak_finding_utils (total: 184)

Process finished with exit code 139 (interrupted by signal 11:SIGSEGV)
```

Three changes:
- `get_components_internal` picks the last **decodable** audio stream. A file with only undecodable audio decodes as video-only with a warning instead of crashing
- the remux path in `save_to` skips streams that have no codec context (they can't be used as an  output template) instead of failing the whole save
- `upload_video_to_comfyapi` wraps the conversion so a failure surfaces as a readable node error suggesting to re-export as MP4

Without this PR:

<details>
<summary>`Load Video - Save Video`:</summary>

<img width="1235" height="428" alt="Screenshot From 2026-07-07 10-35-44" src="https://github.com/user-attachments/assets/3fd16af4-1afc-4d78-a307-2d754fcebf15" />

</details>

<details>
<summary>`Load Video -> Get Video Components`:</summary>

<img width="1672" height="1180" alt="Screenshot From 2026-07-07 10-37-04" src="https://github.com/user-attachments/assets/b41e86cb-4aee-485a-80d2-8f932f57367b" />

</details>

<details>
<summary>With this PR</summary>

<img width="1268" height="648" alt="Screenshot From 2026-07-07 10-40-08" src="https://github.com/user-attachments/assets/19bf3e8f-a741-42e0-804c-20d939912651" />

</details>

Test file:

[iphone_spatial_audio.zip](https://github.com/user-attachments/files/29734725/iphone_spatial_audio.zip)


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

