### PR TITLE
Load weights to process RAM with MRU policy using pinning infrastructure

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -632,13 +632,23 @@ def mark_mmap_dirty(storage):
     if mmap_refs is not None:
         DIRTY_MMAPS.add(mmap_refs[0])
 
+def models_for_pin_eviction(active):
+    for current_prompt in (False, True):
+        for loaded_model in current_loaded_models:
+            model = loaded_model.model
+            if model is None or not model.is_dynamic():
+                continue
+            pin_state = model.model.dynamic_pins[model.load_device]
+            if pin_state["active"] == active and pin_state["current_prompt"] == current_prompt:
+                yield model
+
 def free_pins(size, evict_active=False):
     freed_total = 0
-    for loaded_model in reversed(current_loaded_models):
-        if size <= 0:
-            return freed_total
-        model = loaded_model.model
-        if model is not None and model.is_dynamic() and (evict_active or not model.model.dynamic_pins[model.load_device]["active"]):
+    active_states = (False, True) if evict_active else (False,)
+    for active in active_states:
+        for model in models_for_pin_eviction(active):
+            if size <= 0:
+                return freed_total
             freed = model.partially_unload_ram(size)
             freed_total += freed
             size -= freed
@@ -673,19 +683,15 @@ def free_registrations(shortfall, evict_active=True):
         return True
 
     shortfall += REGISTERABLE_PIN_HYSTERESIS
-    for loaded_model in reversed(current_loaded_models):
-        model = loaded_model.model
-        if model is not None and model.is_dynamic() and not model.model.dynamic_pins[model.load_device]["active"]:
+    for model in models_for_pin_eviction(False):
+        shortfall -= model.unregister_inactive_pins(shortfall)
+        if shortfall <= 0:
+            return True
+    if evict_active:
+        for model in models_for_pin_eviction(True):
             shortfall -= model.unregister_inactive_pins(shortfall)
             if shortfall <= 0:
                 return True
-    if evict_active:
-        for loaded_model in current_loaded_models:
-            model = loaded_model.model
-            if model is not None and model.is_dynamic() and model.model.dynamic_pins[model.load_device]["active"]:
-                shortfall -= model.unregister_inactive_pins(shortfall)
-                if shortfall <= 0:
-                    return True
     return shortfall <= REGISTERABLE_PIN_HYSTERESIS
 
 def ensure_pin_registerable(size, evict_active=True):

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -632,27 +632,49 @@ def mark_mmap_dirty(storage):
     if mmap_refs is not None:
         DIRTY_MMAPS.add(mmap_refs[0])
 
-def models_for_pin_eviction(active):
-    for current_prompt in (False, True):
-        for loaded_model in current_loaded_models:
-            model = loaded_model.model
-            if model is None or not model.is_dynamic():
-                continue
-            pin_state = model.model.dynamic_pins[model.load_device]
-            if pin_state["active"] == active and pin_state["current_prompt"] == current_prompt:
-                yield model
+PIN_SUBSETS = [ "weights", "patches" ]
+LOADED_PIN_SUBSETS = [ "weights-loaded", "patches-loaded" ]
 
-def free_pins(size, evict_active=False):
+def models_for_pin_eviction(active, current_prompt=None):
+    for loaded_model in current_loaded_models:
+        model = loaded_model.model
+        if model is None or not model.is_dynamic():
+            continue
+        pin_state = model.model.dynamic_pins[model.load_device]
+        if ((active is None or pin_state["active"] == active) and
+            (current_prompt is None or pin_state["current_prompt"] == current_prompt)):
+            yield model
+
+def free_model_pins(size, subsets, current_prompt, active, registrations=False):
     freed_total = 0
-    active_states = (False, True) if evict_active else (False,)
-    for active in active_states:
-        for model in models_for_pin_eviction(active):
-            if size <= 0:
-                return freed_total
-            freed = model.partially_unload_ram(size)
-            freed_total += freed
-            size -= freed
+    for model in models_for_pin_eviction(active, current_prompt=current_prompt):
+        if size <= 0:
+            return freed_total
+        if registrations:
+            freed = model.unregister_inactive_pins(size, subsets=subsets)
+        else:
+            freed = model.partially_unload_ram(size, subsets=subsets)
+        freed_total += freed
+        size -= freed
     return freed_total
+
+def pin_eviction_tiers(loaded, evict_active):
+    tiers = [
+        (PIN_SUBSETS, False, None),
+        (LOADED_PIN_SUBSETS, False, None),
+        (LOADED_PIN_SUBSETS, True, None),
+    ]
+    if not loaded:
+        tiers.append((PIN_SUBSETS, True, False))
+        if evict_active:
+            tiers.append((PIN_SUBSETS, True, True))
+    return tiers
+
+def free_pins(size, evict_active=False, loaded=False):
+    freed = 0
+    for subsets, current_prompt, active in pin_eviction_tiers(loaded, evict_active):
+        freed += free_model_pins(size - freed, subsets, current_prompt, active)
+    return freed
 
 def should_free_pins_for_ram_pressure(shortfall):
     if shortfall <= 0:
@@ -663,7 +685,7 @@ def should_free_pins_for_ram_pressure(shortfall):
         return True
     return psutil.swap_memory().percent >= WINDOWS_PIN_EVICTION_SWAP_PERCENT
 
-def ensure_pin_budget(size, evict_active=False):
+def ensure_pin_budget(size, evict_active=False, loaded=False):
     if args.high_ram:
         return True
     if args.fast_disk:
@@ -674,28 +696,21 @@ def ensure_pin_budget(size, evict_active=False):
         return True
 
     to_free = shortfall + PIN_PRESSURE_HYSTERESIS
-    return free_pins(to_free, evict_active=evict_active) >= shortfall
+    return free_pins(to_free, evict_active=evict_active, loaded=loaded) >= shortfall
 
