### PR TITLE
Fix OFT/BOFT constraint scaling when loading lycoris models

### DIFF
--- a/comfy/weight_adapter/boft.py
+++ b/comfy/weight_adapter/boft.py
@@ -78,10 +78,12 @@ class BOFTAdapter(WeightAdapterBase):
             # for Q = -Q^T
             q = blocks - blocks.transpose(-1, -2)
             normed_q = q
-            if alpha > 0:  # alpha in boft/bboft is for constraint
+            # alpha in boft/bboft is the constraint, lycoris stores it unscaled
+            constraint = alpha * block_num * boft_b
+            if constraint > 0:
                 q_norm = torch.norm(q) + 1e-8
-                if q_norm > alpha:
-                    normed_q = q * alpha / q_norm
+                if q_norm > constraint:
+                    normed_q = q * constraint / q_norm
             # use float() to prevent unsupported type in .inverse()
             r = (I + normed_q) @ (I - normed_q).float().inverse()
             r = r.to(weight)
@@ -146,11 +148,12 @@ class BOFTAdapter(WeightAdapterBase):
         q = blocks - blocks.transpose(-1, -2)
         normed_q = q
 
-        # Apply constraint if alpha > 0
-        if alpha > 0:
+        # Apply constraint, lycoris stores it unscaled
+        constraint = alpha * block_num * boft_b
+        if constraint > 0:
             q_norm = torch.norm(q) + 1e-8
-            if q_norm > alpha:
-                normed_q = q * alpha / q_norm
+            if q_norm > constraint:
+                normed_q = q * constraint / q_norm
 
         # Cayley transform: R = (I + Q)(I - Q)^-1
         r = (I + normed_q) @ (I - normed_q).float().inverse()

--- a/comfy/weight_adapter/oft.py
+++ b/comfy/weight_adapter/oft.py
@@ -25,7 +25,8 @@ class OFTDiff(WeightAdapterTrainBase):
         else:
             self.rescaled = False
         self.block_num, self.block_size, _ = blocks.shape
-        self.constraint = float(alpha)
+        # alpha is the constraint, lycoris stores it unscaled
+        self.constraint = float(alpha) * self.block_num * self.block_size
         self.alpha = torch.nn.Parameter(torch.tensor(alpha), requires_grad=False)
 
     def __call__(self, w):
@@ -220,10 +221,12 @@ class OFTAdapter(WeightAdapterBase):
             # for Q = -Q^T
             q = blocks - blocks.transpose(1, 2)
             normed_q = q
-            if alpha > 0:  # alpha in oft/boft is for constraint
+            # alpha in oft/boft is the constraint, lycoris stores it unscaled
+            constraint = alpha * block_num * block_size
+            if constraint > 0:
                 q_norm = torch.norm(q) + 1e-8
-                if q_norm > alpha:
-                    normed_q = q * alpha / q_norm
+                if q_norm > constraint:
+                    normed_q = q * constraint / q_norm
             # use float() to prevent unsupported type in .inverse()
             r = (I + normed_q) @ (I - normed_q).float().inverse()
             r = r.to(weight)
@@ -266,11 +269,12 @@ class OFTAdapter(WeightAdapterBase):
         q = blocks - blocks.transpose(1, 2)
         normed_q = q
 
-        # Apply constraint if alpha > 0
-        if alpha > 0:
+        # Apply constraint, lycoris stores it unscaled
+        constraint = alpha * block_num * block_size
+        if constraint > 0:
             q_norm = torch.norm(q) + 1e-8
-            if q_norm > alpha:
-                normed_q = q * alpha / q_norm
+            if q_norm > constraint:
+                normed_q = q * constraint / q_norm
 
         # Cayley transform: R = (I + Q)(I - Q)^-1
         r = (I + normed_q) @ (I - normed_q).float().inverse()

--- a/tests-unit/comfy_test/weight_adapter_test.py
+++ b/tests-unit/comfy_test/weight_adapter_test.py
@@ -1,0 +1,29 @@
+import torch
+
+from comfy.weight_adapter import BOFTAdapter, OFTAdapter
+
+
+def apply_adapter(adapter_cls, blocks, alpha):
+    adapter = adapter_cls.load("x", {"x.oft_blocks": blocks}, alpha, None)
+    weight = torch.arange(16, dtype=torch.float32).reshape(8, 2)
+    return adapter.calculate_weight(weight, "x", 1.0, 1.0, None, lambda w: w)
+
+
+# 4 blocks of 2x2 gives out_dim 8, so lycoris clamps at alpha * 8 and ||Q|| is 0.283.
+def test_oft_constraint_is_scaled_by_out_dim():
+    blocks = torch.zeros(4, 2, 2)
+    blocks[:, 0, 1] = 0.1
+
+    unclamped = apply_adapter(OFTAdapter, blocks, 0.0)
+    assert torch.allclose(apply_adapter(OFTAdapter, blocks, 0.1), unclamped)
+    assert not torch.allclose(apply_adapter(OFTAdapter, blocks, 0.01), unclamped)
+
+
+# BOFT(3, 4 blocks of 2x2) also gives out_dim 8, with ||Q|| of 0.490.
+def test_boft_constraint_is_scaled_by_out_dim():
+    blocks = torch.zeros(3, 4, 2, 2)
+    blocks[:, :, 0, 1] = 0.1
+
+    unclamped = apply_adapter(BOFTAdapter, blocks, 0.0)
+    assert torch.allclose(apply_adapter(BOFTAdapter, blocks, 0.1), unclamped)
+    assert not torch.allclose(apply_adapter(BOFTAdapter, blocks, 0.01), unclamped)


### PR DESCRIPTION
Both trainers that emit `oft_blocks` store the raw `constraint` in the `alpha` buffer and multiply it by the module's `out_dim` when they build the module, so the clamp on `||Q||` uses `constraint * out_dim`:

- lycoris [`boft.py`](https://github.com/KohakuBlueleaf/LyCORIS/blob/main/lycoris/modules/boft.py) / [`diag_oft.py`](https://github.com/KohakuBlueleaf/LyCORIS/blob/main/lycoris/modules/diag_oft.py): `self.constraint = constraint * out_dim` next to `register_buffer("alpha", torch.tensor(constraint))`, and `make_module_from_state_dict` passes the saved `alpha` straight back in as `constraint`, so the scaling is reapplied on load.
- kohya-ss sd-scripts [`networks/oft.py`](https://github.com/kohya-ss/sd-scripts/blob/main/networks/oft.py): `self.constraint = alpha * out_dim`, same `register_buffer("alpha", torch.tensor(alpha))`.

We compared `torch.norm(q)` against the raw `alpha`, so for the `constraint=0.001` in #15066 the rotation is clamped orders of magnitude harder than it was at training time. The lora loads without an error and generates images that do not resemble the training samples.

`out_dim` is `block_num * block_size` for both adapters, so the scale is available at every clamp site without new plumbing. `alpha` itself is left alone because it is also passed to `weight_decompose`.

Also fixes the identical mismatch in `oft.py` — same convention in both trainers above, and the two adapters already cross-reference each other in their comments. Happy to split it out if you would rather land BOFT alone.

Loras saved with `alpha == 0`, which is what both trainers write when no constraint is set, keep `constraint == 0` and are bit-identical.

Tests: added `tests-unit/comfy_test/weight_adapter_test.py`, which fails on master and passes here. `python -m pytest tests-unit` 1115 passed / 10 skipped, `ruff check .` clean.

Fixes #15066