### PR TITLE
cli_args: bump default background usage clamp to 128GB

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -112,7 +112,7 @@ parser.add_argument("--preview-method", type=LatentPreviewMethod, default=Latent
 parser.add_argument("--preview-size", type=int, default=512, help="Sets the maximum preview size for sampler nodes.")
 
 cache_group = parser.add_mutually_exclusive_group()
-cache_group.add_argument("--cache-ram", nargs='*', type=float, default=[], metavar="GB", help="Use RAM pressure caching with the specified headroom thresholds. This is the default caching mode. The first value sets the active-cache threshold; the optional second value sets the inactive-cache/pin threshold. Defaults when no values are provided: active 10%% of system RAM (min 2GB, max 10GB), inactive 100%% of system RAM (max 96GB).")
+cache_group.add_argument("--cache-ram", nargs='*', type=float, default=[], metavar="GB", help="Use RAM pressure caching with the specified headroom thresholds. This is the default caching mode. The first value sets the active-cache threshold; the optional second value sets the inactive-cache/pin threshold. Defaults when no values are provided: active 10%% of system RAM (min 2GB, max 10GB), inactive 100%% of system RAM (max 128GB).")
 cache_group.add_argument("--cache-classic", action="store_true", help="Use the old style (aggressive) caching.")
 cache_group.add_argument("--cache-lru", type=int, default=0, help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.")
 cache_group.add_argument("--cache-none", action="store_true", help="Reduced RAM/VRAM usage at the expense of executing every node for each run.")

--- a/main.py
+++ b/main.py
@@ -319,7 +319,7 @@ def prompt_worker(q, server_instance):
     cache_ram_inactive = 0
     if not args.cache_classic and not args.cache_none and args.cache_lru <= 0:
         cache_ram = min(10.0, max(2.0, comfy.model_management.total_ram * 0.10 / 1024.0))
-        cache_ram_inactive = min(96.0, comfy.model_management.total_ram / 1024.0)
+        cache_ram_inactive = min(128.0, comfy.model_management.total_ram / 1024.0)
         if len(args.cache_ram) > 0:
             cache_ram = args.cache_ram[0]
         if len(args.cache_ram) > 1:


### PR DESCRIPTION
Some long running chaos testing on a 512GB RAM RTX6000 pro showed that this is a little bit too low for common template workflows switching around. The original number was just a guess from me, so go with the scientific result instead.

5 hours of back to back testing data (after 10 hours straight on a different experiment found the original suspicion)

The agents data:

<img width="1461" height="875" alt="image" src="https://github.com/user-attachments/assets/9d67578a-67c3-417b-ab94-f5b5508d1a82" />

Summary of data:

```
This sample is large enough to establish that:

- 96 GiB is measurably worse for model switches: approximately 2.4 seconds slower for Wan and 2.1 seconds slower for LTX.
- Repeating Wan without switching models is effectively identical at every threshold.
- 128, 192, and 256 GiB are practically equivalent. Their confidence intervals substantially overlap.
- 128 GiB delivered the highest throughput, although the difference from 192/256 is only one cycle.
```