### PR TITLE
Size tiled VAE memory reservation from the tile, not the full tensor

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -1169,11 +1169,67 @@ class VAE:
         pixel_samples = pixel_samples.to(self.output_device).movedim(1,-1)
         return pixel_samples
 
+    def _tiled_shape_candidates(self, shape, dims, tile_x, tile_y, tile_t):
+        """Per-tile shapes the tiled path can actually feed the first stage model.
+
+        comfy.utils.tiled_scale / tiled_scale_multidim narrow every tiled axis to
+        min(tile, dim) before invoking the model, so the activation workspace
+        scales with the tile rather than with the whole tensor.
+
+        decode_tiled_ / encode_tiled_ blend three passes with different tile
+        geometries -- (tx, ty), (tx * 2, ty // 2) and (tx // 2, ty * 2) -- so all
+        of them are returned and the caller takes the largest estimate. Clamping
+        to (tx, ty) alone would under-estimate when one axis is smaller than its
+        tile while the other is not.
+
+        An empty list means no tile-aware estimate is available.
+        """
+        s = list(shape)
+        if dims == 3:
+            # tiled_scale_multidim is called with tile=(tile_t, tile_x, tile_y)
+            geometries = [(tile_t, tile_x, tile_y)]
+            axes = (2, 3, 4)
+        elif dims == 2:
+            # tiled_scale forwards (tile_y, tile_x) to tiled_scale_multidim
+            def scaled(t, mul, div):
+                return None if t is None else max(1, t * mul // div)
+            geometries = [(tile_y, tile_x),
+                          (scaled(tile_y, 1, 2), scaled(tile_x, 2, 1)),
+                          (scaled(tile_y, 2, 1), scaled(tile_x, 1, 2))]
+            axes = (2, 3)
+        elif dims == 1:
+            geometries = [(tile_x,)]
+            axes = (2,)
+        else:
+            return []
+
+        out = []
+        for geom in geometries:
+            c = list(s)
+            for axis, tile in zip(axes, geom):
+                if tile is not None and axis < len(c):
+                    c[axis] = min(c[axis], max(1, int(tile)))
+            out.append(tuple(c))
+        return out
+
+    def _tiled_memory_used(self, shape, dims, tile_x, tile_y, tile_t, encode=False):
+        """Largest reservation any single tile of this tiled run can need."""
+        fn = self.memory_used_encode if encode else self.memory_used_decode
+        candidates = self._tiled_shape_candidates(shape, dims, tile_x, tile_y, tile_t)
+        if not candidates:
+            return fn(shape, self.vae_dtype)
+        return max(fn(c, self.vae_dtype) for c in candidates)
+
     def decode_tiled(self, samples, tile_x=None, tile_y=None, overlap=None, tile_t=None, overlap_t=None):
         self.throw_exception_if_invalid()
-        memory_used = self.memory_used_decode(samples.shape, self.vae_dtype) #TODO: calculate mem required for tile
-        model_management.load_models_gpu([self.patcher], memory_required=memory_used, force_full_load=self.disable_offload)
         dims = samples.ndim - 2
+        if self.handles_tiling or dims == 1 or self.extra_1d_channel is not None:
+            # Model-owned tilers pick their own chunking and the 1d path reshapes
+            # before tiling, so keep the conservative full-shape estimate.
+            memory_used = self.memory_used_decode(samples.shape, self.vae_dtype)
+        else:
+            memory_used = self._tiled_memory_used(samples.shape, dims, tile_x, tile_y, tile_t)
+        model_management.load_models_gpu([self.patcher], memory_required=memory_used, force_full_load=self.disable_offload)
         args = {}
         if tile_x is not None:
             args["tile_x"] = tile_x
@@ -1270,7 +1326,12 @@ class VAE:
             else:
                 pixel_samples = pixel_samples.unsqueeze(2)
 
-        memory_used = self.memory_used_encode(pixel_samples.shape, self.vae_dtype)  # TODO: calculate mem required for tile
+        if self.handles_tiling or dims == 1:
+            # Model-owned tilers pick their own chunking and the 1d path reshapes
+            # before tiling, so keep the conservative full-shape estimate.
+            memory_used = self.memory_used_encode(pixel_samples.shape, self.vae_dtype)
+        else:
+            memory_used = self._tiled_memory_used(pixel_samples.shape, dims, tile_x, tile_y, tile_t, encode=True)
         model_management.load_models_gpu([self.patcher], memory_required=memory_used, force_full_load=self.disable_offload)
 
         args = {}


### PR DESCRIPTION
Fixes #15220.

### The problem

`decode_tiled` and `encode_tiled` computed `memory_required` from the full
latent/pixel shape — the two `#TODO: calculate mem required for tile` comments.
Because the reservation ignored `tile_size`, `load_models_gpu` was asked for
several GB more than a tiled run can allocate and evicted other resident
models even when the tiled path would have fit. Reaching for the tiled node,
which is the usual remedy for exactly that situation, then changed nothing.

### Measurements

RX 9060 XT 16GB, Qwen-image VAE, 1024x1024, bf16, VAE loaded alone, peak from
`torch.cuda.max_memory_allocated()`:

| | plain | tile 512 | tile 256 |
|---|---:|---:|---:|
| decode workspace | 4140.5 MB | 1035.1 MB | 258.8 MB |
| encode workspace | 2310.2 MB | 578.0 MB | 144.5 MB |

At tile 512 the old code reserved 4400 MB for a decode that uses 1035 MB
(4.3x), and 3000 MB for an encode that uses 578 MB (5.2x).

With a 12.5GB diffusion model resident the server reports 1939.5 MB free, so a
tile-512 decode (1035 MB + 242 MB of VAE weights) fits — yet the full-shape
estimate still forced ~2.8GB out of the model, which then had to be re-read
from disk on the next prompt.

### The change

`tiled_scale_multidim` narrows each tiled axis to `min(tile, dim)` before
calling the model, so the estimate mirrors that.

One wrinkle: `decode_tiled_` / `encode_tiled_` blend three passes with
different geometries — `(tx, ty)`, `(tx * 2, ty // 2)`, `(tx // 2, ty * 2)`.
Clamping to `(tx, ty)` alone under-estimates when one axis is smaller than its
tile and the other is not, e.g. `H=64, W=1024, tile=128`, where the
`tx * 2` pass feeds a wider tile than `(tx, ty)` would suggest. So all three
geometries are evaluated and the largest estimate is used.

Model-owned tilers (`handles_tiling`) and the 1d path keep the previous
full-shape estimate, since their chunking is not described by these tile args.
That deliberately leaves cases like #15053 untouched.

### Why this should not cause OOMs

The point of the change is to reserve less, so the risk to check is
under-reservation. Resulting estimates stay above the measured peaks:

| | reserved | measured | margin |
|---|---:|---:|---:|
| decode tile 512 | 1100.0 MB | 1035.1 MB | +64.9 MB |
| decode tile 256 | 275.0 MB | 258.8 MB | +16.2 MB |
| encode tile 512 | 750.0 MB | 578.0 MB | +172.0 MB |
| encode tile 256 | 187.5 MB | 144.5 MB | +43.0 MB |

I also checked that a tile at or above the image size is a no-op — the
estimate then equals the old full-shape value exactly, so workflows that pass
an oversized tile keep their current behaviour.

### Result

The VAE now loads without evicting the diffusion model, and the next prompt
starts sampling with no reload:

```
Requested to load WanVAE
loaded completely; 1077.39 MB usable, 242.03 MB loaded, full load: True
Prompt executed in 153.72 seconds
got prompt
  0%|          | 0/8 [00:00<?, ?it/s]      <- no reload
```

End to end on the same workflow: evictions 1 -> 0, prompt time ~83s -> ~66s.

### Testing

Verified on ComfyUI 0.29.2 / master `f06a187`, RX 9060 XT (gfx1200),
Windows 11, torch 2.10.0+rocm, with a 3D (video-class) VAE.

I have **not** been able to test on a 2D-latent VAE or the 1d/audio paths, nor
on the `handles_tiling` models — those keep the old estimate by design, but a
second pair of eyes on the 2D geometry list would be welcome.