-def free_registrations(shortfall, evict_active=True):
+def free_registrations(shortfall, evict_active=True, loaded=False):
     if MAX_PINNED_MEMORY <= 0:
         return False
     if shortfall <= 0:
         return True
 
     shortfall += REGISTERABLE_PIN_HYSTERESIS
-    for model in models_for_pin_eviction(False):
-        shortfall -= model.unregister_inactive_pins(shortfall)
-        if shortfall <= 0:
-            return True
-    if evict_active:
-        for model in models_for_pin_eviction(True):
-            shortfall -= model.unregister_inactive_pins(shortfall)
-            if shortfall <= 0:
-                return True
+    for subsets, current_prompt, active in pin_eviction_tiers(loaded, evict_active):
+        shortfall -= free_model_pins(shortfall, subsets, current_prompt, active, registrations=True)
     return shortfall <= REGISTERABLE_PIN_HYSTERESIS
 
-def ensure_pin_registerable(size, evict_active=True):
-    return free_registrations(TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY, evict_active=evict_active)
+def ensure_pin_registerable(size, evict_active=True, loaded=False):
+    return free_registrations(TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY, evict_active=evict_active, loaded=loaded)
 
 class LoadedModel:
     def __init__(self, model: ModelPatcher):
@@ -1385,15 +1400,17 @@ def reset_cast_buffers():
             pin_state = model.model.dynamic_pins[model.load_device]
 
             if pin_state["active"]:
-                *_, buckets = pin_state["weights"]
-                for size, bucket in list(buckets.items()):
-                    bucket[:] = [ entry for entry in bucket if entry[-1] is not None ]
-                    if not bucket:
-                        del buckets[size]
+                for subset in ("weights", "weights-loaded"):
+                    *_, buckets = pin_state[subset]
+                    for size, bucket in list(buckets.items()):
+                        bucket[:] = [ entry for entry in bucket if entry[-1] is not None ]
+                        if not bucket:
+                            del buckets[size]
 
             pin_state["active"] = False
