### PR TITLE
fix(image): correct HLG inverse-OETF clamp in hlg_to_linear

### DIFF
--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -891,10 +891,11 @@ def hlg_to_linear(t: torch.Tensor) -> torch.Tensor:
         return torch.cat([hlg_to_linear(rgb), alpha], dim=-1)
 
     # Piecewise: sqrt branch below 0.5, log branch above.
-    # Clamp inside the log branch so negative / out-of-range values don't blow up;
+    # Clamp the log branch at the 0.5 branch point (not above it) so the
+    # unselected lane stays finite in exp() without altering selected values;
     # values above 1.0 are allowed and extrapolate naturally.
     low = (t ** 2) / 3.0
-    high = (torch.exp((t.clamp(min=_HLG_C) - _HLG_C) / _HLG_A) + _HLG_B) / 12.0
+    high = (torch.exp((t.clamp(min=0.5) - _HLG_C) / _HLG_A) + _HLG_B) / 12.0
     return torch.where(t <= 0.5, low, high)
 
 


### PR DESCRIPTION
`hlg_to_linear` (Save Image (Advanced), `input_color_space=HDR`) clamped its exp branch at `_HLG_C` (~0.5599) instead of the 0.5 branch point. Every HLG signal value in (0.500, 0.560] therefore produced the constant 0.10706 instead of the 0.0833->0.1071

<details>
<summary>Without patch</summary>

<img width="1506" height="887" alt="Screenshot From 2026-07-04 10-55-44" src="https://github.com/user-attachments/assets/9e35cebd-156c-4298-bee6-be714864515d" />
</details>

<details>
<summary>With patch from this PR</summary>

<img width="1506" height="887" alt="Screenshot From 2026-07-04 10-56-29" src="https://github.com/user-attachments/assets/cb21db68-a4ba-4e9c-8eb1-997e4d77fd4c" />
</details>


<details>
<summary>Additional data</summary>
<img width="1513" height="846" alt="Screenshot From 2026-07-04 10-41-40" src="https://github.com/user-attachments/assets/73a196f1-e32d-487d-bafa-8e721ebb0e32" />
<img width="1575" height="503" alt="Screenshot From 2026-07-04 10-42-10" src="https://github.com/user-attachments/assets/3c66663e-5b3a-49d7-890d-447c4ee7b101" />
</details>

[wf_plus_input_image.zip](https://github.com/user-attachments/files/29655983/wf_plus_input_image.zip)
