### PR TITLE
Keep memory-efficient attention backend for masked GQA

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -540,6 +540,14 @@ def attention_pytorch(q, k, v, heads, mask=None, attn_precision=None, skip_resha
     sdpa_keys = ("scale", "enable_gqa")
     sdpa_extra = {k: v for k, v in kwargs.items() if k in sdpa_keys}
 
+    # SDPA cannot use the memory-efficient/flash backends with enable_gqa + an explicit attn_mask,
+    # so it falls back to the math backend, which materialises the full [B, heads, S, S] scores
+    # (O(S^2)) and OOMs on long sequences (e.g. a Llama/Qwen text encoder with a long prompt).
+    # Expand KV ourselves and drop enable_gqa so the masked case keeps a memory-efficient backend.
+    if mask is not None and sdpa_extra.get("enable_gqa"):
+        k, v = _repeat_kv_for_gqa(k, v, heads, -3)
+        sdpa_extra.pop("enable_gqa", None)
+
     if SDP_BATCH_LIMIT >= b:
         out = comfy.ops.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False, **sdpa_extra)
         if not skip_output_reshape:


### PR DESCRIPTION
### Problem

`torch.nn.functional.scaled_dot_product_attention` cannot use its memory-efficient / flash backends when `enable_gqa=True` is combined with an explicit float `attn_mask`. It falls back to the **math backend**, which materialises the full `[B, heads, S, S]` score matrix (and upcasts it to fp32) — **O(S²) memory**.

Since #14772 unified GQA handling, `attention_pytorch` reshapes KV with `expand_kv=False` and passes `enable_gqa` straight to SDPA (`sdpa_keys = ("scale", "enable_gqa")`). That is ideal for the unmasked/flash path, but for **masked GQA attention** it now hits the math fallback and blows up on long sequences.

This bites masked GQA **text encoders** (Llama / Qwen3-family) on long prompts. A ~27k-token prompt makes the encoder self-attention try to allocate ~**45 GiB** and OOMs inside `CLIPTextEncode`, before any diffusion work:

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 45.64 GiB.
  ...
  comfy/text_encoders/llama.py   self_attn -> optimized_attention(..., mask=attention_mask, enable_gqa=True)
  comfy/ldm/modules/attention.py attention_pytorch
  comfy/ops.py                   scaled_dot_product_attention(..., attn_mask=mask, enable_gqa=True)
```

Before #14772 this path expanded KV manually and did **not** pass `enable_gqa`, so SDPA kept a memory-efficient (O(S)) backend and the same prompt ran fine.

### Reproduction

Standalone, model-free — measures the extra memory the SDPA call allocates for GQA (16 q / 8 kv heads) with an explicit mask, current vs. fixed:

```python
import torch, torch.nn.functional as F
Hq, Hkv, D = 16, 8, 128

def extra_mem(S, fix):
    torch.cuda.empty_cache()
    q = torch.randn(1, Hq,  S, D, device="cuda", dtype=torch.float16)
    k = torch.randn(1, Hkv, S, D, device="cuda", dtype=torch.float16)
    v = torch.randn(1, Hkv, S, D, device="cuda", dtype=torch.float16)
    mask = torch.zeros(1, 1, S, S, device="cuda", dtype=torch.float16)
    kw = {}
    if fix:                                      # expand KV, drop enable_gqa
        k = k.repeat_interleave(Hq // Hkv, dim=1)
        v = v.repeat_interleave(Hq // Hkv, dim=1)
    else:
        kw = {"enable_gqa": True}
    torch.cuda.synchronize(); base = torch.cuda.memory_allocated()
    torch.cuda.reset_peak_memory_stats()
    try:
        F.scaled_dot_product_attention(q, k, v, attn_mask=mask, **kw)
        torch.cuda.synchronize()
        return "%.2f GiB" % ((torch.cuda.max_memory_allocated() - base) / 2**30)
    except torch.cuda.OutOfMemoryError:
        return "OOM"

for S in [4000, 8000, 16000, 24000, 32000]:
    print(S, "current:", extra_mem(S, False), " fixed:", extra_mem(S, True))
```

Result (torch 2.9.1+cu130, RTX 5090, 32 GB):

| S | `enable_gqa` + mask (current) | expand KV + no `enable_gqa` (this PR) |
|---:|---|---|
| 4,000  | 2.31 GiB | 0.02 GiB |
| 8,000  | 8.89 GiB | 0.03 GiB |
| 16,000 | **OOM**  | 0.06 GiB |
| 24,000 | **OOM**  | 0.09 GiB |
| 32,000 | **OOM**  | 0.12 GiB |

The current path grows O(S²) (and OOMs from ~16k tokens on a 32 GB card); the fixed path is flat.

### Fix

In `attention_pytorch`, when a mask is present **and** `enable_gqa` is requested, expand the KV heads ourselves (`_repeat_kv_for_gqa`) and drop `enable_gqa` before calling SDPA. SDPA then sees a regular masked MHA and keeps a memory-efficient backend — the pre-#14772 behaviour.

```python
if mask is not None and sdpa_extra.get("enable_gqa"):
    k, v = _repeat_kv_for_gqa(k, v, heads, -3)
    sdpa_extra.pop("enable_gqa", None)
```

The **unmasked path is unchanged** (still native `enable_gqa`, no KV duplication, flash backend), so the common case is unaffected; only the masked GQA path is repaired. The extra cost in the masked case is one duplicated KV tensor (a few hundred MiB at most, per the table) instead of the O(S²) score matrix. This helps every masked GQA text encoder, not one specific model.

Verified end to end: a real task that OOM'd (45 GiB) at the text encoder now succeeds and produces an image identical to the pre-#14772 build.