-            model.partially_unload_ram(1e30, subsets=[ "patches" ])
-            model.model.dynamic_pins[model.load_device]["patches"] = (comfy_aimdo.host_buffer.HostBuffer(0, 8 * 1024 * 1024, pinned_hostbuf_size(model.model_size())), [], [-1], [0], [0], {})
+            model.partially_unload_ram(1e30, subsets=[ "patches", "patches-loaded" ])
+            for subset in ("patches", "patches-loaded"):
+                pin_state[subset] = (comfy_aimdo.host_buffer.HostBuffer(0, 8 * 1024 * 1024, pinned_hostbuf_size(model.model_size())), [], [-1], [0], [0], {})
 
     STREAM_CAST_BUFFERS.clear()
     STREAM_AIMDO_CAST_BUFFERS.clear()

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1724,6 +1724,8 @@ class ModelPatcherDynamic(ModelPatcher):
             self.model.dynamic_pins[device] = {
                 "weights": (comfy_aimdo.host_buffer.HostBuffer(0, 0, 0), [], [-1], [0], [0], {}),
                 "patches": (comfy_aimdo.host_buffer.HostBuffer(0, 0, 0), [], [-1], [0], [0], {}),
+                "weights-loaded": (comfy_aimdo.host_buffer.HostBuffer(0, 0, 0), [], [-1], [0], [0], {}),
+                "patches-loaded": (comfy_aimdo.host_buffer.HostBuffer(0, 0, 0), [], [-1], [0], [0], {}),
                 "hostbufs_initialized": False,
                 "failed": False,
                 "active": False,
@@ -1806,6 +1808,8 @@ class ModelPatcherDynamic(ModelPatcher):
                 hostbuf_size = comfy.model_management.pinned_hostbuf_size(self.model_size())
                 pin_state["weights"] = (comfy_aimdo.host_buffer.HostBuffer(0, 64 * 1024 * 1024, hostbuf_size), [], [-1], [0], [0], {})
                 pin_state["patches"] = (comfy_aimdo.host_buffer.HostBuffer(0, 8 * 1024 * 1024, hostbuf_size), [], [-1], [0], [0], {})
+                pin_state["weights-loaded"] = (comfy_aimdo.host_buffer.HostBuffer(0, 64 * 1024 * 1024, hostbuf_size), [], [-1], [0], [0], {})
+                pin_state["patches-loaded"] = (comfy_aimdo.host_buffer.HostBuffer(0, 8 * 1024 * 1024, hostbuf_size), [], [-1], [0], [0], {})
                 pin_state["hostbufs_initialized"] = True
             pin_state["failed"] = False
             pin_state["active"] = True
@@ -1947,12 +1951,14 @@ class ModelPatcherDynamic(ModelPatcher):
         return freed
 
     def loaded_ram_size(self):
-        return (self.model.dynamic_pins[self.load_device]["weights"][0].size)
+        pin_state = self.model.dynamic_pins[self.load_device]
+        return pin_state["weights"][0].size + pin_state["weights-loaded"][0].size
 
     def pinned_memory_size(self):
-        return (self.model.dynamic_pins[self.load_device]["weights"][3][0])
+        pin_state = self.model.dynamic_pins[self.load_device]
+        return pin_state["weights"][3][0] + pin_state["weights-loaded"][3][0]
 
-    def unregister_inactive_pins(self, ram_to_unload, subsets=[ "weights", "patches" ]):
+    def unregister_inactive_pins(self, ram_to_unload, subsets=[ "weights-loaded", "patches-loaded", "weights", "patches" ]):
         freed = 0
         pin_state = self.model.dynamic_pins[self.load_device]
         for subset in subsets:
@@ -1960,15 +1966,17 @@ class ModelPatcherDynamic(ModelPatcher):
             split = stack_split[0]
             while split >= 0:
                 module, offset = stack[split]
+                module_pin = module._pins[subset]
                 split -= 1
                 stack_split[0] = split
-                if not module._pin_registered:
+                if not module_pin["registered"]:
                     continue
-                size = module._pin.numel() * module._pin.element_size()
-                if torch.cuda.cudart().cudaHostUnregister(module._pin.data_ptr()) != 0:
+                pin = module_pin["pin"]
+                size = pin.numel() * pin.element_size()
+                if torch.cuda.cudart().cudaHostUnregister(pin.data_ptr()) != 0:
                     comfy.model_management.discard_cuda_async_error()
                     continue
-                module._pin_registered = False
+                module_pin["registered"] = False
                 comfy.model_management.TOTAL_PINNED_MEMORY = max(0, comfy.model_management.TOTAL_PINNED_MEMORY - size)
                 pinned_size[0] = max(0, pinned_size[0] - size)
                 freed += size
@@ -1977,20 +1985,23 @@ class ModelPatcherDynamic(ModelPatcher):
                     return freed
         return freed
 
-    def partially_unload_ram(self, ram_to_unload, subsets=[ "weights", "patches" ]):
+    def partially_unload_ram(self, ram_to_unload, subsets=[ "weights-loaded", "patches-loaded", "weights", "patches" ]):
         freed = 0
         pin_state = self.model.dynamic_pins[self.load_device]
         for subset in subsets:
             hostbuf, stack, stack_split, pinned_size, *_ = pin_state[subset]
             while len(stack) > 0:
                 module, offset = stack.pop()
-                size = module._pin.numel() * module._pin.element_size()
-                module._pin_balancer_entry[-1] = None
-                del module._pin_balancer_entry
-                del module._pin
-                hostbuf.truncate(offset, do_unregister=module._pin_registered)
+                module_pin = module._pins[subset]
+                pin = module_pin["pin"]
+                size = pin.numel() * pin.element_size()
+                module_pin["balancer_entry"][-1] = None
+                del module_pin["balancer_entry"]
+                del module_pin["pin"]
+                registered = module_pin["registered"]
+                hostbuf.truncate(offset, do_unregister=registered)
                 stack_split[0] = min(stack_split[0], len(stack) - 1)
-                if module._pin_registered:
+                if registered:
                     comfy.model_management.TOTAL_PINNED_MEMORY = max(0, comfy.model_management.TOTAL_PINNED_MEMORY - size)
                     pinned_size[0] = max(0, pinned_size[0] - size)
                 freed += size

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -42,6 +42,52 @@ from comfy.patcher_extension import CallbacksMP, PatcherInjection, WrappersMP
 
 import comfy_aimdo.model_vbar
 
+def is_model_patcher_output(output):
+    return isinstance(output, ModelPatcher) or isinstance(getattr(output, "patcher", None), ModelPatcher)
+
+class PromptModelTracker:
+    def __init__(self):
+        self.models = {}
+
+    def start(self):
+        self.end()
+
+    def add(self, outputs):
+        if isinstance(outputs, collections.abc.Mapping):
+            outputs = outputs.values()
+        elif not isinstance(outputs, (list, tuple)):
+            outputs = (outputs,)
+
+        for output in outputs:
+            if isinstance(output, (collections.abc.Mapping, list, tuple)):
+                self.add(output)
+                continue
+
+            models = []
+            if isinstance(output, ModelPatcher):
+                models.append(output)
+                models.extend(output.model_patches_models())
+                models.extend(output.get_nested_additional_models())
+            else:
+                patcher = getattr(output, "patcher", None)
+                if isinstance(patcher, ModelPatcher):
+                    models.append(patcher)
+                get_models = getattr(output, "get_models", None)
+                if callable(get_models):
+                    models.extend(get_models())
+
+            for model in models:
+                if not isinstance(model, ModelPatcher) or not model.is_dynamic():
+                    continue
+                key = (id(model.model), model.load_device)
+                self.models[key] = model
+                model.set_in_use_by_current_prompt(True)
+
+    def end(self):
+        for model in self.models.values():
+            model.set_in_use_by_current_prompt(False)
+        self.models.clear()
+
 def set_model_options_patch_replace(model_options, patch, name, block_name, number, transformer_index=None):
     to = model_options["transformer_options"].copy()
 

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1727,10 +1727,14 @@ class ModelPatcherDynamic(ModelPatcher):
                 "hostbufs_initialized": False,
                 "failed": False,
                 "active": False,
+                "current_prompt": False,
             }
 
     def is_dynamic(self):
         return True
+
+    def set_in_use_by_current_prompt(self, in_use):
+        self.model.dynamic_pins[self.load_device]["current_prompt"] = in_use
 
     def _vbar_get(self, create=False):
         if self.load_device == torch.device("cpu"):

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -146,7 +146,7 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
         xfer_source = [ s.weight, s.bias ]
         subset = "weights"
         pin = comfy.pinned_memory.get_pin(s, subset=subset)
-        if pin is None:
+        if pin is None and not args.fast_disk:
             loaded_pin = comfy.pinned_memory.get_pin(s, subset="weights-loaded")
             if loaded_pin is not None or signature is not None:
                 subset = "weights-loaded"
@@ -187,8 +187,9 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
             if pin is not None:
                 cast_maybe_lowvram_patch([pin], dest, offload_stream)
                 return
-            comfy.pinned_memory.pin_memory(m, subset=subset, size=size)
-            pin = comfy.pinned_memory.get_pin(m, subset=subset)
+            if signature is None or not args.fast_disk or args.high_ram:
+                comfy.pinned_memory.pin_memory(m, subset=subset, size=size)
+                pin = comfy.pinned_memory.get_pin(m, subset=subset)
             cast_maybe_lowvram_patch(source, pin, offload_stream, xfer_dest2=dest)
 
         handle_pin(s, pin, xfer_source, xfer_dest, subset=subset, size=dest_size)
