### PR TITLE
fix(server): return 400 for unknown /upload/image type instead of 500

### DIFF
--- a/server.py
+++ b/server.py
@@ -377,6 +377,10 @@ class PromptServer():
                 type_dir = folder_paths.get_temp_directory()
             elif dir_type == "output":
                 type_dir = folder_paths.get_output_directory()
+            else:
+                # Unrecognised type: signal "no directory" instead of falling
+                # through to an unbound `type_dir` (UnboundLocalError -> 500).
+                return None, dir_type
 
             return type_dir, dir_type
 
@@ -401,6 +405,8 @@ class PromptServer():
 
             image_upload_type = post.get("type")
             upload_dir, image_upload_type = get_dir_by_type(image_upload_type)
+            if upload_dir is None:
+                return web.Response(status=400)
 
             if image and image.file:
                 filename = image.filename


### PR DESCRIPTION
Fixes #15082.

### What

`get_dir_by_type()` in `server.py` binds its local `type_dir` only inside an `if/elif` chain
covering `"input"`, `"temp"` and `"output"` (with `None` normalised to `"input"` first). The chain
has no `else`, so any other value reaches `return type_dir, dir_type` with `type_dir` never
assigned. CPython raises `UnboundLocalError`, it escapes the handler, and aiohttp answers HTTP 500.

`image_upload()` is the only caller and passes the multipart `type` field through untouched, so both
`POST /upload/image` and `POST /upload/mask` are affected. A client typo produces a server error
where a client error is correct, which is misleading in logs and to API consumers.

### Reproduce

```console
$ curl -i -F "image=@x.png" -F "type=foo" http://127.0.0.1:8188/api/upload/image
HTTP/1.1 500 Internal Server Error
# server log: UnboundLocalError: cannot access local variable 'type_dir'
#             where it is not associated with a value
```

Control, unchanged before and after this patch:

```console
$ curl -i -F "image=@x.png" -F "type=input" http://127.0.0.1:8188/api/upload/image
HTTP/1.1 200 OK
{"name": "x.png", "subfolder": "", "type": "input"}
```

With this patch the first command returns `HTTP/1.1 400 Bad Request` and the second is unchanged.

### Change

Six lines. `get_dir_by_type()` returns `(None, dir_type)` for an unrecognised type instead of
falling through to an unbound local, and `image_upload()` answers 400 when it sees that. The helper
stays a pure function with no `aiohttp.web` dependency, and the 400 matches the convention already
used in `image_upload()` for a missing filename and for a failed containment check.

### Behaviour preserved

- `None` still normalises to `"input"` and returns the input directory.
- `"input"`, `"temp"` and `"output"` return the identical tuple they returned before; uploads with
  those types still return the same `200` JSON body.
- The helper is still called exactly once per upload request.
- The downstream `os.path.abspath` plus `commonpath` containment check, duplicate detection and
  asset registration are untouched. They were unreachable for unrecognised types before this change
  and remain so, because control leaves the function earlier in both cases.
- The empty string is treated as unrecognised and answered with 400 rather than silently coerced to
  `"input"`. That matches the previous intent, since `""` crashed rather than defaulting, and keeps
  `None` as the only value that defaults.

### Tests

No unit test is included. `get_dir_by_type` is a closure nested inside `PromptServer.add_routes`,
and this repository's own test suite records in
`tests-unit/security_test/test_ghsa_779p_05_dangerous_content_types.py` that `server.py` cannot be
imported in a unit test. Hoisting the helper to module scope purely to make it reachable would turn
a six-line fix into a refactor. Happy to add a test in whatever form you prefer if you would rather
have one, including the hoist.

This is a non-security robustness fix, filed as a public pull request per `SECURITY.md`, which lists
crashes and non-default-network-exposure issues as regular bugs rather than vulnerabilities.
