### PR TITLE
Fix overlap-linear context window crash when context_overlap is 0

### DIFF
--- a/comfy/context_windows.py
+++ b/comfy/context_windows.py
@@ -955,6 +955,8 @@ def create_weights_overlap_linear(length: int, full_length: int, idxs: list[int]
     # based on code in Kijai's WanVideoWrapper: https://github.com/kijai/ComfyUI-WanVideoWrapper/blob/dbb2523b37e4ccdf45127e5ae33e31362f755c8e/nodes.py#L1302
     # only expected overlap is given different weights
     weights_torch = torch.ones((length))
+    if context_overlap <= 0:
+        return weights_torch
     # blend left-side on all except first window
     if min(idxs) > 0:
         ramp_up = torch.linspace(1e-37, 1, context_overlap)

--- a/tests-unit/comfy_test/context_windows_test.py
+++ b/tests-unit/comfy_test/context_windows_test.py
@@ -1,0 +1,29 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import torch
+
+# comfy.model_management initializes the torch device at import time and requires
+# CUDA (or --cpu), which the unit-test environment does not provide. Stub it so
+# importing comfy.context_windows does not trigger device initialization.
+with patch.dict(sys.modules, {"comfy.model_management": MagicMock()}):
+    from comfy.context_windows import create_weights_overlap_linear
+
+
+class TestCreateWeightsOverlapLinear:
+    def test_zero_overlap_returns_ones(self):
+        # context_overlap == 0 is reachable (the context-window nodes allow min=0,
+        # and the WAN/LTXV nodes derive it via max(overlap // 4, 0)). With no overlap
+        # band there is nothing to blend, so every weight is 1.
+        w = create_weights_overlap_linear(16, 100, list(range(20, 36)), 0)
+        assert w.shape == (16,)
+        assert torch.equal(w, torch.ones(16))
+
+    def test_overlap_ramps_edges(self):
+        w = create_weights_overlap_linear(16, 100, list(range(20, 36)), 4)
+        assert w.shape == (16,)
+        # middle (non-first) window: left edge ramps up to 1 over the overlap width
+        assert w[0] < w[3]
+        assert torch.isclose(w[3], torch.tensor(1.0))
+        # right edge ramps back down
+        assert w[-1] < w[-4]


### PR DESCRIPTION
### Problem

`create_weights_overlap_linear` builds the right-edge blend ramp with:

```python
weights_torch[-context_overlap:] = ramp_down
```

When `context_overlap == 0`, `-context_overlap` is `-0 == 0`, so the target becomes `weights_torch[0:]` — the entire `(length,)` tensor — while `ramp_down = torch.linspace(1, 1e-37, 0)` is a zero-length tensor. Assigning the empty ramp into the full slice raises:

```
RuntimeError: The expanded size of the tensor (16) must match the existing size (0) at non-singleton dimension 0.
```

`context_overlap == 0` is reachable: the context-window nodes expose `context_overlap` with `min=0`, `overlap-linear` is in the fuse-method list, and the WAN/LTXV nodes derive it as `max(context_overlap // 4, 0)` (0 for any user overlap 0–3). It fires on the first non-last window sampled with `fuse_method="overlap-linear"`.

### Fix

With no overlap there is no band to blend, so return the all-ones weights early. This avoids the `-0` slice entirely and leaves the `context_overlap > 0` behavior unchanged.

### Tests

Added `tests-unit/comfy_test/context_windows_test.py`: `context_overlap=0` returns all-ones (crashes on master), and a `context_overlap>0` case still ramps both edges.
