### PR TITLE
Enable comfy-kitchen Triton backend by default on ROCm/AMD

### DIFF
--- a/comfy/quant_ops.py
+++ b/comfy/quant_ops.py
@@ -25,10 +25,18 @@ try:
             ck.registry.disable("cuda")
             logging.warning("WARNING: You need pytorch with cu130 or higher to use optimized CUDA operations.")
 
-    if args.enable_triton_backend:
+    # On ROCm/AMD the CUDA backend is unavailable, so Triton is the only accelerated
+    # comfy-kitchen backend. Enable it by default there, but only on Triton >= 3.7:
+    # older Triton lacks libdevice.rint on the HIP backend and hard-crashes the INT8 path.
+    if args.enable_triton_backend or torch.version.hip is not None:
         try:
             import triton
-            logging.info("Found triton %s. Enabling comfy-kitchen triton backend.", triton.__version__)
+            triton_version = tuple(int(v) for v in triton.__version__.split(".")[:2])
+            if args.enable_triton_backend or triton_version >= (3, 7):
+                logging.info("Found triton %s. Enabling comfy-kitchen triton backend.", triton.__version__)
+            else:
+                logging.info("Triton %s is too old for the ROCm INT8 path (needs >= 3.7); comfy-kitchen triton backend disabled.", triton.__version__)
+                ck.registry.disable("triton")
         except ImportError as e:
             logging.error(f"Failed to import triton, Error: {e}, the comfy-kitchen triton backend will not be available.")
             ck.registry.disable("triton")


### PR DESCRIPTION
## What
On AMD/ROCm the CUDA backend is unavailable, so Triton is the only accelerated comfy-kitchen backend —
yet it's disabled by default (opt-in `--enable-triton-backend`, #12730). Quantized models on AMD
therefore fall back to the slow (and sometimes crashing, #61) eager path.

This enables Triton by default on ROCm; NVIDIA is unchanged (CUDA stays the fast path there).
```diff
-    if args.enable_triton_backend:
+    if args.enable_triton_backend or (torch.version.hip is not None):
```

## Why it's safe & worth it
- Triton INT8 works on AMD with current ROCm PyTorch (Triton 3.7+) — verified on gfx1100/1201/1151.
- ~2× faster end-to-end than the eager INT8 fallback (DiT-512: ~2.3s vs ~5.4s on gfx1201).
- On import failure Triton is disabled with a log (existing path) → no regression on any platform.
- Older Triton (3.5/3.6) should upgrade to 3.7+ (fixes the upstream `libdevice.rint` issue).

## Testing
Launch on an AMD GPU **without** the flag and confirm the log shows
`Found comfy_kitchen backend triton: {... 'disabled': False ...}` and that an INT8 model runs on the
triton backend (not eager).

Fix: https://github.com/Comfy-Org/ComfyUI/issues/14861
