### PR TITLE
Delay dynamic pin cleanup until model destruction

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1755,6 +1755,9 @@ class ModelPatcherDynamic(ModelPatcher):
         self.register_load_device(self.load_device)
         self.non_dynamic_delegate_model = None
         assert load_device is not None
+        if not hasattr(self.model, "dynamic_patchers"):
+            self.model.dynamic_patchers = set()
+        self.model.dynamic_patchers.add(id(self))
 
     def register_load_device(self, device):
         """Ensure dynamic_pins has an entry for *device*.
@@ -1809,6 +1812,18 @@ class ModelPatcherDynamic(ModelPatcher):
 
     def unpin_all_weights(self):
         self.partially_unload_ram(1e32)
+
+    def __del__(self):
+        model = getattr(self, "model", None)
+        dynamic_patchers = getattr(model, "dynamic_patchers", None)
+        if dynamic_patchers is None or id(self) not in dynamic_patchers:
+            return
+        dynamic_patchers.discard(id(self))
+        try:
+            if not dynamic_patchers:
+                self.unpin_all_weights()
+        finally:
+            self.detach(unpatch_all=False)
 
     def memory_required(self, input_shape):
         #Pad this significantly. We are trying to get away from precise estimates. This

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -558,12 +558,9 @@ class ModelPatcher:
             new_multigpu_models = []
             for mm in multigpu_models:
                 # clone main model, but bring over relevant props from existing multigpu clone
-                n = self.clone()
+                n = self.clone(model_override=mm.get_clone_model_override())
                 n.load_device = mm.load_device
-                n.backup = mm.backup
-                n.object_patches_backup = mm.object_patches_backup
                 n.hook_backup = mm.hook_backup
-                n.model = mm.model
                 n.is_multigpu_base_clone = mm.is_multigpu_base_clone
                 n.remove_additional_models("multigpu")
                 orig_additional_models: dict[str, list[ModelPatcher]] = comfy.patcher_extension.copy_nested_dicts(n.additional_models)


### PR DESCRIPTION
This cleanup routine was triggering on arbitrary ModelPatcher destruction. This could lead to losing the pins and going to disk reload on workflow chances that bounced ModelPatcherDynamic

I think we have had this issue for a while but it is more noticable with the v0.23 memory changes.

This might address some community concerns about disk reloads.

Example Test Conditions:

RTX5090, Linux, 32GB RAM, PCIE5 x4 NVME
ZiT + Lora, rerun with lora strength change

Before:

[Screencast from 2026-08-01 01-22-21.webm](https://github.com/user-attachments/assets/3a2f2c20-1710-4868-9daf-2a0ad136d9bb)


Note in the visualizer the pins reset to 0 then build back up again even though the model is fully loaded. This is doing inplace-replacement of the loaded model via fresh pins.

```
[INFO] Prompt executed in 5.12 seconds
```

After:

[Screencast from 2026-08-01 01-20-39.webm](https://github.com/user-attachments/assets/ca269ecd-5d05-46a8-a5b0-80a0ecb4e885)

No loss of pins. Still inplace replacement but starting from the full pins.

```
[INFO] Prompt executed in 2.47 seconds
```

Regression Tests:
RTX5090, Linux, 32GB RAM, PCIE5 x4 NVME

All run back to back to test evicition of stale models.

Stable Cascade -> Flux2 ✅ 
WAN2.2 ✅ 
LTX2.3 + prompt enhancer ✅ 
ZiT x2 with lora strength change (as above) ✅ 
Ace-step1.5 XL Turbo ✅ 
