### PR TITLE
fix(text_encoders): use selected lm_head module in BaseGenerate.logits

### DIFF
--- a/comfy/text_encoders/llama.py
+++ b/comfy/text_encoders/llama.py
@@ -861,7 +861,7 @@ class BaseGenerate:
         if module.comfy_cast_weights:
             weight, _, offload_stream = comfy.ops.cast_bias_weight(module, input, offloadable=True)
         else:
-            weight = self.model.embed_tokens.weight.to(x)
+            weight = module.weight.to(x)
 
         x = torch.nn.functional.linear(input, weight, None)
 


### PR DESCRIPTION
## What

`BaseGenerate.logits` (`comfy/text_encoders/llama.py`) already selects the output-projection module a few lines above the bug:

```python
if hasattr(self.model, "lm_head"):
    module = self.model.lm_head
else:
    module = self.model.embed_tokens
```

but the `comfy_cast_weights is False` branch below hard-codes `self.model.embed_tokens.weight` instead of `module.weight`. For any model that loads a **separate, untied** `lm_head` (e.g. Qwen2.5-VL-7B, which ships `output.weight` rather than tying word embeddings) and runs with `comfy_cast_weights=False`, this produces incorrect / garbled logits.

Note this differs from `BaseQwen3.logits`, which already handles the untied case correctly by returning `self.model.lm_head(input)` early — so the two code paths are currently inconsistent.

## Fix

Use `module.weight` consistently with the `comfy_cast_weights is True` branch directly above it.

## No regression

When no `lm_head` is present, `module` is `embed_tokens`, so `module.weight` is exactly `embed_tokens.weight` — identical to the previous behavior for all tied-embedding models.

## Scope note

This fixes the ComfyUI-side logic only. GGUF-quantized `lm_head` weights additionally need a shape fix in ComfyUI-GGUF's dequantization path to work end-to-end; that is a separate issue in the ComfyUI-GGUF repo.
