### PR TITLE
Fix user.css loading broken by #14734

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -343,13 +343,22 @@ class UserManager():
             # XSS). Content-Disposition: attachment is the load-bearing guard;
             # the content-type override and nosniff are defence in depth.
             content_type = mimetypes.guess_type(path)[0] or 'application/octet-stream'
-            if folder_paths.is_dangerous_content_type(content_type):
-                content_type = 'application/octet-stream'
+
+            # Strict check: allow inline loading only for the exact user.css file
+            is_user_css = os.path.basename(path) == "user.css"
+
+            if is_user_css:
+                content_type = "text/css"
+                disposition = "inline"
+            else:
+                if folder_paths.is_dangerous_content_type(content_type):
+                    content_type = 'application/octet-stream'
+                disposition = "attachment"
 
             return web.FileResponse(path, headers={
                 "Content-Type": content_type,
                 "X-Content-Type-Options": "nosniff",
-                "Content-Disposition": "attachment",
+                "Content-Disposition": disposition,
             })
 
         @routes.post("/userdata/{file}")

--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -344,8 +344,8 @@ class UserManager():
             # the content-type override and nosniff are defence in depth.
             content_type = mimetypes.guess_type(path)[0] or 'application/octet-stream'
 
-            # Strict check: allow inline loading only for the exact user.css file
-            is_user_css = os.path.basename(path) == "user.css"
+            user_root = self.get_request_user_filepath(request, None, create_dir=False)
+            is_user_css = path == os.path.abspath(os.path.join(user_root, "user.css"))
 
             if is_user_css:
                 content_type = "text/css"


### PR DESCRIPTION
#14734 added security headers to prevent XSS by serving all userdata files as attachments. However, this blocked user.css from loading as a stylesheet.

<img width="1122" height="60" alt="Screenshot 2026-07-20 052159" src="https://github.com/user-attachments/assets/bbd0366a-7d38-45dc-8c78-b3086b1fc6d1" />

This fix allows inline loading specifically for user.css (the only file that needs to render in-browser) while maintaining attachment mode for all other userdata files to preserve XSS protection.