### PR TITLE
Match file extensions case-insensitively in `filter_files_content_types`

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -236,7 +236,7 @@ def filter_files_content_types(files: list[str], content_types: List[Literal["im
     global extension_mimetypes_cache
     result = []
     for file in files:
-        extension = file.split('.')[-1]
+        extension = file.split('.')[-1].lower()
         if extension not in extension_mimetypes_cache:
             mime_type, _ = mimetypes.guess_type(file, strict=False)
             if not mime_type:

--- a/tests-unit/folder_paths_test/filter_by_content_types_test.py
+++ b/tests-unit/folder_paths_test/filter_by_content_types_test.py
@@ -51,6 +51,14 @@ def test_categorizes_all_uniquely(mock_dir, file_extensions, patched_mimetype_ca
         assert len(filtered_files) == len(extensions)
 
 
+def test_categorizes_uppercase_extensions(patched_mimetype_cache):
+    # Extensions must be matched case-insensitively (like filter_files_extensions),
+    # so an uppercase 3D-model extension isn't dropped just because the mimetype
+    # cache keys and the OS mimetypes DB are lowercase.
+    files = ["sample_model.FBX", "sample_model.fbx"]
+    assert filter_files_content_types(files, ["model"]) == ["sample_model.FBX", "sample_model.fbx"]
+
+
 def test_handles_bad_extensions():
     files = ["file1.txt", "file2.py", "file3.example", "file4.pdf", "file5.ini", "file6.doc", "file7.md"]
     assert filter_files_content_types(files, ["image", "audio", "video"]) == []


### PR DESCRIPTION
`filter_files_content_types` looks up the file extension without lowercasing it, so a file with an uppercase extension (e.g. `model.FBX`) misses the pre-seeded `extension_mimetypes_cache` (whose keys are lowercase) and falls through to `mimetypes.guess_type`, which returns `None` for extensions the OS db doesn't know — such as `fbx`. The file is then silently dropped, while the identical lowercase `model.fbx` is kept.

The sibling `filter_files_extensions` already lowercases the extension (`os.path.splitext(a)[-1].lower()`); this brings `filter_files_content_types` in line so extensions are matched case-insensitively.

This helper backs node input-file listing (LoadImage / Load3D-style) and model previews, so uppercase-extension files currently vanish from those lists.