@@ -203,7 +204,7 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
 
                 subset = "patches"
                 pin = comfy.pinned_memory.get_pin(lowvram_source, subset=subset)
-                if pin is None and signature is not None:
+                if pin is None and signature is not None and not args.fast_disk:
                     subset = "patches-loaded"
                     pin = comfy.pinned_memory.get_pin(lowvram_source, subset=subset)
                 handle_pin(lowvram_source, pin, lowvram_source, lowvram_dest, subset=subset, size=lowvram_size)

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -144,8 +144,13 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
         needs_cast = False
 
         xfer_source = [ s.weight, s.bias ]
-
-        pin = comfy.pinned_memory.get_pin(s)
+        subset = "weights"
+        pin = comfy.pinned_memory.get_pin(s, subset=subset)
+        if pin is None:
+            loaded_pin = comfy.pinned_memory.get_pin(s, subset="weights-loaded")
+            if loaded_pin is not None or signature is not None:
+                subset = "weights-loaded"
+                pin = loaded_pin
         if pin is not None:
             xfer_source = [ pin ]
 
@@ -182,12 +187,11 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
             if pin is not None:
                 cast_maybe_lowvram_patch([pin], dest, offload_stream)
                 return
-            if signature is None or args.high_ram:
-                comfy.pinned_memory.pin_memory(m, subset=subset, size=size)
-                pin = comfy.pinned_memory.get_pin(m, subset=subset)
+            comfy.pinned_memory.pin_memory(m, subset=subset, size=size)
+            pin = comfy.pinned_memory.get_pin(m, subset=subset)
             cast_maybe_lowvram_patch(source, pin, offload_stream, xfer_dest2=dest)
 
-        handle_pin(s, pin, xfer_source, xfer_dest, size=dest_size)
+        handle_pin(s, pin, xfer_source, xfer_dest, subset=subset, size=dest_size)
 
         for param_key in ("weight", "bias"):
             lowvram_source = getattr(s, param_key + "_lowvram_function", None)
@@ -197,8 +201,12 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
                 lowvram_dest = get_cast_buffer(lowvram_size)
                 lowvram_source.prepare(lowvram_dest, None, copy=False, commit=True)
 
-                pin = comfy.pinned_memory.get_pin(lowvram_source, subset="patches")
-                handle_pin(lowvram_source, pin, lowvram_source, lowvram_dest, subset="patches", size=lowvram_size)
+                subset = "patches"
+                pin = comfy.pinned_memory.get_pin(lowvram_source, subset=subset)
+                if pin is None and signature is not None:
+                    subset = "patches-loaded"
+                    pin = comfy.pinned_memory.get_pin(lowvram_source, subset=subset)
+                handle_pin(lowvram_source, pin, lowvram_source, lowvram_dest, subset=subset, size=lowvram_size)
 
 
         prefetch["xfer_dest"] = xfer_dest

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -204,9 +204,13 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
 
                 subset = "patches"
                 pin = comfy.pinned_memory.get_pin(lowvram_source, subset=subset)
-                if pin is None and signature is not None and not args.fast_disk:
-                    subset = "patches-loaded"
-                    pin = comfy.pinned_memory.get_pin(lowvram_source, subset=subset)
+                if pin is None:
+                    loaded_pin = comfy.pinned_memory.get_pin(lowvram_source, subset="patches-loaded")
+                    if loaded_pin is not None:
+                        subset = "patches-loaded"
+                        pin = loaded_pin
+                    elif signature is not None and not args.fast_disk:
+                        subset = "patches-loaded"
                 handle_pin(lowvram_source, pin, lowvram_source, lowvram_dest, subset=subset, size=lowvram_size)
 
 

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -9,14 +9,14 @@ import torch
 
 from comfy.cli_args import args
 
-def _add_to_bucket(module, buckets, size, priority):
+def _add_to_bucket(module, module_pin, buckets, size, priority):
     bucket = buckets.setdefault(size, [])
     entry = [-priority, 0, module]
     entry[1] = id(entry)
     bisect.insort(bucket, entry)
-    module._pin_balancer_entry = entry
+    module_pin["balancer_entry"] = entry
 
-def _steal_pin(module, stack, buckets, size, priority):
+def _steal_pin(module, stack, buckets, size, priority, subset):
     bucket = buckets.get(size)
     if bucket is None:
         return False
@@ -31,34 +31,39 @@ def _steal_pin(module, stack, buckets, size, priority):
         return False
 
     *_, victim = bucket.pop()
-    module._pin = victim._pin
-    module._pin_registered = victim._pin_registered
-    module._pin_stack_index = victim._pin_stack_index
-    stack[module._pin_stack_index] = (module, stack[module._pin_stack_index][1])
+    module_pin = module._pins[subset]
+    victim_pin = victim._pins[subset]
+    module_pin["pin"] = victim_pin["pin"]
+    module_pin["registered"] = victim_pin["registered"]
+    module_pin["stack_index"] = victim_pin["stack_index"]
+    stack_index = module_pin["stack_index"]
+    stack[stack_index] = (module, stack[stack_index][1])
 
-    victim._pin_registered = False
-    del victim._pin
-    del victim._pin_stack_index
-    del victim._pin_balancer_entry
+    victim_pin["registered"] = False
+    del victim_pin["pin"]
+    del victim_pin["stack_index"]
+    del victim_pin["balancer_entry"]
 
-    _add_to_bucket(module, buckets, size, priority)
+    _add_to_bucket(module, module_pin, buckets, size, priority)
     return True
 
 def get_pin(module, subset="weights"):
