### PR TITLE
Fix HiDream-O1 LoRA loading (add model_lora_keys_unet branch)

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -304,6 +304,15 @@ def model_lora_keys_unet(model, key_map={}):
                     key_map["lycoris_{}".format(key_lora.replace(".", "_"))] = k #SimpleTuner lycoris format
                     key_map["transformer.{}".format(key_lora)] = k #SimpleTuner regular format
 
+    if isinstance(model, comfy.model_base.HiDreamO1):
+        for k in sdk:
+            if k.startswith("diffusion_model."):
+                if k.endswith(".weight"):
+                    key_lora = k[len("diffusion_model."):-len(".weight")]
+                    key_map["lycoris_{}".format(key_lora.replace(".", "_"))] = k
+                    key_map["transformer.{}".format(key_lora)] = k
+                    key_map["model.{}".format(key_lora)] = k
+
     if isinstance(model, comfy.model_base.ACEStep):
         for k in sdk:
             if k.startswith("diffusion_model.") and k.endswith(".weight"): #Official ACE step lora format

--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -309,8 +309,6 @@ def model_lora_keys_unet(model, key_map={}):
             if k.startswith("diffusion_model."):
                 if k.endswith(".weight"):
                     key_lora = k[len("diffusion_model."):-len(".weight")]
-                    key_map["lycoris_{}".format(key_lora.replace(".", "_"))] = k
-                    key_map["transformer.{}".format(key_lora)] = k
                     key_map["model.{}".format(key_lora)] = k
 
     if isinstance(model, comfy.model_base.ACEStep):


### PR DESCRIPTION
`HiDream-O1` LoRAs trained by the community (including the training scripts distributed on ModelScope's AIGC hub) fail to load: every LoRA key emits `[WARNING] lora key not loaded: model.language_model.layers...` lines.

This PR adds a `HiDreamO1` branch that mirrors the existing `HiDream` / `QwenImage` branches and registers the three standard prefix aliases (`model.*`, `transformer.*`, `lycoris_*`).