### PR TITLE
Fix mask ndim handling in QwenImageDiffsynthControlnet.

### DIFF
--- a/comfy_extras/nodes_model_patch.py
+++ b/comfy_extras/nodes_model_patch.py
@@ -569,7 +569,7 @@ class QwenImageDiffsynthControlnet:
         if mask is not None:
             if mask.ndim == 3:
                 mask = mask.unsqueeze(1)
-            if mask.ndim == 4:
+            elif mask.ndim == 4:
                 mask = mask.unsqueeze(2)
             mask = 1.0 - mask
 


### PR DESCRIPTION
## Problem

`QwenImageDiffsynthControlnet` accepts an optional `MASK` input, but passing one raises:

```
RuntimeError: Tensors must have same number of dimensions: got 4 and 5
```

In `comfy_extras/nodes_model_patch.py`:

```python
if mask is not None:
    if mask.ndim == 3:
        mask = mask.unsqueeze(1)
    if mask.ndim == 4:      # <-- also fires, right after the branch above
        mask = mask.unsqueeze(2)
    mask = 1.0 - mask
```

The two `if` statements are not mutually exclusive. A standard ComfyUI `MASK` is 3D, so it goes through both:

`[B, H, W]` → `unsqueeze(1)` → `[B, 1, H, W]` → `unsqueeze(2)` → `[B, 1, 1, H, W]`

The consumer, `DiffSynthCnetPatch.encode_latent_cond()`, expects 4D. It calls `self.mask.mean(dim=1, keepdim=True)` (averaging over the channel dim), then:

```python
return torch.cat([latent_image, mask_], dim=1)
```

`common_upscale()` preserves the input rank, so `mask_` stays 5D while `latent_image` is 4D, and the `cat` fails.

Both the mask normalization and this consumer were introduced together in 1b2de26 ("Support diffsynth inpaint controlnet (model patch)", #9471), so 4D looks like the intended target shape and the second `if` looks like it was meant to be `elif`.

## Scope

The crash happens whenever a mask is passed together with a DiffSynth **inpaint** controlnet, i.e. `additional_in_dim > 0` — which is the only case where the mask is read at all. With depth/canny DiffSynth controlnets the mask is currently stored and never used, so those workflows are unaffected either way.

`ZImageControlPatch` is also unaffected: it normalizes independently with
`self.mask.view(self.mask.shape[0], -1, self.mask.shape[-2], self.mask.shape[-1])`, so it works with the mask at 4D or 5D. I verified the Z-Image path produces an identical result before and after this change.

## Fix

```diff
             if mask.ndim == 3:
                 mask = mask.unsqueeze(1)
-            if mask.ndim == 4:
+            elif mask.ndim == 4:
                 mask = mask.unsqueeze(2)
             mask = 1.0 - mask
```

## Reproduction

Standalone, no models or GPU needed — it replays the shape handling of the node and of `DiffSynthCnetPatch.encode_latent_cond()`:

```
$ python repro_diffsynth_mask_ndim.py
current (two `if`)       mask=(1, 1, 1, 64, 64)  RuntimeError: Tensors must have same number of dimensions: got 4 and 5
fixed   (`if`/`elif`)    mask=(1, 1, 64, 64)  cat -> (1, 17, 8, 8)  OK
```

(script attached below / in the linked gist)

## Note

This restores the original intent with the smallest possible change. A 4D mask input still ends up at 5D and would hit the same `cat`. If you would rather make the node rank-agnostic, the alternative is to reuse the normalization already used by `ZImageControlPatch`:

```python
mask = mask.view(mask.shape[0], -1, mask.shape[-2], mask.shape[-1])
mask = 1.0 - mask
```

Happy to switch to that if you prefer it.