### PR TITLE
Allow .onnx models in the detection folder (fixes #14050, #14635)

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -58,7 +58,7 @@ folder_names_and_paths["geometry_estimation"] = ([os.path.join(models_dir, "geom
 
 folder_names_and_paths["optical_flow"] = ([os.path.join(models_dir, "optical_flow")], supported_pt_extensions)
 
-folder_names_and_paths["detection"] = ([os.path.join(models_dir, "detection")], supported_pt_extensions)
+folder_names_and_paths["detection"] = ([os.path.join(models_dir, "detection")], supported_pt_extensions | {".onnx"})
 
 output_directory = os.path.join(base_path, "output")
 temp_directory = os.path.join(base_path, "temp")

--- a/tests-unit/folder_paths_test/detection_onnx_extensions_test.py
+++ b/tests-unit/folder_paths_test/detection_onnx_extensions_test.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+
+import folder_paths
+
+
+def test_detection_folder_allows_onnx_extension():
+    _, extensions = folder_paths.folder_names_and_paths["detection"]
+    assert ".onnx" in extensions
+
+
+def test_detection_folder_lists_onnx_files():
+    with tempfile.TemporaryDirectory() as detection_dir:
+        onnx_path = os.path.join(detection_dir, "vitpose-l-wholebody.onnx")
+        with open(onnx_path, "wb") as onnx_file:
+            onnx_file.write(b"onnx")
+
+        folder_paths.add_model_folder_path("detection", detection_dir, is_default=True)
+        folder_paths.filename_list_cache.pop("detection", None)
+
+        filenames = folder_paths.get_filename_list("detection")
+        assert "vitpose-l-wholebody.onnx" in filenames
+        assert folder_paths.get_full_path("detection", "vitpose-l-wholebody.onnx") == onnx_path


### PR DESCRIPTION
## Issue

Fixes #14050
Fixes #14635

After #14025 added the `detection` model folder for MediaPipe nodes, it was registered with `supported_pt_extensions` only. That excludes `.onnx` files, so `get_filename_list("detection")` and prompt validation reject models such as `vitpose-l-wholebody.onnx` and `yolov10m.onnx`.

**Symptoms:**
- Desktop: `OnnxDetectionModelLoader` dropdown empty / runtime `get_full_path_or_raise` failure
- Comfy Cloud: UI dropdown shows ONNX models, but queue fails at prompt validation with `value_not_in_list` before execution

## Fix

Register `.onnx` as an allowed extension for the `detection` folder:

```python
folder_names_and_paths["detection"] = (
    [os.path.join(models_dir, "detection")],
    supported_pt_extensions | {".onnx"},
)
```

## Testing

```bash
pytest tests-unit/folder_paths_test/detection_onnx_extensions_test.py -v
```

Both tests pass locally.

## Side effects

- Additive only: MediaPipe and other `detection` consumers simply gain `.onnx` entries in their model lists.
- Coexists with kijai/ComfyUI-WanAnimatePreprocess import-time extension patch (idempotent).

## Notes

- MediaPipe models use `.task` files; this PR scopes to `.onnx` as reported in the linked issues. Cloud users will need a core release deploy after merge.
- I designed and tested this fix as an actual human in the loop even with AI assistance on the unit test, and automated PR.  ☺️