### PR TITLE
Update cla.yml

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -50,8 +50,8 @@ jobs:
         if: >
           github.event_name == 'pull_request_target' ||
           (github.event_name == 'issue_comment' && github.event.issue.pull_request && (
-            startsWith(github.event.comment.body, 'recheck') ||
-            startsWith(github.event.comment.body, 'I have read and agree to the Contributor License Agreement')
+            github.event.comment.body == 'recheck' ||
+            github.event.comment.body == 'I have read and agree to the Contributor License Agreement'
           ))
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,8 +24,8 @@ jobs:
         if: >
           github.event_name == 'pull_request_target' ||
           (github.event_name == 'issue_comment' && github.event.issue.pull_request && (
-            startsWith(github.event.comment.body, 'recheck') ||
-            startsWith(github.event.comment.body, 'I have read and agree to the Contributor License Agreement')
+            github.event.comment.body == 'recheck' ||
+            github.event.comment.body == 'I have read and agree to the Contributor License Agreement'
           ))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,17 +24,19 @@ jobs:
         if: >
           github.event_name == 'pull_request_target' ||
           (github.event_name == 'issue_comment' && github.event.issue.pull_request && (
-            github.event.comment.body == 'recheck' ||
-            github.event.comment.body == 'I have read and agree to the Contributor License Agreement'
+            startsWith(github.event.comment.body, 'recheck') ||
+            startsWith(github.event.comment.body, 'I have read and agree to the Contributor License Agreement')
           ))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
           BASE_ALLOWLIST: action@github.com,actions-user,ampagent,claude,comfy-pr-bot,GitHub Action,github-actions,github-actions[bot],Glary Bot,Glary-Bot,*[bot]
+        # For each commit emit the GitHub login when the author/committer email resolves to a GitHub account
+        # otherwise fall back to the raw git name.
         run: |
           others=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | (.author.login // empty), (.committer.login // empty)' \
+            --jq '.[] | (.author.login // .commit.author.name // empty), (.committer.login // .commit.committer.name // empty)' \
             | sort -u | grep -vix "${PR_AUTHOR}" | paste -sd, -)
           if [ -n "$others" ]; then
             echo "allowlist=${BASE_ALLOWLIST},${others}" >> "$GITHUB_OUTPUT"
@@ -43,13 +45,13 @@ jobs:
           fi
 
       - name: CLA Assistant
-        # Run on PR events, on "recheck" comment, or when someone posts the exact signing phrase.
+        # Run on PR events, on "recheck" comment, or when someone posts the signing phrase.
         # IMPORTANT: this phrase must match `custom-pr-sign-comment` below.
         if: >
           github.event_name == 'pull_request_target' ||
           (github.event_name == 'issue_comment' && github.event.issue.pull_request && (
-            github.event.comment.body == 'recheck' ||
-            github.event.comment.body == 'I have read and agree to the Contributor License Agreement'
+            startsWith(github.event.comment.body, 'recheck') ||
+            startsWith(github.event.comment.body, 'I have read and agree to the Contributor License Agreement')
           ))
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:


### PR DESCRIPTION
Make CLA more robust by including commit authors in the allowlist even if they have no GitHub account. This to ensure only PR authors are required to sign.