### PR TITLE
fix(ops): skip AIMDO cast path on non-CUDA/ROCm devices (MPS/CPU support)

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -317,7 +317,10 @@ def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None, of
         prefetched = hasattr(s, "_prefetch")
         offload_stream = None
         offload_device = None
-        if not prefetched:
+        # comfy_aimdo is only registered for CUDA / ROCm backends. On MPS (and
+        # CPU) we have to skip the vbar fast path and fall back to the plain
+        # cast in resolve_cast_module_with_vbar below.
+        if not prefetched and device.type not in ("cpu", "mps"):
             offload_stream = cast_modules_with_vbar([s], dtype, device, bias_dtype, non_blocking)
             comfy.model_management.sync_stream(device, offload_stream)
 


### PR DESCRIPTION
## Problem

Since [CORE-111 (commit 783782d5, May 3 2026)](https://github.com/comfyanonymous/ComfyUI/commit/783782d5), `cast_modules_with_vbar` is the default path in `comfy/ops.py:cast_bias_weight`. However `comfy_aimdo` is only registered for **CUDA** and **ROCm** backends — there is no MPS / CPU backend registration.

As a result, **every Apple Silicon (MPS) user hits a runtime error on the first model load** since May 2026. CPU users too.

## Repro

```bash
python main.py --force-upcast-attention --output-directory ~/output
# load any checkpoint (SDXL / Flux / SD3 / etc.)
# -> RuntimeError: aimdo backend not initialized / No registered backend
```

Verified on: PyTorch 2.11, macOS 15, M-series, master `7f287b70`.

## Fix

Add a `device.type` guard in `cast_bias_weight` so the AIMDO fast path is only used on CUDA / ROCm:

```python
if not prefetched and device.type not in ("cpu", "mps"):
    offload_stream = cast_modules_with_vbar([s], dtype, device, bias_dtype, non_blocking)
    comfy.model_management.sync_stream(device, offload_stream)
```

MPS and CPU fall through to the plain `resolve_cast_module_with_vbar()` path (line below) which is device-agnostic.

## Why a separate guard instead of registering an MPS backend in comfy_aimdo?

AIMDO depends on CUDA streams / ROCm streams for the offload_stream semantics. The MPS backend doesn't expose stream-based async transfer the same way, so a working MPS AIMDO backend would need a separate implementation. This PR fixes the immediate crash with a minimal guard; a full MPS-aware AIMDO backend can come later.

## Verified

- MPS model load: ✅ succeeds (was: RuntimeError)
- CUDA path: ✅ unchanged (the new condition is True for device.type=='cuda')
- ROCm path: ✅ unchanged

Same fix is also useful for CPU-only / `--cpu` runs (they shouldn't be hitting the AIMDO path either).