### PR TITLE
Fix LTXAV crash when sampling without an audio latent

### DIFF
--- a/comfy/ldm/lightricks/model.py
+++ b/comfy/ldm/lightricks/model.py
@@ -671,9 +671,10 @@ def freqs_cis_matrix(freqs, pad_size, split_mode, num_attention_heads, out_dtype
         cos_freq = torch.cat((cos_padding, cos_freq), dim=-1)
         sin_freq = torch.cat((sin_padding, sin_freq), dim=-1)
 
-    B, T, _ = cos_freq.shape
-    cos_freq = cos_freq.reshape(B, T, num_attention_heads, -1)
-    sin_freq = sin_freq.reshape(B, T, num_attention_heads, -1)
+    # T can be 0 (LTXAV without an audio latent), which makes a -1 reshape ambiguous
+    B, T, half_HD = cos_freq.shape
+    cos_freq = cos_freq.reshape(B, T, num_attention_heads, half_HD // num_attention_heads)
+    sin_freq = sin_freq.reshape(B, T, num_attention_heads, half_HD // num_attention_heads)
     rotation_matrix = torch.stack(
         (cos_freq, -sin_freq, sin_freq, cos_freq), dim=-1
     )

--- a/comfy/ldm/lightricks/model.py
+++ b/comfy/ldm/lightricks/model.py
@@ -671,7 +671,6 @@ def freqs_cis_matrix(freqs, pad_size, split_mode, num_attention_heads, out_dtype
         cos_freq = torch.cat((cos_padding, cos_freq), dim=-1)
         sin_freq = torch.cat((sin_padding, sin_freq), dim=-1)
 
-    # T can be 0 (LTXAV without an audio latent), which makes a -1 reshape ambiguous
     B, T, half_HD = cos_freq.shape
     cos_freq = cos_freq.reshape(B, T, num_attention_heads, half_HD // num_attention_heads)
     sin_freq = sin_freq.reshape(B, T, num_attention_heads, half_HD // num_attention_heads)


### PR DESCRIPTION
Since #15056, sampling LTXAV with only a video latent crashes while preparing the audio positional embeddings:

```
  File "comfy/ldm/lightricks/model.py", line 675, in freqs_cis_matrix
    cos_freq = cos_freq.reshape(B, T, num_attention_heads, -1)
RuntimeError: cannot reshape tensor of 0 elements into shape [1, 0, 32, -1] because the unspecified dimension size -1 can be any value and is ambiguous
```

The audio blocks are already skipped for an empty audio stream; only this precompute step fails. With an explicit head dim the empty stream reshapes cleanly again, and non-empty streams reshape identically to before (checked both rope modes).