### PR TITLE
ComfyUI backport release v0.29.2

### DIFF
--- a/comfy_api_nodes/apis/ideogram.py
+++ b/comfy_api_nodes/apis/ideogram.py
@@ -231,6 +231,25 @@ class IdeogramV3Request(BaseModel):
     )
 
 
+class IdeogramPImageRequest(BaseModel):
+    prompt: str = Field(
+        ...,
+        description="The text prompt, or an Ideogram 4.0 structured JSON caption "
+        "(used verbatim when prompt_upsampling is 'OFF').",
+    )
+    quality: str | None = Field(
+        None, description="Generation tier: 'VERY_LOW', 'LOW', 'MEDIUM' or 'HIGH'."
+    )
+    resolution: str | None = Field(None, description="Output size class: '1K' or '2K'.")
+    aspect_ratio: str | None = Field(
+        None, description="Aspect ratio in WxH format", examples=['16x9']
+    )
+    prompt_upsampling: str | None = Field(
+        None, description="Prompt expansion: 'AUTO', 'ON' or 'OFF'."
+    )
+    seed: int | None = Field(None, ge=0, le=2147483647)
+
+
 class IdeogramV4Request(BaseModel):
     text_prompt: str | None = Field(
         None,

--- a/comfy_api_nodes/apis/minimax.py
+++ b/comfy_api_nodes/apis/minimax.py
@@ -118,3 +118,81 @@ class MinimaxVideoGenerationResponse(BaseModel):
     task_id: str = Field(
         ..., description='The task ID for the asynchronous video generation task.'
     )
+
+
+class Hailuo03TextContent(BaseModel):
+    type: str = Field("text")
+    text: str = Field(...)
+
+
+class Hailuo03ImageContentUrl(BaseModel):
+    url: str = Field(...)
+
+
+class Hailuo03ImageContent(BaseModel):
+    type: str = Field("image_url")
+    image_url: Hailuo03ImageContentUrl = Field(...)
+    role: str = Field(...)
+
+
+class Hailuo03VideoContentUrl(BaseModel):
+    url: str = Field(...)
+
+
+class Hailuo03VideoContent(BaseModel):
+    type: str = Field("video_url")
+    video_url: Hailuo03VideoContentUrl = Field(...)
+    role: str = Field("reference_video")
+
+
+class Hailuo03AudioContentUrl(BaseModel):
+    url: str = Field(...)
+
+
+class Hailuo03AudioContent(BaseModel):
+    type: str = Field("audio_url")
+    audio_url: Hailuo03AudioContentUrl = Field(...)
+    role: str = Field("reference_audio")
+
+
+class Hailuo03TaskCreationRequest(BaseModel):
+    model: str = Field(...)
+    content: list[Hailuo03TextContent | Hailuo03ImageContent | Hailuo03VideoContent | Hailuo03AudioContent] = Field(
+        ..., min_length=1
+    )
+    resolution: str = Field(...)
+    duration: int = Field(..., ge=5, le=15)
+    ratio: str | None = Field(None)
+    seed: int | None = Field(None, ge=0, le=4294967295)
+    aigc_watermark: bool | None = Field(None)
+
+
+class Hailuo03TaskCreationResponse(BaseModel):
+    task_id: str = Field(...)
+
+
+class Hailuo03TaskError(BaseModel):
+    code: int | str | None = Field(None)
+    message: str | None = Field(None)
+
+
+class Hailuo03TaskContent(BaseModel):
+    url: str | None = Field(None)
+
+
+class Hailuo03TaskUsage(BaseModel):
+    total_seconds: float = Field(0)
+    input_seconds: float = Field(0)
+    output_seconds: float = Field(0)
+
+
+class Hailuo03Task(BaseModel):
+    id: str = Field(...)
+    status: str = Field(...)
+    error: Hailuo03TaskError | None = Field(None)
+    content: Hailuo03TaskContent | None = Field(None)
+    usage: Hailuo03TaskUsage | None = Field(None)
+
+
+class Hailuo03TaskQueryResponse(BaseModel):
+    task: Hailuo03Task = Field(...)

--- a/comfy_api_nodes/nodes_bria.py
+++ b/comfy_api_nodes/nodes_bria.py
@@ -289,7 +289,7 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.0042,"format":{"suffix":"/second"}}""",
+                expr="""{"type":"usd","usd":0.005,"format":{"suffix":"/second"}}""",
             ),
         )
 
@@ -533,7 +533,7 @@ class BriaTransparentVideoBackground(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.0042,"format":{"suffix":"/second"}}""",
+                expr="""{"type":"usd","usd":0.005,"format":{"suffix":"/second"}}""",
             ),
         )
 

