### PR TITLE
fix(image): grayscale image support for save image advanced

### DIFF
--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -1144,6 +1144,9 @@ def _encode_image(
     codec.pix_fmt = stream_fmt
     codec.time_base = Fraction(1, 1)
 
+    if num_channels == 1:
+        img_np = img_np.squeeze(-1)
+
     frame = av.VideoFrame.from_ndarray(img_np, format=frame_fmt)
     if frame_fmt != stream_fmt:
         frame = frame.reformat(format=stream_fmt)

--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -1101,10 +1101,27 @@ def _encode_image(
     For PNG, colorspace selection does not modify pixels — PNG is delivered
     sRGB-encoded and there is no PNG path for wide-gamut HDR in this node.
     """
+
+    if img_tensor.ndim == 2: # 2 channel grayscales
+        img_tensor = img_tensor.unsqueeze(-1)
+
     height, width, num_channels = img_tensor.shape
     has_alpha = num_channels == 4
 
     spec = _FORMAT_SPECS[(file_format, bit_depth, has_alpha)]
+
+    frame_fmt = spec["frame_fmt"]
+    stream_fmt = spec["stream_fmt"]
+
+    if num_channels == 1:
+        if spec["dtype"] == np.float32:
+            frame_fmt = stream_fmt = "grayf32le"
+        elif spec["dtype"] == np.uint16:
+            frame_fmt = "gray16le"
+            # Ensure big-endian for PNG
+            stream_fmt = "gray16be" if "be" in stream_fmt else "gray16le"
+        else:
+            frame_fmt = stream_fmt = "gray"
 
     if spec["dtype"] == np.float32:
         # EXR path: preserve full range, no clamp.
@@ -1124,12 +1141,12 @@ def _encode_image(
     codec = av.CodecContext.create(file_format, "w")
     codec.width = width
     codec.height = height
-    codec.pix_fmt = spec["stream_fmt"]
+    codec.pix_fmt = stream_fmt
     codec.time_base = Fraction(1, 1)
 
-    frame = av.VideoFrame.from_ndarray(img_np, format=spec["frame_fmt"])
-    if spec["frame_fmt"] != spec["stream_fmt"]:
-        frame = frame.reformat(format=spec["stream_fmt"])
+    frame = av.VideoFrame.from_ndarray(img_np, format=frame_fmt)
+    if frame_fmt != stream_fmt:
+        frame = frame.reformat(format=stream_fmt)
     frame.pts = 0
     frame.time_base = codec.time_base
 


### PR DESCRIPTION
Adds a channel in case of 2d channel grayscales. 
Changes the grayscale format depending on dtype.
Before and after screenshots:

<img width="1324" height="909" alt="Screenshot 2026-07-03 174514" src="https://github.com/user-attachments/assets/396b4d5d-bd30-474c-a7a5-1b529cd59fc0" />
<img width="1708" height="770" alt="Screenshot 2026-07-03 174832" src="https://github.com/user-attachments/assets/18f238d0-3407-41a0-9ce5-f21cda9445b5" />
