### PR TITLE
Fix out-of-range frame indices in strided context windows

### DIFF
--- a/comfy/context_windows.py
+++ b/comfy/context_windows.py
@@ -1033,7 +1033,7 @@ def shift_window_to_start(window: list[int], num_frames: int):
 def shift_window_to_end(window: list[int], num_frames: int):
     # 1) shift window to start
     shift_window_to_start(window, num_frames)
-    end_val = window[-1]
+    end_val = max(window)
     end_delta = num_frames - end_val - 1
     for i in range(len(window)):
         # 2) add end_delta to each val to slide windows to end

--- a/tests-unit/comfy_test/context_windows_test.py
+++ b/tests-unit/comfy_test/context_windows_test.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from comfy.context_windows import create_windows_uniform_standard, shift_window_to_end
+
+
+def test_shift_window_to_end_uses_window_max():
+    # A dilated (strided) window wraps around, so it is not monotonic and its last
+    # element is not its largest. shift_window_to_end must slide the window so its
+    # maximum lands on num_frames - 1 and every index stays in range -- shifting
+    # based on window[-1] instead over-shifts and produces out-of-bounds indices.
+    num_frames = 48
+    window = [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 0, 4, 8, 12]
+    shift_window_to_end(window, num_frames)
+    assert max(window) == num_frames - 1
+    assert all(0 <= i < num_frames for i in window)
+
+
+def test_create_windows_uniform_standard_strided_indices_in_range():
+    # WAN/LTXV-style manual context windows with context_stride >= 2 produce dilated
+    # windows; every generated index must be a valid frame index. create_windows_
+    # uniform_standard only reads these handler attributes.
+    num_frames = 48
+    handler = SimpleNamespace(context_length=16, context_stride=3, context_overlap=0, _step=0)
+    windows = create_windows_uniform_standard(num_frames, handler, {})
+    assert windows
+    for window in windows:
+        for idx in window:
+            assert 0 <= idx < num_frames, f"index {idx} out of range in window {window}"


### PR DESCRIPTION
`shift_window_to_end` computes its shift from `window[-1]`, but for **dilated (strided) context windows** the window wraps around and is not monotonic, so the last element isn't the largest. It then slides the window past the end of the video and produces frame indices `>= num_frames`, which crash sampling with `IndexError` when they index the latent (`IndexListContextWindow.get_tensor` / `add_window`).

This hits `create_windows_uniform_standard` — the default schedule for the WAN / LTXV manual context-window nodes — whenever `context_stride >= 2` and `num_frames` isn't a clean multiple of `context_length` (the common case).

Example (`num_frames=48, context_length=16, context_stride=3`): the largest dilated window comes out as

```
[35, 39, 43, 47, 51, 55, 59, 63, 67, 71, 75, 79, 35, 39, 43, 47]
```

— indices 51–79 are out of bounds for a 48-frame latent.

Fix: shift based on `max(window)` instead of `window[-1]`. `shift_window_to_end` has a single caller, and for the default stride-1 windows `window[-1] == max(window)`, so contiguous-window output is unchanged.

Added a test covering both the helper and the `create_windows_uniform_standard` entry point with strided windows.
