### PR TITLE
[Node]: Add ConditioningVariation node

### DIFF
--- a/comfy_extras/nodes_cond.py
+++ b/comfy_extras/nodes_cond.py
@@ -1,3 +1,4 @@
+import torch
 from typing_extensions import override
 
 from comfy_api.latest import ComfyExtension, io
@@ -57,12 +58,73 @@ class T5TokenizerOptions(io.ComfyNode):
         return io.NodeOutput(clip)
 
 
+def _vary(tensor: torch.Tensor, noise: torch.Tensor, strength: float) -> torch.Tensor:
+    eps = 1e-8
+    norm = tensor.norm(dim=-1, keepdim=True)
+    varied = tensor + strength * noise * (norm / (noise.norm(dim=-1, keepdim=True) + eps))
+    return varied / (varied.norm(dim=-1, keepdim=True) + eps) * norm
+
+
+class ConditioningVariation(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="ConditioningVariation",
+            display_name="Conditioning Variation",
+            category="model/conditioning/transform",
+            description="Nudges a conditioning with seeded noise to explore variations of a prompt "
+            "without changing the sampler seed. Noise is scaled per-token and the result is "
+            "renormalized, so strength controls how far the variation drifts in content without "
+            "changing the prompt's overall strength.",
+            search_aliases=["variation seed", "prompt variation", "vary conditioning", "vary prompt"],
+            inputs=[
+                io.Conditioning.Input("conditioning"),
+                io.Float.Input(
+                    "strength",
+                    default=0.1,
+                    min=0.0,
+                    max=2.0,
+                    step=0.01,
+                    tooltip="How far to nudge. 0 = unchanged; ~0.1 gives close variations; "
+                    "higher drifts further from the prompt.",
+                ),
+                io.Int.Input(
+                    "seed",
+                    default=0,
+                    min=0,
+                    max=0xffffffffffffffff,
+                    control_after_generate=True,
+                    tooltip="Variation seed — change it to get a different variation.",
+                ),
+            ],
+            outputs=[io.Conditioning.Output()],
+            is_experimental=True,
+        )
+
+    @classmethod
+    def execute(cls, conditioning, strength, seed) -> io.NodeOutput:
+        if strength == 0.0:
+            return io.NodeOutput(conditioning)
+        generator = torch.Generator().manual_seed(seed)
+        c = []
+        for t in conditioning:
+            noise = torch.randn(t[0].shape, generator=generator).to(t[0])
+            n = [_vary(t[0], noise, strength), t[1].copy()]
+            pooled = n[1].get("pooled_output", None)
+            if pooled is not None:
+                pnoise = torch.randn(pooled.shape, generator=generator).to(pooled)
+                n[1]["pooled_output"] = _vary(pooled, pnoise, strength)
+            c.append(n)
+        return io.NodeOutput(c)
+
+
 class CondExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[io.ComfyNode]]:
         return [
             CLIPTextEncodeControlnet,
             T5TokenizerOptions,
+            ConditioningVariation,
         ]
 
 


### PR DESCRIPTION
## Summary

Adds a **Conditioning Variation** node — a "variation seed" for conditioning.
It perturbs a `CONDITIONING` with seeded noise so you can explore neighbouring
variations of the same prompt **without touching the sampler seed**.

This is the conditioning-space analog of the familiar latent variation seed:
instead of jittering the starting noise, it jitters the prompt embedding. There
is currently no core node that perturbs a conditioning, so this fills a gap next
to `ConditioningMultiply` / `ConditioningAverage`.

## How it works

- Noise is scaled to each token's own magnitude, so `strength` means the same
  thing regardless of how "loud" a given conditioning is — consistent behaviour
  across prompts and models.
- The result is renormalized back to the original per-token magnitude, so
  `strength` moves the variation's **direction (content)** rather than the
  prompt's overall strength (that remains `ConditioningMultiply`'s job).
- `pooled_output` is perturbed with the same seeded generator when present.
- Uses a CPU `torch.Generator`, so a given seed reproduces regardless of device.
- The input conditioning is left unmutated (metadata is copied per entry).

## Screenshots
<img width="366" height="248" alt="image" src="https://github.com/user-attachments/assets/54bd092e-6c72-4195-b83b-741412cf7a66" />

### 0.4 Strength

<img width="2009" height="1019" alt="image" src="https://github.com/user-attachments/assets/9e5436d8-d55c-45c2-b8f7-a96f275f3da4" />

### 0.7 Strength

<img width="2158" height="1045" alt="image" src="https://github.com/user-attachments/assets/34c3c3ad-7bb6-4932-be6e-6e514ae1fab7" />

### Sweep
<img width="2235" height="730" alt="image" src="https://github.com/user-attachments/assets/15d12f8f-b77c-48f2-98d0-c56a7a792732" />


## Inputs

| input | type | notes |
|-------|------|-------|
| `conditioning` | CONDITIONING | |
| `strength` | FLOAT (default 0.1) | 0 = unchanged; ~0.1 close variations; higher drifts further |
| `seed` | INT | change it for a different variation (`control_after_generate`) |

Output: `CONDITIONING`.

## Notes

- Placed in `comfy_extras/nodes_cond.py`, category `model/conditioning/transform`.
- Marked **experimental**.
- `strength = 0` short-circuits and returns the input unchanged.

## Testing

Verified locally: same seed reproduces exactly, different seed differs,
`strength=0` is a no-op, per-token magnitude is preserved, `pooled_output` is
perturbed, and the input conditioning is not mutated.
