### PR TITLE
feat(api): expose effective extension filter on /experiment/models

### DIFF
--- a/app/model_manager.py
+++ b/app/model_manager.py
@@ -35,7 +35,11 @@ class ModelFileManager:
             for folder in model_types:
                 if folder in folder_black_list:
                     continue
-                output_folders.append({"name": folder, "folders": folder_paths.get_folder_paths(folder)})
+                output_folders.append({
+                    "name": folder,
+                    "folders": folder_paths.get_folder_paths(folder),
+                    "extensions": sorted(folder_paths.folder_names_and_paths[folder][1]),
+                })
             return web.json_response(output_folders)
 
         # NOTE: This is an experiment to replace `/models/{folder}`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -783,6 +783,14 @@ components:
         ModelFolder:
             description: Represents a folder containing models
             properties:
+                extensions:
+                    description: The folder's registered file-extension allowlist. An empty array means the folder accepts any extension (match-all).
+                    example:
+                        - .ckpt
+                        - .safetensors
+                    items:
+                        type: string
+                    type: array
                 folders:
                     description: List of paths where models of this type are stored
                     example:

--- a/tests-unit/app_test/model_manager_test.py
+++ b/tests-unit/app_test/model_manager_test.py
@@ -24,6 +24,28 @@ def app(model_manager):
     app.add_routes(routes)
     return app
 
+async def test_get_model_folders_includes_registered_extensions(aiohttp_client, app, tmp_path):
+    """Folders expose their registered extension set verbatim; an empty list
+    means match-all (filter_files_extensions semantics)."""
+    with patch('folder_paths.folder_names_and_paths', {
+        'test_checkpoints': ([str(tmp_path)], {'.safetensors', '.ckpt'}),
+        'test_configs': ([str(tmp_path)], ['.yaml']),
+        'test_match_all': ([str(tmp_path)], set()),
+        'configs': ([str(tmp_path)], ['.yaml']),
+    }):
+        client = await aiohttp_client(app)
+        response = await client.get('/experiment/models')
+
+        assert response.status == 200
+        folders = {f['name']: f for f in await response.json()}
+
+        assert 'configs' not in folders  # blocklisted
+        assert folders['test_checkpoints']['folders'] == [str(tmp_path)]
+        assert folders['test_checkpoints']['extensions'] == ['.ckpt', '.safetensors']
+        assert folders['test_configs']['extensions'] == ['.yaml']
+        # Match-all registrations are exposed honestly, not substituted.
+        assert folders['test_match_all']['extensions'] == []
+
 async def test_get_model_preview_safetensors(aiohttp_client, app, tmp_path):
     img = Image.new('RGB', (100, 100), 'white')
     img_byte_arr = BytesIO()


### PR DESCRIPTION
This PR exposes the registered `extensions` for each model "folder" registration on `/api/experiment/models`

**Why:**
1. To allow an assets-backed-sidebar to keep a consistent UX (with the non-assets-backed source) the FE needs to perform some additional filtering/logic not performed within the assets system.
   1. Some folder registrations (from custom nodes) do _not_ register an extension allowlist meaning that `.md` files etc. are considered valid assets for the loader. If the custom node also *downloads* entire repositories this clutters the asset system.
   2. The non-assets-backed sidebar filters to a default set of extensions. Changing the sidebar to be assets-backed, the intent is to more faithfully represent the assets registered in a folder. Current behaviour for non-assets-backed sidebar is to *only* show files from a known set of extensions. Having an assets-backed sidebar include _technically correct to include_ assets would regress UX.
   3. The cleanest approach is to make this a **presentation** concern and keep the assets API honest. This means the FE needs additional data to make the presentation-filter decision.
2. Knowing the authoritative extension set for a `model_type:` tag unlocks bidirectional SSOT-mapping of an assets path (aka loader key) to its `model_type:`(s) and folder(s).
   1. Because model folders can overlap the *directory* but carry distinct (or even partially overlapping) extension sets just knowing the path is not enough - exposing the extensions means this endpoint is enough to reason about asset placement and tagging.

**Example:**
Including some custom-node registered model folders
```
// curl http://localhost:61040/api/experiment/models
[
  {
    "name": "checkpoints",
    "folders": [
      "/home/simon/comfy/installs/fpmatch-mext/models/checkpoints",
      "/home/simon/comfy/extra-models/checkpoints",
      "/home/simon/comfy/installs/fpmatch-mext/output/checkpoints"
    ],
    "extensions": [".bin", ".ckpt", ".pkl", ".pt", ".pt2", ".pth", ".safetensors", ".sft"]
  },
  // ...
  {
    "name": "diffusers",
    "folders": ["/home/simon/comfy/installs/fpmatch-mext/models/diffusers"],
    "extensions": ["folder"]
  },
  // ...
  {
    "name": "diffusion_models",
    "folders": [
      "/home/simon/comfy/installs/fpmatch-mext/models/unet",
      "/home/simon/comfy/installs/fpmatch-mext/output/diffusion_models"
    ],
    "extensions": [".bin", ".ckpt", ".pkl", ".pt", ".pt2", ".pth", ".safetensors", ".sft"]
  },
  // ...
  {
    "name": "unet_gguf",
    "folders": [
      "/home/simon/comfy/installs/fpmatch-mext/models/unet",
      "/home/simon/comfy/installs/fpmatch-mext/output/diffusion_models"
    ],
    "extensions": [".gguf"]
  },
  {
    // custom-node registration without an extension allowlist: match-all
    "name": "LLM",
    "folders": ["/home/simon/comfy/installs/fpmatch-mext/models/LLM"],
    "extensions": []
  }
  // ...
]

```

## Changes
- Each folder entry in `GET /api/experiment/models` now carries an `extensions` array: the registered extension allowlist, verbatim. An empty array means the folder accepts any extension (match-all), mirroring `filter_files_extensions` semantics. Presentation-level filtering of match-all folders is deliberately the consumer's concern (the FE holds its own default list).
- `openapi.yaml` `ModelFolder` schema updated; unit test covers registered-set, list-registered, and match-all (empty) cases.


