### PR TITLE
comfy-aimdo 0.4.11

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -172,6 +172,7 @@ vram_group.add_argument("--cpu", action="store_true", help="To use the CPU for e
 
 parser.add_argument("--reserve-vram", type=float, default=None, help="Set the amount of vram in GB you want to reserve for use by your OS/other software. By default some amount is reserved depending on your OS.")
 parser.add_argument("--vram-headroom", type=float, default=0, help="Set the amount of vram in GB for DynamicVRAM to maintain as extra headroom above default. ComfyUI will try and keep this much VRAM completely free and unused, even counting VRAM from other apps.")
+parser.add_argument("--disable-nvml-pressure", action="store_true", help="Use CUDA instead of NVML for DynamicVRAM memory pressure.")
 
 parser.add_argument("--async-offload", nargs='?', const=2, type=int, default=None, metavar="NUM_STREAMS", help="Use async weight offloading. An optional argument controls the amount of offload streams. Default is 2. Enabled by default on Nvidia.")
 parser.add_argument("--disable-async-offload", action="store_true", help="Disable async weight offloading.")

--- a/main.py
+++ b/main.py
@@ -58,11 +58,16 @@ if __name__ == "__main__" and args.debug_hang:
 import comfy_aimdo.control
 
 if enables_dynamic_vram():
+    simple_vram_headroom = None if args.reserve_vram is None else int(args.reserve_vram * 1024 ** 3)
     try:
-        comfy_aimdo.control.init(simple_vram_headroom=None if args.reserve_vram is None else int(args.reserve_vram * 1024 ** 3))
+        comfy_aimdo.control.init(simple_vram_headroom=simple_vram_headroom, nvml_pressure=not args.disable_nvml_pressure)
     except TypeError:
-        # comfy-aimdo 0.4.9 protocol.
-        comfy_aimdo.control.init()
+        # comfy-aimdo 0.4.10 protocol.
+        try:
+            comfy_aimdo.control.init(simple_vram_headroom=simple_vram_headroom)
+        except TypeError:
+            # comfy-aimdo 0.4.9 protocol.
+            comfy_aimdo.control.init()
 
 if os.name == "nt":
     os.environ['MIMALLOC_PURGE_DELAY'] = '0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy>=2.0.0
 filelock
 av>=16.0.0
 comfy-kitchen==0.2.26
-comfy-aimdo==0.4.10
+comfy-aimdo==0.4.11
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
Changes:

Remove sequential scan hint
Prefer NVML pressure on windows
Add async malloc clamp option (unused by comfy so far) 
Workaround AMD windows GPU virtual address space leak

The largest change is the NVML pressure, which works around a cuMemGetInfo drift from actual VRAM in some circumstances.

Example test conditions (which MiniMax unmerged content as of this writing):

Windows RTX5090, 96GB
MiniMax H3 T2V full int8
--vram-headroom 1

Before:

<img width="527" height="665" alt="scr" src="https://github.com/user-attachments/assets/432e2d4c-7a41-46fa-8fb5-ec87ff5c22e3" />


After:

<img width="522" height="643" alt="scr" src="https://github.com/user-attachments/assets/ce081013-c575-414c-b998-773456500d8a" />


Regression and Performance tests (this change only):

```
Mean of 2 runs

+------------------------------------------+----------------------------------------------+----------------------------------------------+
| Workload                                 | RTX 5090 / Windows / 96 GB / PCIe 1 x4 NVMe | RTX 3060 / Windows / 32 GB / PCIe 1 x4 NVMe |
|                                          | Time (s), Before -> After                    | Time (s), Before -> After                    |
+------------------------------------------+----------------------------------------------+----------------------------------------------+
| STANDALONE                                                                                                 |
+------------------------------------------+----------------------------------------------+----------------------------------------------+
| LTX 2.3                                  |  1.8 ->  1.8   (+3.2%)                      |  5.3 ->  5.0   (-5.2%)                      |
| WAN 2.2 (640x640 / 320x320)              | 0.36 -> 0.36   (-0.41%)                     | 0.84 -> 0.84   (-0.42%)                     |
| ACE-Step 1.5 XL                          | 0.45 -> 0.42   (-5.9%)                      | 0.94 -> 0.95   (+0.96%)                     |
| SDXL                                     | 0.77 -> 0.74   (-3.7%)                      |  2.1 ->  2.0   (-3.3%)                      |
| Flux 2 Klein 9B                          | 0.81 -> 0.82   (+0.98%)                     |  5.9 ->  5.9   (-0.19%)                     |
+------------------------------------------+----------------------------------------------+----------------------------------------------+
| TRANSITIONS                                                                                                 |
+------------------------------------------+----------------------------------------------+----------------------------------------------+
| LTX -> WAN (640x640 / 320x320)            |   22 ->   22   (-0.81%)                     |   11 ->   11   (-4.3%)                      |
| WAN (640x640 / 320x320) -> LTX            |   26 ->   20   (-24%)                       |   34 ->   34   (-0.12%)                     |
| LTX -> WAN again (640x640 / 320x320)      |   22 ->   16   (-29%)                       |   11 ->   11   (-2.7%)                      |
| Flux 2 -> SDXL                            |  4.1 ->  4.1   (-0.78%)                     |  7.9 ->  7.9   (+0.48%)                     |
+------------------------------------------+----------------------------------------------+----------------------------------------------+

Negative percentage means faster after the change.
```