-    pin = getattr(module, "_pin", None)
-    if pin is None or module._pin_registered or args.disable_pinned_memory:
+    pins = module.__dict__.get("_pins")
+    module_pin = None if pins is None else pins.get(subset)
+    pin = None if module_pin is None else module_pin.get("pin")
+    if pin is None or module_pin["registered"] or args.disable_pinned_memory:
         return pin
 
     _, _, stack_split, pinned_size, *_ = module._pin_state[subset]
     size = pin.nbytes
-    comfy.model_management.ensure_pin_registerable(size)
+    comfy.model_management.ensure_pin_registerable(size, loaded=subset.endswith("-loaded"))
 
     if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
         comfy.model_management.discard_cuda_async_error()
         return pin
 
-    module._pin_registered = True
-    stack_split[0] = max(stack_split[0], module._pin_stack_index)
+    module_pin["registered"] = True
+    stack_split[0] = max(stack_split[0], module_pin["stack_index"])
     comfy.model_management.TOTAL_PINNED_MEMORY += size
     pinned_size[0] += size
     return pin
@@ -72,23 +77,26 @@ def pin_memory(module, subset="weights", size=None):
     if pin is not None:
         return
 
+    pins = module.__dict__.setdefault("_pins", {})
+    module_pin = pins.setdefault(subset, {})
     hostbuf, stack, stack_split, pinned_size, counter, buckets = pin_state[subset]
     if size is None:
         size = comfy.memory_management.vram_aligned_size([ module.weight, module.bias ])
-    offset = hostbuf.size
     registerable_size = size
-    priority = getattr(module, "_pin_balancer_priority", None)
+    loaded = subset.endswith("-loaded")
+    priority = module_pin.get("balancer_priority")
 
     if priority is None:
         priority = comfy.utils.bit_reverse_range(counter[0], 16)
         counter[0] += 1
-        module._pin_balancer_priority = priority
+        module_pin["balancer_priority"] = priority
 
     comfy.memory_management.extra_ram_release(comfy.memory_management.RAM_CACHE_HEADROOM)
-    if (not comfy.model_management.ensure_pin_budget(size) or
-        not comfy.model_management.ensure_pin_registerable(registerable_size)):
-        return _steal_pin(module, stack, buckets, size, priority)
+    if (not comfy.model_management.ensure_pin_budget(size, loaded=loaded) or
+        not comfy.model_management.ensure_pin_registerable(registerable_size, loaded=loaded)):
+        return _steal_pin(module, stack, buckets, size, priority, subset)
 
+    offset = hostbuf.size
     extended = False
     try:
         hostbuf.extend(size=size, register=False)
@@ -97,23 +105,23 @@ def pin_memory(module, subset="weights", size=None):
         pin.untyped_storage()._comfy_hostbuf = hostbuf
         if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
             comfy.model_management.discard_cuda_async_error()
-            comfy.model_management.free_registrations(size)
+            comfy.model_management.free_registrations(size, loaded=loaded)
             if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
                 comfy.model_management.discard_cuda_async_error()
                 del pin
                 hostbuf.truncate(offset, do_unregister=False)
-                return _steal_pin(module, stack, buckets, size, priority)
+                return _steal_pin(module, stack, buckets, size, priority, subset)
     except RuntimeError:
         if extended:
             hostbuf.truncate(offset, do_unregister=False)
-        return _steal_pin(module, stack, buckets, size, priority)
+        return _steal_pin(module, stack, buckets, size, priority, subset)
 
-    module._pin = pin
+    module_pin["pin"] = pin
     stack.append((module, offset))
-    module._pin_registered = True
-    module._pin_stack_index = len(stack) - 1
-    stack_split[0] = max(stack_split[0], module._pin_stack_index)
+    module_pin["registered"] = True
+    module_pin["stack_index"] = len(stack) - 1
+    stack_split[0] = max(stack_split[0], module_pin["stack_index"])
     comfy.model_management.TOTAL_PINNED_MEMORY += size
     pinned_size[0] += size
-    _add_to_bucket(module, buckets, size, priority)
+    _add_to_bucket(module, module_pin, buckets, size, priority)
     return True

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -567,7 +567,7 @@ class RAMPressureCache(LRUCache):
                     elif isinstance(output, torch.Tensor) and output.device.type == 'cpu':
                         ram_usage += output.numel() * output.element_size()
                         oom_ram_usage += output.numel() * output.element_size()
-                    elif isinstance(output, ModelPatcher) and self.used_generation[key] != self.generation:
+                    elif (isinstance(output, ModelPatcher) or isinstance(getattr(output, "patcher", None), ModelPatcher)) and self.used_generation[key] != self.generation:
                         #old ModelPatchers are the first to go
                         oom_ram_usage = 1e30
             scan_list_for_ram_usage(cache_entry.outputs)

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -5,7 +5,7 @@ import psutil
 import time
 import torch
 from typing import Sequence, Mapping, Dict
-from comfy.model_patcher import ModelPatcher
+from comfy.model_patcher import is_model_patcher_output
 from comfy_execution.graph import DynamicPrompt
 from abc import ABC, abstractmethod
 
@@ -567,7 +567,7 @@ class RAMPressureCache(LRUCache):
                     elif isinstance(output, torch.Tensor) and output.device.type == 'cpu':
                         ram_usage += output.numel() * output.element_size()
                         oom_ram_usage += output.numel() * output.element_size()
-                    elif (isinstance(output, ModelPatcher) or isinstance(getattr(output, "patcher", None), ModelPatcher)) and self.used_generation[key] != self.generation:
+                    elif is_model_patcher_output(output) and self.used_generation[key] != self.generation:
                         #old ModelPatchers are the first to go
                         oom_ram_usage = 1e30
             scan_list_for_ram_usage(cache_entry.outputs)

