### PR TITLE
FreSca: 5D+ (ex. Anima) fix, model-agnostic iteration

### DIFF
--- a/comfy_extras/nodes_fresca.py
+++ b/comfy_extras/nodes_fresca.py
@@ -10,7 +10,7 @@ def Fourier_filter(x, scale_low=1.0, scale_high=1.5, freq_cutoff=20):
     Apply frequency-dependent scaling to an image tensor using Fourier transforms.
 
     Parameters:
-        x:           Input tensor of shape (B, C, H, W)
+        x:           Input tensor of shape (..., H, W)
         scale_low:   Scaling factor for low-frequency components (default: 1.0)
         scale_high:  Scaling factor for high-frequency components (default: 1.5)
         freq_cutoff: Number of frequency indices around center to consider as low-frequency (default: 20)

--- a/comfy_extras/nodes_fresca.py
+++ b/comfy_extras/nodes_fresca.py
@@ -31,8 +31,8 @@ def Fourier_filter(x, scale_low=1.0, scale_high=1.5, freq_cutoff=20):
     # Initialize mask with high-frequency scaling factor
     mask = torch.ones(x_freq.shape, device=device) * scale_high
     m = mask
-    for d in range(len(x_freq.shape) - 2):
-        dim = d + 2
+    for d in range(2):
+        dim = len(x_freq.shape) - 2 + d
         cc = x_freq.shape[dim] // 2
         f_c = min(freq_cutoff, cc)
         m = m.narrow(dim, cc - f_c, f_c * 2)


### PR DESCRIPTION
For a 5D [B, C, T, H, W] tensor — ex. Anima, original loop runs 3 times instead of 2, thus `scale_low` has zero effect on the output. 

This commit fixes it, ensuring FreSca always applied over the last 2 dimensions — new version always treats them as [H, W]. 

For SDXL 4D [B, C, H, W], new loop correctly covers only H and W, so it's backward compatible. 

Overall, this makes FreSca model-agnostic: it always narrows over the same dims (-2, -1) that fftn and fftshift operated on, regardless of whether the latent is 4D or 5D.