### PR TITLE
ci: split long Windows release workflow steps for readability

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -95,7 +95,8 @@ jobs:
             ${{ inputs.cache_tag }}_python_deps.tar
             update_comfyui_and_python_dependencies.bat
           key: ${{ runner.os }}-build-${{ inputs.cache_tag }}-${{ inputs.python_minor }}
-      - shell: bash
+      - name: Extract cached Python dependencies
+        shell: bash
         run: |
           mv ${{ inputs.cache_tag }}_python_deps.tar ../
           mv update_comfyui_and_python_dependencies.bat ../
@@ -104,7 +105,8 @@ jobs:
           pwd
           ls
 
-      - shell: bash
+      - name: Set up embedded Python and install dependencies
+        shell: bash
         run: |
           cd ..
           cp -r ComfyUI ComfyUI_copy
@@ -129,8 +131,10 @@ jobs:
             rm ./Lib/site-packages/torch/lib/libprotobuf.lib
           fi
 
+      - name: Bundle ComfyUI portable layout
+        shell: bash
+        run: |
           cd ..
-
           git clone --depth 1 https://github.com/comfyanonymous/taesd
           cp taesd/*.safetensors ./ComfyUI_copy/models/vae_approx/
 
@@ -147,12 +151,15 @@ jobs:
 
           echo 'local-portable' > ComfyUI/.comfy_environment
 
+      - name: Create portable 7z archive
+        shell: bash
+        run: |
           cd ..
-
           "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=9 -mfb=128 -md=768m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
           mv ComfyUI_windows_portable.7z ComfyUI/ComfyUI_windows_portable_${{ inputs.rel_name }}${{ inputs.rel_extra_name }}.7z
 
-      - shell: bash
+      - name: Quick-test portable package
+        shell: bash
         if: ${{ inputs.test_release }}
         run: |
           cd ..

--- a/.github/workflows/windows_release_dependencies.yml
+++ b/.github/workflows/windows_release_dependencies.yml
@@ -43,7 +43,8 @@ jobs:
           with:
             python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
 
-        - shell: bash
+        - name: Write dependency update batch script
+          shell: bash
           run: |
             echo "@echo off
             call update_comfyui.bat nopause
@@ -56,6 +57,9 @@ jobs:
             ..\python_embeded\python.exe -s -m pip install --upgrade torch torchvision torchaudio ${{ inputs.xformers }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
             pause" > update_comfyui_and_python_dependencies.bat
 
+        - name: Build Python dependency wheels and archive
+          shell: bash
+          run: |
             grep -v comfyui requirements.txt > requirements_nocomfyui.txt
             python -m pip wheel --no-cache-dir torch torchvision torchaudio ${{ inputs.xformers }} ${{ inputs.extra_dependencies }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r requirements_nocomfyui.txt pygit2 -w ./temp_wheel_dir
             python -m pip install --no-cache-dir ./temp_wheel_dir/*

--- a/.github/workflows/windows_release_dependencies_manual.yml
+++ b/.github/workflows/windows_release_dependencies_manual.yml
@@ -35,7 +35,8 @@ jobs:
           with:
             python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
 
-        - shell: bash
+        - name: Write dependency update batch script
+          shell: bash
           run: |
             echo "@echo off
             call update_comfyui.bat nopause
@@ -48,6 +49,9 @@ jobs:
             ..\python_embeded\python.exe -s -m pip install --upgrade ${{ inputs.torch_dependencies }} -r ../ComfyUI/requirements.txt pygit2
             pause" > update_comfyui_and_python_dependencies.bat
 
+        - name: Build Python dependency wheels and archive
+          shell: bash
+          run: |
             grep -v comfyui requirements.txt > requirements_nocomfyui.txt
             python -m pip wheel --no-cache-dir ${{ inputs.torch_dependencies }} -r requirements_nocomfyui.txt pygit2 -w ./temp_wheel_dir
             python -m pip install --no-cache-dir ./temp_wheel_dir/*

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -39,7 +39,8 @@ jobs:
         - uses: actions/setup-python@v5
           with:
             python-version: 3.${{ inputs.python_minor }}.${{ inputs.python_patch }}
-        - shell: bash
+        - name: Set up embedded Python and install nightly PyTorch
+          shell: bash
           run: |
             cd ..
             cp -r ComfyUI ComfyUI_copy
@@ -55,8 +56,11 @@ jobs:
             sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
 
             rm ./Lib/site-packages/torch/lib/dnnl.lib #I don't think this is actually used and I need the space
-            cd ..
 
+        - name: Bundle nightly portable layout
+          shell: bash
+          run: |
+            cd ..
             git clone --depth 1 https://github.com/comfyanonymous/taesd
             cp taesd/*.safetensors ./ComfyUI_copy/models/vae_approx/
 
@@ -74,12 +78,18 @@ jobs:
             echo "call update_comfyui.bat nopause
             ..\python_embeded\python.exe -s -m pip install --upgrade --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
             pause" > ./update/update_comfyui_and_python_dependencies.bat
-            cd ..
 
+        - name: Create nightly portable 7z archive
+          shell: bash
+          run: |
+            cd ..
             "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=9 -mfb=128 -md=512m -ms=on -mf=BCJ2 ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI_windows_portable_nightly_pytorch
             mv ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI/ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
 
-            cd ComfyUI_windows_portable_nightly_pytorch
+        - name: Quick-test nightly portable package
+          shell: bash
+          run: |
+            cd ../ComfyUI_windows_portable_nightly_pytorch
             python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
             ls

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -39,7 +39,8 @@ jobs:
               cu${{ inputs.cu }}_python_deps.tar
               update_comfyui_and_python_dependencies.bat
             key: ${{ runner.os }}-build-cu${{ inputs.cu }}-${{ inputs.python_minor }}
-        - shell: bash
+        - name: Extract cached Python dependencies
+          shell: bash
           run: |
             mv cu${{ inputs.cu }}_python_deps.tar ../
             mv update_comfyui_and_python_dependencies.bat ../
@@ -52,7 +53,8 @@ jobs:
           with:
             fetch-depth: 150
             persist-credentials: false
-        - shell: bash
+        - name: Set up embedded Python and install dependencies
+          shell: bash
           run: |
             cd ..
             cp -r ComfyUI ComfyUI_copy
@@ -68,8 +70,11 @@ jobs:
             rm ./Lib/site-packages/torch/lib/dnnl.lib #I don't think this is actually used and I need the space
             rm ./Lib/site-packages/torch/lib/libprotoc.lib
             rm ./Lib/site-packages/torch/lib/libprotobuf.lib
-            cd ..
 
+        - name: Bundle ComfyUI portable layout
+          shell: bash
+          run: |
+            cd ..
             git clone --depth 1 https://github.com/comfyanonymous/taesd
             cp taesd/*.safetensors ./ComfyUI_copy/models/vae_approx/
 
@@ -84,12 +89,17 @@ jobs:
             cp -r ComfyUI/.ci/windows_nvidia_base_files/* ./
             cp ../update_comfyui_and_python_dependencies.bat ./update/
 
+        - name: Create portable 7z archive
+          shell: bash
+          run: |
             cd ..
-
             "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma2 -mx=9 -mfb=128 -md=768m -ms=on -mf=BCJ2 ComfyUI_windows_portable.7z ComfyUI_windows_portable
             mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
 
-            cd ComfyUI_windows_portable
+        - name: Quick-test portable package
+          shell: bash
+          run: |
+            cd ../ComfyUI_windows_portable
             python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
 
             python_embeded/python.exe -s ./update/update.py ComfyUI/


### PR DESCRIPTION
## Problem

Several Windows release workflows pack a large amount of packaging logic into a single unnamed `run` step (well over 300 characters). In the GitHub Actions UI that collapses into a generic step label, which makes failures harder to locate.

## Changes

No command semantics were changed — the same shell commands run in the same order. Long steps were split into named units, and short helper steps also received `name:` labels.

### `.github/workflows/stable-release.yml`
- Extract cached dependencies
- Set up embedded Python and install dependencies
- Bundle portable layout
- Create 7z archive
- Quick-test portable package

### `.github/workflows/windows_release_package.yml`
- Same packaging breakdown as above (extract → setup → bundle → archive → quick-test)

### `.github/workflows/windows_release_nightly_pytorch.yml`
- Set up embedded Python / nightly PyTorch
- Bundle nightly layout
- Create archive
- Quick-test

### `.github/workflows/windows_release_dependencies.yml` / `windows_release_dependencies_manual.yml`
- Write update `.bat` script
- Build wheels and create dependency archive

## Test plan
- [ ] Review the diff: command order and arguments match the previous single-step scripts
- [ ] (Optional) Dry-run a Windows release workflow_dispatch on this branch
