### PR TITLE
docs(readme): add new third-party installers and launchers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ ComfyUI is the AI creation engine for visual professionals who demand control ov
 #### [Manual Install](#manual-install-windows-linux)
 Supports all operating systems and GPU types (NVIDIA, AMD, Intel, Apple Silicon, Ascend).
 
+#### Third-Party Installers & Launchers
+
+- [LynxHub](https://github.com/KindaBrazy/LynxHub): Cross-platform visual management dashboard and terminal/browser for installing, configuring, and launching ComfyUI.
+
+
 ### Cloud
 
 #### [Comfy Cloud](https://www.comfy.org/cloud)


### PR DESCRIPTION
Hi ComfyUI team, I've added a new section in readme as `Third-Party Installers & Launchers` for community managers and installers.

Listed [LynxHub](https://github.com/KindaBrazy/LynxHub) in this section.

Currently placed under `## Get Started > ### Local`, If you prefer a different location (under `Manual Install` or a separate section), let me know and I will update it.