### PR TITLE
fix(ops): dequantize GGUF GGMLTensor weights in cast_bias_weight

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -366,6 +366,21 @@ def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None, of
 
     comfy.model_management.sync_stream(device, offload_stream)
 
+    # GGUF quantized weights are stored as a custom GGMLTensor subclass rather
+    # than ComfyUI's QuantizedTensor, so the isinstance check in the block below
+    # misses them and the block-packed storage reaches F.linear with the wrong
+    # shape. The discriminator here is GGUF's own protocol marker (tensor_type,
+    # the GGUF quant type) -- NOT the presence of a dequantize() method: a plain
+    # torch.Tensor (including ordinary int8/uint8 weights) also exposes
+    # dequantize() and would fail at runtime if gated on that alone. tensor_type
+    # is set by GGMLTensor.__init__ and preserved by to()/new_empty(), and nothing
+    # else in the codebase assigns it, so only genuine GGMLTensor weights enter
+    # this branch and get dequantized. This is duck-typed: core never imports GGUF.
+    # Runs after sync_stream because cast_to above may use an offload stream and
+    # the async device copy must finish before we read the weight.
+    if not isinstance(weight, QuantizedTensor) and getattr(weight, "tensor_type", None) is not None:
+        weight = weight.dequantize()
+
     bias_a = bias
     weight_a = weight
 


### PR DESCRIPTION
## What

`comfy.ops.cast_bias_weight` only dequantized `QuantizedTensor` weights
(comfy/ops.py). GGUF stores quantized weights as a custom `GGMLTensor`
subclass, so it slipped through un-dequantized and its block-packed storage
reached `F.linear` with the wrong shape, crashing `generate()` on GGUF text
encoders such as Qwen2.5-VL:

    RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x3584 and 2940x152064)

GGUF's own `GGMLLayer.cast_bias_weight` does dequantize correctly, but
`BaseGenerate.logits` (and any core code calling the generic
`comfy.ops.cast_bias_weight`) bypasses that module method.

## Fix

Dequantize any weight that exposes a duck-typed `dequantize()` method, so the
real (un-packed) shape is what downstream matmul sees. This is GGUF-agnostic:
core does not import GGUF types, and only weights that opt in with a
`dequantize()` method are affected. Normal tensors and `QuantizedTensor` keep
their existing behavior unchanged.

Requires city96/ComfyUI-GGUF#468 which adds the `GGMLTensor.dequantize()`
method.

## Verification

Loaded a real Qwen2.5-VL GGUF clip and called the unmodified `transformer.logits`
directly: before the fix it crashed with the shape error above; after, it returns
`(1, 1, 152064)` as expected.
