### PR TITLE
Fix AttributeError in VAE.is_dynamic() for VAEs constructed without a patcher

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -1255,7 +1255,10 @@ class VAE:
             return None
 
     def is_dynamic(self):
-        return self.patcher.is_dynamic()
+        # A VAE built from a state dict with no detectable VAE weights returns early
+        # from __init__ ("No VAE weights detected") before self.patcher is assigned.
+        patcher = getattr(self, "patcher", None)
+        return patcher is not None and patcher.is_dynamic()
 
 class StyleModel:
     def __init__(self, model, device="cpu"):


### PR DESCRIPTION
Fixes #14806

## Problem

`VAE.__init__` returns early (`WARNING: No VAE weights detected, VAE not initalized.`) for state dicts it cannot detect as a VAE — **before** `self.patcher` is assigned. The object is still returned to the workflow and stored in the output cache.

`VAE.is_dynamic()` (added in #14799) assumes `self.patcher` always exists. With `--cache-ram` (the default cache mode), the per-node `RAMPressureCache.ram_release` scan walks all cached outputs through `all_outputs_dynamic`; the `hasattr(output, "is_dynamic")` guard passes (the method exists), the call raises `AttributeError: 'VAE' object has no attribute 'patcher'`, and the exception kills the `prompt_worker` thread.

`CheckpointLoaderSimple` always constructs the VAE from the checkpoint state dict even when the VAE output socket is unconnected, so loading any UNET-only checkpoint plants the broken VAE — the crash then fires on the next prompt.

Full analysis: https://github.com/Comfy-Org/ComfyUI/issues/14806#issuecomment-4913414733

## Repro

1. Run any workflow whose checkpoint logs `No VAE weights detected` (VAE output need not be connected).
2. Run any second prompt → `AttributeError` in `ram_release` → prompt_worker dies.

## Fix

Guard `is_dynamic()` with `getattr`; a VAE without a patcher is not dynamically managed, so returning `False` is the correct semantic (it stays evictable like any static entry).

Verified on a production fork of this codebase: the AttributeError storm is gone with the patcher-less VAE still cached, RAM-pressure eviction works again (`removed=10` on the next scan), and a workload that previously OOM-killed the process (eviction disabled → RAM grew unbounded) now completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
