### PR TITLE
[Partner Nodes] fix(GPT Image): make custom_width/custom_height optional

### DIFF
--- a/comfy_api_nodes/nodes_openai.py
+++ b/comfy_api_nodes/nodes_openai.py
@@ -747,6 +747,7 @@ class OpenAIGPTImageNodeV2(IO.ComfyNode):
                                     max=3840,
                                     step=16,
                                     tooltip="Used only when `size` is 'Custom'. Must be a multiple of 16.",
+                                    optional=True,
                                 ),
                                 IO.Int.Input(
                                     "custom_height",
@@ -755,6 +756,7 @@ class OpenAIGPTImageNodeV2(IO.ComfyNode):
                                     max=3840,
                                     step=16,
                                     tooltip="Used only when `size` is 'Custom'. Must be a multiple of 16.",
+                                    optional=True,
                                 ),
                                 IO.Combo.Input(
                                     "background",

--- a/tests-unit/comfy_api_test/gpt_image_size_inputs_test.py
+++ b/tests-unit/comfy_api_test/gpt_image_size_inputs_test.py
@@ -1,0 +1,27 @@
+from comfy_api.latest._io import get_finalized_class_inputs
+from comfy_api_nodes.nodes_openai import OpenAIGPTImageNodeV2
+
+
+def _finalized_inputs(live_inputs):
+    class_inputs, _, _ = get_finalized_class_inputs(
+        OpenAIGPTImageNodeV2.INPUT_TYPES(), live_inputs
+    )
+    return class_inputs
+
+
+def test_gpt_image_2_custom_size_inputs_are_optional():
+    """A preset `size` must not require the custom width/height widgets to be present."""
+    class_inputs = _finalized_inputs({"model": "gpt-image-2", "model.size": "1536x1024"})
+
+    assert "model.custom_width" not in class_inputs["required"]
+    assert "model.custom_height" not in class_inputs["required"]
+    assert "model.custom_width" in class_inputs["optional"]
+    assert "model.custom_height" in class_inputs["optional"]
+    assert "model.size" in class_inputs["required"]
+
+
+def test_gpt_image_legacy_models_have_no_custom_size_inputs():
+    for model in ("gpt-image-1", "gpt-image-1.5"):
+        class_inputs = _finalized_inputs({"model": model, "model.size": "1536x1024"})
+        assert "model.custom_width" not in class_inputs["required"]
+        assert "model.custom_width" not in class_inputs["optional"]


### PR DESCRIPTION
## ELI-5

The OpenAI GPT Image 2 node made you fill in "custom width" and "custom height" even when you had already picked a normal size like `1536x1024`. If a workflow left them out, the run failed before it started. Those two boxes are now optional, so picking a preset size just works.

## Problem

`OpenAIGPTImageNodeV2` declares `custom_width` / `custom_height` as **required** nested inputs of the `gpt-image-2` `DynamicCombo` option. `get_finalized_class_inputs` flattens them to `model.custom_width` / `model.custom_height` under `required`, so `validate_inputs` raises `required_input_missing` for any prompt that omits them — including one that selected a named preset such as `1536x1024`, where the values are meaningless.

## Change

Mark both inputs `optional=True`. Nothing else changes: `execute()` already reads them as `model.get("custom_width", 1024)` / `model.get("custom_height", 1024)`, and the `size == "Custom"` validation block is untouched.

Two precedents in-tree do exactly this, which is also the Chesterton's-fence answer for why the flag was absent rather than deliberate — `git blame` shows both lines landed in #13838 with no explicit intent to make them required:

- The deprecated `OpenAIGPTImage1` node in the **same file** already marks its `custom_width` / `custom_height` `optional=True` (`comfy_api_nodes/nodes_openai.py:463-480`).
- Seedream's `width` / `height` are `optional=True` and fall back to the widget defaults when `size_preset` is `Custom` (`comfy_api_nodes/nodes_bytedance.py:559-576`, `nodes_bytedance.py:672-673`).

Scoped deliberately: `model.size`, `model.background` and `model.quality` stay **required**. `execute()` indexes those directly (`model["background"]`, `model["quality"]`), so relaxing them would turn a clear validation error into a `KeyError` at runtime.

Resulting flattened schema for `model="gpt-image-2"`:

- required: `prompt`, `seed`, `n`, `model`, `model.size`, `model.background`, `model.quality`
- optional: `model.custom_width`, `model.custom_height`, `model.mask`, `model.images.image_1..16`

## Behavior note (judgment call)

With the fix, selecting `size="Custom"` while omitting the dimensions no longer errors — it falls back to the 1024x1024 widget defaults and generates. That is the pre-existing intent of the `.get(..., 1024)` defaults in `execute()`, and it matches both precedents above (`OpenAIGPTImage1` and Seedream both fall back to their widget defaults in the same situation). Flagging it because it is the one user-visible behavior change beyond the bug fix.

## Tests

New `tests-unit/comfy_api_test/gpt_image_size_inputs_test.py` asserts the flattened schema puts the custom size inputs under `optional` (and `model.size` under `required`) for `gpt-image-2`, and that the legacy `gpt-image-1` / `gpt-image-1.5` options expose no custom size inputs at all. Verified red before the fix (`required_input_missing` assertion fails) and green after.

- `pytest tests-unit` — 1114 passed, 10 skipped, 1 failed. The single failure is `comfy_extras_test/nodes_math_test.py::test_sqrt_negative_raises`, pre-existing and unrelated: my local interpreter is Python 3.14, which reworded `math domain error` to `expected a nonnegative input`. CI runs 3.12, where it passes.
- `ruff check .` — clean.
- `pylint comfy_api_nodes` — 10.00/10.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**
