### PR TITLE
Fix SplitSigmasDenoise returning empty high_sigmas at low denoise

### DIFF
--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -245,7 +245,7 @@ class SplitSigmasDenoise(io.ComfyNode):
     def execute(cls, sigmas, denoise) -> io.NodeOutput:
         steps = max(sigmas.shape[-1] - 1, 0)
         total_steps = round(steps * denoise)
-        sigmas1 = sigmas[:-(total_steps)]
+        sigmas1 = sigmas[:len(sigmas) - total_steps]
         sigmas2 = sigmas[-(total_steps + 1):]
         return io.NodeOutput(sigmas1, sigmas2)
 

--- a/tests-unit/comfy_extras_test/split_sigmas_denoise_test.py
+++ b/tests-unit/comfy_extras_test/split_sigmas_denoise_test.py
@@ -1,0 +1,23 @@
+import torch
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+from comfy_extras.nodes_custom_sampler import SplitSigmasDenoise
+
+
+class TestSplitSigmasDenoise:
+    def test_low_denoise_keeps_full_high_sigmas(self):
+        # denoise small enough that round(steps * denoise) == 0. sigmas[:-0] == sigmas[:0]
+        # collapsed high_sigmas to empty; it should stay the full schedule.
+        sigmas = torch.linspace(10, 0, 21)  # 20 steps
+        high, low = SplitSigmasDenoise.execute(sigmas, 0.02)
+        assert high.shape[-1] == 21
+        assert low.shape[-1] == 1
+
+    def test_normal_denoise_split(self):
+        sigmas = torch.linspace(10, 0, 21)
+        high, low = SplitSigmasDenoise.execute(sigmas, 0.5)  # total_steps = 10
+        assert high.shape[-1] == 11
+        assert low.shape[-1] == 11


### PR DESCRIPTION
### Problem

`SplitSigmasDenoise` computes `total_steps = round(steps * denoise)` and then `sigmas1 = sigmas[:-(total_steps)]`. When `total_steps == 0` (any denoise small enough to round to 0), `-(total_steps)` is `-0 == 0`, so `sigmas[:-0]` is `sigmas[:0]` — the **empty** tensor. `high_sigmas` collapses to length 0 instead of the full schedule, silently producing a zero-length sampling branch.

### Fix

Slice with `sigmas[:len(sigmas) - total_steps]`. For `total_steps == 0` this keeps the whole schedule; for `total_steps > 0` it is identical to the original slice.

### Tests

Added `tests-unit/comfy_extras_test/split_sigmas_denoise_test.py`: a low denoise (`total_steps == 0`) keeps the full 21-value `high_sigmas` (empty on master), and a normal 0.5 denoise splits 11/11 as before.
