### PR TITLE
Fix migration 0004 aborting when ix_tags_tag_type is missing

### DIFF
--- a/alembic_db/versions/0004_drop_tag_type.py
+++ b/alembic_db/versions/0004_drop_tag_type.py
@@ -21,8 +21,15 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Some databases in the wild are missing ix_tags_tag_type (created by
+    # older builds whose tags table never had the index), and an unconditional
+    # drop_index aborts the whole upgrade at startup. Only drop it if present.
+    inspector = sa.inspect(op.get_bind())
+    index_names = {index["name"] for index in inspector.get_indexes("tags")}
+
     with op.batch_alter_table("tags") as batch_op:
-        batch_op.drop_index("ix_tags_tag_type")
+        if "ix_tags_tag_type" in index_names:
+            batch_op.drop_index("ix_tags_tag_type")
         batch_op.drop_column("tag_type")
 
 

--- a/tests-unit/app_test/test_migrations.py
+++ b/tests-unit/app_test/test_migrations.py
@@ -51,6 +51,25 @@ def test_upgrade_to_head(migration_db):
     command.upgrade(migration_db, "head")
 
 
+def test_upgrade_succeeds_when_tag_type_index_is_missing(migration_db):
+    """0004 must tolerate databases whose tags table lacks ix_tags_tag_type.
+
+    Databases created by older builds can be at revision 0003 without the
+    index; an unconditional drop_index aborted the whole upgrade (see #15022).
+    """
+    command.upgrade(migration_db, "0003_add_metadata_job_id")
+
+    db_path = _sqlite_path(migration_db)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP INDEX ix_tags_tag_type")
+
+    command.upgrade(migration_db, "head")
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(tags)")}
+        assert "tag_type" not in columns
+
+
 def test_downgrade_to_baseline(migration_db):
     """Upgrade to head then downgrade back to baseline."""
     command.upgrade(migration_db, "head")


### PR DESCRIPTION
Fixes #15022

## Summary
- Migration `0004_drop_tag_type` unconditionally calls `drop_index("ix_tags_tag_type")`. Databases in the wild can be at revision 0003 without that index (tables created by older builds), so the whole upgrade aborts with `ValueError: No such index: 'ix_tags_tag_type'` and ComfyUI fails to start.
- Inspect the existing indexes on `tags` and only drop the index when it is present. The `tag_type` column is still dropped either way, so the resulting schema is identical in both cases.

## Testing
- New regression test: upgrade to 0003, drop the index to simulate the wild state, upgrade to head — previously raised `ValueError`, now succeeds and `tag_type` is gone.
- `.venv/bin/python -m pytest tests-unit/app_test/test_migrations.py -q` (5 passed)
- `.venv/bin/python -m ruff check .`