--- a/comfy_execution/graph.py
+++ b/comfy_execution/graph.py
@@ -195,9 +195,10 @@ class ExecutionList(TopologicalSort):
     ExecutionList implements a topological dissolve of the graph. After a node is staged for execution,
     it can still be returned to the graph after having further dependencies added.
     """
-    def __init__(self, dynprompt, output_cache):
+    def __init__(self, dynprompt, output_cache, output_link_callback=None):
         super().__init__(dynprompt)
         self.output_cache = output_cache
+        self.output_link_callback = output_link_callback
         self.staged_node_id = None
         self.execution_cache = {}
         self.execution_cache_listeners = {}
@@ -205,13 +206,16 @@ class ExecutionList(TopologicalSort):
     def is_cached(self, node_id):
         return self.output_cache.get_local(node_id) is not None
 
-    def cache_link(self, from_node_id, to_node_id):
+    def cache_link(self, from_node_id, to_node_id, from_socket=None):
         if to_node_id not in self.execution_cache:
             self.execution_cache[to_node_id] = {}
-        self.execution_cache[to_node_id][from_node_id] = self.output_cache.get_local(from_node_id)
+        value = self.output_cache.get_local(from_node_id)
+        self.execution_cache[to_node_id][from_node_id] = value
         if from_node_id not in self.execution_cache_listeners:
             self.execution_cache_listeners[from_node_id] = set()
-        self.execution_cache_listeners[from_node_id].add(to_node_id)
+        self.execution_cache_listeners[from_node_id].add((to_node_id, from_socket))
+        if value is not None and from_socket is not None and self.output_link_callback is not None:
+            self.output_link_callback(value.outputs[from_socket])
 
     def get_cache(self, from_node_id, to_node_id):
         if to_node_id not in self.execution_cache:
@@ -225,13 +229,15 @@ class ExecutionList(TopologicalSort):
 
     def cache_update(self, node_id, value):
         if node_id in self.execution_cache_listeners:
-            for to_node_id in self.execution_cache_listeners[node_id]:
+            for to_node_id, from_socket in self.execution_cache_listeners[node_id]:
                 if to_node_id in self.execution_cache:
                     self.execution_cache[to_node_id][node_id] = value
+                if from_socket is not None and self.output_link_callback is not None:
+                    self.output_link_callback(value.outputs[from_socket])
 
     def add_strong_link(self, from_node_id, from_socket, to_node_id):
         super().add_strong_link(from_node_id, from_socket, to_node_id)
-        self.cache_link(from_node_id, to_node_id)
+        self.cache_link(from_node_id, to_node_id, from_socket)
 
     async def stage_node_execution(self):
         assert self.staged_node_id is None

--- a/execution.py
+++ b/execution.py
@@ -8,7 +8,7 @@ import threading
 import time
 import traceback
 from enum import Enum
-from typing import List, Literal, Mapping, NamedTuple, Optional, Union
+from typing import List, Literal, NamedTuple, Optional, Union
 import asyncio
 
 import torch
@@ -16,7 +16,7 @@ import torch
 from comfy.cli_args import args
 import comfy.memory_management
 import comfy.model_management
-from comfy.model_patcher import ModelPatcher
+import comfy.model_patcher
 import comfy.model_prefetch
 import comfy_aimdo.model_vbar
 
@@ -665,44 +665,8 @@ class PromptExecutor:
         self.cache_args = cache_args
         self.cache_type = cache_type
         self.server = server
-        self.current_prompt_models = {}
+        self.prompt_model_tracker = comfy.model_patcher.PromptModelTracker()
         self.reset()
-
-    def _mark_current_prompt_models(self, outputs):
-        if isinstance(outputs, Mapping):
-            outputs = outputs.values()
-        elif not isinstance(outputs, (list, tuple)):
-            outputs = (outputs,)
-
-        for output in outputs:
-            if isinstance(output, (Mapping, list, tuple)):
-                self._mark_current_prompt_models(output)
-                continue
-
-            models = []
-            if isinstance(output, ModelPatcher):
-                models.append(output)
-                models.extend(output.model_patches_models())
-                models.extend(output.get_nested_additional_models())
-            else:
-                patcher = getattr(output, "patcher", None)
-                if isinstance(patcher, ModelPatcher):
-                    models.append(patcher)
-                get_models = getattr(output, "get_models", None)
-                if callable(get_models):
-                    models.extend(get_models())
-
-            for model in models:
-                if not isinstance(model, ModelPatcher) or not model.is_dynamic():
-                    continue
-                key = (id(model.model), model.load_device)
-                self.current_prompt_models[key] = model
-                model.set_in_use_by_current_prompt(True)
-
-    def _clear_current_prompt_models(self):
-        for model in self.current_prompt_models.values():
-            model.set_in_use_by_current_prompt(False)
-        self.current_prompt_models.clear()
 
     def reset(self):
         self.caches = CacheSet(cache_type=self.cache_type, cache_args=self.cache_args)
@@ -766,7 +730,7 @@ class PromptExecutor:
         set_preview_method(extra_data.get("preview_method"))
 
         nodes.interrupt_processing(False)
-        self._clear_current_prompt_models()
+        self.prompt_model_tracker.start()
 
         if "client_id" in extra_data:
             self.server.client_id = extra_data["client_id"]
@@ -809,7 +773,7 @@ class PromptExecutor:
                 pending_async_nodes = {} # TODO - Unify this with pending_subgraph_results
                 ui_node_outputs = {}
                 executed = set()
-                execution_list = ExecutionList(dynamic_prompt, self.caches.outputs, self._mark_current_prompt_models)
+                execution_list = ExecutionList(dynamic_prompt, self.caches.outputs, self.prompt_model_tracker.add)
                 current_outputs = self.caches.outputs.all_node_ids()
                 for node_id in list(execute_outputs):
                     execution_list.add_node(node_id)
@@ -872,7 +836,7 @@ class PromptExecutor:
                     comfy.model_management.unload_all_models()
         finally:
             comfy.memory_management.set_ram_cache_release_state(None, 0)
-            self._clear_current_prompt_models()
+            self.prompt_model_tracker.end()
             self._notify_prompt_lifecycle("end", prompt_id)
 
 

--- a/execution.py
+++ b/execution.py
@@ -8,7 +8,7 @@ import threading
 import time
 import traceback
 from enum import Enum
-from typing import List, Literal, NamedTuple, Optional, Union
+from typing import List, Literal, Mapping, NamedTuple, Optional, Union
 import asyncio
 
 import torch
@@ -16,6 +16,7 @@ import torch
 from comfy.cli_args import args
 import comfy.memory_management
 import comfy.model_management
+from comfy.model_patcher import ModelPatcher
 import comfy.model_prefetch
 import comfy_aimdo.model_vbar
 
@@ -664,7 +665,44 @@ class PromptExecutor:
         self.cache_args = cache_args
         self.cache_type = cache_type
         self.server = server
+        self.current_prompt_models = {}
         self.reset()
+
+    def _mark_current_prompt_models(self, outputs):
+        if isinstance(outputs, Mapping):
+            outputs = outputs.values()
+        elif not isinstance(outputs, (list, tuple)):
+            outputs = (outputs,)
+
+        for output in outputs:
+            if isinstance(output, (Mapping, list, tuple)):
+                self._mark_current_prompt_models(output)
+                continue
+
+            models = []
+            if isinstance(output, ModelPatcher):
+                models.append(output)
+                models.extend(output.model_patches_models())
+                models.extend(output.get_nested_additional_models())
+            else:
+                patcher = getattr(output, "patcher", None)
+                if isinstance(patcher, ModelPatcher):
+                    models.append(patcher)
+                get_models = getattr(output, "get_models", None)
+                if callable(get_models):
+                    models.extend(get_models())
+
+            for model in models:
+                if not isinstance(model, ModelPatcher) or not model.is_dynamic():
+                    continue
+                key = (id(model.model), model.load_device)
+                self.current_prompt_models[key] = model
+                model.set_in_use_by_current_prompt(True)
+
+    def _clear_current_prompt_models(self):
+        for model in self.current_prompt_models.values():
+            model.set_in_use_by_current_prompt(False)
+        self.current_prompt_models.clear()
 
     def reset(self):
         self.caches = CacheSet(cache_type=self.cache_type, cache_args=self.cache_args)
@@ -728,6 +766,7 @@ class PromptExecutor:
         set_preview_method(extra_data.get("preview_method"))
 
         nodes.interrupt_processing(False)
+        self._clear_current_prompt_models()
 
         if "client_id" in extra_data:
             self.server.client_id = extra_data["client_id"]
@@ -770,7 +809,7 @@ class PromptExecutor:
                 pending_async_nodes = {} # TODO - Unify this with pending_subgraph_results
                 ui_node_outputs = {}
                 executed = set()
-                execution_list = ExecutionList(dynamic_prompt, self.caches.outputs)
+                execution_list = ExecutionList(dynamic_prompt, self.caches.outputs, self._mark_current_prompt_models)
                 current_outputs = self.caches.outputs.all_node_ids()
                 for node_id in list(execute_outputs):
                     execution_list.add_node(node_id)
@@ -833,6 +872,7 @@ class PromptExecutor:
                     comfy.model_management.unload_all_models()
         finally:
             comfy.memory_management.set_ram_cache_release_state(None, 0)
+            self._clear_current_prompt_models()
             self._notify_prompt_lifecycle("end", prompt_id)
 
 


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/14618

Currently comfy relies on the OS disk cache to cache model weights that are loaded directly to the GPU (and not offloaded). There are a number of reports of this being unreliable.

This change brings the caching logic in-house to comfy with a lower priority set of pinned weights for loaded (as in not offloaded) weights. This achieves three goals:

1: Forcibly use RAM to load as much model as possible so for any weird OS decision to de-prioritize comfy RAM, we now have the RAM greedily as actual allocation

2: Bring into play pinning of the primary model load. Users with lots of RAM doing multi-model flows should be able to benefit from having the models pinned in ram each workflow RAM and get it onto the GPU with no RAM->RAM copy at all

3: Evict RAM on a watermark level rather than LRU. This avoids the scenario where the user has to reload the entire workflow from disk if their RAM is less than their needs and all the eviction schemes are LRU and it just evicts everything in cycles.

The cost is an extra RAM->RAM copy in the first place which makes it a little slower on the first workflow run in particular. It also hogs all RAM for the process which means means no consolidation of caching across comfy restarts or multiple instances of comfy.

Use --fast-disk if you want to knock this out and rely on disk performance to minimize/share RAM. --fast-disk is slightly different with its pinning behaviours relative to current no args, but its far closer than this change. We can make the old way a separate option but its probably best to just consolidate with this and --fast-disk.

The retention policy now changes to retaining older models over new ones while still deprioritizing inactive workflow models. This avoids the LRU problem, but at the cost of sometimes retaining an un-needed model over a needed one when considering caching behaviors. The classic case is same prompt with sampler seed change, where you want to keep the diffusion model more than the TE. It will however learn after another run as the TE will get kicked out as an inactive model. So it can take an extra workflow run to reach steady state after prompt change. There isnt really a good solution to this as we simply dont have future knowledge on what the next workflow is going to do. But the reasonable best assumption is the user is going to rerun everything exactly as you just did ignoring any cachables. So MRU evicition / watermark system is preferable to avoid repeat runners having LRU cascade failure. This will regress second run performance in particular for some usage points, but the steady state takes priority. See below in the "after" with the 3rd run being faster than anything else.

Example test conditions:

RTX5090, 32GB, Linux, WAN 2x14B FP16, PCIE1 x4 NVME (downgraded from PCIE5)

<img width="1446" height="962" alt="image" src="https://github.com/user-attachments/assets/b95540f3-2f21-4290-96e4-cf65079d688d" />


This case used to lose everything to the LRU problem. Also because Linux it fully pins what it retains so extra boost on the rerun speed.

Before (2 runs):

```
[INFO] got prompt
[INFO] Using pytorch attention in VAE
[INFO] Using pytorch attention in VAE
[INFO] VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
[INFO] Found quantization metadata version 1
[INFO] Using MixedPrecisionOps for text encoder
[INFO] CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
[INFO] Requested to load WanTEModel
[INFO] Model WanTEModel prepared for dynamic VRAM loading. 6419MB Staged. 0 patches attached. Force pre-loaded 73 weights: 488 KB.
[INFO] Model WanTEModel prepared for dynamic VRAM loading. 6419MB Staged. 0 patches attached. Force pre-loaded 73 weights: 488 KB.
[INFO] Requested to load WanVAE
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] model weight dtype torch.float16, manual cast: None
[INFO] model_type FLOW
[INFO] Requested to load WAN21
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:15<00:00,  7.86s/it]                                   
[INFO] model weight dtype torch.float16, manual cast: None
[INFO] model_type FLOW
[INFO] Requested to load WAN21
[INFO] 0 models unloaded.
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:14<00:00,  7.19s/it]                                   
[INFO] 0 models unloaded.
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] Prompt executed in 103.51 seconds
[INFO] got prompt
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:13<00:00,  6.58s/it]                                   
[INFO] 0 models unloaded.
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:06<00:00,  3.22s/it]                                   
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] Prompt executed in 88.36 seconds
```

End of run state (2 runs):

<img width="321" height="797" alt="image" src="https://github.com/user-attachments/assets/2f1e17c4-cb69-43cd-ac57-388ea1a1dd60" />


After:

```
[INFO] got prompt
[INFO] Using pytorch attention in VAE
[INFO] Using pytorch attention in VAE
[INFO] VAE load device: cuda:0, offload device: cpu, dtype: torch.bfloat16
[INFO] Found quantization metadata version 1
[INFO] Using MixedPrecisionOps for text encoder
[INFO] CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
[INFO] Requested to load WanTEModel
[INFO] Model WanTEModel prepared for dynamic VRAM loading. 6419MB Staged. 0 patches attached. Force pre-loaded 73 weights: 488 KB.
[INFO] Model WanTEModel prepared for dynamic VRAM loading. 6419MB Staged. 0 patches attached. Force pre-loaded 73 weights: 488 KB.
[INFO] Requested to load WanVAE
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] model weight dtype torch.float16, manual cast: None
[INFO] model_type FLOW
[INFO] Requested to load WAN21
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:17<00:00,  8.59s/it]                                   
[INFO] model weight dtype torch.float16, manual cast: None
[INFO] model_type FLOW
[INFO] Requested to load WAN21
[INFO] 0 models unloaded.
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:08<00:00,  4.20s/it]                                   
[INFO] 0 models unloaded.
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] Prompt executed in 106.85 seconds
[INFO] got prompt
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:06<00:00,  3.21s/it]                                   
[INFO] 0 models unloaded.
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:06<00:00,  3.22s/it]                                   
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] Prompt executed in 80.87 seconds
[INFO] got prompt
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:13<00:00,  6.54s/it]                                   
[INFO] 0 models unloaded.
[INFO] Model WAN21 prepared for dynamic VRAM loading. 27251MB Staged. 400 patches attached. Force pre-loaded 160 weights: 1603 KB.
100%|██████████| 2/2 [00:14<00:00,  7.01s/it]                                   
[INFO] 0 models unloaded.
[INFO] Model WanVAE prepared for dynamic VRAM loading. 241MB Staged. 0 patches attached. Force pre-loaded 60 weights: 61 KB.
[INFO] Prompt executed in 74.72 seconds
```

Load state after (3 runs)

<img width="321" height="797" alt="image" src="https://github.com/user-attachments/assets/cf74193a-cb99-4cde-a038-d7dee467f555" />


Performance / Regression Tests (3 runs of each WF - time in seconds):

Windows, RTX3060, 32GB RAM, PCIE1 x4 NVME

```
Workflow    comfy/master                  This change
SD1.5       6.644 /   2.531 /   2.518     6.629 /   2.540 /   2.519
SDXL       22.994 /  13.764 /  13.798    23.397 /  13.740 /  13.788
Wan FP8   114.228 / 102.461 / 102.294   121.956 / 105.311 /  98.747
Wan FP16  147.798 / 130.049 / 134.715   151.782 / 137.637 / 140.645
Flux 2    307.268 / 239.772 / 239.617   309.525 / 243.040 / 244.548
Z-Image    39.546 /  20.320 /  20.371    37.201 /  20.300 /  20.373
```

Linux, RTX5090, 32GB RAM, PCIE1 x4 NVME

```
Workflow    comfy/master                This Change
SD1.5       3.464 /  0.453 /  0.444     3.663 /  0.455 /  0.442
SDXL        9.767 /  1.960 /  1.958    10.753 /  1.953 /  1.957
Wan FP8    48.917 /  9.814 /  8.586    52.187 /  8.543 /  8.550
Wan FP16   73.427 / 71.949 / 71.961    79.596 / 53.223 / 53.983
Flux 2     77.886 / 16.225 / 15.508    82.292 / 16.746 / 17.216
Z-Image    18.787 /  2.636 /  2.642    19.775 /  2.640 /  2.641
```