### PR TITLE
Fix RegexExtract crashing/returning None on non-participating capture groups

### DIFF
--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -349,7 +349,11 @@ class RegexExtract(io.ComfyNode):
 
             elif mode == "First Group":
                 match = re.search(regex_pattern, string, flags)
-                if match and len(match.groups()) >= group_index:
+                if (
+                    match
+                    and len(match.groups()) >= group_index
+                    and match.group(group_index) is not None
+                ):
                     result = match.group(group_index)
                 else:
                     result = ""
@@ -358,7 +362,11 @@ class RegexExtract(io.ComfyNode):
                 matches = re.finditer(regex_pattern, string, flags)
                 results = []
                 for match in matches:
-                    if match.groups() and len(match.groups()) >= group_index:
+                    if (
+                        match.groups()
+                        and len(match.groups()) >= group_index
+                        and match.group(group_index) is not None
+                    ):
                         results.append(match.group(group_index))
                 result = join_delimiter.join(results)
             else:

--- a/tests-unit/comfy_extras_test/nodes_string_test.py
+++ b/tests-unit/comfy_extras_test/nodes_string_test.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch, MagicMock
+
+mock_nodes = MagicMock()
+mock_nodes.MAX_RESOLUTION = 16384
+mock_server = MagicMock()
+
+with patch.dict("sys.modules", {"nodes": mock_nodes, "server": mock_server}):
+    from comfy_extras.nodes_string import RegexExtract
+
+
+def _extract(string, pattern, mode, group_index=1):
+    return RegexExtract.execute(
+        string=string,
+        regex_pattern=pattern,
+        mode=mode,
+        case_insensitive=True,
+        multiline=False,
+        dotall=False,
+        group_index=group_index,
+    )[0]
+
+
+class TestRegexExtractNonParticipatingGroup:
+    def test_first_group_non_participating_returns_empty_string(self):
+        # An alternation where the requested group is on the branch that did
+        # not match: match.group(1) is None. The node output is a String, so
+        # it must return "" rather than leaking None downstream.
+        result = _extract("hello", r"(\d+)-(\d+)|(\w+)", "First Group", 1)
+        assert result == ""
+        assert isinstance(result, str)
+
+    def test_all_groups_non_participating_does_not_crash(self):
+        # Previously appended None and crashed in join() with a TypeError.
+        assert _extract("hello world", r"(\d+)|(\w+)", "All Groups", 1) == ""
+
+    def test_all_groups_mixes_participating_and_non(self):
+        assert _extract("x 5 y", r"([a-z])|(\d)", "All Groups", 1) == "x\ny"
+
+    def test_first_group_normal_still_works(self):
+        assert _extract("2026-07", r"(\d+)-(\d+)", "First Group", 2) == "07"


### PR DESCRIPTION
### Problem

The `RegexExtract` node (Extract Text) crashes or leaks a non-string value when a requested capture group didn't participate in the match.

In "First Group" and "All Groups" modes the code only checks `len(match.groups()) >= group_index`, then calls `match.group(group_index)`. When the group is optional or on a non-taken alternation branch, `match.group()` returns `None`:

```python
# "First Group"
re.search(r"(\d+)-(\d+)|(\w+)", "hello")   # matches via the (\w+) branch
match.group(1)                              # -> None  (returned from a String output)

# "All Groups"
# appends None, then join() raises:
# TypeError: sequence item 0: expected str instance, NoneType found  (workflow aborts)
```

So a common pattern with an alternation or optional group either silently sends `None` into string-consuming nodes ("First Group") or hard-crashes prompt execution ("All Groups").

### Fix

Guard both branches with `is not None`, so a non-participating group yields `""` (matching the node's existing "no match" behaviour). Normal matches are unchanged.

Added `tests-unit/comfy_extras_test/nodes_string_test.py` covering both modes with non-participating groups plus the normal paths; it fails before this change (None return + TypeError) and passes after. The full test runs green against the real node.

---
*Disclosure: I used an AI assistant while working on this; I reproduced the bug, wrote the fix and test, and verified everything myself.*
