### PR TITLE
Honor `strict_duration` in `VideoFromComponents.as_trimmed`

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -598,7 +598,7 @@ class VideoFromComponents(VideoInput):
         duration: float | None = None,
         strict_duration: bool = True,
     ) -> VideoInput | None:
-        if self.get_duration() < start_time + duration:
+        if strict_duration and self.get_duration() < start_time + duration:
             return None
         #TODO Consider tracking duration and trimming at time of save?
         return VideoFromFile(self.get_stream_source(), start_time=start_time, duration=duration)

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -116,6 +116,16 @@ def test_video_from_components_get_dimensions(video_components):
     assert height == 2
 
 
+def test_video_from_components_as_trimmed_respects_strict_duration(video_components):
+    """as_trimmed honors strict_duration, matching VideoFromFile.as_trimmed."""
+    video = VideoFromComponents(video_components)
+    over = video.get_duration() + 100
+    # Non-strict: a window longer than the source yields a best-effort clip, not None.
+    assert video.as_trimmed(start_time=0, duration=over, strict_duration=False) is not None
+    # Strict: the same over-long window is rejected.
+    assert video.as_trimmed(start_time=0, duration=over, strict_duration=True) is None
+
+
 def test_video_from_file_get_duration(simple_video_file):
     """Duration extracted from file metadata"""
     video = VideoFromFile(simple_video_file)


### PR DESCRIPTION
`VideoFromComponents.as_trimmed` accepts a `strict_duration` parameter but never uses it — it always returns `None` when the requested window exceeds the source. So `strict_duration=False` (best-effort trim) is broken for component-backed videos: the TrimVideo node feeding a `CreateVideo` output an over-long `duration` gets `None` back and raises `ValueError("Failed to slice video…")`, while the identical file-backed input succeeds.

The sibling `VideoFromFile.as_trimmed` already gates its `None` return on `strict_duration`; this brings `VideoFromComponents.as_trimmed` in line.
