### PR TITLE
Clarify GLSL PyOpenGL acceleration log

### DIFF
--- a/comfy_extras/nodes_glsl.py
+++ b/comfy_extras/nodes_glsl.py
@@ -38,6 +38,10 @@ os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
 
 import OpenGL
 OpenGL.USE_ACCELERATE = False
+logging.getLogger("OpenGL.acceleratesupport").setLevel(logging.WARNING)
+logger.info(
+    "Using ComfyUI GLSL ANGLE/EGL backend; optional PyOpenGL wrapper acceleration is disabled for compatibility. GPU shader rendering remains enabled."
+)
 
 
 def _patch_find_library():


### PR DESCRIPTION
## Summary

Clarifies the startup log emitted when the GLSL node disables `PyOpenGL_accelerate`.

The previous PyOpenGL info message reads like GPU/OpenGL acceleration is missing. In this path, ComfyUI is intentionally using the ANGLE/EGL GLSL backend and disabling only PyOpenGL's optional wrapper acceleration layer for compatibility.

## Why

`OpenGL.USE_ACCELERATE = False` is intentional here, but PyOpenGL logs `No OpenGL_accelerate module loaded: Acceleration disabled`, which can be misleading for users because it sounds like GPU shader rendering is disabled.

This adds a ComfyUI-side info line that makes the distinction explicit and raises the PyOpenGL accelerate-support logger to `WARNING` so the misleading info line does not appear.

## Validation

- `python -m py_compile comfy_extras/nodes_glsl.py`
