### PR TITLE
Fix dtype mismatch in AudioVAE.encode for bf16/fp16 audio VAE

### DIFF
--- a/comfy/ldm/lightricks/vae/audio_vae.py
+++ b/comfy/ldm/lightricks/vae/audio_vae.py
@@ -154,6 +154,10 @@ class AudioVAE(torch.nn.Module):
             waveform, waveform_sample_rate, device=waveform.device
         )
 
+        # Cast mel spectrogram to match encoder weight dtype (bf16 VAE + float32 audio input)
+        encoder_dtype = next(self.autoencoder.encoder.parameters()).dtype
+        mel_spec = mel_spec.to(dtype=encoder_dtype)
+
         latents = self.autoencoder.encode(mel_spec)
         posterior = DiagonalGaussianDistribution(latents)
         latent_mode = posterior.mode()


### PR DESCRIPTION
> Greetings! First time contributor here; grateful for the work your team does. 
> While building some experimental workflows, I encountered a minor enhancement
> recommendation which may assist those with hardware that is a little aged. I'd be 
> happy to adjust anything to match your conventions. Just let me know.
>
> # What this does:
> AudioVAE.encode() can raise a dtype mismatch when the audio VAE's weights are not
> float32. The mel spectrogram produced by AudioPreprocessor.waveform_to_mel() is
> always float32 (coming from torchaudio's MelSpectrogram + log), but if the
> encoder is loaded in bf16/fp16, feeding the float32 mel into the encoder throws:
>
> ```
> RuntimeError: Input type (c10::Float) and weight type (c10::BFloat16) should be the same
> ```
>
> # Tiny Fix:
> Cast the mel to the encoder's actual parameter dtype right before encoding. This is a
> no-op when the VAE is float32, and resolves the mismatch when it isn't:
>
> ```python
> encoder_dtype = next(self.autoencoder.encoder.parameters()).dtype
> mel_spec = mel_spec.to(dtype=encoder_dtype)
> ```
>
> # Why encode() instead of decode():
> decode()'s input (latents) originates from inside the model, so it already carries the
> model dtype. encode()'s input (mel) originates *outside* the model from torchaudio
> DSP, which is fixed at float32. So encode() is the only path exposed to the mismatch.
>
> # How this surfaced for me:
> Running the LTX-2.3 audio VAE in bf16 (for VRAM headroom on a 16 GB card).
>
> # Option:
> If you'd prefer the cast handled at the VAE dtype-loading layer rather than inside
> encode(), I can move it there, just let me know what fits your codebase best.