### PR TITLE
Fix math errors, variable overwriting, and RF support in dpmpp_2s_ancestral_cfg_pp

### DIFF
--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -1316,14 +1316,18 @@ def sample_euler_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disabl
 @torch.no_grad()
 def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
+    if isinstance(model.inner_model.inner_model.model_sampling, comfy.model_sampling.CONST):
+        return sample_dpmpp_2s_ancestral_RF_cfg_pp(model, x, sigmas, extra_args, callback, disable, eta, s_noise, noise_sampler)
+
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
     noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
 
-    temp = [0]
+    uncond_denoised = None
     def post_cfg_function(args):
-        temp[0] = args["uncond_denoised"]
+        nonlocal uncond_denoised
+        uncond_denoised = args["uncond_denoised"]
         return args["denoised"]
 
     model_options = extra_args.get("model_options", {}).copy()
@@ -1335,26 +1339,95 @@ def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback
 
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)
+        guidance_vector = denoised - uncond_denoised
         sigma_down, sigma_up = get_ancestral_step(sigmas[i], sigmas[i + 1], eta=eta)
         if callback is not None:
             callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised})
         if sigma_down == 0:
             # Euler method
-            d = to_d(x, sigmas[i], temp[0])
-            x = denoised + d * sigma_down
+            d = to_d(x, sigmas[i], uncond_denoised)
+            dt = sigma_down - sigmas[i]
+            x = x + d * dt
         else:
             # DPM-Solver++(2S)
             t, t_next = t_fn(sigmas[i]), t_fn(sigma_down)
-            # r = torch.sinh(1 + (2 - eta) * (t_next - t) / (t - t_fn(sigma_up))) works only on non-cfgpp, weird
             r = 1 / 2
             h = t_next - t
             s = t + r * h
-            x_2 = (sigma_fn(s) / sigma_fn(t)) * (x + (denoised - temp[0])) - (-h * r).expm1() * denoised
+            x_2 = (sigma_fn(s) / sigma_fn(t)) * x - (-h * r).expm1() * uncond_denoised
             denoised_2 = model(x_2, sigma_fn(s) * s_in, **extra_args)
-            x = (sigma_fn(t_next) / sigma_fn(t)) * (x + (denoised - temp[0])) - (-h).expm1() * denoised_2
+            uncond_denoised_2 = uncond_denoised
+            x = (sigma_fn(t_next) / sigma_fn(t)) * x - (-h).expm1() * uncond_denoised_2
         # Noise addition
         if sigmas[i + 1] > 0:
             x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * s_noise * sigma_up
