### PR TITLE
fix(server): "Preview Text" node breaking image previews in Assets tab

### DIFF
--- a/comfy_execution/jobs.py
+++ b/comfy_execution/jobs.py
@@ -296,8 +296,6 @@ def get_outputs_summary(outputs: dict) -> tuple[int, Optional[dict]]:
                                     'nodeId': node_id,
                                     'mediaType': media_type
                                 }
-                                if fallback_preview is None:
-                                    fallback_preview = enriched
                         continue
                     # normalize_output_item returned a dict (e.g. 3D file)
                     item = normalized


### PR DESCRIPTION
## Summary

When a workflow uses a **Preview Text** node alongside image generation nodes, generated images were failing to display in the **Assets** tab.

This PR replaces [#13027](https://github.com/Comfy-Org/ComfyUI/pull/13027) with a clean 2-line fix updated against current `master`.

## Steps to Reproduce
1. Create a workflow with both **`Preview as Text`** and **`Preview Image`**
2. Connect any node to **`Preview as Text`**
3. Run the workflow  
4. Image does not appear in the **Assets** tab

## Root Cause

`get_outputs_summary` processes output data in dictionary order. 

If a text output (like `"text"`) appeared before an image output (like `"images"`) in the dictionary, the text node assigned itself to `fallback_preview`. When the image node was processed later, `fallback_preview` was already occupied and could not be replaced by the image.

As a result, the Assets tab received a text string instead of the generated image thumbnail.

## Fix

Removed the lines in `get_outputs_summary` that allowed text entries to set `fallback_preview`:

```python
- if fallback_preview is None:
-     fallback_preview = enriched