### PR TITLE
Unload text encoders before loading diffusion models

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -917,6 +917,7 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
             models_temp[mm] = None
 
     models = list(models_temp)
+    unload_text_encoders_for_sampling(models)
     models.reverse()
 
     models_to_load = []
@@ -2039,6 +2040,35 @@ def soft_empty_cache(force=False):
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
         torch.cuda.ipc_collect()
+
+def unload_text_encoders_for_sampling(loading_models):
+    # Release CLIP / text encoder weights before loading diffusion models.
+    # Conditioning is already tensors; keeping TE on GPU starves the UNet on ~16GB cards.
+    if vram_state == VRAMState.HIGH_VRAM or cpu_mode():
+        return
+    # Prompt encoding loads CLIP/T5 only — keep them resident.
+    if loading_models and all(m.is_clip for m in loading_models):
+        return
+
+    freed_bytes = 0.0
+    unloaded = False
+    for i in range(len(current_loaded_models) - 1, -1, -1):
+        loaded = current_loaded_models[i]
+        if loaded.is_dead() or not loaded.model.is_clip:
+            continue
+        freed_bytes += loaded.model_loaded_memory()
+        loaded.model_unload()
+        current_loaded_models.pop(i)
+        unloaded = True
+
+    if not unloaded:
+        return
+
+    soft_empty_cache()
+    logging.info(
+        "Unloaded text encoders before diffusion sampling: %.2f MB VRAM freed",
+        freed_bytes / (1024 * 1024),
+    )
 
 def unload_all_models():
     for device in get_all_torch_devices():

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -2050,11 +2050,18 @@ def unload_text_encoders_for_sampling(loading_models):
     if loading_models and all(m.is_clip for m in loading_models):
         return
 
+    requested_clip_uuids = set()
+    for m in loading_models or []:
+        if m.is_clip:
+            requested_clip_uuids.add(m.clone_base_uuid)
+
     freed_bytes = 0.0
     unloaded = False
     for i in range(len(current_loaded_models) - 1, -1, -1):
         loaded = current_loaded_models[i]
         if loaded.is_dead() or not loaded.model.is_clip:
+            continue
+        if loaded.model.clone_base_uuid in requested_clip_uuids:
             continue
         freed_bytes += loaded.model_loaded_memory()
         loaded.model_unload()


### PR DESCRIPTION
On capacity-constrained GPUs (~16 GB), CLIP/T5 text encoders can stay resident on VRAM while the diffusion model loads for sampling. Prompt conditioning is already materialized as tensors at that point, so keeping text encoders loaded wastes VRAM and can severely slow the first sampling pass.

This adds `unload_text_encoders_for_sampling()` and calls it from `load_models_gpu()` before loading non-CLIP models. Text encoders are unloaded when diffusion models are about to load; CLIP-only loads (prompt encoding) are unchanged. The change is skipped on HIGH_VRAM and CPU mode.

**Test platform:** gfx1201, 16 GB VRAM, NORMAL_VRAM, ROCm 7.14, Windows, 1024x1024, batch 1, 2 iterations

### SD3.5 Large FP8 (28 steps)

| | Before fix | After fix |
| --- | --- | --- |
| **Iteration 1** | | |
| Wall time | 168.8 s | 46.0 s |
| Throughput | 0.17 steps/s | 0.61 steps/s |
| KSampler | ~5.4 s/step | ~1.05 s/step |
| **Iteration 2** | | |
| Wall time | 34.1 s | 33.6 s |
| Throughput | 0.82 steps/s | 0.83 steps/s |
| KSampler | ~1.05 s/step | ~1.05 s/step |

### SD3.5 Large Turbo FP8 (4 steps)

| | Before fix | After fix |
| --- | --- | --- |
| **Iteration 1** | | |
| Wall time | 41.3 s | 21.6 s |
| Throughput | 0.10 steps/s | 0.19 steps/s |
| KSampler | ~3.0 s/step | ~0.7-1.5 s/step |
| **Iteration 2** | | |
| Wall time | 5.2 s | 6.6 s |
| Throughput | 0.19 steps/s | 0.19 steps/s |
| KSampler | ~0.56 s/step | ~0.55 s/step |

### SD3.5 Medium FP8 (40 steps, control)

| | Before fix | After fix |
| --- | --- | --- |
| **Iteration 1** | | |
| Wall time | 27.6 s | 27.1 s |
| Throughput | 1.45 steps/s | 1.48 steps/s |
| KSampler | ~2.38 it/s | ~2.37 it/s |
| **Iteration 2** | | |
| Wall time | 18.2 s | 17.2 s |
| Throughput | 2.20 steps/s | 2.33 steps/s |
| KSampler | ~2.42 it/s | ~2.41 it/s |