### PR TITLE
fix(text_encoders): add stop_tokens to Qwen25_7BVLI_Config

### DIFF
--- a/comfy/text_encoders/llama.py
+++ b/comfy/text_encoders/llama.py
@@ -303,6 +303,11 @@ class Qwen25_7BVLI_Config:
     rms_norm_add = False
     mlp_activation = "silu"
     qkv_bias = True
+    # Qwen2.5-VL stop tokens: <|im_end|> / <|endoftext|>. Without this,
+    # transformer.generate() (in this file) crashes with AttributeError when it
+    # falls back to self.model.config.stop_tokens, because this config omitted
+    # it while every other Qwen config defines it.
+    stop_tokens = [151643, 151645]
     rope_dims = [16, 24, 24]
     q_norm = None
     k_norm = None


### PR DESCRIPTION
## Description
Fixes #15032

Using a Qwen2.5-VL text encoder for text generation (built-in `TextGenerate` node, or calling `clip.generate()` directly) crashes with:

    AttributeError: 'Qwen25_7BVLI_Config' object has no attribute 'stop_tokens'

## Root cause
`transformer.generate()` (comfy/text_encoders/llama.py) falls back to reading `self.model.config.stop_tokens` to decide when to stop on EOS. Every other Qwen config in that file defines `stop_tokens = [151643, 151645]`, but `Qwen25_7BVLI_Config` omits it, so the attribute lookup fails and generation aborts.

## Fix
Add `stop_tokens = [151643, 151645]` (<|im_end|> / <|endoftext|>) to `Qwen25_7BVLI_Config`, matching all sibling Qwen configs.

## Testing
Loaded a Qwen2.5-VL-7B GGUF text encoder and called `clip.generate()`:
- Without the attribute: raises `AttributeError: 'Qwen25_7BVLI_Config' object has no attribute 'stop_tokens'`.
- With the fix: generation completes and returns token ids.

## Side effects
None. This only defines a previously-missing attribute to the standard Qwen2.5-VL stop tokens; it does not change any generation behavior for models that already worked.

## Type of change
- Bug fix (non-breaking change that fixes an issue)