### PR TITLE
Fix sampler issues for audio with minimax, support more samplers.

### DIFF
--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -75,15 +75,7 @@ def get_ancestral_step(sigma_from, sigma_to, eta=1.):
     return sigma_down, sigma_up
 
 
-def model_noise_rescaler(model):
-    # models with multiple sigma schedules in one packed latent expose
-    # scale_stochastic_noise on their model_sampling (see ModelSamplingAV)
-    if model is None:
-        return None
-    return getattr(model.inner_model.inner_model.model_sampling, "scale_stochastic_noise", None)
-
-
-def default_noise_sampler(x, seed=None, model=None):
+def default_noise_sampler(x, seed=None):
     if seed is not None:
         if x.device == torch.device("cpu"):
             seed += 1
@@ -93,12 +85,7 @@ def default_noise_sampler(x, seed=None, model=None):
     else:
         generator = None
 
-    rescale = model_noise_rescaler(model)
-
-    def noise_sampler(sigma, sigma_next):
-        noise = torch.randn(x.size(), dtype=x.dtype, layout=x.layout, device=x.device, generator=generator)
-        return noise if rescale is None else rescale(noise, sigma, sigma_next)
-    return noise_sampler
+    return lambda sigma, sigma_next: torch.randn(x.size(), dtype=x.dtype, layout=x.layout, device=x.device, generator=generator)
 
 
 class BatchedBrownianTree:
@@ -152,16 +139,14 @@ class BrownianTreeNoiseSampler:
             internal timestep.
     """
 
-    def __init__(self, x, sigma_min, sigma_max, seed=None, transform=lambda x: x, cpu=False, model=None):
+    def __init__(self, x, sigma_min, sigma_max, seed=None, transform=lambda x: x, cpu=False):
         self.transform = transform
-        self.rescale = model_noise_rescaler(model)
         t0, t1 = self.transform(torch.as_tensor(sigma_min)), self.transform(torch.as_tensor(sigma_max))
         self.tree = BatchedBrownianTree(x, t0, t1, seed, cpu=cpu)
 
     def __call__(self, sigma, sigma_next):
         t0, t1 = self.transform(torch.as_tensor(sigma)), self.transform(torch.as_tensor(sigma_next))
-        noise = self.tree(t0, t1) / (t1 - t0).abs().sqrt()
-        return noise if self.rescale is None else self.rescale(noise, sigma, sigma_next)
+        return self.tree(t0, t1) / (t1 - t0).abs().sqrt()
 
 
 def sigma_to_half_log_snr(sigma, model_sampling):
@@ -234,7 +219,7 @@ def sample_euler_ancestral(model, x, sigmas, extra_args=None, callback=None, dis
     """Ancestral sampling with Euler method steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)
@@ -256,7 +241,7 @@ def sample_euler_ancestral_RF(model, x, sigmas, extra_args=None, callback=None, 
     """Ancestral sampling with Euler method steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
@@ -359,7 +344,7 @@ def sample_dpm_2_ancestral(model, x, sigmas, extra_args=None, callback=None, dis
     """Ancestral sampling with DPM-Solver second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)
