### PR TITLE
[Partner Nodes] fix(Tencent): restore Tencent3DPartNode FBX output

### DIFF
--- a/comfy_api_nodes/apis/hunyuan3d.py
+++ b/comfy_api_nodes/apis/hunyuan3d.py
@@ -77,6 +77,7 @@ class To3DUVTaskRequest(BaseModel):
 
 class To3DPartTaskRequest(BaseModel):
     File: TaskFile3DInput = Field(...)
+    EnableStagedGeneration: bool | None = Field(None)
 
 
 class TextureEditImageInfo(BaseModel):

--- a/comfy_api_nodes/nodes_hunyuan3d.py
+++ b/comfy_api_nodes/nodes_hunyuan3d.py
@@ -642,6 +642,7 @@ class Tencent3DPartNode(IO.ComfyNode):
             response_model=To3DProTaskCreateResponse,
             data=To3DPartTaskRequest(
                 File=TaskFile3DInput(Type=file_format.upper(), Url=model_url),
+                EnableStagedGeneration=True,
             ),
             is_rate_limited=_is_tencent_rate_limited,
         )


### PR DESCRIPTION
Tencent has made changes to its API, requiring an additional parameter to obtain FBX output.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

