### PR TITLE
Fix SaveVideo description: says images, saves video

### DIFF
--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -81,7 +81,7 @@ class SaveVideo(io.ComfyNode):
             display_name="Save Video",
             category="video",
             essentials_category="Basics",
-            description="Saves the input images to your ComfyUI output directory.",
+            description="Saves the input video to your ComfyUI output directory.",
             inputs=[
                 io.Video.Input("video", tooltip="The video to save."),
                 io.String.Input("filename_prefix", default="video/ComfyUI", tooltip="The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."),

--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -81,7 +81,7 @@ class SaveVideo(io.ComfyNode):
             display_name="Save Video",
             category="video",
             essentials_category="Basics",
-            description="Saves the input video to your ComfyUI output directory.",
+            description="Saves the input videos to your ComfyUI output directory.",
             inputs=[
                 io.Video.Input("video", tooltip="The video to save."),
                 io.String.Input("filename_prefix", default="video/ComfyUI", tooltip="The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."),


### PR DESCRIPTION
Fixes #14747 — the `SaveVideo` description reads "Saves the input **images** to your ComfyUI output directory", copied from `SaveImage`. #14871 fixed the same copied wording on the preview nodes but did not touch `SaveVideo`; a grep confirms it is the only remaining video node with the wrong copy. One-line change in `comfy_extras/nodes_video.py`.

Tests run:
```
python -c "from comfy_extras.nodes_video import SaveVideo; print(SaveVideo.define_schema().description)"
→ Saves the input video to your ComfyUI output directory.
pytest tests-unit -q   → 1095 passed, 10 skipped   (identical to master; string-only change)
```
Non-English tooltips live in the frontend locale files (ComfyUI_frontend), out of scope here.