--- a/comfy_api_nodes/nodes_ideogram.py
+++ b/comfy_api_nodes/nodes_ideogram.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 from comfy_api_nodes.apis.ideogram import (
     IdeogramGenerateResponse,
+    IdeogramPImageRequest,
     IdeogramV3Request,
     IdeogramV3EditRequest,
     IdeogramV4Request,
@@ -524,12 +525,155 @@ class IdeogramV4(IO.ComfyNode):
         return IO.NodeOutput(await download_and_process_images(image_urls))
 
 
+class IdeogramPImage(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="IdeogramPImage",
+            display_name="Ideogram P-Image",
+            category="partner/image/Ideogram",
+            description="Generates images using P-Image, Ideogram's fast text-to-image model. "
+                        "Strong typography and photorealism; "
+                        "supports Ideogram 4.0 structured JSON captions for exact text, "
+                        "colors and layout.",
+            inputs=[
+                IO.String.Input(
+                    "prompt",
+                    multiline=True,
+                    default="",
+                    tooltip="Text prompt. Also accepts an Ideogram 4.0 structured JSON caption "
+                            "(exact colors as #RRGGBB hexes, exact text strings, bounding-box "
+                            "layout) — set prompt_upsampling to OFF to use it verbatim.",
+                ),
+                IO.Combo.Input(
+                    "quality",
+                    options=["VERY_LOW", "LOW", "MEDIUM", "HIGH"],
+                    default="MEDIUM",
+                    tooltip="Speed/price/quality tier. MEDIUM is the everyday default; HIGH for "
+                            "complex prompts, fine detail and difficult text; VERY_LOW/LOW for "
+                            "drafts at scale. Difficult text renders poorly below MEDIUM.",
+                ),
+                IO.Combo.Input(
+                    "resolution",
+                    options=["1K", "2K"],
+                    default="1K",
+                    tooltip="Output size class (exact pixels follow the aspect ratio, e.g. "
+                            "16:9 gives 1280x720 at 1K and 2560x1440 at 2K). "
+                            "Prefer HIGH + 2K for crisp typography.",
+                ),
+                IO.Combo.Input(
+                    "aspect_ratio",
+                    options=list(V3_RATIO_MAP.keys()),
+                    default="1:1",
+                    tooltip="The aspect ratio for image generation.",
+                ),
+                IO.Combo.Input(
+                    "prompt_upsampling",
+                    options=["AUTO", "ON", "OFF"],
+                    default="AUTO",
+                    tooltip="Expands short prompts into a detailed structured caption before "
+                            "generation (the rewritten prompt is returned as final_prompt). "
+                            "Set OFF when supplying your own JSON caption or exact wording.",
+                ),
+                IO.Int.Input(
+                    "seed",
+                    default=42,
+                    min=0,
+                    max=2147483647,
+                    step=1,
+                    control_after_generate=True,
+                    display_mode=IO.NumberDisplay.number,
+                    optional=True,
+                    tooltip="Seed for reproducible generation. With prompt_upsampling OFF, "
+                            "the same seed and settings return the same image; with ON/AUTO "
+                            "the prompt rewrite varies per run — reproduce a result by reusing "
+                            "its final_prompt output with prompt_upsampling OFF and the same "
+                            "seed.",
+                ),
+            ],
+            outputs=[
+                IO.Image.Output(),
+                IO.String.Output(
+                    "final_prompt",
+                    tooltip="The prompt the image was actually generated from (the rewritten "
+                            "structured caption when prompt_upsampling ran, else your prompt). "
+                            "Feed it back with prompt_upsampling OFF and the same seed to "
+                            "reproduce this image.",
+                ),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=IO.PriceBadge(
+                depends_on=IO.PriceBadgeDepends(widgets=["quality", "resolution"]),
+                expr="""
+                (
+                  $q := widgets.quality;
+                  $is2k := $contains(widgets.resolution, "2k");
+                  $usd :=
+                    $contains($q, "very_low") ? ($is2k ? 0.00858 : 0.00429) :
+                    $contains($q, "high")     ? ($is2k ? 0.0429  : 0.02145) :
+                    $contains($q, "medium")   ? ($is2k ? 0.0286  : 0.0143)  :
+                                                ($is2k ? 0.02145 : 0.010725);
+                  {"type": "usd", "usd": $usd}
+                )
+                """,
+            ),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        prompt: str,
+        quality: str = "MEDIUM",
+        resolution: str = "1K",
+        aspect_ratio: str = "1:1",
+        prompt_upsampling: str = "AUTO",
+        seed: int = 42,
+    ):
+        validate_string(prompt, strip_whitespace=True, min_length=1)
+        request = IdeogramPImageRequest(
+            prompt=prompt,
+            quality=quality,
+            resolution=resolution,
+            aspect_ratio=V3_RATIO_MAP[aspect_ratio],
+            prompt_upsampling=prompt_upsampling,
+            seed=seed,
+        )
+        response = await sync_op(
+            cls,
+            ApiEndpoint(path="/proxy/ideogram/text-to-image/p-image-ideogram", method="POST"),
+            response_model=IdeogramGenerateResponse,
+            data=request,
+            max_retries=1,
+        )
+        if not response.data:
+            raise Exception("No images were generated in the response")
+        image_urls = [image_data.url for image_data in response.data if image_data.url]
+        if not image_urls:
+            if any(image_data.is_image_safe is False for image_data in response.data):
+                raise Exception(
+                    "The generation was blocked by Ideogram's content safety filter. "
+                    "Adjust the prompt and try again."
+                )
+            raise Exception("No image URLs were generated in the response")
+        return IO.NodeOutput(
+            await download_and_process_images(image_urls),
+            response.data[0].prompt or prompt,
+        )
+
+
 class IdeogramExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
         return [
             IdeogramV3,
             IdeogramV4,
+            IdeogramPImage,
         ]
 
 

--- a/comfy_api_nodes/nodes_minimax.py
+++ b/comfy_api_nodes/nodes_minimax.py
@@ -5,6 +5,16 @@ from typing_extensions import override
 
 from comfy_api.latest import IO, ComfyExtension
 from comfy_api_nodes.apis.minimax import (
+    Hailuo03AudioContent,
+    Hailuo03AudioContentUrl,
+    Hailuo03ImageContent,
+    Hailuo03ImageContentUrl,
+    Hailuo03TaskCreationRequest,
+    Hailuo03TaskCreationResponse,
+    Hailuo03TaskQueryResponse,
+    Hailuo03TextContent,
+    Hailuo03VideoContent,
+    Hailuo03VideoContentUrl,
     MinimaxFileRetrieveResponse,
     MiniMaxModel,
     MinimaxTaskResultResponse,
@@ -17,7 +27,11 @@ from comfy_api_nodes.util import (
     download_url_to_video_output,
     poll_op,
     sync_op,
+    upload_audio_to_comfyapi,
     upload_images_to_comfyapi,
+    upload_video_to_comfyapi,
+    validate_image_aspect_ratio,
+    validate_image_dimensions,
     validate_string,
 )
 
@@ -293,9 +307,9 @@ class MinimaxHailuoVideoNode(IO.ComfyNode):
     def define_schema(cls) -> IO.Schema:
         return IO.Schema(
             node_id="MinimaxHailuoVideoNode",
-            display_name="MiniMax Hailuo Video",
+            display_name="MiniMax Hailuo 02 Video",
             category="partner/video/MiniMax",
-            description="Generates videos from prompt, with optional start frame using the new MiniMax Hailuo-02 model.",
+            description="Generates videos from prompt, with optional start frame using the MiniMax Hailuo-02 model.",
             inputs=[
                 IO.String.Input(
                     "prompt_text",
@@ -437,6 +451,491 @@ class MinimaxHailuoVideoNode(IO.ComfyNode):
         return IO.NodeOutput(await download_url_to_video_output(file_url))
 
 
+HAILUO_03_CREATE_ENDPOINT = "/proxy/minimax/v2/video_generation"
+HAILUO_03_QUERY_ENDPOINT = "/proxy/minimax/v2/query/video_generation"  # + /{task_id}
+HAILUO_03_MODELS = {"MiniMax H3": "MiniMax-H3"}
+HAILUO_03_FAILED_STATUSES = ["failed", "cancelled", "expired"]
+
+
+def _hailuo03_model_inputs(include_ratio: bool = True, allow_adaptive: bool = True):
+    inputs = [
+        IO.String.Input(
+            "prompt",
+            multiline=True,
+            default="",
+            tooltip="Text prompt for video generation.",
+        ),
+        IO.Combo.Input(
+            "resolution",
+            options=["2K"],
+            tooltip="Resolution of the output video.",
+        ),
+    ]
+    if include_ratio:
+        ratio_options = ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9"]
+        if allow_adaptive:
+            ratio_options.insert(0, "adaptive")
+        inputs.append(
+            IO.Combo.Input(
+                "ratio",
+                options=ratio_options,
+                default=ratio_options[0],
+                tooltip="Aspect ratio of the output video.",
+            )
+        )
+    inputs.append(
+        IO.Int.Input(
+            "duration",
+            default=5,
+            min=5,
+            max=15,
+            step=1,
+            tooltip="Duration of the output video in seconds (5-15).",
+            display_mode=IO.NumberDisplay.slider,
+        )
+    )
+    return inputs
+
+
+async def _hailuo03_run_task(
+    cls: type[IO.ComfyNode],
+    *,
+    model_id: str,
+    content: list,
+    resolution: str,
+    duration: int,
+    ratio: str | None,
+    seed: int,
+    watermark: bool,
+) -> IO.NodeOutput:
+    response = await sync_op(
+        cls,
+        ApiEndpoint(path=HAILUO_03_CREATE_ENDPOINT, method="POST"),
+        response_model=Hailuo03TaskCreationResponse,
+        data=Hailuo03TaskCreationRequest(
+            model=model_id,
+            content=content,
+            resolution=resolution,
+            duration=duration,
+            ratio=ratio,
+            seed=seed,
+            aigc_watermark=watermark,
+        ),
+    )
+    task_result = await poll_op(
+        cls,
+        ApiEndpoint(path=f"{HAILUO_03_QUERY_ENDPOINT}/{response.task_id}"),
+        response_model=Hailuo03TaskQueryResponse,
+        status_extractor=lambda r: r.task.status,
+        failed_statuses=HAILUO_03_FAILED_STATUSES,
+        poll_interval=15,
+    )
+    video_url = task_result.task.content.url if task_result.task.content else None
+    if not video_url:
+        raise Exception(f"No video URL in the response: {task_result.model_dump()}")
+    return IO.NodeOutput(await download_url_to_video_output(video_url))
+
+
+class MinimaxHailuo03TextToVideoNode(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="MinimaxHailuo03TextToVideoNode",
+            display_name="MiniMax H3 Text to Video",
+            category="partner/video/MiniMax",
+            description="Generate video from a text prompt using the MiniMax H3 model.",
+            inputs=[
+                IO.DynamicCombo.Input(
+                    "model",
+                    options=[IO.DynamicCombo.Option("MiniMax H3", _hailuo03_model_inputs(allow_adaptive=False))],
+                    tooltip="Model to use for video generation.",
+                ),
+                IO.Int.Input(
+                    "seed",
+                    default=42,
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    display_mode=IO.NumberDisplay.number,
+                    control_after_generate=True,
+                    tooltip="Random seed. The same request with the same seed gives similar, "
+                    "but not guaranteed identical, results.",
+                ),
+                IO.Boolean.Input(
+                    "watermark",
+                    default=False,
+                    tooltip="Whether to add an AIGC watermark to the video.",
+                    advanced=True,
+                ),
+            ],
+            outputs=[
+                IO.Video.Output(),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=IO.PriceBadge(
+                depends_on=IO.PriceBadgeDepends(widgets=["model.duration"]),
+                expr="""
+                (
+                  $dur := $lookup(widgets, "model.duration");
+                  {"type": "usd", "usd": $dur * 0.1859}
+                )
+                """,
+            ),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        model: dict,
+        seed: int,
+        watermark: bool,
+    ) -> IO.NodeOutput:
+        validate_string(model["prompt"], strip_whitespace=True, min_length=1)
+        return await _hailuo03_run_task(
+            cls,
+            model_id=HAILUO_03_MODELS[model["model"]],
+            content=[Hailuo03TextContent(text=model["prompt"])],
+            resolution=model["resolution"],
+            duration=model["duration"],
+            ratio=model["ratio"],
+            seed=seed,
+            watermark=watermark,
+        )
+
+
+class MinimaxHailuo03FirstLastFrameNode(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="MinimaxHailuo03FirstLastFrameNode",
+            display_name="MiniMax H3 First-Last-Frame to Video",
+            category="partner/video/MiniMax",
+            description="Generate video from a first frame image and an optional last frame image "
+            "using the MiniMax H3 model. The aspect ratio of the video follows the supplied images.",
+            inputs=[
+                IO.DynamicCombo.Input(
+                    "model",
+                    options=[IO.DynamicCombo.Option("MiniMax H3", _hailuo03_model_inputs(include_ratio=False))],
+                    tooltip="Model to use for video generation.",
+                ),
+                IO.Image.Input(
+                    "first_frame",
+                    tooltip="First frame image for the video.",
+                ),
+                IO.Image.Input(
+                    "last_frame",
+                    tooltip="Optional last frame image for the video.",
+                    optional=True,
+                ),
+                IO.Int.Input(
+                    "seed",
+                    default=42,
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    display_mode=IO.NumberDisplay.number,
+                    control_after_generate=True,
+                    tooltip="Random seed. The same request with the same seed gives similar, "
+                    "but not guaranteed identical, results.",
+                ),
+                IO.Boolean.Input(
+                    "watermark",
+                    default=False,
+                    tooltip="Whether to add an AIGC watermark to the video.",
+                    advanced=True,
+                ),
+            ],
+            outputs=[
+                IO.Video.Output(),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=IO.PriceBadge(
+                depends_on=IO.PriceBadgeDepends(widgets=["model.duration"]),
+                expr="""
+                (
+                  $dur := $lookup(widgets, "model.duration");
+                  {"type": "usd", "usd": $dur * 0.1859}
+                )
+                """,
+            ),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        model: dict,
+        first_frame: torch.Tensor,
+        seed: int,
+        watermark: bool,
+        last_frame: torch.Tensor | None = None,
+    ) -> IO.NodeOutput:
+        validate_string(model["prompt"], strip_whitespace=True, min_length=1)
+        for frame in (first_frame, last_frame):
+            if frame is not None:
+                validate_image_aspect_ratio(frame, (2, 5), (5, 2), strict=False)  # 0.4 to 2.5
+                validate_image_dimensions(frame, min_width=256, min_height=256)
+
+        content: list = [
+            Hailuo03TextContent(text=model["prompt"]),
+            Hailuo03ImageContent(
+                image_url=Hailuo03ImageContentUrl(
+                    url=(
+                        await upload_images_to_comfyapi(
+                            cls, first_frame, max_images=1, wait_label="Uploading first frame"
+                        )
+                    )[0],
+                ),
+                role="first_frame",
+            ),
+        ]
+        if last_frame is not None:
+            content.append(
+                Hailuo03ImageContent(
+                    image_url=Hailuo03ImageContentUrl(
+                        url=(
+                            await upload_images_to_comfyapi(
+                                cls, last_frame, max_images=1, wait_label="Uploading last frame"
+                            )
+                        )[0],
+                    ),
+                    role="last_frame",
+                )
+            )
+        return await _hailuo03_run_task(
+            cls,
+            model_id=HAILUO_03_MODELS[model["model"]],
+            content=content,
+            resolution=model["resolution"],
+            duration=model["duration"],
+            ratio=None,
+            seed=seed,
+            watermark=watermark,
+        )
+
+
+class MinimaxHailuo03ReferenceNode(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="MinimaxHailuo03ReferenceNode",
+            display_name="MiniMax H3 Reference to Video",
+            category="partner/video/MiniMax",
+            description="Generate video conditioned on reference images, videos, and audio using the "
+            "MiniMax H3 model. Refer to the references in the prompt by their order: "
+            "'Image 1', 'Image 2', 'Video 1', 'Audio 1', and so on.",
+            inputs=[
+                IO.DynamicCombo.Input(
+                    "model",
+                    options=[
+                        IO.DynamicCombo.Option(
+                            "MiniMax H3",
+                            [
+                                *_hailuo03_model_inputs(),
+                                IO.Autogrow.Input(
+                                    "reference_images",
+                                    template=IO.Autogrow.TemplateNames(
+                                        IO.Image.Input("reference_image"),
+                                        names=[
+                                            "image_1",
+                                            "image_2",
+                                            "image_3",
+                                            "image_4",
+                                            "image_5",
+                                            "image_6",
+                                            "image_7",
+                                            "image_8",
+                                            "image_9",
+                                        ],
+                                        min=0,
+                                    ),
+                                    tooltip="Subject or style reference images, referred to in the prompt "
+                                    "as 'Image 1'..'Image 9' in connection order. Up to 9 images.",
+                                ),
+                                IO.Autogrow.Input(
+                                    "reference_videos",
+                                    template=IO.Autogrow.TemplateNames(
+                                        IO.Video.Input("reference_video"),
+                                        names=["video_1", "video_2", "video_3"],
+                                        min=0,
+                                    ),
+                                    tooltip="Motion or scene reference videos, referred to in the prompt "
+                                    "as 'Video 1'..'Video 3' in connection order. Up to 3 videos, "
+                                    "2-15 seconds each, 15 seconds in total.",
+                                ),
+                                IO.Autogrow.Input(
+                                    "reference_audios",
+                                    template=IO.Autogrow.TemplateNames(
+                                        IO.Audio.Input("reference_audio"),
+                                        names=["audio_1", "audio_2", "audio_3"],
+                                        min=0,
+                                    ),
+                                    tooltip="Audio references, referred to in the prompt as "
+                                    "'Audio 1'..'Audio 3' in connection order. Up to 3 clips, "
+                                    "2-15 seconds each, 15 seconds in total. Cannot be used without "
+                                    "a reference image or video.",
+                                ),
+                            ],
+                        )
+                    ],
+                    tooltip="Model to use for video generation.",
+                ),
+                IO.Int.Input(
+                    "seed",
+                    default=42,
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    display_mode=IO.NumberDisplay.number,
+                    control_after_generate=True,
+                    tooltip="Random seed. The same request with the same seed gives similar, "
+                    "but not guaranteed identical, results.",
+                ),
+                IO.Boolean.Input(
+                    "watermark",
+                    default=False,
+                    tooltip="Whether to add an AIGC watermark to the video.",
+                    advanced=True,
+                ),
+            ],
+            outputs=[
+                IO.Video.Output(),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=IO.PriceBadge(
+                depends_on=IO.PriceBadgeDepends(
+                    widgets=["model.duration"],
+                    input_groups=["model.reference_images", "model.reference_videos"],
+                ),
+                expr="""
+                (
+                  $dur := $lookup(widgets, "model.duration");
+                  $imgsRaw := $lookup(inputGroups, "model.reference_images");
+                  $imgs := $imgsRaw ? $imgsRaw : 0;
+                  $vidsRaw := $lookup(inputGroups, "model.reference_videos");
+                  $vids := $vidsRaw ? $vidsRaw : 0;
+                  $base := $dur * 0.1859 + ($imgs > 5 ? ($imgs - 5) * 0.0572 : 0);
+                  $vids > 0
+                    ? {"type": "range_usd", "min_usd": $base + $vids * 2 * 0.1859,
+                       "max_usd": $base + 15 * 0.1859, "format": {"approximate": true}}
+                    : {"type": "usd", "usd": $base}
+                )
+                """,
+            ),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        model: dict,
+        seed: int,
+        watermark: bool,
+    ) -> IO.NodeOutput:
+        validate_string(model["prompt"], strip_whitespace=True, min_length=1)
+
+        reference_images = model.get("reference_images", {})
+        reference_videos = model.get("reference_videos", {})
+        reference_audios = model.get("reference_audios", {})
+        if not reference_images and not reference_videos:
+            raise ValueError("At least one reference image or video is required.")
+
+        for image in reference_images.values():
+            validate_image_aspect_ratio(image, (2, 5), (5, 2), strict=False)  # 0.4 to 2.5
+            validate_image_dimensions(image, min_width=256, min_height=256)
+
+        total_video_duration = 0.0
+        for i, video in enumerate(reference_videos.values(), 1):
+            try:
+                fps = float(video.get_frame_rate())
+            except Exception:
+                fps = 0.0
+            if fps and not (23.9 <= fps <= 60.5):
+                raise ValueError(f"Reference video {i} is {fps:.2f} FPS. Supported range is 23.976-60 FPS.")
+            try:
+                dur = video.get_duration()
+            except Exception:
+                continue
+            if dur < 1.8:
+                raise ValueError(f"Reference video {i} is too short: {dur:.1f}s. Minimum duration is 2 seconds.")
+            total_video_duration += dur
+        if total_video_duration > 15.1:
+            raise ValueError(
+                f"Total reference video duration is {total_video_duration:.1f}s. Maximum is 15 seconds."
+            )
+
+        total_audio_duration = 0.0
+        for i, audio in enumerate(reference_audios.values(), 1):
+            dur = int(audio["waveform"].shape[-1]) / int(audio["sample_rate"])
+            if dur < 1.8:
+                raise ValueError(f"Reference audio {i} is too short: {dur:.1f}s. Minimum duration is 2 seconds.")
+            total_audio_duration += dur
+        if total_audio_duration > 15.1:
+            raise ValueError(
+                f"Total reference audio duration is {total_audio_duration:.1f}s. Maximum is 15 seconds."
+            )
+
+        content: list = [Hailuo03TextContent(text=model["prompt"])]
+        for i, image in enumerate(reference_images.values(), 1):
+            content.append(
+                Hailuo03ImageContent(
+                    image_url=Hailuo03ImageContentUrl(
+                        url=(
+                            await upload_images_to_comfyapi(
+                                cls, image, max_images=1, wait_label=f"Uploading image {i}"
+                            )
+                        )[0],
+                    ),
+                    role="reference_image",
+                )
+            )
+        for i, video in enumerate(reference_videos.values(), 1):
+            content.append(
+                Hailuo03VideoContent(
+                    video_url=Hailuo03VideoContentUrl(
+                        url=await upload_video_to_comfyapi(cls, video, wait_label=f"Uploading video {i}"),
+                    ),
+                )
+            )
+        for audio in reference_audios.values():
+            content.append(
+                Hailuo03AudioContent(
+                    audio_url=Hailuo03AudioContentUrl(
+                        url=await upload_audio_to_comfyapi(
+                            cls,
+                            audio,
+                            container_format="mp3",
+                            codec_name="libmp3lame",
+                            mime_type="audio/mpeg",
+                        ),
+                    ),
+                )
+            )
+        return await _hailuo03_run_task(
+            cls,
+            model_id=HAILUO_03_MODELS[model["model"]],
+            content=content,
+            resolution=model["resolution"],
+            duration=model["duration"],
+            ratio=model["ratio"],
+            seed=seed,
+            watermark=watermark,
+        )
+
+
 class MinimaxExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
@@ -445,6 +944,9 @@ class MinimaxExtension(ComfyExtension):
             MinimaxImageToVideoNode,
             # MinimaxSubjectToVideoNode,
             MinimaxHailuoVideoNode,
+            MinimaxHailuo03TextToVideoNode,
+            MinimaxHailuo03FirstLastFrameNode,
+            MinimaxHailuo03ReferenceNode,
         ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.47.11
-comfyui-workflow-templates==0.11.19
+comfyui-workflow-templates==0.11.20
 comfyui-embedded-docs==0.5.9
 torch
 torchsde


### PR DESCRIPTION
## Summary

Backport the following changes for the v0.29.2 release:

- Add MiniMax H3 support (#15167)
- Update workflow templates to v0.11.20 (#15165)
- Add Ideogram P-Image model support (#15154)
- Adjust Bria Video Remove Background pricing (#15155)

## Testing

Not run (clean cherry-picks of previously merged changes).

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

