### PR TITLE
fix(minimax): cast raw parameters to input device in H3 VAEs

### DIFF
--- a/comfy/ldm/minimax/audio_vae.py
+++ b/comfy/ldm/minimax/audio_vae.py
@@ -35,7 +35,8 @@ class Snake1d(nn.Module):
         self.alpha = nn.Parameter(torch.empty(1, channels, 1))
 
     def forward(self, x):
-        return snake(x, self.alpha, self.alpha)
+        alpha = comfy.ops.cast_to_input(self.alpha, x)
+        return snake(x, alpha, alpha)
 
 
 class SnakeBeta(nn.Module):
@@ -47,8 +48,8 @@ class SnakeBeta(nn.Module):
         self.beta = nn.Parameter(torch.empty(in_features))
 
     def forward(self, x):
-        alpha = torch.exp(self.alpha).view(1, -1, 1)
-        beta = torch.exp(self.beta).view(1, -1, 1)
+        alpha = torch.exp(comfy.ops.cast_to_input(self.alpha, x)).view(1, -1, 1)
+        beta = torch.exp(comfy.ops.cast_to_input(self.beta, x)).view(1, -1, 1)
         return snake(x, alpha, beta)
 
 
@@ -239,7 +240,7 @@ class CausalAttention(nn.Module):
     def forward(self, x):
         B, N, C = x.shape
         weight, _, offload_stream = comfy.ops.cast_bias_weight(self.qkv, x, offloadable=True)
-        qkv = F.linear(x, weight=weight, bias=torch.cat((self.q_bias, self.zero_k_bias, self.v_bias)))
+        qkv = F.linear(x, weight=weight, bias=comfy.ops.cast_to_input(torch.cat((self.q_bias, self.zero_k_bias, self.v_bias)), x))
         comfy.ops.uncast_bias_weight(self.qkv, weight, None, offload_stream)
         q, k, v = qkv.reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4).unbind(0)
 

--- a/comfy/ldm/minimax/vae.py
+++ b/comfy/ldm/minimax/vae.py
@@ -253,8 +253,8 @@ class TransformerBlock(nn.Module):
         self.scale2 = nn.Parameter(torch.empty(dim))
 
     def forward(self, x, rotary_pos_emb=None):
-        x = x.addcmul_(self.attn(comfy.rmsnorm.rms_norm(x, self.norm1.weight, self.norm1.eps), rotary_pos_emb), self.scale1)
-        return x.addcmul_(self.ff(comfy.rmsnorm.rms_norm(x, self.norm2.weight, self.norm2.eps)), self.scale2)
+        x = x.addcmul_(self.attn(comfy.rmsnorm.rms_norm(x, self.norm1.weight, self.norm1.eps), rotary_pos_emb), comfy.ops.cast_to_input(self.scale1, x))
+        return x.addcmul_(self.ff(comfy.rmsnorm.rms_norm(x, self.norm2.weight, self.norm2.eps)), comfy.ops.cast_to_input(self.scale2, x))
 
 
 class ViT3DDecoder(nn.Module):
@@ -289,7 +289,7 @@ class ViT3DDecoder(nn.Module):
         num_patches = h.shape[1]
         num_suffix = 1 + self.num_register_tokens
 
-        h = torch.cat([h, self.register_tokens.expand(B, -1, -1), torch.zeros_like(h[:, 0:1, :])], dim=1)
+        h = torch.cat([h, comfy.ops.cast_to_input(self.register_tokens, h).expand(B, -1, -1), torch.zeros_like(h[:, 0:1, :])], dim=1)
 
         img_ids = create_token_ids((latent_T, latent_H, latent_W), x.device, x.dtype).expand(B, -1, -1)
         suffix_ids = torch.zeros((B, num_suffix, 3), device=x.device, dtype=img_ids.dtype)


### PR DESCRIPTION
### Problem

The MiniMax H3 video and audio VAEs access several `nn.Parameter`s directly in `forward()`, bypassing the `comfy.ops` weight-cast machinery:

- `comfy/ldm/minimax/vae.py`: `register_tokens` (ViT3DDecoder), `scale1`/`scale2` (every transformer block)
- `comfy/ldm/minimax/audio_vae.py`: `Snake1d.alpha`, `SnakeBeta.alpha`/`beta`, `CausalAttention.q_bias`/`v_bias`/`zero_k_bias`

When the VAE is loaded in offload / manual-cast mode (VRAM pressure — e.g. the 33B text encoder is still partially resident), Linear/Conv weights are cast to the input device per-op, but these raw parameters stay on the offload device (CPU) while activations are on GPU. Decoding then crashes:

```
RuntimeError: Expected all tensors to be on the same device, but got tensors is
on cpu, different from other tensors on cuda:0 (when checking argument in method
wrapper_CUDA_cat)
  File "comfy/ldm/minimax/vae.py", line 292, in forward
    h = torch.cat([h, self.register_tokens.expand(B, -1, -1), ...], dim=1)
```

Reproduced on 2x 32 GB GPUs (gfx1201, ROCm 7.2): t2v sampling completes, then VAEDecode raises the error above on every run where the VAE cannot fully load.

### Fix

Cast at the use sites with `comfy.ops.cast_to_input(...)`, the same pattern `comfy.rmsnorm.rms_norm` already uses for the norm weights in these files. No-op when the parameter is already on the right device/dtype.

### Testing

- Before: VAEDecode crashes 100% of the time under VRAM pressure (device mismatch at `vae.py:292`; after fixing only that line, the same error surfaces at `scale1`/`scale2`, then in the audio VAE).
- After: full t2v runs (sampling → video VAE decode → audio VAE decode → mux) complete repeatedly; output video and audio verified playable.
- Unaffected path: with the VAE fully loaded on GPU (no memory pressure), the cast is a no-op and outputs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
