### PR TITLE
Fix ImageBlend difference mode

### DIFF
--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -62,7 +62,7 @@ class Blend(io.ComfyNode):
         elif mode == "soft_light":
             return torch.where(img2 <= 0.5, img1 - (1 - 2 * img2) * img1 * (1 - img1), img1 + (2 * img2 - 1) * (cls.g(img1) - img1))
         elif mode == "difference":
-            return img1 - img2
+            return torch.abs(img1 - img2)
         raise ValueError(f"Unsupported blend mode: {mode}")
 
     @classmethod

--- a/tests-unit/comfy_extras_test/nodes_post_processing_test.py
+++ b/tests-unit/comfy_extras_test/nodes_post_processing_test.py
@@ -1,0 +1,20 @@
+import sys
+
+import torch
+
+import comfy.options
+
+comfy.options.enable_args_parsing()
+sys.argv = [sys.argv[0], "--cpu"]
+
+from comfy_extras.nodes_post_processing import Blend  # noqa: E402
+
+
+def test_image_blend_difference_uses_absolute_difference():
+    image1 = torch.tensor([[[[0.2, 0.8, 0.4]]]])
+    image2 = torch.tensor([[[[0.7, 0.3, 0.4]]]])
+
+    result = Blend.blend_mode(image1, image2, "difference")
+
+    expected = torch.tensor([[[[0.5, 0.5, 0.0]]]])
+    assert torch.allclose(result, expected)


### PR DESCRIPTION
Fixes #15178

## Summary

ImageBlend's `difference` mode now returns the absolute per-channel difference instead of clipping negative differences to black during the final clamp.

## Testing

- `python -m pytest -q tests-unit/comfy_extras_test/nodes_post_processing_test.py`
- `python -m py_compile comfy_extras/nodes_post_processing.py tests-unit/comfy_extras_test/nodes_post_processing_test.py`
- `git diff --check`
