### PR TITLE
Fix kl_optimal scheduler producing NaN at steps=1

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -729,7 +729,7 @@ def linear_quadratic_schedule(model_sampling, steps, threshold_noise=0.025, line
 
 # Referenced from https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15608
 def kl_optimal_scheduler(n: int, sigma_min: float, sigma_max: float) -> torch.Tensor:
-    adj_idxs = torch.arange(n, dtype=torch.float).div_(n - 1)
+    adj_idxs = torch.arange(n, dtype=torch.float).div_(max(n - 1, 1))
     sigmas = adj_idxs.new_zeros(n + 1)
     sigmas[:-1] = (adj_idxs * math.atan(sigma_min) + (1 - adj_idxs) * math.atan(sigma_max)).tan_()
     return sigmas

--- a/tests-unit/comfy_test/kl_optimal_scheduler_test.py
+++ b/tests-unit/comfy_test/kl_optimal_scheduler_test.py
@@ -1,0 +1,25 @@
+import torch
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+from comfy.samplers import kl_optimal_scheduler
+
+
+class TestKLOptimalScheduler:
+    def test_single_step_is_not_nan(self):
+        # steps=1 is a valid KSampler input; div by (n - 1) made the first sigma NaN.
+        sigmas = kl_optimal_scheduler(1, 0.0291675, 14.614642)
+        assert not torch.isnan(sigmas).any()
+        assert sigmas.shape == (2,)
+        # the single step should start at sigma_max and end at 0
+        assert torch.isclose(sigmas[0], torch.tensor(14.614642), atol=1e-3)
+        assert sigmas[-1] == 0
+
+    def test_multi_step_unchanged(self):
+        sigmas = kl_optimal_scheduler(20, 0.0291675, 14.614642)
+        assert not torch.isnan(sigmas).any()
+        assert sigmas.shape == (21,)
+        assert torch.isclose(sigmas[0], torch.tensor(14.614642), atol=1e-3)
+        assert sigmas[-1] == 0


### PR DESCRIPTION
### Problem

`kl_optimal_scheduler` computes `torch.arange(n).div_(n - 1)`. When `n == 1` this divides by zero, so `adj_idxs` becomes `[nan]` and the first sigma is `nan`. `kl_optimal` is a selectable scheduler and `KSampler`/`BasicScheduler` allow `steps` down to `1`, so a single-step kl_optimal run yields `[nan, 0.0]` and the model input scaling turns the whole output into garbage.

### Fix

Clamp the divisor to at least 1 (`max(n - 1, 1)`). For `n == 1` this gives `adj_idxs = [0]`, so the single step correctly starts at `sigma_max` (`tan(atan(sigma_max))`); all other step counts are unchanged.

### Tests

Added `tests-unit/comfy_test/kl_optimal_scheduler_test.py`: `steps=1` no longer contains NaN and starts at `sigma_max`/ends at 0 (NaN on master); a 20-step schedule is unchanged.
