### PR TITLE
fix: Load3D failing path validation from double path resolution

### DIFF
--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -61,14 +61,10 @@ class Load3D(IO.ComfyNode):
 
     @classmethod
     def execute(cls, model_file, image, **kwargs) -> IO.NodeOutput:
-        image_path = folder_paths.get_annotated_filepath(image['image'])
-        mask_path = folder_paths.get_annotated_filepath(image['mask'])
-        normal_path = folder_paths.get_annotated_filepath(image['normal'])
-
         load_image_node = nodes.LoadImage()
-        output_image, ignore_mask = load_image_node.load_image(image=image_path)
-        ignore_image, output_mask = load_image_node.load_image(image=mask_path)
-        normal_image, ignore_mask2 = load_image_node.load_image(image=normal_path)
+        output_image, ignore_mask = load_image_node.load_image(image=image['image'])
+        ignore_image, output_mask = load_image_node.load_image(image=image['mask'])
+        normal_image, ignore_mask2 = load_image_node.load_image(image=image['normal'])
 
         video = None
 


### PR DESCRIPTION
Load3D.execute resolved the annotated image paths itself, then passed the resulting absolute paths to LoadImage.load_image, which resolves them again. 
The second resolution has no [temp] annotation, so it uses the input directory as base and the path containment check added then rejects the temp-directory path as invalid.

Pass the raw annotated names to LoadImage and let it resolve them once.

## Screenshot
before
<img width="1314" height="1257" alt="image" src="https://github.com/user-attachments/assets/6e390ff5-de83-4e40-9090-bdf1470bcab3" />

after
<img width="1206" height="1249" alt="image" src="https://github.com/user-attachments/assets/a98f1975-c444-419d-86e8-0f0949748020" />
