### PR TITLE
[Partner Nodes] adjust pricing for the Bria Video RemoveBackground nodes

### DIFF
--- a/comfy_api_nodes/nodes_bria.py
+++ b/comfy_api_nodes/nodes_bria.py
@@ -289,7 +289,7 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.0042,"format":{"suffix":"/second"}}""",
+                expr="""{"type":"usd","usd":0.005,"format":{"suffix":"/second"}}""",
             ),
         )
 
@@ -533,7 +533,7 @@ class BriaTransparentVideoBackground(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.0042,"format":{"suffix":"/second"}}""",
+                expr="""{"type":"usd","usd":0.005,"format":{"suffix":"/second"}}""",
             ),
         )
 


### PR DESCRIPTION
Only for the `video/edit/remove_background` endpoint. `0.0042` -> `0.005` $ per second.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [x] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

