### PR TITLE
fix: pass low_precision_attention=False for MiniMax H3

### DIFF
--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -178,7 +178,7 @@ class Attention(nn.Module):
         q = q.transpose(0, 1).unsqueeze(0)
         k = k.transpose(0, 1).unsqueeze(0)
         v = v.transpose(0, 1).unsqueeze(0)
-        out = optimized_attention(q, k, v, self.heads, mask=None, skip_reshape=True, transformer_options=transformer_options)
+        out = optimized_attention(q, k, v, self.heads, mask=None, skip_reshape=True, low_precision_attention=False, transformer_options=transformer_options)
         return self.out_proj(out.squeeze(0))
 
 


### PR DESCRIPTION
## Summary\n\nMiniMax H3's `Attention.forward()` does not pass `low_precision_attention=False` to `optimized_attention`, causing SageAttention's INT8 QK quantization path to produce pure noise output.\n\nH3's partial split-half RoPE creates channel-wise magnitude outliers that corrupt INT8 quantization. Every other model in the codebase already passes this flag.\n\n**One-line fix** in `comfy/ldm/minimax/model.py:181` — adds `low_precision_attention=False` to the `optimized_attention` call.\n\n## Test plan\n\n- [x] Verified SageAttention produces noise without the fix (issue #15263)\n- [x] Verified clean output with the fix applied on both local ComfyUI installs\n- [ ] Maintainer verification with SageAttention enabled on H3 i2v/r2v workflows\n\nFixes #15263