### PR TITLE
fix pin registration priority

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -671,6 +671,19 @@ def pin_eviction_tiers(loaded, evict_active):
             tiers.append((PIN_SUBSETS, True, True))
     return tiers
 
+def registration_eviction_tiers(evict_active):
+    subsets = PIN_SUBSETS + LOADED_PIN_SUBSETS
+    tiers = [
+        (subsets, False, False),
+        (subsets, True, False),
+    ]
+    if evict_active:
+        tiers.extend([
+            (subsets, False, True),
+            (subsets, True, True),
+        ])
+    return tiers
+
 def free_pins(size, evict_active=False, loaded=False):
     freed = 0
     for subsets, current_prompt, active in pin_eviction_tiers(loaded, evict_active):
@@ -699,19 +712,19 @@ def ensure_pin_budget(size, evict_active=False, loaded=False):
     to_free = shortfall + PIN_PRESSURE_HYSTERESIS
     return free_pins(to_free, evict_active=evict_active, loaded=loaded) >= shortfall
 
-def free_registrations(shortfall, evict_active=True, loaded=False):
+def free_registrations(shortfall, evict_active=True):
     if MAX_PINNED_MEMORY <= 0:
         return False
     if shortfall <= 0:
         return True
 
     shortfall += REGISTERABLE_PIN_HYSTERESIS
-    for subsets, current_prompt, active in pin_eviction_tiers(loaded, evict_active):
+    for subsets, current_prompt, active in registration_eviction_tiers(evict_active):
         shortfall -= free_model_pins(shortfall, subsets, current_prompt, active, registrations=True)
     return shortfall <= REGISTERABLE_PIN_HYSTERESIS
 
-def ensure_pin_registerable(size, evict_active=True, loaded=False):
-    return free_registrations(TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY, evict_active=evict_active, loaded=loaded)
+def ensure_pin_registerable(size, evict_active=True):
+    return free_registrations(TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY, evict_active=evict_active)
 
 class LoadedModel:
     def __init__(self, model: ModelPatcher):

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -56,7 +56,7 @@ def get_pin(module, subset="weights"):
 
     _, _, stack_split, pinned_size, *_ = module._pin_state[subset]
     size = pin.nbytes
-    comfy.model_management.ensure_pin_registerable(size, loaded=subset.endswith("-loaded"))
+    comfy.model_management.ensure_pin_registerable(size)
 
     if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
         comfy.model_management.discard_cuda_async_error()
@@ -93,7 +93,7 @@ def pin_memory(module, subset="weights", size=None):
 
     comfy.memory_management.extra_ram_release(comfy.memory_management.RAM_CACHE_HEADROOM)
     if (not comfy.model_management.ensure_pin_budget(size, loaded=loaded) or
-        not comfy.model_management.ensure_pin_registerable(registerable_size, loaded=loaded)):
+        not comfy.model_management.ensure_pin_registerable(registerable_size)):
         return _steal_pin(module, stack, buckets, size, priority, subset)
 
     offset = hostbuf.size
@@ -105,7 +105,7 @@ def pin_memory(module, subset="weights", size=None):
         pin.untyped_storage()._comfy_hostbuf = hostbuf
         if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
             comfy.model_management.discard_cuda_async_error()
-            comfy.model_management.free_registrations(size, loaded=loaded)
+            comfy.model_management.free_registrations(size)
             if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
                 comfy.model_management.discard_cuda_async_error()
                 del pin


### PR DESCRIPTION
    This priority scheme was broken in the case where you have pin
    registration exhaustion while loading a VBAR that gets a big evicition.
    The weight would stay in the loaded set but inherit the MRU priority
    against other workflow models WRT pin registration which leads to async
    offload without pinning.
    
    Fix by universally promiting active pin registration above workflow
    pins without concern for the weights/weights-loaded split. This diverges
    from the actual budgeting where the split still makes sense.


Note on regression results:

Its a mixed bag and some wfs are slightly slower due to moving pins for the TE and back to diffusion. We need a non-greedy heuristic to get this behavior while preserving pin reliability so we need to take that loss until we have a better workflow level RAM planner.

Example test conditions (based on minimax H3 branch)

Windows, RTX5090, 96GB
Minimax H3 full model int8, T2V

Before:

Weights of the active diffusion model are loaded but not pinned, and the idle TE is pinned.

<img width="520" height="644" alt="scr2" src="https://github.com/user-attachments/assets/6bbe6ef0-6bde-4d20-b4fc-d9c28823b854" />


After:

Diffusion model takes the pin registrations.

<img width="517" height="637" alt="scr" src="https://github.com/user-attachments/assets/8f2029d3-622e-42f4-9062-9ea5f62431bf" />

Regression and performance tests (this change only):



Workflow reruns:

```
Hardware                                  Workload                 Change       Before     After      Delta
----------------------------------------  -----------------------  -----------  ---------  ---------  -------
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    LTX 2.3 512x512x17       seed-only      6.3 s      5.5 s      -12%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    LTX 2.3 512x512x17       prompt-only    8.0 s      7.1 s      -11%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    WAN 2.2 640x640x17       seed-only      1.9 s      1.9 s     +0.07%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    WAN 2.2 640x640x17       prompt-only    2.1 s      2.1 s      +0.47%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    Flux 2 Klein 9B 640x640  seed-only      2.9 s      2.9 s     +0.08%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    Flux 2 Klein 9B 640x640  prompt-only    3.1 s      3.2 s      +0.52%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    ACE-Step 1.5 XL 15 s     seed-only     0.97 s     0.96 s       -1.0%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    ACE-Step 1.5 XL 15 s     prompt-only    1.1 s      1.1 s      +0.62%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    SDXL 1024x1024           seed-only      2.1 s      2.1 s      -0.30%
RTX 5090, Windows, 96 GB, PCIe 4x NVMe    SDXL 1024x1024           prompt-only    2.2 s      2.2 s      +0.12%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    LTX 2.3 320x320x17       seed-only       18 s       20 s       +7.4%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    LTX 2.3 320x320x17       prompt-only     30 s       33 s        +10%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    WAN 2.2 320x320x17       seed-only      4.3 s      4.3 s     +0.09%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    WAN 2.2 320x320x17       prompt-only    5.7 s      5.7 s      +0.40%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    Flux 2 Klein 9B 640x640  seed-only       23 s       25 s       +8.7%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    Flux 2 Klein 9B 640x640  prompt-only     25 s       27 s       +7.8%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    ACE-Step 1.5 XL 15 s     seed-only      2.1 s      2.1 s      -0.19%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    ACE-Step 1.5 XL 15 s     prompt-only    2.4 s      2.4 s     -0.055%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    SDXL 1024x1024           seed-only       14 s       14 s      -0.019%
RTX 3060, Windows, 32 GB, PCIe 4x NVMe    SDXL 1024x1024           prompt-only     14 s       14 s       -0.11%
```

```
+--------------------------------------------------+----------------------+----------+----------+---------+
| System                                           | Workload             | Before   | After    | Change  |
+--------------------------------------------------+----------------------+----------+----------+---------+
| RTX 5090, Windows, 96 GB, PCIe 1 x4 NVMe         | LTX -> WAN           |     23 s |     23 s |  -0.14% |
| RTX 5090, Windows, 96 GB, PCIe 1 x4 NVMe         | WAN -> LTX           |     21 s |     21 s | -0.044% |
| RTX 5090, Windows, 96 GB, PCIe 1 x4 NVMe         | LTX -> WAN again     |     15 s |     15 s |  -0.15% |
| RTX 5090, Windows, 96 GB, PCIe 1 x4 NVMe         | Flux 2 -> SDXL       |    4.1 s |    4.1 s |  -0.49% |
| RTX 3060, Windows, 32 GB, PCIe 1 x4 NVMe         | LTX -> WAN           |     11 s |     11 s |  -0.39% |
| RTX 3060, Windows, 32 GB, PCIe 1 x4 NVMe         | WAN -> LTX           |     35 s |     35 s |  -0.76% |
| RTX 3060, Windows, 32 GB, PCIe 1 x4 NVMe         | LTX -> WAN again     |     11 s |     11 s |  +0.69% |
| RTX 3060, Windows, 32 GB, PCIe 1 x4 NVMe         | Flux 2 -> SDXL       |    8.3 s |    8.0 s |   -3.1% |
+--------------------------------------------------+----------------------+----------+----------+---------+
```
