### PR TITLE
Fix int8_tensorwise Embedding when cast returns a dequantized weight

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -1617,7 +1617,8 @@ def mixed_precision_ops(quant_config={}, compute_dtype=torch.bfloat16, full_prec
                 # Optimized path: lookup in fp8/int8, dequantize only the selected rows.
                 if isinstance(weight, QuantizedTensor) and len(self.weight_function) == 0:
                     qdata, _, offload_stream = cast_bias_weight(self, device=input.device, dtype=weight.dtype, offloadable=True)
-                    if isinstance(qdata, QuantizedTensor):
+                    still_quantized = isinstance(qdata, QuantizedTensor)
+                    if still_quantized:
                         params = qdata._params
                         scale = params.scale
                         qdata = qdata._qdata
@@ -1625,8 +1626,15 @@ def mixed_precision_ops(quant_config={}, compute_dtype=torch.bfloat16, full_prec
                         params = weight._params
                         scale = None
 
-                    # int8: per-row scale possible ConvRot, so let the layout do the gather
-                    if self.quant_format == "int8_tensorwise":
+                    # int8: per-row scale possible ConvRot, so let the layout do the gather.
+                    # Only when the cast actually returned quantized data: on some paths
+                    # (e.g. CPU-offloaded weights) cast_bias_weight hands back an
+                    # already-dequantized plain tensor — feeding that into the int8
+                    # gather kernel raises "No backend can handle
+                    # 'dequantize_int8_embedding'". Plain data falls through to the
+                    # standard F.embedding below, mirroring the guard in the int8
+                    # linear path.
+                    if self.quant_format == "int8_tensorwise" and still_quantized:
                         x = get_layout_class(self.layout_type).dequantize_embedding(qdata, params, input)
                         uncast_bias_weight(self, qdata, None, offload_stream)
                         return x if out_dtype is None else x.to(dtype=out_dtype)


### PR DESCRIPTION
Fixes #15291

`cast_bias_weight` intentionally hands back an already-dequantized plain tensor on some paths (e.g. CPU-resident/offloaded weights). The quantized-Embedding forward handled that case for params/scale bookkeeping, but still routed the now-plain bf16 tensor into the int8 gather kernel, which requires int8 input:

```
NoCapableBackendError: No backend can handle 'dequantize_int8_embedding': eager: q: dtype torch.bfloat16 not in {torch.int8}
```

This gates the gather on the cast actually returning a `QuantizedTensor`; plain data falls through to the existing `F.embedding` path below. Mirrors the guard the int8 **linear** path already has for the same situation.

Hit in the wild by users running int8/convrot text encoders on ≤12 GB cards (where the TE gets staged/offloaded): lbouaraba/comfyui-krea2edit#19. FP8 TEs are unaffected, which is why this mostly surfaces for int8 checkpoints.

CPU-only repro in the linked issue.