+        # Not RF: alpha = 1
+        x += guidance_vector
+    return x
+
+@torch.no_grad()
+def sample_dpmpp_2s_ancestral_RF_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
+    """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
+    extra_args = {} if extra_args is None else extra_args
+    seed = extra_args.get("seed", None)
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
+
+    uncond_denoised = None
+    def post_cfg_function(args):
+        nonlocal uncond_denoised
+        uncond_denoised = args["uncond_denoised"]
+        return args["denoised"]
+
+    model_options = extra_args.get("model_options", {}).copy()
+    extra_args["model_options"] = comfy.model_patcher.set_model_options_post_cfg_function(model_options, post_cfg_function, disable_cfg1_optimization=True)
+
+    s_in = x.new_ones([x.shape[0]])
+    sigma_fn = lambda lbda: (lbda.exp() + 1) ** -1
+    lambda_fn = lambda sigma: ((1-sigma)/sigma).log()
+
+    # logged_x = x.unsqueeze(0)
+
+    for i in trange(len(sigmas) - 1, disable=disable):
+        denoised = model(x, sigmas[i] * s_in, **extra_args)
+        guidance_vector = denoised - uncond_denoised
+        downstep_ratio = 1 + (sigmas[i+1]/sigmas[i] - 1) * eta
+        sigma_down = sigmas[i+1] * downstep_ratio
+        alpha_ip1 = 1 - sigmas[i+1]
+        alpha_down = 1 - sigma_down
+        renoise_coeff = (sigmas[i+1]**2 - sigma_down**2*alpha_ip1**2/alpha_down**2)**0.5
+        # sigma_down, sigma_up = get_ancestral_step(sigmas[i], sigmas[i + 1], eta=eta)
+        if callback is not None:
+            callback({'x': x, 'i': i, 'sigma': sigmas[i], 'sigma_hat': sigmas[i], 'denoised': denoised})
+        if sigmas[i + 1] == 0:
+            # Euler method
+            d = to_d(x, sigmas[i], uncond_denoised)
+            dt = sigma_down - sigmas[i]
+            x = x + d * dt
+        else:
+            # DPM-Solver++(2S)
+            if sigmas[i] == 1.0:
+                sigma_s = 0.9999
+            else:
+                t_i, t_down = lambda_fn(sigmas[i]), lambda_fn(sigma_down)
+                r = 1 / 2
+                h = t_down - t_i
+                s = t_i + r * h
+                sigma_s = sigma_fn(s)
+            # sigma_s = sigmas[i+1]
+            sigma_s_i_ratio = sigma_s / sigmas[i]
+            u = sigma_s_i_ratio * x + (1 - sigma_s_i_ratio) * uncond_denoised
+            D_i = model(u, sigma_s * s_in, **extra_args)
+            uncond_D_i = uncond_denoised
+            sigma_down_i_ratio = sigma_down / sigmas[i]
+            x = sigma_down_i_ratio * x + (1 - sigma_down_i_ratio) * uncond_D_i
+            # print("sigma_i", sigmas[i], "sigma_ip1", sigmas[i+1],"sigma_down", sigma_down, "sigma_down_i_ratio", sigma_down_i_ratio, "sigma_s_i_ratio", sigma_s_i_ratio, "renoise_coeff", renoise_coeff)
+        # Noise addition
+        if sigmas[i + 1] > 0 and eta > 0:
+            x = (alpha_ip1/alpha_down) * x + noise_sampler(sigmas[i], sigmas[i + 1]) * s_noise * renoise_coeff
+        ### RF: alpha = 1 - t = 1 - sigma
+        x += (1 - sigmas[i + 1]) * guidance_vector
+        # logged_x = torch.cat((logged_x, x.unsqueeze(0)), dim=0)
     return x
 
 @torch.no_grad()

--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -1355,7 +1355,7 @@ def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback
             h = t_next - t
             s = t + r * h
             x_2 = (sigma_fn(s) / sigma_fn(t)) * x - (-h * r).expm1() * uncond_denoised
-            denoised_2 = model(x_2, sigma_fn(s) * s_in, **extra_args)
+            _ = model(x_2, sigma_fn(s) * s_in, **extra_args)
             uncond_denoised_2 = uncond_denoised
             x = (sigma_fn(t_next) / sigma_fn(t)) * x - (-h).expm1() * uncond_denoised_2
         # Noise addition
@@ -1417,7 +1417,7 @@ def sample_dpmpp_2s_ancestral_RF_cfg_pp(model, x, sigmas, extra_args=None, callb
             # sigma_s = sigmas[i+1]
             sigma_s_i_ratio = sigma_s / sigmas[i]
             u = sigma_s_i_ratio * x + (1 - sigma_s_i_ratio) * uncond_denoised
-            D_i = model(u, sigma_s * s_in, **extra_args)
+            _ = model(u, sigma_s * s_in, **extra_args)
             uncond_D_i = uncond_denoised
             sigma_down_i_ratio = sigma_down / sigmas[i]
             x = sigma_down_i_ratio * x + (1 - sigma_down_i_ratio) * uncond_D_i

--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -1316,13 +1316,14 @@ def sample_euler_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disabl
 @torch.no_grad()
 def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
-    if isinstance(model.inner_model.inner_model.model_sampling, comfy.model_sampling.CONST):
+    model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
+    if isinstance(model_sampling, comfy.model_sampling.CONST):
         return sample_dpmpp_2s_ancestral_RF_cfg_pp(model, x, sigmas, extra_args, callback, disable, eta, s_noise, noise_sampler)
 
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
     noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
-    s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
+    s_noise = s_noise * getattr(model_sampling, "noise_scale", 1.0)
 
     uncond_denoised = None
     def post_cfg_function(args):
@@ -1365,7 +1366,6 @@ def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback
         x += guidance_vector
     return x
 
-@torch.no_grad()
 def sample_dpmpp_2s_ancestral_RF_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args


### PR DESCRIPTION
This will change the output of `dpmpp_2s_ancestral_cfg_pp` for all models.

The current implementation of DPM++ 2S Ancestral CFG++ contains mathematical errors and an engineering oversight. Specifically:

1. It does not strictly keep the higher-order correction terms unconditional, as is mandated by CFG++ in their [paper](https://openreview.net/pdf?id=E77uvbOTtp#page=5), page 5, Eq. 14-15.

2. It does not account for the fact that the unconditional denoised estimate (stored in `temp[0]`) is overwritten after the second `model(...)` call, and uses it as if it hadn't been.

3. It does not account for Rectified Flow models. 

```py

@torch.no_grad()
def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
    """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
    ...
    # issue 1: mixes in conditional denoised into higher order term      
    #                                                 vvvvvvvvvvvvvvvvvv
            x_2 = (sigma_fn(s) / sigma_fn(t)) * (x + (denoised - temp[0])) - (-h * r).expm1() * denoised
            denoised_2 = model(x_2, sigma_fn(s) * s_in, **extra_args)
    #                    ^^^^^
    # issue 2: does not account for the fact that after the above call, temp[0] is overwritten with the new unconditional denoised estimate,
    #          and is no longer the original unconditional denoised estimate, making any (denoised - temp[0]) down the line calculate the wrong quantity
            x = (sigma_fn(t_next) / sigma_fn(t)) * (x + (denoised - temp[0])) - (-h).expm1() * denoised_2
    ...
    # issue 3: generally does not account for RF in its ancestral noising logic, nor the CFG++ correction logic.
    return x
