### PR TITLE
Fix Wan Animate temporal mask packing

### DIFF
--- a/comfy_extras/nodes_wan.py
+++ b/comfy_extras/nodes_wan.py
@@ -1108,6 +1108,18 @@ class WanHuMoImageToVideo(io.ComfyNode):
         out_latent["samples"] = latent
         return io.NodeOutput(positive, negative, out_latent)
 
+def _apply_wan_animate_mask(mask_refmotion, character_mask, ref_motion_latent_length):
+    character_mask = torch.cat((
+        torch.repeat_interleave(character_mask[:, :, :1], repeats=4, dim=2),
+        character_mask[:, :, 1:],
+    ), dim=2)
+    mask_start = ref_motion_latent_length * 4
+    mask_end = min(character_mask.shape[2], mask_refmotion.shape[2])
+    if mask_end > mask_start:
+        mask_refmotion[:, :, mask_start:mask_end] = character_mask[:, :, mask_start:mask_end]
+    return mask_refmotion
+
+
 class WanAnimateToVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -1232,8 +1244,7 @@ class WanAnimateToVideo(io.ComfyNode):
                 if character_mask.ndim == 4:
                     character_mask = character_mask.unsqueeze(1)
                 character_mask = comfy.utils.common_upscale(character_mask[:, :, :length], concat_latent_image.shape[-1], concat_latent_image.shape[-2], "nearest-exact", "center")
-                if character_mask.shape[2] > ref_images_num:
-                    mask_refmotion[:, :, ref_images_num:character_mask.shape[2]] = character_mask[:, :, ref_images_num:]
+                mask_refmotion = _apply_wan_animate_mask(mask_refmotion, character_mask, ref_motion_latent_length)
 
         concat_latent_image = torch.cat((concat_latent_image, vae.encode(image[:, :, :, :3])), dim=2)
 

--- a/tests-unit/comfy_extras_test/nodes_wan_test.py
+++ b/tests-unit/comfy_extras_test/nodes_wan_test.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+from comfy_extras.nodes_wan import _apply_wan_animate_mask  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("ref_motion_latent_length", "mask_start"),
+    [
+        (0, 0),
+        (1, 4),
+        (2, 8),
+    ],
+)
+def test_wan_animate_mask_uses_causal_temporal_layout(
+    ref_motion_latent_length,
+    mask_start,
+):
+    character_mask = torch.arange(77, dtype=torch.float32).view(1, 1, 77, 1, 1)
+    expected = torch.cat((
+        torch.repeat_interleave(character_mask[:, :, :1], repeats=4, dim=2),
+        character_mask[:, :, 1:],
+    ), dim=2)
+    mask_refmotion = torch.ones_like(expected)
+    mask_refmotion[:, :, :mask_start] = 0.0
+
+    actual = _apply_wan_animate_mask(
+        mask_refmotion,
+        character_mask,
+        ref_motion_latent_length,
+    )
+
+    assert actual.shape[2] == 80
+    assert torch.equal(actual[:, :, :mask_start], torch.zeros_like(actual[:, :, :mask_start]))
+    assert torch.equal(actual[:, :, mask_start:], expected[:, :, mask_start:])


### PR DESCRIPTION
## Summary

- pack the character mask with Wan's causal temporal layout before grouping it into four mask channels
- preserve the complete packed continuation region for 1- and 5-frame motion context
- add CPU regression coverage for 77-frame masks

`WanAnimateToVideo` allocated 80 temporal mask slots for a 77-frame clip, but copied the 77 character-mask frames into those slots directly. With a 5-frame continuation, this also began the copy at pixel-frame index 5 instead of packed slot 8. As a result, three continuation slots were overwritten and the final three slots kept their default value.

This follows the official Wan2.2 mask packing: repeat the first frame four times, append the remaining frames, then group the result into four channels.

Reference: https://github.com/Wan-Video/Wan2.2/blob/main/wan/animate.py#L208-L217

## Testing

- `pytest -q tests-unit/comfy_extras_test/nodes_wan_test.py` (3 passed)
- `ruff check comfy_extras/nodes_wan.py tests-unit/comfy_extras_test/nodes_wan_test.py`
- `git diff --check`
