### PR TITLE
Fix MageFlow on cards that don't support bf16

### DIFF
--- a/comfy/ldm/mage_flow/model.py
+++ b/comfy/ldm/mage_flow/model.py
@@ -22,10 +22,9 @@ class MageTimestepProjEmbeddings(nn.Module):
         )
 
     def forward(self, timestep, hidden_states):
-        timestep = timestep.to(torch.bfloat16) # timesteps have to be rounded to bf16 for Mage-Flow's timestep frequency table.
         half_dim = 128
         exponent = -math.log(10000) * torch.arange(half_dim, dtype=torch.float32, device=timestep.device) / half_dim
-        emb = torch.exp(exponent).to(torch.bfloat16)
+        emb = torch.exp(exponent).to(timestep.dtype)
         emb = timestep[:, None].float() * emb[None, :]
         emb = 1000.0 * emb
         emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)

--- a/comfy/ldm/mage_flow/model.py
+++ b/comfy/ldm/mage_flow/model.py
@@ -22,10 +22,10 @@ class MageTimestepProjEmbeddings(nn.Module):
         )
 
     def forward(self, timestep, hidden_states):
-        timestep = timestep.to(hidden_states.dtype)
+        timestep = timestep.to(torch.bfloat16) # timesteps have to be rounded to bf16 for Mage-Flow's timestep frequency table.
         half_dim = 128
         exponent = -math.log(10000) * torch.arange(half_dim, dtype=torch.float32, device=timestep.device) / half_dim
-        emb = torch.exp(exponent).to(timestep.dtype)
+        emb = torch.exp(exponent).to(torch.bfloat16)
         emb = timestep[:, None].float() * emb[None, :]
         emb = 1000.0 * emb
         emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -2279,6 +2279,10 @@ class MageFlow(QwenImage):
     def __init__(self, model_config, model_type=ModelType.FLOW, device=None):
         super().__init__(model_config, model_type, device=device, unet_model=comfy.ldm.mage_flow.model.MageFlowTransformer2DModel)
 
+    def process_timestep(self, timestep, **kwargs):
+        # Mage runs in bf16 and rounds its timestep frequency table to the timestep dtype, keep that on fp32 devices.
+        return timestep.to(torch.bfloat16)
+
     def extra_conds_shapes(self, **kwargs):
         out = {}
         ref_latents = kwargs.get("reference_latents", None)


### PR DESCRIPTION
The timestep frequency table and sigma were rounded to hidden_states.dtype instead of bf16. Mage was trained with bf16 rounding here and the reference vendors its own get_timestep_embedding specifically to preserve it.

Confirmed broken output by using fp32 compute dtype, and it working with this change.