### PR TITLE
Fix image_alpha_fix only padding a single channel

### DIFF
--- a/node_helpers.py
+++ b/node_helpers.py
@@ -86,6 +86,7 @@ def image_alpha_fix(destination, source):
     if destination.shape[-1] < source.shape[-1]:
         source = source[...,:destination.shape[-1]]
     elif destination.shape[-1] > source.shape[-1]:
-        source = torch.nn.functional.pad(source, (0, 1))
-        source[..., -1] = 1.0
+        pad = destination.shape[-1] - source.shape[-1]
+        source = torch.nn.functional.pad(source, (0, pad))
+        source[..., -pad:] = 1.0
     return destination, source

--- a/tests-unit/node_helpers_test.py
+++ b/tests-unit/node_helpers_test.py
@@ -1,0 +1,27 @@
+import torch
+
+import node_helpers
+
+
+class TestImageAlphaFix:
+    def test_pads_rgb_to_rgba(self):
+        destination = torch.zeros(1, 2, 2, 4)
+        source = torch.full((1, 2, 2, 3), 0.5)
+        _, source = node_helpers.image_alpha_fix(destination, source)
+        assert source.shape[-1] == 4
+        assert torch.all(source[..., :3] == 0.5)  # original channels preserved
+        assert torch.all(source[..., 3] == 1.0)   # added alpha
+
+    def test_pads_more_than_one_channel(self):
+        # channel gap > 1 (grayscale source, RGBA destination) must still match up.
+        destination = torch.zeros(1, 2, 2, 4)
+        source = torch.zeros(1, 2, 2, 1)
+        _, source = node_helpers.image_alpha_fix(destination, source)
+        assert source.shape[-1] == 4
+        assert torch.all(source[..., 1:] == 1.0)
+
+    def test_truncates_when_source_has_more_channels(self):
+        destination = torch.zeros(1, 2, 2, 3)
+        source = torch.ones(1, 2, 2, 4)
+        _, source = node_helpers.image_alpha_fix(destination, source)
+        assert source.shape[-1] == 3


### PR DESCRIPTION
### Problem

`image_alpha_fix` makes `source`'s channel count match `destination`'s. When the destination has more channels it pads the source:

```python
source = torch.nn.functional.pad(source, (0, 1))
source[..., -1] = 1.0
```

This always adds exactly **one** channel. If the channel difference is greater than one — e.g. a single-channel (grayscale) source against a 4-channel RGBA destination — the padded source still has the wrong channel count, so the following `ImageBlend` / `ImageCompositeMasked` operation gets mismatched tensors. The common RGB(3)→RGBA(4) case has a gap of one, which is why it went unnoticed.

### Fix

Pad by the actual channel difference and set all added channels to `1.0`, matching the existing single-channel intent.

### Tests

Added `tests-unit/node_helpers_test.py`: RGB→RGBA still adds one alpha channel and preserves the originals, a >1 channel gap now matches up (fails on master), and the source-has-more case still truncates.