@@ -388,7 +373,7 @@ def sample_dpm_2_ancestral_RF(model, x, sigmas, extra_args=None, callback=None, 
     """Ancestral sampling with DPM-Solver second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
@@ -540,7 +525,7 @@ class DPMSolver(nn.Module):
         return x_3, eps_cache
 
     def dpm_solver_fast(self, x, t_start, t_end, nfe, eta=0., s_noise=1., noise_sampler=None):
-        noise_sampler = default_noise_sampler(x, seed=self.extra_args.get("seed", None), model=self.model) if noise_sampler is None else noise_sampler
+        noise_sampler = default_noise_sampler(x, seed=self.extra_args.get("seed", None)) if noise_sampler is None else noise_sampler
         if not t_end > t_start and eta:
             raise ValueError('eta must be 0 for reverse sampling')
 
@@ -579,7 +564,7 @@ class DPMSolver(nn.Module):
         return x
 
     def dpm_solver_adaptive(self, x, t_start, t_end, order=3, rtol=0.05, atol=0.0078, h_init=0.05, pcoeff=0., icoeff=1., dcoeff=0., accept_safety=0.81, eta=0., s_noise=1., noise_sampler=None):
-        noise_sampler = default_noise_sampler(x, seed=self.extra_args.get("seed", None), model=self.model) if noise_sampler is None else noise_sampler
+        noise_sampler = default_noise_sampler(x, seed=self.extra_args.get("seed", None)) if noise_sampler is None else noise_sampler
         if order not in {2, 3}:
             raise ValueError('order should be 2 or 3')
         forward = t_end > t_start
@@ -667,7 +652,7 @@ def sample_dpmpp_2s_ancestral(model, x, sigmas, extra_args=None, callback=None, 
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
     sigma_fn = lambda t: t.neg().exp()
     t_fn = lambda sigma: sigma.log().neg()
@@ -702,7 +687,7 @@ def sample_dpmpp_2s_ancestral_RF(model, x, sigmas, extra_args=None, callback=Non
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
     sigma_fn = lambda lbda: (lbda.exp() + 1) ** -1
@@ -758,7 +743,7 @@ def sample_dpmpp_sde(model, x, sigmas, extra_args=None, callback=None, disable=N
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
     seed = extra_args.get("seed", None)
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -845,7 +830,7 @@ def sample_dpmpp_2m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -903,7 +888,7 @@ def sample_dpmpp_3m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -962,7 +947,7 @@ def sample_dpmpp_3m_sde_gpu(model, x, sigmas, extra_args=None, callback=None, di
         return x
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False) if noise_sampler is None else noise_sampler
     return sample_dpmpp_3m_sde(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=eta, s_noise=s_noise, noise_sampler=noise_sampler)
 
 
@@ -972,7 +957,7 @@ def sample_dpmpp_2m_sde_heun_gpu(model, x, sigmas, extra_args=None, callback=Non
         return x
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False) if noise_sampler is None else noise_sampler
     return sample_dpmpp_2m_sde_heun(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=eta, s_noise=s_noise, noise_sampler=noise_sampler, solver_type=solver_type)
 
 
@@ -982,7 +967,7 @@ def sample_dpmpp_2m_sde_gpu(model, x, sigmas, extra_args=None, callback=None, di
         return x
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False) if noise_sampler is None else noise_sampler
     return sample_dpmpp_2m_sde(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=eta, s_noise=s_noise, noise_sampler=noise_sampler, solver_type=solver_type)
 
 
@@ -992,7 +977,7 @@ def sample_dpmpp_sde_gpu(model, x, sigmas, extra_args=None, callback=None, disab
         return x
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False) if noise_sampler is None else noise_sampler
     return sample_dpmpp_sde(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=eta, s_noise=s_noise, noise_sampler=noise_sampler, r=r)
 
 
@@ -1009,7 +994,7 @@ def DDPMSampler_step(x, sigma, sigma_prev, noise, noise_sampler):
 def generic_step_sampler(model, x, sigmas, extra_args=None, callback=None, disable=None, noise_sampler=None, step_function=None):
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     for i in trange(len(sigmas) - 1, disable=disable):
@@ -1034,7 +1019,7 @@ def sample_lcm(model, x, sigmas, extra_args=None, callback=None, disable=None, n
 
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
     n_steps = max(1, len(sigmas) - 1)
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -1282,7 +1267,7 @@ def sample_euler_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback=No
     """Ancestral sampling with Euler method steps (CFG++)."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
 
     model_sampling = model.inner_model.model_patcher.get_model_object("model_sampling")
     lambda_fn = partial(sigma_to_half_log_snr, model_sampling=model_sampling)
@@ -1333,7 +1318,7 @@ def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
 
     temp = [0]
@@ -1409,7 +1394,7 @@ def sample_dpmpp_2m_cfg_pp(model, x, sigmas, extra_args=None, callback=None, dis
 def res_multistep(model, x, sigmas, extra_args=None, callback=None, disable=None, s_noise=1., noise_sampler=None, eta=1., cfg_pp=False):
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
     sigma_fn = lambda t: t.neg().exp()
@@ -1543,7 +1528,7 @@ def sample_er_sde(model, x, sigmas, extra_args=None, callback=None, disable=None
     """
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
 
@@ -1613,7 +1598,7 @@ def sample_seeds_2(model, x, sigmas, extra_args=None, callback=None, disable=Non
 
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -1685,7 +1670,7 @@ def sample_seeds_3(model, x, sigmas, extra_args=None, callback=None, disable=Non
     """
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -1752,7 +1737,7 @@ def sample_sa_solver(model, x, sigmas, extra_args=None, callback=None, disable=F
         return x
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object("model_sampling")
@@ -1852,7 +1837,7 @@ def sample_sa_solver(model, x, sigmas, extra_args=None, callback=None, disable=F
 
 @torch.no_grad()
 def sample_sa_solver_pece(model, x, sigmas, extra_args=None, callback=None, disable=False, tau_func=None, s_noise=1.0, noise_sampler=None, predictor_order=3, corrector_order=4, simple_order_2=False):
-    """Stochastic Adams Solver with PECE (Predictâ€“Evaluateâ€“Correctâ€“Evaluate) mode (NeurIPS 2023)."""
+    """Stochastic Adams Solver with PECE (Predict–Evaluate–Correct–Evaluate) mode (NeurIPS 2023)."""
     return sample_sa_solver(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, tau_func=tau_func, s_noise=s_noise, noise_sampler=noise_sampler, predictor_order=predictor_order, corrector_order=corrector_order, use_pece=True, simple_order_2=simple_order_2)
 
 
@@ -1886,7 +1871,7 @@ def sample_ar_video(model, x, sigmas, extra_args=None, callback=None, disable=No
         raise TypeError(
             "ar_video sampler requires a Causal-WAN compatible model whose diffusion_model "
             "exposes init_kv_caches() and init_crossattn_caches(). The loaded checkpoint "
-            "does not support this interface â€” choose a different sampler."
+            "does not support this interface — choose a different sampler."
         )
 
     seed = extra_args.get("seed", 0)

--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -75,7 +75,15 @@ def get_ancestral_step(sigma_from, sigma_to, eta=1.):
     return sigma_down, sigma_up
 
 
-def default_noise_sampler(x, seed=None):
+def model_noise_rescaler(model):
+    # models with multiple sigma schedules in one packed latent expose
+    # scale_stochastic_noise on their model_sampling (see ModelSamplingAV)
+    if model is None:
+        return None
+    return getattr(model.inner_model.inner_model.model_sampling, "scale_stochastic_noise", None)
+
+
+def default_noise_sampler(x, seed=None, model=None):
     if seed is not None:
         if x.device == torch.device("cpu"):
             seed += 1
@@ -85,7 +93,12 @@ def default_noise_sampler(x, seed=None):
     else:
         generator = None
 
-    return lambda sigma, sigma_next: torch.randn(x.size(), dtype=x.dtype, layout=x.layout, device=x.device, generator=generator)
+    rescale = model_noise_rescaler(model)
+
+    def noise_sampler(sigma, sigma_next):
+        noise = torch.randn(x.size(), dtype=x.dtype, layout=x.layout, device=x.device, generator=generator)
+        return noise if rescale is None else rescale(noise, sigma, sigma_next)
+    return noise_sampler
 
 
 class BatchedBrownianTree:
@@ -139,14 +152,16 @@ class BrownianTreeNoiseSampler:
             internal timestep.
     """
 
-    def __init__(self, x, sigma_min, sigma_max, seed=None, transform=lambda x: x, cpu=False):
+    def __init__(self, x, sigma_min, sigma_max, seed=None, transform=lambda x: x, cpu=False, model=None):
         self.transform = transform
+        self.rescale = model_noise_rescaler(model)
         t0, t1 = self.transform(torch.as_tensor(sigma_min)), self.transform(torch.as_tensor(sigma_max))
         self.tree = BatchedBrownianTree(x, t0, t1, seed, cpu=cpu)
 
     def __call__(self, sigma, sigma_next):
         t0, t1 = self.transform(torch.as_tensor(sigma)), self.transform(torch.as_tensor(sigma_next))
-        return self.tree(t0, t1) / (t1 - t0).abs().sqrt()
+        noise = self.tree(t0, t1) / (t1 - t0).abs().sqrt()
+        return noise if self.rescale is None else self.rescale(noise, sigma, sigma_next)
 
 
 def sigma_to_half_log_snr(sigma, model_sampling):
@@ -219,7 +234,7 @@ def sample_euler_ancestral(model, x, sigmas, extra_args=None, callback=None, dis
     """Ancestral sampling with Euler method steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)
@@ -241,7 +256,7 @@ def sample_euler_ancestral_RF(model, x, sigmas, extra_args=None, callback=None, 
     """Ancestral sampling with Euler method steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
@@ -344,7 +359,7 @@ def sample_dpm_2_ancestral(model, x, sigmas, extra_args=None, callback=None, dis
     """Ancestral sampling with DPM-Solver second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)
@@ -373,7 +388,7 @@ def sample_dpm_2_ancestral_RF(model, x, sigmas, extra_args=None, callback=None, 
     """Ancestral sampling with DPM-Solver second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
     for i in trange(len(sigmas) - 1, disable=disable):
@@ -525,7 +540,7 @@ class DPMSolver(nn.Module):
         return x_3, eps_cache
 
     def dpm_solver_fast(self, x, t_start, t_end, nfe, eta=0., s_noise=1., noise_sampler=None):
-        noise_sampler = default_noise_sampler(x, seed=self.extra_args.get("seed", None)) if noise_sampler is None else noise_sampler
+        noise_sampler = default_noise_sampler(x, seed=self.extra_args.get("seed", None), model=self.model) if noise_sampler is None else noise_sampler
         if not t_end > t_start and eta:
             raise ValueError('eta must be 0 for reverse sampling')
 
@@ -564,7 +579,7 @@ class DPMSolver(nn.Module):
         return x
 
     def dpm_solver_adaptive(self, x, t_start, t_end, order=3, rtol=0.05, atol=0.0078, h_init=0.05, pcoeff=0., icoeff=1., dcoeff=0., accept_safety=0.81, eta=0., s_noise=1., noise_sampler=None):
-        noise_sampler = default_noise_sampler(x, seed=self.extra_args.get("seed", None)) if noise_sampler is None else noise_sampler
+        noise_sampler = default_noise_sampler(x, seed=self.extra_args.get("seed", None), model=self.model) if noise_sampler is None else noise_sampler
         if order not in {2, 3}:
             raise ValueError('order should be 2 or 3')
         forward = t_end > t_start
@@ -652,7 +667,7 @@ def sample_dpmpp_2s_ancestral(model, x, sigmas, extra_args=None, callback=None, 
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
     sigma_fn = lambda t: t.neg().exp()
     t_fn = lambda sigma: sigma.log().neg()
@@ -687,7 +702,7 @@ def sample_dpmpp_2s_ancestral_RF(model, x, sigmas, extra_args=None, callback=Non
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
     sigma_fn = lambda lbda: (lbda.exp() + 1) ** -1
@@ -743,7 +758,7 @@ def sample_dpmpp_sde(model, x, sigmas, extra_args=None, callback=None, disable=N
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
     seed = extra_args.get("seed", None)
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -830,7 +845,7 @@ def sample_dpmpp_2m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -888,7 +903,7 @@ def sample_dpmpp_3m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=seed, cpu=True, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -947,7 +962,7 @@ def sample_dpmpp_3m_sde_gpu(model, x, sigmas, extra_args=None, callback=None, di
         return x
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False, model=model) if noise_sampler is None else noise_sampler
     return sample_dpmpp_3m_sde(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=eta, s_noise=s_noise, noise_sampler=noise_sampler)
 
 
@@ -957,7 +972,7 @@ def sample_dpmpp_2m_sde_heun_gpu(model, x, sigmas, extra_args=None, callback=Non
         return x
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False, model=model) if noise_sampler is None else noise_sampler
     return sample_dpmpp_2m_sde_heun(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=eta, s_noise=s_noise, noise_sampler=noise_sampler, solver_type=solver_type)
 
 
@@ -967,7 +982,7 @@ def sample_dpmpp_2m_sde_gpu(model, x, sigmas, extra_args=None, callback=None, di
         return x
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False, model=model) if noise_sampler is None else noise_sampler
     return sample_dpmpp_2m_sde(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=eta, s_noise=s_noise, noise_sampler=noise_sampler, solver_type=solver_type)
 
 
@@ -977,7 +992,7 @@ def sample_dpmpp_sde_gpu(model, x, sigmas, extra_args=None, callback=None, disab
         return x
     extra_args = {} if extra_args is None else extra_args
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
-    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False) if noise_sampler is None else noise_sampler
+    noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=extra_args.get("seed", None), cpu=False, model=model) if noise_sampler is None else noise_sampler
     return sample_dpmpp_sde(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, eta=eta, s_noise=s_noise, noise_sampler=noise_sampler, r=r)
 
 
@@ -994,7 +1009,7 @@ def DDPMSampler_step(x, sigma, sigma_prev, noise, noise_sampler):
 def generic_step_sampler(model, x, sigmas, extra_args=None, callback=None, disable=None, noise_sampler=None, step_function=None):
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     for i in trange(len(sigmas) - 1, disable=disable):
@@ -1019,7 +1034,7 @@ def sample_lcm(model, x, sigmas, extra_args=None, callback=None, disable=None, n
 
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
     n_steps = max(1, len(sigmas) - 1)
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -1267,7 +1282,7 @@ def sample_euler_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback=No
     """Ancestral sampling with Euler method steps (CFG++)."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
 
     model_sampling = model.inner_model.model_patcher.get_model_object("model_sampling")
     lambda_fn = partial(sigma_to_half_log_snr, model_sampling=model_sampling)
@@ -1318,7 +1333,7 @@ def sample_dpmpp_2s_ancestral_cfg_pp(model, x, sigmas, extra_args=None, callback
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
 
     temp = [0]
@@ -1394,7 +1409,7 @@ def sample_dpmpp_2m_cfg_pp(model, x, sigmas, extra_args=None, callback=None, dis
 def res_multistep(model, x, sigmas, extra_args=None, callback=None, disable=None, s_noise=1., noise_sampler=None, eta=1., cfg_pp=False):
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
     sigma_fn = lambda t: t.neg().exp()
@@ -1528,7 +1543,7 @@ def sample_er_sde(model, x, sigmas, extra_args=None, callback=None, disable=None
     """
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_noise = s_noise * getattr(model.inner_model.model_patcher.get_model_object('model_sampling'), "noise_scale", 1.0)
     s_in = x.new_ones([x.shape[0]])
 
@@ -1598,7 +1613,7 @@ def sample_seeds_2(model, x, sigmas, extra_args=None, callback=None, disable=Non
 
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -1670,7 +1685,7 @@ def sample_seeds_3(model, x, sigmas, extra_args=None, callback=None, disable=Non
     """
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object('model_sampling')
@@ -1737,7 +1752,7 @@ def sample_sa_solver(model, x, sigmas, extra_args=None, callback=None, disable=F
         return x
     extra_args = {} if extra_args is None else extra_args
     seed = extra_args.get("seed", None)
-    noise_sampler = default_noise_sampler(x, seed=seed) if noise_sampler is None else noise_sampler
+    noise_sampler = default_noise_sampler(x, seed=seed, model=model) if noise_sampler is None else noise_sampler
     s_in = x.new_ones([x.shape[0]])
 
     model_sampling = model.inner_model.model_patcher.get_model_object("model_sampling")
@@ -1837,7 +1852,7 @@ def sample_sa_solver(model, x, sigmas, extra_args=None, callback=None, disable=F
 
 @torch.no_grad()
 def sample_sa_solver_pece(model, x, sigmas, extra_args=None, callback=None, disable=False, tau_func=None, s_noise=1.0, noise_sampler=None, predictor_order=3, corrector_order=4, simple_order_2=False):
-    """Stochastic Adams Solver with PECE (Predict–Evaluate–Correct–Evaluate) mode (NeurIPS 2023)."""
+    """Stochastic Adams Solver with PECE (Predictâ€“Evaluateâ€“Correctâ€“Evaluate) mode (NeurIPS 2023)."""
     return sample_sa_solver(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, tau_func=tau_func, s_noise=s_noise, noise_sampler=noise_sampler, predictor_order=predictor_order, corrector_order=corrector_order, use_pece=True, simple_order_2=simple_order_2)
 
 
@@ -1871,7 +1886,7 @@ def sample_ar_video(model, x, sigmas, extra_args=None, callback=None, disable=No
         raise TypeError(
             "ar_video sampler requires a Causal-WAN compatible model whose diffusion_model "
             "exposes init_kv_caches() and init_crossattn_caches(). The loaded checkpoint "
-            "does not support this interface — choose a different sampler."
+            "does not support this interface â€” choose a different sampler."
         )
 
     seed = extra_args.get("seed", 0)

--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -9,8 +9,9 @@ The packed sequence is:
 Timestep domain: the model receives the *video* sigma from the sampler and
 derives per-token timesteps t = 1 - sigma internally; the audio stream runs on
 its own shifted schedule (sigma_shift video 12.0 / audio 3.0), mapped from the
-video sigma in closed form. The audio velocity is returned scaled by the
-schedule map's derivative d(sigma_a)/d(sigma_v).
+video sigma in closed form. _forward returns raw per-stream velocity; forward()
+scales the audio velocity by d(sigma_a)/d(sigma_v) so stock samplers can
+integrate the flat pack on the video schedule.
 """
 
 import math
@@ -496,11 +497,19 @@ class MiniMaxH3Model(nn.Module):
         return torch.cat(rows, dim=0) if rows else None
 
     def forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
-        return comfy.patcher_extension.WrapperExecutor.new_class_executor(
+        out = comfy.patcher_extension.WrapperExecutor.new_class_executor(
             self._forward,
             self,
             comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options)
         ).execute(x, timestep, context, transformer_options, minimax_payload=minimax_payload, **kwargs)
+        # scale the audio velocity by d(sigma_a)/d(sigma_v) so the flat ODE on video
+        # sigmas integrates the audio stream correctly; done outside the wrappers so
+        # they see the raw velocity
+        shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+        shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+        sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+        out[1] = out[1] * time_shift_slope(sigma_v, shift_v, shift_a).to(out[1].dtype)
+        return out
 
     def _forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
         video_x, audio_x = x[0], x[1]
@@ -639,8 +648,4 @@ class MiniMaxH3Model(nn.Module):
         video_out = video_out[:, :, :orig_t, :orig_h, :orig_w]
         audio_out = unpack_audio(a)
 
-        # The sampler integrates the flat ODE dX/dsigma_v = (X - denoised)/sigma_v.
-        # Scaling the audio velocity by d(sigma_a)/d(sigma_v) makes that ODE equal
-        # to the audio stream's true ODE on its own shifted schedule.
-        slope_a = time_shift_slope(sigma_v, shift_v, shift_a).to(audio_out.dtype)
-        return [-video_out.to(video_x.dtype), (-slope_a) * audio_out.to(audio_x.dtype)]
+        return [-video_out.to(video_x.dtype), -audio_out.to(audio_x.dtype)]

--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -39,11 +39,6 @@ def time_shift_sigma(sigma, from_shift, to_shift):
     return to_shift * base / (1.0 + (to_shift - 1.0) * base)
 
 
-def audio_stream_scale(from_shift, to_shift):
-    # a shift is a pure scale on lambda = sigma/(1-sigma), so the schedules differ by this constant
-    return from_shift / to_shift
-
-
 def patchify_video(latent, patch_size=(1, 2, 2)):
     # [B, C, T, H, W] -> [B*t*h*w, C*pt*ph*pw]
     b, c, t_full, h_full, w_full = latent.shape
@@ -497,7 +492,7 @@ class MiniMaxH3Model(nn.Module):
         shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
         sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
         sigma_a = time_shift_sigma(sigma_v, shift_v, shift_a)
-        scale = audio_stream_scale(shift_v, shift_a)
+        scale = float((minimax_payload or {}).get("audio_scale", 1.0))
 
         audio_x = x[1]
         if scale != 1.0:

--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -488,14 +488,13 @@ class MiniMaxH3Model(nn.Module):
     def forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
         # the sampler carries the audio as (sigma_v / sigma_a) * x_audio; undo it outside
         # the wrappers so they and the network see the stream's own latent and velocity
-        shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
-        shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
-        sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
-        sigma_a = time_shift_sigma(sigma_v, shift_v, shift_a)
         scale = float((minimax_payload or {}).get("audio_scale", 1.0))
-
         audio_x = x[1]
         if scale != 1.0:
+            shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+            shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+            sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+            sigma_a = time_shift_sigma(sigma_v, shift_v, shift_a)
             audio_x = audio_x * (sigma_a / sigma_v).to(audio_x.dtype)
             x = [x[0], audio_x]
 

--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -9,9 +9,9 @@ The packed sequence is:
 Timestep domain: the model receives the *video* sigma from the sampler and
 derives per-token timesteps t = 1 - sigma internally; the audio stream runs on
 its own shifted schedule (sigma_shift video 12.0 / audio 3.0), mapped from the
-video sigma in closed form. _forward returns raw per-stream velocity; forward()
-scales the audio velocity by d(sigma_a)/d(sigma_v) so stock samplers can
-integrate the flat pack on the video schedule.
+video sigma in closed form. The sampler carries the audio latent scaled onto the
+video schedule (ModelSamplingAV); forward() undoes that scale and converts the
+velocity back, so _forward only ever sees the stream's own latent.
 """
 
 import math
@@ -39,15 +39,9 @@ def time_shift_sigma(sigma, from_shift, to_shift):
     return to_shift * base / (1.0 + (to_shift - 1.0) * base)
 
 
-def time_shift_slope(sigma, from_shift, to_shift):
-    """d(sigma_to)/d(sigma_from) at the same base-grid point.
-
-    Scaling a stream's returned velocity by this slope makes the flat ODE that
-    any sampler integrates on the from-schedule equal to that stream's true ODE
-    on its own schedule.
-    """
-    base = sigma / (from_shift + sigma * (1.0 - from_shift))
-    return (to_shift * (1.0 + (from_shift - 1.0) * base) ** 2) / (from_shift * (1.0 + (to_shift - 1.0) * base) ** 2)
+def audio_stream_scale(from_shift, to_shift):
+    # a shift is a pure scale on lambda = sigma/(1-sigma), so the schedules differ by this constant
+    return from_shift / to_shift
 
 
 def patchify_video(latent, patch_size=(1, 2, 2)):
@@ -497,18 +491,29 @@ class MiniMaxH3Model(nn.Module):
         return torch.cat(rows, dim=0) if rows else None
 
     def forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):
+        # the sampler carries the audio as (sigma_v / sigma_a) * x_audio; undo it outside
+        # the wrappers so they and the network see the stream's own latent and velocity
+        shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
+        shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
+        sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
+        sigma_a = time_shift_sigma(sigma_v, shift_v, shift_a)
+        scale = audio_stream_scale(shift_v, shift_a)
+
+        audio_x = x[1]
+        if scale != 1.0:
+            audio_x = audio_x * (sigma_a / sigma_v).to(audio_x.dtype)
+            x = [x[0], audio_x]
+
         out = comfy.patcher_extension.WrapperExecutor.new_class_executor(
             self._forward,
             self,
             comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options)
         ).execute(x, timestep, context, transformer_options, minimax_payload=minimax_payload, **kwargs)
-        # scale the audio velocity by d(sigma_a)/d(sigma_v) so the flat ODE on video
-        # sigmas integrates the audio stream correctly; done outside the wrappers so
-        # they see the raw velocity
-        shift_v = float(transformer_options.get("minimax_h3_sigma_shift_video", self.sigma_shift_video))
-        shift_a = float(transformer_options.get("minimax_h3_sigma_shift_audio", self.sigma_shift_audio))
-        sigma_v = (timestep.flatten()[0] / 1000.0).float().clamp(min=1e-6)
-        out[1] = out[1] * time_shift_slope(sigma_v, shift_v, shift_a).to(out[1].dtype)
+
+        if scale != 1.0:
+            # d/d(sigma_v) of the carried variable
+            out[1] = ((1.0 - scale) * audio_x
+                      + (1.0 + (scale - 1.0) * sigma_a).to(out[1].dtype) * out[1])
         return out
 
     def _forward(self, x, timestep, context, transformer_options={}, minimax_payload=None, **kwargs):

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -2118,9 +2118,6 @@ class MiniMaxH3(BaseModel):
         out['minimax_payload'] = comfy.conds.CONDConstant(payload)
         return out
 
-    def scale_latent_inpaint(self, sigma, noise, latent_image, **kwargs):
-        return latent_image
-
 class TripoSplat(BaseModel):
     def __init__(self, model_config, model_type=ModelType.FLOW, device=None):
         super().__init__(model_config, model_type, device=device, unet_model=comfy.ldm.triposplat.model.LatentSeqMMFlowModel)

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -22,6 +22,7 @@ import torch
 import logging
 import comfy.ldm.lightricks.av_model
 import comfy.ldm.minimax.model
+import comfy.nested_tensor
 import comfy.ldm.lightricks.symmetric_patchifier
 import comfy.context_windows
 from comfy.ldm.modules.diffusionmodules.openaimodel import UNetModel, Timestep
@@ -2072,6 +2073,26 @@ class MiniMaxH3(BaseModel):
     def __init__(self, model_config, model_type=ModelType.FLOW_AV, device=None):
         super().__init__(model_config, model_type, device=device, unet_model=comfy.ldm.minimax.model.MiniMaxH3Model)
 
+    def _scale_audio_slice(self, latent, scale):
+        # the sampler carries the audio stream scaled onto the video schedule
+        if scale == 1.0:
+            return latent
+        if getattr(latent, "is_nested", False):  # x0 output hands back the unpacked view
+            streams = latent.unbind()
+            return comfy.nested_tensor.NestedTensor([streams[0], streams[1] * scale] + list(streams[2:]))
+        n = self.model_sampling.video_numel()
+        if n is None or latent.ndim != 3 or latent.shape[-1] <= n:
+            return latent  # not the flat pack
+        latent = latent.clone()
+        latent[..., n:] *= scale
+        return latent
+
+    def process_latent_in(self, latent):
+        return self._scale_audio_slice(super().process_latent_in(latent), self.model_sampling.audio_scale)
+
+    def process_latent_out(self, latent):
+        return super().process_latent_out(self._scale_audio_slice(latent, 1.0 / self.model_sampling.audio_scale))
+
     def extra_conds(self, **kwargs):
         out = super().extra_conds(**kwargs)
         cross_attn = kwargs.get("cross_attn", None)
@@ -2084,8 +2105,6 @@ class MiniMaxH3(BaseModel):
         latent_shapes = kwargs.get("latent_shapes", None)
         if latent_shapes is not None:
             out['latent_shapes'] = comfy.conds.CONDConstant(latent_shapes)
-
-        self.model_sampling.latent_shapes = latent_shapes
 
         # Everything H3-specific rides in one dict so _apply_model's dtype cast
         # (which would flatten fp32 cond latents and long tags to bf16) skips it.

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -2073,6 +2073,12 @@ class MiniMaxH3(BaseModel):
     def __init__(self, model_config, model_type=ModelType.FLOW_AV, device=None):
         super().__init__(model_config, model_type, device=device, unet_model=comfy.ldm.minimax.model.MiniMaxH3Model)
 
+    def audio_scale(self):
+        """Scale the sampler carries the audio stream at, 1.0 when not sampling the packed latent."""
+        if self.model_sampling.video_numel() is None:
+            return 1.0
+        return self.model_sampling.audio_scale
+
     def _scale_audio_slice(self, latent, scale):
         # the sampler carries the audio stream scaled onto the video schedule
         if scale == 1.0:
@@ -2088,10 +2094,10 @@ class MiniMaxH3(BaseModel):
         return latent
 
     def process_latent_in(self, latent):
-        return self._scale_audio_slice(super().process_latent_in(latent), self.model_sampling.audio_scale)
+        return self._scale_audio_slice(super().process_latent_in(latent), self.audio_scale())
 
     def process_latent_out(self, latent):
-        return super().process_latent_out(self._scale_audio_slice(latent, 1.0 / self.model_sampling.audio_scale))
+        return super().process_latent_out(self._scale_audio_slice(latent, 1.0 / self.audio_scale()))
 
     def extra_conds(self, **kwargs):
         out = super().extra_conds(**kwargs)
@@ -2127,6 +2133,8 @@ class MiniMaxH3(BaseModel):
         if kwargs.get("minimax_audio_cond_noise_aug", None) is not None:
             payload["audio_cond_noise_aug"] = kwargs["minimax_audio_cond_noise_aug"]
         payload["seed"] = kwargs.get("seed", 0)
+        # same value process_latent_in/out used, so the model never undoes a scale that was not applied
+        payload["audio_scale"] = self.audio_scale()
         if cross_attn is not None and latent_shapes is not None and len(latent_shapes) > 1:
             # packed layout built once per sampling run, h/w rounded up to the DiT's 2x2 patch
             vs = latent_shapes[0]

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -185,6 +185,7 @@ class BaseModel(torch.nn.Module):
 
         self.model_type = model_type
         self.model_sampling = model_sampling(model_config, model_type)
+        self.latent_shapes = None  # set by the sampler for models that pack several streams into one latent
 
         self.adm_channels = unet_config.get("adm_in_channels", None)
         if self.adm_channels is None:
@@ -2075,7 +2076,7 @@ class MiniMaxH3(BaseModel):
 
     def audio_scale(self):
         """Scale the sampler carries the audio stream at, 1.0 when not sampling the packed latent."""
-        if self.model_sampling.video_numel() is None:
+        if self.latent_shapes is None or len(self.latent_shapes) < 2:
             return 1.0
         return self.model_sampling.audio_scale
 
@@ -2083,12 +2084,10 @@ class MiniMaxH3(BaseModel):
         # the sampler carries the audio stream scaled onto the video schedule
         if scale == 1.0:
             return latent
-        if getattr(latent, "is_nested", False):  # x0 output hands back the unpacked view
+        if latent.is_nested:  # the x0 output hands back the unpacked view
             streams = latent.unbind()
             return comfy.nested_tensor.NestedTensor([streams[0], streams[1] * scale] + list(streams[2:]))
-        n = self.model_sampling.video_numel()
-        if n is None or latent.ndim != 3 or latent.shape[-1] <= n:
-            return latent  # not the flat pack
+        n = math.prod(self.latent_shapes[0][1:])
         latent = latent.clone()
         latent[..., n:] *= scale
         return latent

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -100,6 +100,7 @@ class ModelType(Enum):
     FLOW_COSMOS = 10
     IMG_TO_IMG_FLOW = 11
     V_PREDICTION_DDPM = 12
+    FLOW_AV = 13
 
 
 def model_sampling(model_config, model_type):
@@ -136,6 +137,9 @@ def model_sampling(model_config, model_type):
         c = comfy.model_sampling.IMG_TO_IMG_FLOW
     elif model_type == ModelType.V_PREDICTION_DDPM:
         c = comfy.model_sampling.V_PREDICTION_DDPM
+    elif model_type == ModelType.FLOW_AV:
+        c = comfy.model_sampling.CONST
+        s = comfy.model_sampling.ModelSamplingAV
 
     class ModelSampling(s, c):
         pass
@@ -2065,7 +2069,7 @@ class Hunyuan3Dv2_1(BaseModel):
         return out
 
 class MiniMaxH3(BaseModel):
-    def __init__(self, model_config, model_type=ModelType.FLOW, device=None):
+    def __init__(self, model_config, model_type=ModelType.FLOW_AV, device=None):
         super().__init__(model_config, model_type, device=device, unet_model=comfy.ldm.minimax.model.MiniMaxH3Model)
 
     def extra_conds(self, **kwargs):
@@ -2080,6 +2084,8 @@ class MiniMaxH3(BaseModel):
         latent_shapes = kwargs.get("latent_shapes", None)
         if latent_shapes is not None:
             out['latent_shapes'] = comfy.conds.CONDConstant(latent_shapes)
+
+        self.model_sampling.latent_shapes = latent_shapes
 
         # Everything H3-specific rides in one dict so _apply_model's dtype cast
         # (which would flatten fp32 cond latents and long tags to bf16) skips it.

--- a/comfy/model_sampling.py
+++ b/comfy/model_sampling.py
@@ -335,7 +335,6 @@ class ModelSamplingAV(ModelSamplingDiscreteFlow):
         super().__init__(model_config)
         sampling_settings = model_config.sampling_settings if model_config is not None else {}
         self.audio_shift = sampling_settings.get("audio_shift", None)
-        self.latent_shapes = None
 
     def set_parameters(self, shift=1.0, audio_shift=None, timesteps=1000, multiplier=1000):
         self.audio_shift = audio_shift
@@ -346,12 +345,6 @@ class ModelSamplingAV(ModelSamplingDiscreteFlow):
         if self.audio_shift is None:
             return 1.0
         return self.shift / self.audio_shift
-
-    def video_numel(self):
-        """Width of the video slice in the flat pack, None when not sampling one."""
-        if not self.latent_shapes or len(self.latent_shapes) < 2:
-            return None
-        return math.prod(self.latent_shapes[0][1:])
 
 class StableCascadeSampling(ModelSamplingDiscrete):
     def __init__(self, model_config=None):

--- a/comfy/model_sampling.py
+++ b/comfy/model_sampling.py
@@ -326,9 +326,11 @@ class ModelSamplingDiscreteFlow(torch.nn.Module):
         return time_snr_shift(self.shift, 1.0 - percent)
 
 class ModelSamplingAV(ModelSamplingDiscreteFlow):
-    """Flow sampling for packed audio-video latents where the audio stream runs on
-    its own flow shift (sampling_settings "audio_shift"). The model's extra_conds
-    stashes latent_shapes each run; each stream is then noised at its own sigma."""
+    """Flow sampling for packed audio-video latents whose audio stream has its own flow shift.
+
+    Carrying the audio latent scaled by sigma / audio_sigma makes the pack an ordinary
+    single-schedule flow latent whose audio target is scaled by audio_scale.
+    """
     def __init__(self, model_config=None):
         super().__init__(model_config)
         sampling_settings = model_config.sampling_settings if model_config is not None else {}
@@ -345,38 +347,17 @@ class ModelSamplingAV(ModelSamplingDiscreteFlow):
         base = float(sigma) / (self.shift + float(sigma) * (1.0 - self.shift))
         return shift_a * base / (1.0 + (shift_a - 1.0) * base)
 
-    def _column_sigmas(self, sigma, device):
-        # [1, 1, N]: video columns get the sampler's sigma, audio columns their own
-        cols = [torch.full((math.prod(s[1:]),), v, device=device) for s, v in zip(self.latent_shapes, (float(sigma), self.audio_sigma(sigma)))]
-        return torch.cat(cols).reshape(1, 1, -1)
+    @property
+    def audio_scale(self):
+        if self.audio_shift is None:
+            return 1.0
+        return self.shift / self.audio_shift
 
-    def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
-        if self.latent_shapes is None:  # not sampling the packed AV latent
-            return super().noise_scaling(sigma, noise, latent_image, max_denoise)
-        sigmas = self._column_sigmas(sigma, noise.device)
-        return sigmas * (self.noise_scale * noise) + (1.0 - sigmas) * latent_image
-
-    def inverse_noise_scaling(self, sigma, latent):
-        if self.latent_shapes is None:
-            return super().inverse_noise_scaling(sigma, latent)
-        return latent / (1.0 - self._column_sigmas(sigma, latent.device))
-
-    def scale_stochastic_noise(self, noise, sigma, sigma_next):
-        # per-stream / sampler-schedule ratio of RF-ancestral noise magnitudes;
-        # exact for euler_ancestral, first order for the other stochastic samplers
-        s_from, s_to = float(sigma), float(sigma_next)
-        if self.latent_shapes is None or s_to <= 0.0 or s_from <= s_to:
-            return noise
-
-        def coeff_sq(sf, st):
-            sigma_down = st * st / sf
-            return st ** 2 - sigma_down ** 2 * (1.0 - st) ** 2 / (1.0 - sigma_down) ** 2
-
-        base = coeff_sq(s_from, s_to)
-        if base <= 0.0:
-            return noise
-        cols = coeff_sq(self._column_sigmas(s_from, noise.device), self._column_sigmas(s_to, noise.device))
-        return noise * (cols.clamp(min=0.0).sqrt() / base ** 0.5)
+    def video_numel(self):
+        """Width of the video slice in the flat pack, None when not sampling one."""
+        if not self.latent_shapes or len(self.latent_shapes) < 2:
+            return None
+        return math.prod(self.latent_shapes[0][1:])
 
 class StableCascadeSampling(ModelSamplingDiscrete):
     def __init__(self, model_config=None):

--- a/comfy/model_sampling.py
+++ b/comfy/model_sampling.py
@@ -328,7 +328,7 @@ class ModelSamplingDiscreteFlow(torch.nn.Module):
 class ModelSamplingAV(ModelSamplingDiscreteFlow):
     """Flow sampling for packed audio-video latents whose audio stream has its own flow shift.
 
-    Carrying the audio latent scaled by sigma / audio_sigma makes the pack an ordinary
+    Carrying the audio latent scaled onto the video schedule makes the pack an ordinary
     single-schedule flow latent whose audio target is scaled by audio_scale.
     """
     def __init__(self, model_config=None):
@@ -340,12 +340,6 @@ class ModelSamplingAV(ModelSamplingDiscreteFlow):
     def set_parameters(self, shift=1.0, audio_shift=None, timesteps=1000, multiplier=1000):
         self.audio_shift = audio_shift
         super().set_parameters(shift=shift, timesteps=timesteps, multiplier=multiplier)
-
-    def audio_sigma(self, sigma):
-        """The audio stream's sigma at the sampler's (video) sigma."""
-        shift_a = self.shift if self.audio_shift is None else self.audio_shift
-        base = float(sigma) / (self.shift + float(sigma) * (1.0 - self.shift))
-        return shift_a * base / (1.0 + (shift_a - 1.0) * base)
 
     @property
     def audio_scale(self):

--- a/comfy/model_sampling.py
+++ b/comfy/model_sampling.py
@@ -325,6 +325,59 @@ class ModelSamplingDiscreteFlow(torch.nn.Module):
             return 0.0
         return time_snr_shift(self.shift, 1.0 - percent)
 
+class ModelSamplingAV(ModelSamplingDiscreteFlow):
+    """Flow sampling for packed audio-video latents where the audio stream runs on
+    its own flow shift (sampling_settings "audio_shift"). The model's extra_conds
+    stashes latent_shapes each run; each stream is then noised at its own sigma."""
+    def __init__(self, model_config=None):
+        super().__init__(model_config)
+        sampling_settings = model_config.sampling_settings if model_config is not None else {}
+        self.audio_shift = sampling_settings.get("audio_shift", None)
+        self.latent_shapes = None
+
+    def set_parameters(self, shift=1.0, audio_shift=None, timesteps=1000, multiplier=1000):
+        self.audio_shift = audio_shift
+        super().set_parameters(shift=shift, timesteps=timesteps, multiplier=multiplier)
+
+    def audio_sigma(self, sigma):
+        """The audio stream's sigma at the sampler's (video) sigma."""
+        shift_a = self.shift if self.audio_shift is None else self.audio_shift
+        base = float(sigma) / (self.shift + float(sigma) * (1.0 - self.shift))
+        return shift_a * base / (1.0 + (shift_a - 1.0) * base)
+
+    def _column_sigmas(self, sigma, device):
+        # [1, 1, N]: video columns get the sampler's sigma, audio columns their own
+        cols = [torch.full((math.prod(s[1:]),), v, device=device) for s, v in zip(self.latent_shapes, (float(sigma), self.audio_sigma(sigma)))]
+        return torch.cat(cols).reshape(1, 1, -1)
+
+    def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
+        if self.latent_shapes is None:  # not sampling the packed AV latent
+            return super().noise_scaling(sigma, noise, latent_image, max_denoise)
+        sigmas = self._column_sigmas(sigma, noise.device)
+        return sigmas * (self.noise_scale * noise) + (1.0 - sigmas) * latent_image
+
+    def inverse_noise_scaling(self, sigma, latent):
+        if self.latent_shapes is None:
+            return super().inverse_noise_scaling(sigma, latent)
+        return latent / (1.0 - self._column_sigmas(sigma, latent.device))
+
+    def scale_stochastic_noise(self, noise, sigma, sigma_next):
+        # per-stream / sampler-schedule ratio of RF-ancestral noise magnitudes;
+        # exact for euler_ancestral, first order for the other stochastic samplers
+        s_from, s_to = float(sigma), float(sigma_next)
+        if self.latent_shapes is None or s_to <= 0.0 or s_from <= s_to:
+            return noise
+
+        def coeff_sq(sf, st):
+            sigma_down = st * st / sf
+            return st ** 2 - sigma_down ** 2 * (1.0 - st) ** 2 / (1.0 - sigma_down) ** 2
+
+        base = coeff_sq(s_from, s_to)
+        if base <= 0.0:
+            return noise
+        cols = coeff_sq(self._column_sigmas(s_from, noise.device), self._column_sigmas(s_to, noise.device))
+        return noise * (cols.clamp(min=0.0).sqrt() / base ** 0.5)
+
 class StableCascadeSampling(ModelSamplingDiscrete):
     def __init__(self, model_config=None):
         super().__init__()

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1218,9 +1218,7 @@ class CFGGuider:
         return sampling_function(self.inner_model, x, timestep, self.conds.get("negative", None), self.conds.get("positive", None), self.cfg, model_options=model_options, seed=seed)
 
     def inner_sample(self, noise, latent_image, device, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=None):
-        if hasattr(self.inner_model.model_sampling, "latent_shapes"):
-            # models that pack several streams into one latent need the split before process_latent_in
-            self.inner_model.model_sampling.latent_shapes = latent_shapes
+        self.inner_model.latent_shapes = latent_shapes
 
         if latent_image is not None and torch.count_nonzero(latent_image) > 0: #Don't shift the empty latent image.
             latent_image = self.inner_model.process_latent_in(latent_image)

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1218,6 +1218,10 @@ class CFGGuider:
         return sampling_function(self.inner_model, x, timestep, self.conds.get("negative", None), self.conds.get("positive", None), self.cfg, model_options=model_options, seed=seed)
 
     def inner_sample(self, noise, latent_image, device, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=None):
+        if hasattr(self.inner_model.model_sampling, "latent_shapes"):
+            # models that pack several streams into one latent need the split before process_latent_in
+            self.inner_model.model_sampling.latent_shapes = latent_shapes
+
         if latent_image is not None and torch.count_nonzero(latent_image) > 0: #Don't shift the empty latent image.
             latent_image = self.inner_model.process_latent_in(latent_image)
 

--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -963,6 +963,7 @@ class MiniMaxH3(supported_models_base.BASE):
 
     sampling_settings = {
         "shift": 12.0,
+        "audio_shift": 3.0,
     }
 
     unet_extra_config = {}

--- a/comfy_extras/nodes_lt.py
+++ b/comfy_extras/nodes_lt.py
@@ -758,22 +758,60 @@ class LTXVConcatAVLatent(io.ComfyNode):
             ],
         )
 
+    @staticmethod
+    def fit_audio(reference, audio, noise_mask):
+        """Trim or zero-pad the audio stream to the length of the one it replaces.
+
+        The padded tail is left unmasked so the model generates it, which is what a
+        clip shorter than the video should do.
+        """
+        dims = [i for i in range(reference.ndim) if reference.shape[i] != audio.shape[i]]
+        if len(dims) == 0:
+            return audio, noise_mask
+        if len(dims) > 1 or dims[0] < 2:
+            raise ValueError("audio latent {} cannot be fitted to {}".format(tuple(audio.shape), tuple(reference.shape)))
+
+        dim, length = dims[0], reference.shape[dims[0]]
+        if noise_mask is not None:  # masks carry their own shape until sampling resizes them
+            noise_mask = comfy.utils.reshape_mask(noise_mask, audio.shape)
+
+        if audio.shape[dim] > length:
+            audio = audio.narrow(dim, 0, length)
+            if noise_mask is not None:
+                noise_mask = noise_mask.narrow(dim, 0, length)
+        else:
+            pad = torch.zeros_like(audio.narrow(dim, 0, 1)).repeat(
+                [length - audio.shape[dim] if i == dim else 1 for i in range(audio.ndim)])
+            audio = torch.cat([audio, pad], dim=dim)
+            if noise_mask is not None:
+                noise_mask = torch.cat([noise_mask, torch.ones_like(pad)], dim=dim)
+        return audio, noise_mask
+
     @classmethod
     def execute(cls, video_latent, audio_latent) -> io.NodeOutput:
         output = {}
         output.update(video_latent)
         output.update(audio_latent)
+        video_samples = video_latent["samples"]
+        audio_samples = audio_latent["samples"]
         video_noise_mask = video_latent.get("noise_mask", None)
         audio_noise_mask = audio_latent.get("noise_mask", None)
 
+        if video_samples.is_nested:  # already an AV latent: keep its video and swap the audio stream
+            streams = video_samples.unbind()
+            video_samples = streams[0]
+            if video_noise_mask is not None:
+                video_noise_mask = video_noise_mask.unbind()[0]
+            audio_samples, audio_noise_mask = cls.fit_audio(streams[1], audio_samples, audio_noise_mask)
+
         if video_noise_mask is not None or audio_noise_mask is not None:
             if video_noise_mask is None:
-                video_noise_mask = torch.ones_like(video_latent["samples"])
+                video_noise_mask = torch.ones_like(video_samples)
             if audio_noise_mask is None:
-                audio_noise_mask = torch.ones_like(audio_latent["samples"])
+                audio_noise_mask = torch.ones_like(audio_samples)
             output["noise_mask"] = comfy.nested_tensor.NestedTensor((video_noise_mask, audio_noise_mask))
 
-        output["samples"] = comfy.nested_tensor.NestedTensor((video_latent["samples"], audio_latent["samples"]))
+        output["samples"] = comfy.nested_tensor.NestedTensor((video_samples, audio_samples))
 
         return io.NodeOutput(output)
 

--- a/comfy_extras/nodes_minimax_h3.py
+++ b/comfy_extras/nodes_minimax_h3.py
@@ -280,7 +280,7 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
         return io.NodeOutput(cond, latent)
 
 
-class ModelSamplingMiniMaxH3(io.ComfyNode):
+class MiniMaxH3SigmaShift(io.ComfyNode):
     """Set the video/audio flow shifts coherently.
 
     The video shift drives the sampler's sigma schedule (ModelSamplingAV); both
@@ -291,7 +291,7 @@ class ModelSamplingMiniMaxH3(io.ComfyNode):
     @classmethod
     def define_schema(cls):
         return io.Schema(
-            node_id="ModelSamplingMiniMaxH3",
+            node_id="MiniMaxH3SigmaShift",
             description="Set the video/audio flow shifts.",
             display_name="ModelSamplingMiniMaxH3",
             search_aliases=["sigma shift", "minimax shift"],
@@ -312,7 +312,6 @@ class ModelSamplingMiniMaxH3(io.ComfyNode):
             pass
 
         original = m.get_model_object("model_sampling")
-        # ModelSamplingAV keeps per-stream (audio schedule) noise handling intact
         model_sampling = ModelSamplingAdvanced(model.model.model_config)
         model_sampling.set_parameters(shift=shift_video, audio_shift=shift_audio)
         if hasattr(original, "noise_scale"):
@@ -331,7 +330,7 @@ class MiniMaxH3Extension(ComfyExtension):
             EmptyMiniMaxH3LatentAV,
             MiniMaxH3ImageToVideo,
             MiniMaxH3ReferenceToVideo,
-            ModelSamplingMiniMaxH3,
+            MiniMaxH3SigmaShift,
             ]
 
 

--- a/comfy_extras/nodes_minimax_h3.py
+++ b/comfy_extras/nodes_minimax_h3.py
@@ -280,20 +280,21 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
         return io.NodeOutput(cond, latent)
 
 
-class MiniMaxH3SigmaShift(io.ComfyNode):
+class ModelSamplingMiniMaxH3(io.ComfyNode):
     """Set the video/audio flow shifts coherently.
 
-    The video shift drives the sampler's sigma schedule; both values are also
-    handed to the DiT, which inverts the video schedule to the shared base grid
-    and derives the audio schedule from it.
+    The video shift drives the sampler's sigma schedule (ModelSamplingAV); both
+    values are also handed to the DiT, which inverts the video schedule to the
+    shared base grid and derives the audio schedule from it.
     """
 
     @classmethod
     def define_schema(cls):
         return io.Schema(
-            node_id="MiniMaxH3SigmaShift",
+            node_id="ModelSamplingMiniMaxH3",
             description="Set the video/audio flow shifts.",
-            display_name="MiniMax H3 Sigma Shift",
+            display_name="ModelSamplingMiniMaxH3",
+            search_aliases=["sigma shift", "minimax shift"],
             category="model/patch/minimax",
             inputs=[
                 io.Model.Input("model"),
@@ -307,12 +308,13 @@ class MiniMaxH3SigmaShift(io.ComfyNode):
     def execute(cls, model, shift_video, shift_audio) -> io.NodeOutput:
         m = model.clone()
 
-        class ModelSamplingAdvanced(comfy.model_sampling.ModelSamplingDiscreteFlow, comfy.model_sampling.CONST):
+        class ModelSamplingAdvanced(comfy.model_sampling.ModelSamplingAV, comfy.model_sampling.CONST):
             pass
 
         original = m.get_model_object("model_sampling")
+        # ModelSamplingAV keeps per-stream (audio schedule) noise handling intact
         model_sampling = ModelSamplingAdvanced(model.model.model_config)
-        model_sampling.set_parameters(shift=shift_video)
+        model_sampling.set_parameters(shift=shift_video, audio_shift=shift_audio)
         if hasattr(original, "noise_scale"):
             model_sampling.set_noise_scale(original.noise_scale)
         m.add_object_patch("model_sampling", model_sampling)
@@ -329,7 +331,7 @@ class MiniMaxH3Extension(ComfyExtension):
             EmptyMiniMaxH3LatentAV,
             MiniMaxH3ImageToVideo,
             MiniMaxH3ReferenceToVideo,
-            MiniMaxH3SigmaShift
+            ModelSamplingMiniMaxH3,
             ]
 
 


### PR DESCRIPTION
Allows audio to work with stochastic samplers and low step counts.


The video/audio schedules are the same curve stretched by a constant factor, so the audio latent
can simply be carried at a scale that puts it on the video's schedule. The sampler then
sees one ordinary flow latent with one schedule, and is already correct on it, without samplers needing to know anything. 

The model divides the scale back out before the network, so the DiT still sees the audio at its own sigma exactly as trained.

### Changes

- `model_sampling.py`: `ModelSamplingAV` — flow sampling carrying `audio_shift`, exposing
  `audio_scale` and the pack split.
- `model_base.py`: `MiniMaxH3.process_latent_in/out` scale the audio slice; new `FLOW_AV`
  model type.
- `ldm/minimax/model.py`: `forward()` undoes the carried scale and converts the returned
  velocity.
- `samplers.py`: hand `latent_shapes` to `model_sampling` before `process_latent_in`.
- `supported_models.py`, `nodes_minimax_h3.py`: `audio_shift` sampling setting, and the
  shift node renamed to `ModelSamplingMiniMaxH3` with both shifts.

### Note

Output changes for MiniMax-H3 at every step count. Audio is the point, but video moves
too, since the streams denoise in one attention sequence and the audio trajectory feeds
back into it. Arguably this is still more correct
