### PR TITLE
`float`: bound GPU memory in the CK stochastic-rounding path (fixes OOM loading large models)

### DIFF
--- a/comfy/float.py
+++ b/comfy/float.py
@@ -14,6 +14,8 @@ if not _CK_STOCHASTIC_ROUNDING_AVAILABLE:
     def _ck_stochastic_rounding_fp8(value, rng, dtype):
         raise NotImplementedError("comfy_kitchen does not support stochastic FP8 rounding")
 
+_CK_SLICE_NUMEL = 4096 * 4096
+
 
 def _ck_stochastic_round_slice(value, dtype, generator):
     rng = torch.randint(0, 256, value.size(), dtype=torch.uint8, layout=value.layout, device=value.device, generator=generator)
@@ -79,14 +81,19 @@ def stochastic_rounding(value, dtype, seed=0):
         generator.manual_seed(seed)
 
         if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
-            if value.numel() <= 4096 * 4096:
+            if value.numel() <= _CK_SLICE_NUMEL:
                 return _ck_stochastic_round_slice(value, dtype, generator)
 
-            num_slices = value.numel() / (4096 * 4096)
-            slice_size = max(1, round(value.shape[0] / num_slices))
             output = torch.empty_like(value, dtype=dtype)
-            for i in range(0, value.shape[0], slice_size):
-                output[i:i+slice_size].copy_(_ck_stochastic_round_slice(value[i:i+slice_size], dtype, generator))
+            rows_per_slice = _CK_SLICE_NUMEL // (value.numel() // value.shape[0])
+            if rows_per_slice > 0:
+                for i in range(0, value.shape[0], rows_per_slice):
+                    output[i:i+rows_per_slice].copy_(_ck_stochastic_round_slice(value[i:i+rows_per_slice], dtype, generator))
+            else:
+                flat_value = value.reshape(-1)
+                flat_output = output.reshape(-1)
+                for i in range(0, flat_value.numel(), _CK_SLICE_NUMEL):
+                    flat_output[i:i+_CK_SLICE_NUMEL].copy_(_ck_stochastic_round_slice(flat_value[i:i+_CK_SLICE_NUMEL], dtype, generator))
             return output
 
         output = torch.empty_like(value, dtype=dtype)

--- a/comfy/float.py
+++ b/comfy/float.py
@@ -14,6 +14,8 @@ if not _CK_STOCHASTIC_ROUNDING_AVAILABLE:
     def _ck_stochastic_rounding_fp8(value, rng, dtype):
         raise NotImplementedError("comfy_kitchen does not support stochastic FP8 rounding")
 
