### PR TITLE
[Partner Nodes] chore(Bria): increase price for video endpoints

### DIFF
--- a/comfy_api_nodes/nodes_bria.py
+++ b/comfy_api_nodes/nodes_bria.py
@@ -289,7 +289,7 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.005,"format":{"suffix":"/second"}}""",
+                expr="""{"type":"usd","usd":0.05,"format":{"suffix":"/second"}}""",
             ),
         )
 
@@ -357,7 +357,7 @@ class BriaVideoGreenScreen(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.005,"format":{"suffix":"/second"}}""",
+                expr="""{"type":"usd","usd":0.05,"format":{"suffix":"/second"}}""",
             ),
         )
 
@@ -433,7 +433,7 @@ class BriaVideoReplaceBackground(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.005,"format":{"suffix":"/second"}}""",
+                expr="""{"type":"usd","usd":0.05,"format":{"suffix":"/second"}}""",
             ),
         )
 
@@ -533,7 +533,7 @@ class BriaTransparentVideoBackground(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.005,"format":{"suffix":"/second"}}""",
+                expr="""{"type":"usd","usd":0.05,"format":{"suffix":"/second"}}""",
             ),
         )
 


### PR DESCRIPTION
New Bria price is `0.05` per second instead of `0.005` per second.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [x] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [x] Metronome rate cards updated
- [x] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

