### PR TITLE
comfy-aimdo 0.4.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy>=2.0.0
 filelock
 av>=16.0.0
 comfy-kitchen==0.2.26
-comfy-aimdo==0.4.11
+comfy-aimdo==0.4.13
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
Comfy-aimdo 0.4.12 increases error logging reliablity to help root cause os errors in some of the C APIs that are causing issues for some users.

The log is also unified with python logging, so non-terminal users see the logs properly.

Example log output:

```
[INFO] Testing comfy-aimdo 0.4.12.dev8
[ERROR] aimdo: src-win/model-mmap.c:99:ERROR:model_mmap_allocate:
could not open file ... OS Error: 3
[INFO] Expected test exception: ModelMMAP allocation failed ...
```

Regression Tests:

```
+----------------+------------------------------------+-------------------------+----------------------+---------------------------+
| Model          | Test                               | --disable-async-offload | Normal async offload | Comparison                |
+----------------+------------------------------------+-------------------------+----------------------+---------------------------+
| SDXL           | 512x512, 2 steps, VAE decode      | PASS                    | PASS                 | Pixel-identical           |
| Z-Image Turbo  | BF16, 512x512, 2 steps, decode    | PASS                    | PASS                 | Pixel-identical           |
| Flux.2 Dev     | FP8, 512x512, 2 steps, decode     | PASS                    | PASS                 | Pixel-identical           |
| LTX-2.3        | FP8, 256x256, 9 frames, decode    | PASS                    | PASS                 | All 9 frames identical    |
| MiniMax H3     | INT8, 256x256, 5 frames, decode   | PASS                    | PASS                 | All 5 frames identical    |
+----------------+------------------------------------+-------------------------+----------------------+---------------------------+
| Overall        | AIMDO 0.4.13                      | 5/5 PASS                | 5/5 PASS             | No output differences     |
+----------------+------------------------------------+-------------------------+----------------------+---------------------------+
```