+CK_SLICE_NUMEL = 4096 * 4096
+
 
 def calc_mantissa(abs_x, exponent, normal_mask, MANTISSA_BITS, EXPONENT_BIAS, generator=None):
     mantissa_scaled = torch.where(
@@ -73,17 +75,24 @@ def stochastic_rounding(value, dtype, seed=0):
         generator = torch.Generator(device=value.device)
         generator.manual_seed(seed)
 
+        if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
+            def ck_round(chunk):
+                rng = torch.randint(0, 256, chunk.size(), dtype=torch.uint8, layout=chunk.layout, device=chunk.device, generator=generator)
+                return _ck_stochastic_rounding_fp8(chunk, rng, dtype)
+
+            if value.numel() <= CK_SLICE_NUMEL:
+                return ck_round(value)
+
+            num_slices = value.numel() / CK_SLICE_NUMEL
+            slice_size = max(1, round(value.shape[0] / num_slices))
+            output = torch.empty_like(value, dtype=dtype)
+            for i in range(0, value.shape[0], slice_size):
+                output[i:i+slice_size].copy_(ck_round(value[i:i+slice_size]))
+            return output
+
         output = torch.empty_like(value, dtype=dtype)
         num_slices = max(1, (value.numel() / (4096 * 4096)))
         slice_size = max(1, round(value.shape[0] / num_slices))
-
-        if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
-            for i in range(0, value.shape[0], slice_size):
-                chunk = value[i:i+slice_size]
-                rng = torch.randint(0, 256, chunk.size(), dtype=torch.uint8, layout=chunk.layout, device=chunk.device, generator=generator)
-                output[i:i+slice_size].copy_(_ck_stochastic_rounding_fp8(chunk, rng, dtype))
-            return output
-
         for i in range(0, value.shape[0], slice_size):
             output[i:i+slice_size].copy_(manual_stochastic_round_to_float8(value[i:i+slice_size], dtype, generator=generator))
         return output

--- a/comfy/float.py
+++ b/comfy/float.py
@@ -72,13 +72,22 @@ def stochastic_rounding(value, dtype, seed=0):
     if dtype == torch.float8_e4m3fn or dtype == torch.float8_e5m2:
         generator = torch.Generator(device=value.device)
         generator.manual_seed(seed)
-        if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
-            rng = torch.randint(0, 256, value.size(), dtype=torch.uint8, layout=value.layout, device=value.device, generator=generator)
-            return _ck_stochastic_rounding_fp8(value, rng, dtype)
 
         output = torch.empty_like(value, dtype=dtype)
         num_slices = max(1, (value.numel() / (4096 * 4096)))
         slice_size = max(1, round(value.shape[0] / num_slices))
+
+        if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
+            # Slice the same way as the fallback below: the rng buffer is one
+            # uint8 per element, so allocating it for the whole tensor at once
+            # adds transient VRAM proportional to the weight being rounded.
+            # That is enough to OOM a 24GB card while loading a 14B fp8 expert.
+            for i in range(0, value.shape[0], slice_size):
+                chunk = value[i:i+slice_size]
+                rng = torch.randint(0, 256, chunk.size(), dtype=torch.uint8, layout=chunk.layout, device=chunk.device, generator=generator)
+                output[i:i+slice_size].copy_(_ck_stochastic_rounding_fp8(chunk, rng, dtype))
+            return output
+
         for i in range(0, value.shape[0], slice_size):
             output[i:i+slice_size].copy_(manual_stochastic_round_to_float8(value[i:i+slice_size], dtype, generator=generator))
         return output

--- a/comfy/float.py
+++ b/comfy/float.py
@@ -14,7 +14,10 @@ if not _CK_STOCHASTIC_ROUNDING_AVAILABLE:
     def _ck_stochastic_rounding_fp8(value, rng, dtype):
         raise NotImplementedError("comfy_kitchen does not support stochastic FP8 rounding")
 
-CK_SLICE_NUMEL = 4096 * 4096
+
+def _ck_stochastic_round_slice(value, dtype, generator):
+    rng = torch.randint(0, 256, value.size(), dtype=torch.uint8, layout=value.layout, device=value.device, generator=generator)
+    return _ck_stochastic_rounding_fp8(value, rng, dtype)
 
 
 def calc_mantissa(abs_x, exponent, normal_mask, MANTISSA_BITS, EXPONENT_BIAS, generator=None):
@@ -76,18 +79,14 @@ def stochastic_rounding(value, dtype, seed=0):
         generator.manual_seed(seed)
 
         if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
-            def ck_round(chunk):
-                rng = torch.randint(0, 256, chunk.size(), dtype=torch.uint8, layout=chunk.layout, device=chunk.device, generator=generator)
-                return _ck_stochastic_rounding_fp8(chunk, rng, dtype)
+            if value.numel() <= 4096 * 4096:
+                return _ck_stochastic_round_slice(value, dtype, generator)
 
-            if value.numel() <= CK_SLICE_NUMEL:
-                return ck_round(value)
-
-            num_slices = value.numel() / CK_SLICE_NUMEL
+            num_slices = value.numel() / (4096 * 4096)
             slice_size = max(1, round(value.shape[0] / num_slices))
             output = torch.empty_like(value, dtype=dtype)
             for i in range(0, value.shape[0], slice_size):
-                output[i:i+slice_size].copy_(ck_round(value[i:i+slice_size]))
+                output[i:i+slice_size].copy_(_ck_stochastic_round_slice(value[i:i+slice_size], dtype, generator))
             return output
 
         output = torch.empty_like(value, dtype=dtype)

--- a/comfy/float.py
+++ b/comfy/float.py
@@ -78,10 +78,6 @@ def stochastic_rounding(value, dtype, seed=0):
         slice_size = max(1, round(value.shape[0] / num_slices))
 
         if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
-            # Slice the same way as the fallback below: the rng buffer is one
-            # uint8 per element, so allocating it for the whole tensor at once
-            # adds transient VRAM proportional to the weight being rounded.
-            # That is enough to OOM a 24GB card while loading a 14B fp8 expert.
             for i in range(0, value.shape[0], slice_size):
                 chunk = value[i:i+slice_size]
                 rng = torch.randint(0, 256, chunk.size(), dtype=torch.uint8, layout=chunk.layout, device=chunk.device, generator=generator)

--- a/tests-unit/comfy_test/float_test.py
+++ b/tests-unit/comfy_test/float_test.py
@@ -1,0 +1,54 @@
+import pytest
+import torch
+
+import comfy.float
+
+
+@pytest.fixture
+def rng_numels(monkeypatch):
+    """Stub the CK kernel and record the numel of every rng buffer it is
+    handed, so the slicing arithmetic can be checked without comfy_kitchen
+    or a GPU."""
+    seen = []
+
+    def fake_kernel(value, rng, dtype):
+        assert rng.numel() == value.numel()
+        seen.append(rng.numel())
+        return torch.zeros_like(value, dtype=dtype)
+
+    monkeypatch.setattr(comfy.float, "_CK_STOCHASTIC_ROUNDING_AVAILABLE", True)
+    monkeypatch.setattr(comfy.float, "_ck_stochastic_rounding_fp8", fake_kernel)
+    monkeypatch.setattr(comfy.float, "_CK_SLICE_NUMEL", 1024)  # Shrink the bound to keep the shapes below small
+    return seen
+
+
+@pytest.mark.parametrize("shape", [
+    (32, 32),      # Within the bound, takes the zero-copy path
+    (64, 64),      # Splits evenly across rows
+    (100, 41),     # Splits across rows, not a round multiple
+    (2, 5000),     # A single row is wider than the bound
+    (1, 20000),    # One row only, far over the bound
+    (20000, 1),    # Many rows, one element each
+])
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_ck_rng_buffer_never_exceeds_slice_bound(rng_numels, shape, dtype):
+    value = torch.zeros(shape, dtype=torch.float16)
+
+    out = comfy.float.stochastic_rounding(value, dtype)
+
+    assert rng_numels, "the CK path was not exercised"
+    assert max(rng_numels) <= comfy.float._CK_SLICE_NUMEL
+    assert out.shape == value.shape
+    assert out.dtype == dtype
+
+
+def test_ck_single_slice_allocates_no_output_buffer(rng_numels, monkeypatch):
+    monkeypatch.setattr(
+        torch, "empty_like",
+        lambda *a, **k: pytest.fail("allocated an output buffer for a single slice"),
+    )
+
+    value = torch.zeros((16, 16), dtype=torch.float16)
+    comfy.float.stochastic_rounding(value, torch.float8_e4m3fn)
+
+    assert rng_numels == [256]


### PR DESCRIPTION
# Summary

`684296148e` ("float: use CK stochastic rounding cuda kernel", #13971) made
`stochastic_rounding()` allocate a **full-size** `uint8` RNG tensor on the GPU
per call. The pre-existing PyTorch path deliberately sliced this work to bound
peak memory; the new comfy-kitchen fast path does not.

On a 24 GB card this makes it impossible to load a large fp8-quantised model
that loaded fine before the commit. Wan 2.2 I2V (two 14B experts) now OOMs
while loading the first expert.

# Environment

- GPU: 24 GB (RTX 3090 / 4090 class)
- Model: Wan 2.2 I2V, 14B expert (~13.8 GB), mixed-precision quantised
- Flags: `--cache-classic` (also reproduces with `--cache-none`,
  `--disable-mmap`, `--disable-dynamic-vram`, and with
  `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`)

# Reproduction

Load a Wan 2.2 I2V workflow, 640x640, 81 frames, one LoRA pair. The text
encoder and VAE load fine; the failure is on the expert:

```
Requested to load WanTEModel
loaded completely; 22084.80 MB usable, 6419.48 MB loaded, full load: True
Requested to load WanVAE
loaded completely; 11724.90 MB usable,  242.03 MB loaded, full load: True
Requested to load WAN21
!!! Exception during processing !!! Allocation on device 0 would exceed allowed memory.
Currently allocated     : 12.29 GiB
Requested               : 50.00 MiB
Device limit            : 24.00 GiB
Free (according to CUDA): 0 bytes
```

Note the shape of it: only ~12.3 GiB is accounted for, the request that fails
is **50 MiB**, and CUDA reports **0 bytes free** on a 24 GiB device. The
`torch.cuda.memory_summary()` ComfyUI dumps alongside this error reads **zero
for every counter** — allocated, reserved segments, active allocs — which is
consistent with the memory being held outside PyTorch's caching allocator.

# Bisect

Bisected against a fixed workload (same seed, resolution, frame count, LoRA):

| commit | date | result |
|---|---|---|
| `5e3f15a8` (v0.19.3) | 2026-04-25 | good |
| `fce03984` dynamicVRAM | 2026-04-28 | good |
| `a8d25190` (v0.22.0) | 2026-05-20 | good |
| `5aa5ccc9` threaded loader | 2026-05-21 | good |
| `0a2dd86e` MultiGPU work units | 2026-05-26 | good |
| `26aad73c` | 2026-05-29 | good |
| `ade4dfd9` pin comfy-kitchen 0.2.9 | 2026-05-29 | good |
| **`684296148e` CK stochastic rounding** | **2026-05-29** | **bad** |
| `e154da83` threaded loader fixes | 2026-05-30 | bad |
| `a88e02b1` (v0.23.0) | 2026-06-01 | bad |
| `f6c162dd` (v0.26.0) | 2026-06-23 | bad |
| `a8c44f9b` (v0.29.0) | 2026-07-28 | bad |

`ade4dfd9` and `684296148e` are adjacent, so the regression is isolated to that
one commit. The OOM signature is identical at every bad revision
(~12.0–12.7 GiB allocated, 50 MiB requested, 0 bytes free).

Worth noting for anyone else chasing this: it is **not** DynamicVRAM.
`fce03984`, which introduced it, tests good.

# Root cause

Before `684296148e`, `stochastic_rounding()` chunked the work so peak memory
stayed bounded regardless of tensor size:

```python
output = torch.empty_like(value, dtype=dtype)
num_slices = max(1, (value.numel() / (4096 * 4096)))
slice_size = max(1, round(value.shape[0] / num_slices))
```

The CK fast path added in front of it does not chunk:

```python
if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
    rng = torch.randint(0, 256, value.size(), dtype=torch.uint8,
                        layout=value.layout, device=value.device,
                        generator=generator)
    return _ck_stochastic_rounding_fp8(value, rng, dtype)
```

`rng` is one `uint8` element per element of `value`, allocated on the GPU in a
single call, on top of `value` itself and the kernel's own output. For the
large weight tensors in a 14B expert this is enough additional transient VRAM
to exhaust a 24 GB card during load, where the sliced path fit comfortably.

# Proposed fix

Keep the CK kernel, apply the same slicing the fallback path already uses, so
the RNG buffer is bounded by slice size rather than tensor size:

```python
if dtype == torch.float8_e4m3fn or dtype == torch.float8_e5m2:
    generator = torch.Generator(device=value.device)
    generator.manual_seed(seed)

    output = torch.empty_like(value, dtype=dtype)
    num_slices = max(1, (value.numel() / (4096 * 4096)))
    slice_size = max(1, round(value.shape[0] / num_slices))

    if _CK_STOCHASTIC_ROUNDING_AVAILABLE:
        for i in range(0, value.shape[0], slice_size):
            chunk = value[i:i + slice_size]
            rng = torch.randint(0, 256, chunk.size(), dtype=torch.uint8,
                                layout=chunk.layout, device=chunk.device,
                                generator=generator)
            output[i:i + slice_size] = _ck_stochastic_rounding_fp8(chunk, rng, dtype)
        return output

    # ... existing sliced fallback ...
```

This preserves the speedup for the common case (small tensors take a single
slice and behave exactly as today) while restoring the memory ceiling for
large ones.

Note this changes the RNG consumption pattern versus the current
single-allocation form, so sampled values for a given seed will differ from
current `master`. If bit-identical output across the change matters, an
alternative is to keep the single-shot path but fall back to the sliced
PyTorch implementation when `value.numel()` exceeds a threshold.

# Verification

Tested on current `master` (`f06a187`) with `--cache-classic`, no other
changes. Unpatched, this workflow OOMs at expert load. With the slicing patch
applied, the same expert loads whole and the job completes:

```
Requested to load WAN21
loaded completely; 16623.10 MB usable, 13852.98 MB loaded, full load: True
Prompt executed in 178.4 seconds
```

Three things checked, since a chunked kernel call could plausibly break any of
them:

- **OOM fixed** — the 13.8 GB expert loads fully rather than failing on a
  50 MiB request.
- **No throughput regression** — 178.4s for 81 frames at 640x640, against
  181.0s with the CK path disabled entirely, and ~160-182s on `v0.19.3`
  (pre-regression). The slicing does not measurably cost anything here.
- **Output is correct** — decoded frames are coherent, not corrupted, so
  `stochastic_rounding_fp8` behaves as expected on a chunk view.

Sampled values for a given seed differ from current `master`, as expected from
the changed RNG consumption pattern noted above.
