### PR TITLE
Fix LoRA training with 5D latents in bucket and multi-res modes

### DIFF
--- a/comfy_extras/nodes_train.py
+++ b/comfy_extras/nodes_train.py
@@ -923,7 +923,7 @@ def _run_training_loop(
 
     if bucket_mode:
         # Use first bucket's first latent as dummy for guider
-        dummy_latent = latents[0][:1].repeat(num_images, 1, 1, 1)
+        dummy_latent = latents[0][:1].repeat(num_images, *([1] * (latents[0].dim() - 1)))
         guider.sample(
             noise.generate_noise({"samples": dummy_latent}),
             dummy_latent,
@@ -933,7 +933,7 @@ def _run_training_loop(
         )
     elif multi_res:
         # use first latent as dummy latent if multi_res
-        latents = latents[0].repeat(num_images, 1, 1, 1)
+        latents = latents[0].repeat(num_images, *([1] * (latents[0].dim() - 1)))
         guider.sample(
             noise.generate_noise({"samples": latents}),
             latents,


### PR DESCRIPTION
## Problem

`TrainLoraNode` crashes for any model whose VAE produces 5D latents — Qwen Image, Krea 2, and other video-style `[B, C, T, H, W]` VAEs — whenever `bucket_mode` is enabled (with `ResolutionBucket`) or the dataset contains mixed resolutions (multi-res path):

```
RuntimeError: Number of dimensions of repeat dims can not be smaller than number of dimensions of tensor
```

Uniform-resolution datasets are unaffected because that path takes `torch.cat` instead. This effectively limits aspect-ratio-bucketed training to 4D-latent models only.

## Cause

Both dummy-latent constructions in `_run_training_loop` hardcode a 4D repeat:

```python
dummy_latent = latents[0][:1].repeat(num_images, 1, 1, 1)   # bucket_mode
latents = latents[0].repeat(num_images, 1, 1, 1)            # multi_res
```

## Fix

Repeat along the batch dim only and keep every remaining dim, so the guider dummy works for latents of any rank:

```python
latents[0][:1].repeat(num_images, *([1] * (latents[0].dim() - 1)))
```

The train steps themselves (`_train_step_standard_mode` / `_train_step_bucket_mode` / `_train_step_multires_mode`) already index only the batch dimension, so no other change is needed. For 4D latents the expansion is byte-identical to the previous behavior.

## Testing

On an RTX 5090 with Krea 2 RAW fp8 (Qwen Image VAE, 5D latents) and a 14-image mixed-resolution image/caption dataset:

- **Before**: both `ResolutionBucket` + `bucket_mode=true` and plain mixed-resolution (multi-res) training crash at `_run_training_loop` with the RuntimeError above.
- **After**: both paths train to completion (20-step runs, `training_dtype=none`, `bypass_mode`, `quantized_backward`) and `SaveLoRA` produces a working LoRA.
- Uniform-resolution 4D-path behavior unchanged (also re-tested on the same setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruwJZq4Tv7rVZa7pz7cqS