### PR TITLE
Fix HyperTile random_divisor never picking the last option

### DIFF
--- a/comfy_extras/nodes_hypertile.py
+++ b/comfy_extras/nodes_hypertile.py
@@ -16,7 +16,7 @@ def random_divisor(value: int, min_value: int, /, max_options: int = 1) -> int:
     ns = [value // i for i in divisors[:max_options]]  # has at least 1 element
 
     if len(ns) - 1 > 0:
-        idx = randint(low=0, high=len(ns) - 1, size=(1,)).item()
+        idx = randint(low=0, high=len(ns), size=(1,)).item()
     else:
         idx = 0
 

--- a/tests-unit/comfy_extras_test/nodes_hypertile_test.py
+++ b/tests-unit/comfy_extras_test/nodes_hypertile_test.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch, MagicMock
+
+import torch
+
+mock_nodes = MagicMock()
+mock_nodes.MAX_RESOLUTION = 16384
+mock_server = MagicMock()
+
+with patch.dict("sys.modules", {"nodes": mock_nodes, "server": mock_server}):
+    from comfy_extras.nodes_hypertile import random_divisor
+
+
+class TestRandomDivisor:
+    def test_all_options_are_reachable(self):
+        # value=8, min=2, max_options=2 -> candidate tile counts {4, 2}; both must be
+        # selectable. torch.randint's high is exclusive, so the last option was unreachable.
+        torch.manual_seed(0)
+        results = {random_divisor(8, 2, 2) for _ in range(200)}
+        assert results == {2, 4}
+
+    def test_single_option_is_deterministic(self):
+        assert random_divisor(8, 8, 1) == 1


### PR DESCRIPTION
### Problem

`random_divisor` picks a tile count with:

```python
idx = randint(low=0, high=len(ns) - 1, size=(1,)).item()
```

`torch.randint`'s `high` is exclusive, so this samples indices `0 .. len(ns) - 2` and never selects the last element of `ns`. With `swap_size=2` (two candidate tile counts) it therefore always returns the first option — identical to `swap_size=1` — silently defeating HyperTile's randomization.

### Fix

Use `high=len(ns)` so the full index range is sampled and every candidate is reachable.

### Tests

Added `tests-unit/comfy_extras_test/nodes_hypertile_test.py`: over many draws `random_divisor(8, 2, 2)` must yield both candidate counts `{2, 4}` (only `{4}` on master), and the single-option case stays deterministic.
