### PR TITLE
fix: resend cached histogram UI for CurveEditor after page refresh

### DIFF
--- a/comfy_extras/nodes_curve.py
+++ b/comfy_extras/nodes_curve.py
@@ -12,6 +12,7 @@ class CurveEditor(io.ComfyNode):
             node_id="CurveEditor",
             display_name="Curve Editor",
             category="utilities",
+            has_intermediate_output=True,
             inputs=[
                 io.Curve.Input("curve"),
                 io.Histogram.Input("histogram", optional=True),


### PR DESCRIPTION
add has_intermediate_output for curve to fix cache issue

before
<img width="1291" height="1051" alt="image" src="https://github.com/user-attachments/assets/9b7ce771-1a0d-4639-9d4a-1d94390023f1" />

after
<img width="448" height="1686" alt="image" src="https://github.com/user-attachments/assets/ba7b5348-dae4-4838-b818-3f7a113ca6bd" />
