### PR TITLE
Fix websocket publish loop stalling on a hung client send

### DIFF
--- a/server.py
+++ b/server.py
@@ -71,11 +71,15 @@ def _remove_sensitive_from_queue(queue: list) -> list:
     return [item[:5] for item in queue]
 
 
+SEND_SOCKET_TIMEOUT = 10.0
+
 async def send_socket_catch_exception(function, message):
     try:
-        await function(message)
+        await asyncio.wait_for(function(message), timeout=SEND_SOCKET_TIMEOUT)
     except (aiohttp.ClientError, aiohttp.ClientPayloadError, ConnectionResetError, BrokenPipeError, ConnectionError) as err:
         logging.warning("send error: {}".format(err))
+    except asyncio.TimeoutError:
+        logging.warning("send error: timed out sending to a websocket client")
 
 # Track deprecated paths that have been warned about to only warn once per file
 _deprecated_paths_warned = set()

--- a/tests-unit/server_test/test_send_socket_catch_exception.py
+++ b/tests-unit/server_test/test_send_socket_catch_exception.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+import server as server_module  # noqa: E402
+from server import send_socket_catch_exception  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_successful_send_delivers_message():
+    sent = []
+
+    async def ok(message):
+        sent.append(message)
+
+    await send_socket_catch_exception(ok, "hello")
+    assert sent == ["hello"]
+
+
+async def test_swallows_connection_reset():
+    async def raise_connection_reset(message):
+        raise ConnectionResetError()
+
+    await send_socket_catch_exception(raise_connection_reset, "test")
+
+
+async def test_hanging_send_times_out_without_blocking_forever(monkeypatch):
+    # A send that never completes (e.g. a stalled/unresponsive client) must not
+    # block the caller indefinitely, otherwise it would stall delivery to every
+    # other websocket client sharing the same publish loop.
+    monkeypatch.setattr(server_module, "SEND_SOCKET_TIMEOUT", 0.05)
+
+    async def hang(message):
+        await asyncio.sleep(10)
+
+    await asyncio.wait_for(send_socket_catch_exception(hang, "test"), timeout=1.0)


### PR DESCRIPTION
Fixes #15240

## Problem

`PromptServer.publish_loop()` delivers queued websocket messages to
clients one at a time via `send_socket_catch_exception`, which awaits
the underlying `ws.send_bytes`/`ws.send_json` call with no timeout:

```python
async def send_socket_catch_exception(function, message):
    try:
        await function(message)
    except (aiohttp.ClientError, aiohttp.ClientPayloadError, ConnectionResetError, BrokenPipeError, ConnectionError) as err:
        logging.warning("send error: {}".format(err))
```

If a client's TCP connection stalls in a way that never surfaces as an
exception (e.g. the peer stops acking and the OS just leaves the write
pending), that `await` never returns. Because `publish_loop` sends
messages serially, this permanently blocks delivery to *every* other
connected client, even though `/prompt` submissions keep completing
successfully and `/history/{prompt_id}` keeps reporting
`execution_success`. Only a full server restart clears it, matching
the report in #15240.

## Fix

Wrap the send in `asyncio.wait_for` with a bounded timeout
(`SEND_SOCKET_TIMEOUT = 10.0`) and treat a timeout the same way as the
other per-client send failures already handled here: log a warning and
move on, instead of blocking the loop indefinitely.

## Testing

Added `tests-unit/server_test/test_send_socket_catch_exception.py`:
- `test_successful_send_delivers_message` — normal sends still work.
- `test_swallows_connection_reset` — existing exception-handling
  behavior is unchanged.
- `test_hanging_send_times_out_without_blocking_forever` — a send that
  never completes must not block the caller indefinitely. Confirmed
  this fails without the fix (reverting `server.py` alone raises
  `AttributeError: module 'server' has no attribute
  'SEND_SOCKET_TIMEOUT'` since the timeout doesn't exist yet) and
  passes with it.

```
$ python -m pytest tests-unit/server_test/test_send_socket_catch_exception.py -v
tests-unit/server_test/test_send_socket_catch_exception.py::test_successful_send_delivers_message PASSED
tests-unit/server_test/test_send_socket_catch_exception.py::test_swallows_connection_reset PASSED
tests-unit/server_test/test_send_socket_catch_exception.py::test_hanging_send_times_out_without_blocking_forever PASSED
3 passed in 6.19s

$ python -m pytest tests-unit -q
1130 passed, 10 skipped in 36.79s

$ ruff check server.py tests-unit/server_test/test_send_socket_catch_exception.py
All checks passed!
```

---
Written with the assistance of Claude Code.
