### PR TITLE
Don't assume sampler_function has a __name__ attribute in detail logging

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -997,7 +997,7 @@ class KSAMPLER(Sampler):
         def k_callback(x):
             nonlocal first_step
             if first_step:
-                detail("First sampler step: model=%s sampler=%s step=%s total_steps=%s cfg=%s seed=%s sigma=%s sigma_hat=%s latent_shape=%s denoised_shape=%s", model_wrap.model_patcher.model.__class__.__name__, self.sampler_function.__name__, x["i"], total_steps, model_wrap.cfg, extra_args.get("seed"), x.get("sigma"), x.get("sigma_hat"), tuple(x["x"].shape), tuple(x["denoised"].shape))
+                detail("First sampler step: model=%s sampler=%s step=%s total_steps=%s cfg=%s seed=%s sigma=%s sigma_hat=%s latent_shape=%s denoised_shape=%s", model_wrap.model_patcher.model.__class__.__name__, getattr(self.sampler_function, "__name__", "unknown"), x["i"], total_steps, model_wrap.cfg, extra_args.get("seed"), x.get("sigma"), x.get("sigma_hat"), tuple(x["x"].shape), tuple(x["denoised"].shape))
                 first_step = False
             if callback is not None:
                 callback(x["i"], x["denoised"], x["x"], total_steps)


### PR DESCRIPTION
#15064 assumes that `self.sampler_function.__name__` exists, but that's not necessarily the case for an arbitrary callable. For example, a `functools.partial` wrapper does not have that property. This tiny change just adds a safe fallback to rendering `unknown` as the name in the case where that property doesn't exist. It could fallback to `__class__.__name__` (which I think should exist) but `unknown` is probably more useful/less confusing for users than something like `partial`.

This causes sampling to fail even when detail logging is disabled, since all the dict and property lookups happen regardless of whether they'll actually be used.

@kijai - Tagging you since detail logging was your pull.