### PR TITLE
restore SDPA non-cudnn small attention bypass

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -73,6 +73,8 @@ try:
             ]
 
             def scaled_dot_product_attention(q, k, v, *args, **kwargs):
+                if q.nelement() < 1024 * 128:  # arbitrary number, for small inputs cudnn attention seems slower
+                    return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)
                 attn_mask = args[0] if len(args) > 0 else kwargs.get("attn_mask")
                 if kwargs.get("enable_gqa", False) and attn_mask is not None and not comfy.model_management.is_nvidia():
                     k, v = repeat_kv_for_gqa(k, v, q.shape[-3], -3)


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/15293

This is performance critical for ACE step.

Example test conditions:

RTX5090, Linux, Ryzen5 9600
Ace-step Turbo XL 1.5

<img width="1965" height="949" alt="image" src="https://github.com/user-attachments/assets/5538e105-8014-48b8-ad97-e84b7a51f31a" />


Before:

```
LM sampling: 100%|██████████| 600/600 [00:15<00:00, 39.49it/s] 
```

After:

```
LM sampling: 100%|██████████| 600/600 [00:05<00:00, 110.22it/s] 
```

Audio output checked ✅ 