### PR TITLE
Fix cached outputs missing from job results when prompt has no client_id

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -426,12 +426,12 @@ def _is_intermediate_output(dynprompt, node_id):
 
 
 def _send_cached_ui(server, node_id, display_node_id, cached, prompt_id, ui_outputs):
+    if cached.ui is not None:
+        ui_outputs[node_id] = cached.ui
     if server.client_id is None:
         return
     cached_ui = cached.ui or {}
     server.send_sync("executed", { "node": node_id, "display_node": display_node_id, "output": cached_ui.get("output", None), "prompt_id": prompt_id }, server.client_id)
-    if cached.ui is not None:
-        ui_outputs[node_id] = cached.ui
 
 async def execute(server, dynprompt, caches, current_item, extra_data, executed, prompt_id, execution_list, pending_subgraph_results, pending_async_nodes, ui_outputs):
     unique_id = current_item

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -818,6 +818,30 @@ class TestExecution:
         except urllib.error.HTTPError:
             pass  # Expected behavior
 
+    def test_cached_outputs_in_job_without_client_id(self, client: ComfyClient, builder: GraphBuilder):
+        g = builder
+        image = g.node("StubImage", content="BLACK", height=32, width=32, batch_size=1)
+        output = g.node("SaveImage", images=image.out(0))
+
+        # Prime the cache with a normal run.
+        client.run(g)
+
+        # Resubmit anonymously (no client_id) so output nodes are cache hits with no websocket client.
+        data = json.dumps({"prompt": g.finalize()}).encode('utf-8')
+        req = urllib.request.Request(f"http://{client.server_address}/prompt", data=data)
+        prompt_id = json.loads(urllib.request.urlopen(req).read())['prompt_id']
+
+        for _ in range(100):
+            job = client.get_job(prompt_id)
+            if job is not None and job['status'] not in ('pending', 'in_progress'):
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError("Prompt did not complete in time")
+
+        assert job['status'] == 'completed'
+        assert output.id in job['outputs'], "Cached outputs must appear in job outputs without a client_id"
+
     def _create_history_item(self, client, builder):
         g = GraphBuilder(prefix="offset_test")
         input_node = g.node(


### PR DESCRIPTION
When a prompt is submitted without `client_id` and its output nodes are served
from cache, the cached outputs never make it into history: `_send_cached_ui`
returns early before recording them, so `/api/jobs/{job_id}` (and the legacy
`/history/{prompt_id}`) report a completed job with empty `outputs`.

Reproduce: run a workflow once, resubmit the identical prompt via `POST /prompt`
without `client_id`, check `/api/jobs/{prompt_id}` — outputs are empty.

Tested with the new execution test asserting cached outputs appear in
`/api/jobs/{job_id}` for an anonymous resubmission, under all three cache modes.