```

The above problems combined cause the sampler produce much dimmer and blurrier outputs compared to any other existing `cfg_pp` sampler. This problem is exacerbated when using lower cfg scales and/or more steps.
It is also completely dysfunctional on modern models based on RF such as FLUX, ZIT, Anima.

This PR provides a corrected implementation of `dpmpp_2s_ancestral_cfg_pp`, fixing problems 1 and 2. 
It also implements `dpmpp_2s_ancestral_RF_cfg_pp`, which `dpmpp_2s_ancestral_cfg_pp` calls when a `comfy.model_sampling.CONST` model is detected. It builds on top of `dpmpp_2s_ancestral_RF` and applies the correct CFG++ corrections, resolving problem 3.

Due to changes across the board described above, this changes outputs of `dpmpp_2s_ancestral_cfg_pp` for all models.
The below comparison grid is generated on an Illustrious finetune and base Anima. All images used `cfg=1.2, scheduler=simple, steps=25`. 

<img width="2768" height="2552" alt="comparisons" src="https://github.com/user-attachments/assets/e63173dc-3868-42bd-bf7d-aa7b158ab5bd" />

(The white rectangle for Anima is not an oversight, but the actual output.)

---

Specifically, the corrected `dpmpp_2s_ancestral_cfg_pp` and `dpmpp_2s_ancestral_RF_cfg_pp` are built by taking the original `dpmpp_2s_ancestral` and `dpmpp_2s_ancestral_RF`, and applying the following changes:

1. Structure the sampler such that it only ever sees the unconditional denoised estimates. This means the sampler is purely unconditional, and it predicts the next-step unconditional estimate.
2. At the end of a sampling step, apply the CFG++ guidance shift: $x_{t, cfg++} = x_{t, \varnothing} + \alpha_t (\hat x_{0, cond} - \hat x_{0, \varnothing}).$ This becomes the guided latent for that step.

Below I provide a short proof that this leads to a correct CFG++ implementation: 

Start from the CFG++ formulation provided in the paper's Appendix D (*CFG++ as Reweighted CFG*, Eq. 50), which defines the update step as:

$$x_{t-1} = x_{t-1, \varnothing} + (\hat{\epsilon}_c - \hat{\epsilon}_{\varnothing}) \left( \omega' \sqrt{1 - \bar{\alpha}_{t-1}} - \omega \sqrt{\frac{1 - \bar{\alpha}_{t-1}}{\alpha_t}} \right)$$

For CFG++, the paper specifies the weights $\omega'=0$ and $\omega=1$. Substituting these values gives:

$$x_{t-1} = x_{t-1, \varnothing} + (\hat{\epsilon}_c - \hat{\epsilon}_{\varnothing}) \left(-\sqrt{\frac{1 - \bar{\alpha}_{t-1}}{\alpha_t^{DDPM}}}\right)$$

To map this DDPM notation to modern alpha and sigma schedules, use the standard conventions:
-  $\sqrt{\bar\alpha_t^{DDPM}} = \alpha_t$
-  $\sqrt{1-\bar\alpha_t^{DDPM}} = \sigma_t$
-  $\sqrt{\alpha_t^{DDPM}} = \sqrt{\bar\alpha_t^{DDPM} / \bar\alpha_{t-1}^{DDPM}} = \alpha_t / \alpha_{t-1}$

Substitute in, yielding:

$$x_{t-1} = x_{t-1, \varnothing} + (\hat{\epsilon}_c - \hat{\epsilon}_{\varnothing}) \left(-\frac{\alpha_{t-1}}{\alpha_t}\sigma_{t}\right)$$

Converting the eps-pred model into a x0-pred model via Tweedie's formula simplifies the above to:

$$x_{t-1} = x_{t-1,\varnothing} + \alpha_{t-1}\left(\hat x_{0,c} - \hat x_{0,\varnothing}\right)$$

This implies any CFG++ sampler can be constructed by shifting an unconditional sampler by $\alpha_t\left(\hat x_{0,c} - \hat x_{0,\varnothing}\right),$ and is how this PR implements these samplers.