### PR TITLE
Fix BOFT adapter silently dropping LoRAs without an alpha key

### DIFF
--- a/comfy/weight_adapter/boft.py
+++ b/comfy/weight_adapter/boft.py
@@ -60,6 +60,8 @@ class BOFTAdapter(WeightAdapterBase):
         blocks = v[0]
         rescale = v[1]
         alpha = v[2]
+        if alpha is None:
+            alpha = 0
         dora_scale = v[3]
 
         blocks = comfy.model_management.cast_to_device(

--- a/tests-unit/comfy_test/weight_adapter_boft_test.py
+++ b/tests-unit/comfy_test/weight_adapter_boft_test.py
@@ -1,0 +1,32 @@
+import torch
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+from comfy.weight_adapter.boft import BOFTAdapter
+
+
+def _apply(alpha):
+    torch.manual_seed(0)
+    blocks = torch.randn(1, 2, 2, 2) * 0.1
+    weight = torch.eye(4)
+    adapter = BOFTAdapter("w", (blocks, None, alpha, None))
+    out = adapter.calculate_weight(
+        weight.clone(), "w", 1.0, 1.0, 0, lambda x: x,
+        intermediate_dtype=torch.float32, original_weight=None,
+    )
+    return out, weight
+
+
+class TestBOFTAdapter:
+    def test_applies_when_alpha_missing(self):
+        # a BOFT LoRA without an ".alpha" key arrives with alpha=None; it must still
+        # apply the rotation (None means "no constraint"), like the OFT adapter.
+        out, weight = _apply(None)
+        assert not torch.equal(out, weight)
+
+    def test_missing_alpha_matches_zero_alpha(self):
+        out_none, _ = _apply(None)
+        out_zero, _ = _apply(0)
+        assert torch.allclose(out_none, out_zero)


### PR DESCRIPTION
### Problem

When a BOFT LoRA has no `{key}.alpha` entry, `load_lora` passes `alpha=None` (`comfy/lora.py`). `BOFTAdapter.calculate_weight` then evaluates `if alpha > 0:` with `alpha=None`, raising `TypeError: '>' not supported between instances of 'NoneType' and 'int'`. That exception is swallowed by the broad `except Exception` in the caller (which logs and returns the weight unchanged), so **the BOFT LoRA is silently applied with no effect** — no error surfaces to the user.

`OFTAdapter` already guards this exact case (`if alpha is None: alpha = 0`), and `BOFTAdapter._get_orthogonal_matrices` guards it too; only `calculate_weight` was missing it.

### Fix

Treat a missing `alpha` as `0` (no constraint) before the comparison, mirroring `OFTAdapter`.

### Tests

Added `tests-unit/comfy_test/weight_adapter_boft_test.py`: with `alpha=None` the adapter now modifies the weight (returned it unchanged before) and matches the `alpha=0` result. Both fail on master (the weight is unchanged) and pass with this change.
