### PR TITLE
Fix model file list cache never being reused

### DIFF
--- a/app/model_manager.py
+++ b/app/model_manager.py
@@ -125,8 +125,6 @@ class ModelFileManager:
             return None
         if not os.path.isdir(folder):
             return None
-        if os.path.getmtime(folder) != model_file_list_cache[1]:
-            return None
         for x in model_file_list_cache[1]:
             time_modified = model_file_list_cache[1][x]
             folder = x
@@ -145,6 +143,11 @@ class ModelFileManager:
 
         result: list[str] = []
         dirs: dict[str, float] = {}
+
+        try:
+            dirs[directory] = os.path.getmtime(directory)
+        except FileNotFoundError:
+            logging.warning(f"Warning: Unable to access {directory}. Skipping this path.")
 
         for dirpath, subdirs, filenames in os.walk(directory, followlinks=True, topdown=True):
             subdirs[:] = [d for d in subdirs if d not in excluded_dir_names]

--- a/tests-unit/app_test/model_file_cache_test.py
+++ b/tests-unit/app_test/model_file_cache_test.py
@@ -1,0 +1,29 @@
+import os
+
+from app.model_manager import ModelFileManager
+
+
+class TestModelFileListCache:
+    def test_cache_is_reused_when_unchanged(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "m.safetensors").write_bytes(b"x")
+
+        mgr = ModelFileManager()
+        out = mgr.recursive_search_models_(str(tmp_path), 0)
+        mgr.set_cache(str(tmp_path), out)
+
+        # nothing changed, so the cached result must be returned instead of None
+        assert mgr.cache_model_file_list_(str(tmp_path)) is out
+
+    def test_cache_invalidated_when_top_folder_changes(self, tmp_path):
+        mgr = ModelFileManager()
+        out = mgr.recursive_search_models_(str(tmp_path), 0)
+        mgr.set_cache(str(tmp_path), out)
+        assert mgr.cache_model_file_list_(str(tmp_path)) is out
+
+        # a file added directly under the top folder changes its mtime, which must
+        # invalidate the cache (the top folder is tracked, not just subfolders)
+        bumped = os.path.getmtime(str(tmp_path)) + 100
+        os.utime(str(tmp_path), (bumped, bumped))
+        assert mgr.cache_model_file_list_(str(tmp_path)) is None


### PR DESCRIPTION
### Problem

`ModelFileManager.cache_model_file_list_` validates its cache with:

```python
if os.path.getmtime(folder) != model_file_list_cache[1]:
    return None
```

`model_file_list_cache` is the `(result, dirs, timestamp)` tuple, so `model_file_list_cache[1]` is the **dirs dict**. `os.path.getmtime(folder)` is a **float**, and `float != dict` is always `True`, so this always returns `None` — the cache is never reused and `recursive_search_models_` re-walks the whole model tree on every `/experiment/models/{folder}` request.

The top-level `folder` is also never stored in `dirs` (only subdirectories are), so there was no recorded mtime to compare it against in the first place.

### Fix

Drop the broken scalar comparison, and seed the searched directory's own mtime into `dirs` in `recursive_search_models_` — mirroring `folder_paths.recursive_search`. The existing per-directory validation loop then covers the top folder too, so the cache is reused when nothing changed and still invalidates when a file is added directly under the folder.

### Tests

Added `tests-unit/app_test/model_file_cache_test.py`: an unchanged tree returns the cached result (returned `None` on master), and bumping the top folder's mtime invalidates it.
