### PR TITLE
fix: support MPS in RIFE/FILM frame interpolation warp

### DIFF
--- a/comfy_extras/frame_interpolation_models/film_net.py
+++ b/comfy_extras/frame_interpolation_models/film_net.py
@@ -33,7 +33,17 @@ def _warp_core(image, flow, grid_x, grid_y):
     dx = flow[:, 0].float() / (W * 0.5)
     dy = flow[:, 1].float() / (H * 0.5)
     grid = torch.stack([grid_x[None, None, :] + dx, grid_y[None, :, None] + dy], dim=3)
-    return F.grid_sample(image.float(), grid, mode="bilinear", padding_mode="border", align_corners=False).to(dtype)
+    padding_mode = "border"
+    if image.device.type == "mps":
+        # MPS does not implement "border" padding. With align_corners=False the valid
+        # sampling range is +-(1 - 1/size) per axis (grid[..., 0] is x -> width,
+        # grid[..., 1] is y -> height), so clamping there makes "zeros" produce
+        # results identical to "border".
+        bx = 1.0 - 1.0 / image.shape[-1]
+        by = 1.0 - 1.0 / image.shape[-2]
+        grid = torch.stack([grid[..., 0].clamp(-bx, bx), grid[..., 1].clamp(-by, by)], dim=-1)
+        padding_mode = "zeros"
+    return F.grid_sample(image.float(), grid, mode="bilinear", padding_mode=padding_mode, align_corners=False).to(dtype)
 
 
 def build_image_pyramid(image, pyramid_levels):

--- a/comfy_extras/frame_interpolation_models/ifnet.py
+++ b/comfy_extras/frame_interpolation_models/ifnet.py
@@ -12,7 +12,14 @@ def _warp(img, flow, warp_grids):
     base_grid, flow_div = warp_grids[(H, W)]
     flow_norm = torch.cat([flow[:, 0:1] / flow_div[0], flow[:, 1:2] / flow_div[1]], 1).float()
     grid = (base_grid.expand(B, -1, -1, -1) + flow_norm).permute(0, 2, 3, 1)
-    return F.grid_sample(img.float(), grid, mode="bilinear", padding_mode="border", align_corners=True).to(img.dtype)
+    padding_mode = "border"
+    if img.device.type == "mps":
+        # MPS does not implement "border" padding. With align_corners=True the valid
+        # sampling range is exactly [-1, 1], so clamping the grid to it makes "zeros"
+        # produce results identical to "border".
+        grid = grid.clamp(-1.0, 1.0)
+        padding_mode = "zeros"
+    return F.grid_sample(img.float(), grid, mode="bilinear", padding_mode=padding_mode, align_corners=True).to(img.dtype)
 
 
 class Head(nn.Module):


### PR DESCRIPTION
## Problem

The Frame Interpolation node fails on Apple Silicon for **every** RIFE and FILM model:

```
File "comfy_extras/frame_interpolation_models/ifnet.py", line 15, in _warp
  return F.grid_sample(img.float(), grid, mode="bilinear", padding_mode="border", align_corners=True)
RuntimeError: MPS: Unsupported Border padding mode
```

The MPS backend implements `grid_sample` but supports only two of its three padding modes:

```
zeros      : OK
border     : MPS: Unsupported Border padding mode
reflection : OK
```

Because the op *is* implemented and only the argument is rejected, `PYTORCH_ENABLE_MPS_FALLBACK=1` does not help. The upstream PyTorch issue, [pytorch/pytorch#125098](https://github.com/pytorch/pytorch/issues/125098), has been open since April 2024, so waiting for a torch-side fix is not practical.

Both built-in interpolation models hit this: `ifnet.py` `_warp()` (RIFE) and `film_net.py` `_warp_core()` (FILM).

## Fix

`border` padding clamps sampling coordinates to the image edge, which is exactly reproduced by clamping the grid ourselves and then using `zeros`. The valid range depends on `align_corners`:

- `align_corners=True` → `[-1, 1]` on both axes
- `align_corners=False` → `±(1 - 1/W)` for x (`grid[..., 0]`), `±(1 - 1/H)` for y (`grid[..., 1]`)

Both call sites are gated on `device.type == "mps"`, so CUDA and CPU paths are untouched and bit-identical.

## Verification

Measured against a CPU `border` reference on an M4 Mac mini, torch 2.10.0:

| check | max abs diff |
|---|---|
| clamp equivalence, non-square input, `align_corners=True` | 2.4e-07 |
| clamp equivalence, non-square input, `align_corners=False` | 6.0e-07 |
| same test with x/y clamp bounds deliberately swapped | 1.9 (confirms the test detects axis errors) |
| `film_net._warp_core`, large out-of-bounds flow | 1.4e-05 |
| full RIFE forward, `rife_v4.25_lite`, 128x256 | 1.1e-03 max / 1.9e-05 mean |

The residual on the full RIFE forward is ordinary MPS float variance across the conv stack, not the clamp — the clamp itself is exact to float32 rounding. A non-square input is used deliberately, since a square one cannot detect an x/y swap in the `align_corners=False` bounds.

End-to-end, the Frame Interpolation node now runs on MPS with `rife_v4.25_lite.safetensors`, `rife_v4.25.safetensors`, and `rife_v4.26.safetensors`.

## Notes

The same MPS limitation exists at other `padding_mode="border"` call sites in the repo (`comfy_extras/nodes_gaussian_splat.py`, `comfy/ldm/moge/panorama.py`). Those are separate features and are intentionally left alone here rather than patched blind or worked around with a global `grid_sample` shim, which would silently change numerics repo-wide.
