### PR TITLE
Fix MiniMax H3 noise mask sampling

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -2112,9 +2112,6 @@ class MiniMaxH3(BaseModel):
         out['minimax_payload'] = comfy.conds.CONDConstant(payload)
         return out
 
-    def scale_latent_inpaint(self, sigma, noise, latent_image, **kwargs):
-        return latent_image
-
 class TripoSplat(BaseModel):
     def __init__(self, model_config, model_type=ModelType.FLOW, device=None):
         super().__init__(model_config, model_type, device=device, unet_model=comfy.ldm.triposplat.model.LatentSeqMMFlowModel)


### PR DESCRIPTION
## Summary

Remove MiniMax H3's `scale_latent_inpaint()` override so masked sampling uses the shared `BaseModel` noise scaling. Sampling without a denoise mask is unchanged.

## Testing

- MiniMax H3 Ref2VA with a video mask at 20 steps