### PR TITLE
fix: handle BrokenPipeError in logger flush and disable stdout output

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -66,9 +66,13 @@ class LogInterceptor(io.TextIOWrapper):
         super().write(data)
 
     def flush(self):
-        super().flush()
+        try:
+            super().flush()
+        except (BrokenPipeError, OSError): pass
         for cb in self._flush_callbacks:
-            cb(self._logs_since_flush)
+            try:
+                cb(self._logs_since_flush)
+            except (BrokenPipeError, OSError): pass
             self._logs_since_flush = []
 
     def on_flush(self, callback):

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import folder_paths
 import time
 from comfy.cli_args import enables_dynamic_vram
 from app.logger import setup_logger
-setup_logger(log_level=args.verbose, use_stdout=args.log_stdout)
+setup_logger(log_level=args.verbose, use_stdout=False)
 
 from app.assets.seeder import asset_seeder
 from app.assets.services import register_output_files


### PR DESCRIPTION
## Summary

### Logger flush resilience
- `app/logger.py`: Wrap `super().flush()` and flush callbacks in try/except to silently discard `BrokenPipeError` and `OSError`, preventing crashes when stdout pipe is closed (e.g. head/tail piped output).

### Disable stdout log duplication
- `main.py`: Set `use_stdout=False` instead of `use_stdout=args.log_stdout` to avoid duplicating log output that already goes through the configured logger sinks.

## Test Plan
- [ ] Run ComfyUI with piped output: `python main.py | head -20`
- [ ] Verify no duplicate log lines in console output