### PR TITLE
Allow using float fps for LTXVEmptyLatentAudio

### DIFF
--- a/comfy/ldm/lightricks/vae/audio_vae.py
+++ b/comfy/ldm/lightricks/vae/audio_vae.py
@@ -185,7 +185,7 @@ class AudioVAE(torch.nn.Module):
             self.autoencoder.mel_bins,
         )
 
-    def num_of_latents_from_frames(self, frames_number: int, frame_rate: int) -> int:
+    def num_of_latents_from_frames(self, frames_number: int, frame_rate: float) -> int:
         return math.ceil((float(frames_number) / frame_rate) * self.latents_per_second)
 
     def run_vocoder(self, mel_spec: torch.Tensor) -> torch.Tensor:

--- a/comfy_extras/nodes_lt_audio.py
+++ b/comfy_extras/nodes_lt_audio.py
@@ -107,14 +107,17 @@ class LTXVEmptyLatentAudio(io.ComfyNode):
                     display_mode=io.NumberDisplay.number,
                     tooltip="Number of frames.",
                 ),
-                io.Int.Input(
-                    "frame_rate",
-                    default=25,
-                    min=1,
-                    max=1000,
-                    step=1,
-                    display_mode=io.NumberDisplay.number,
-                    tooltip="Number of frames per second.",
+                io.MultiType.Input(
+                    io.Float.Input(
+                        "frame_rate",
+                        default=25.0,
+                        min=1.0,
+                        max=1000.0,
+                        step=0.01,
+                        display_mode=io.NumberDisplay.number,
+                        tooltip="Number of frames per second.",
+                    ),
+                    [io.Int],
                 ),
                 io.Int.Input(
                     "batch_size",
@@ -137,7 +140,7 @@ class LTXVEmptyLatentAudio(io.ComfyNode):
     def execute(
         cls,
         frames_number: int,
-        frame_rate: int,
+        frame_rate: float,
         batch_size: int,
         audio_vae,
     ) -> io.NodeOutput:


### PR DESCRIPTION
All other nodes use FLOAT as the fps value, and I can't see a reason to limit this to INT only. Using multitype to still accept INT to keep old workflows functional.