### PR TITLE
Add prompt queue and execution lifecycle hooks

### DIFF
--- a/comfy_api/latest/__init__.py
+++ b/comfy_api/latest/__init__.py
@@ -24,6 +24,7 @@ class ComfyAPI_latest(ComfyAPIBase):
         self.node_replacement = self.NodeReplacement()
         self.execution = self.Execution()
         self.caching = self.Caching()
+        self.execution_lifecycle = self.ExecutionLifecycle()
 
     class NodeReplacement(ProxiedSingleton):
         async def register(self, node_replace: io.NodeReplace) -> None:
@@ -113,6 +114,33 @@ class ComfyAPI_latest(ComfyAPIBase):
             from comfy_execution.cache_provider import unregister_cache_provider
             unregister_cache_provider(provider)
 
+    class ExecutionLifecycle(ProxiedSingleton):
+        from ._execution_lifecycle import (
+            CancelledEvent,
+            FailedEvent,
+            FailureSource,
+            InterruptedEvent,
+            LifecycleEvent,
+            LifecycleHandler as Handler,
+            QueuedEvent,
+            StartedEvent,
+            SucceededEvent,
+            TerminalEvent,
+        )
+
+        async def register(
+            self,
+            handler: "ComfyAPI_latest.ExecutionLifecycle.Handler",
+        ) -> None:
+            """Register a task lifecycle handler during extension loading."""
+            from comfy_execution.lifecycle import _register_handler
+            _register_handler(handler)
+
+    node_replacement: NodeReplacement
+    execution: Execution
+    caching: Caching
+    execution_lifecycle: ExecutionLifecycle
+
 class ComfyExtension(ABC):
     async def on_load(self) -> None:
         """
@@ -148,6 +176,7 @@ class Types:
 
 
 Caching = ComfyAPI_latest.Caching
+ExecutionLifecycle = ComfyAPI_latest.ExecutionLifecycle
 
 ComfyAPI = ComfyAPI_latest
 
@@ -169,6 +198,7 @@ __all__ = [
     "InputImpl",
     "Types",
     "Caching",
+    "ExecutionLifecycle",
     "ComfyExtension",
     "io",
     "IO",

--- a/comfy_api/latest/_execution_lifecycle.py
+++ b/comfy_api/latest/_execution_lifecycle.py
@@ -1,0 +1,107 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, TypeAlias
+
+
+class FailureSource(str, Enum):
+    NODE = "node"
+    INTERNAL = "internal"
+
+
+@dataclass(frozen=True, slots=True)
+class QueuedEvent:
+    prompt_id: str
+    queue_number: float
+    output_node_ids: tuple[str, ...]
+    metadata: Mapping[str, Any]
+    queued_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class StartedEvent:
+    prompt_id: str
+    metadata: Mapping[str, Any]
+    queued_at_ms: int
+    started_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class SucceededEvent:
+    prompt_id: str
+    metadata: Mapping[str, Any]
+    history_result: Mapping[str, Any] | None
+    queued_at_ms: int
+    started_at_ms: int
+    finished_at_ms: int
+    execution_duration_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class FailedEvent:
+    prompt_id: str
+    metadata: Mapping[str, Any]
+    source: FailureSource
+    node_id: str | None
+    node_type: str | None
+    exception_type: str
+    exception_message: str
+    traceback: tuple[str, ...]
+    executed_nodes: tuple[str, ...]
+    history_result: Mapping[str, Any] | None
+    history_task_done_succeeded: bool
+    queued_at_ms: int
+    started_at_ms: int
+    error_reported_at_ms: int
+    finished_at_ms: int
+    execution_duration_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class InterruptedEvent:
+    prompt_id: str
+    metadata: Mapping[str, Any]
+    node_id: str | None
+    node_type: str | None
+    executed_nodes: tuple[str, ...]
+    history_result: Mapping[str, Any] | None
+    queued_at_ms: int
+    started_at_ms: int
+    interruption_reported_at_ms: int
+    finished_at_ms: int
+    execution_duration_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class CancelledEvent:
+    prompt_id: str
+    metadata: Mapping[str, Any]
+    queued_at_ms: int
+    cancelled_at_ms: int
+
+
+TerminalEvent: TypeAlias = SucceededEvent | FailedEvent | InterruptedEvent | CancelledEvent
+LifecycleEvent: TypeAlias = QueuedEvent | StartedEvent | TerminalEvent
+
+
+class LifecycleHandler:
+    def accepts(self, event: LifecycleEvent) -> bool:
+        return True
+
+    def on_queued(self, event: QueuedEvent) -> None:
+        pass
+
+    def on_started(self, event: StartedEvent) -> None:
+        pass
+
+    def on_succeeded(self, event: SucceededEvent) -> None:
+        pass
+
+    def on_failed(self, event: FailedEvent) -> None:
+        pass
+
+    def on_interrupted(self, event: InterruptedEvent) -> None:
+        pass
+
+    def on_cancelled(self, event: CancelledEvent) -> None:
+        pass

--- a/comfy_api/latest/generated/ComfyAPISyncStub.pyi
+++ b/comfy_api/latest/generated/ComfyAPISyncStub.pyi
@@ -1,9 +1,40 @@
 from typing import Any, Dict, List, Optional, Tuple, Union, Set, Sequence, cast, NamedTuple
 from comfy_api.latest import ComfyAPI_latest
 from PIL.Image import Image
+from comfy_api.latest._caching import CacheProvider
+from comfy_api.latest._execution_lifecycle import LifecycleHandler
+from comfy_api.latest._io import NodeReplace
 from torch import Tensor
 class ComfyAPISyncStub:
     def __init__(self) -> None: ...
+
+    class CachingSync:
+        """
+        External cache provider API for sharing cached node outputs
+        across ComfyUI instances.
+
+        Example::
+
+            from comfy_api.latest import Caching
+
+            class MyCacheProvider(Caching.CacheProvider):
+                async def on_lookup(self, context):
+                    ...  # check external storage
+
+                async def on_store(self, context, value):
+                    ...  # store to external storage
+
+            Caching.register_provider(MyCacheProvider())
+        """
+        def __init__(self) -> None: ...
+        """
+        Register an external cache provider. Providers are called in registration order.
+        """
+        def register_provider(self, provider: CacheProvider) -> None: ...
+        """
+        Unregister a previously registered cache provider.
+        """
+        def unregister_provider(self, provider: CacheProvider) -> None: ...
 
     class ExecutionSync:
         def __init__(self) -> None: ...
@@ -17,4 +48,21 @@ class ComfyAPISyncStub:
         """
         def set_progress(self, value: float, max_value: float, node_id: Union[str, None] = None, preview_image: Union[Image, Tensor, None] = None, ignore_size_limit: bool = False) -> None: ...
 
+    class ExecutionLifecycleSync:
+        def __init__(self) -> None: ...
+        """
+        Register a task lifecycle handler during extension loading.
+        """
+        def register(self, handler: LifecycleHandler) -> None: ...
+
+    class NodeReplacementSync:
+        def __init__(self) -> None: ...
+        """
+        Register a node replacement mapping.
+        """
+        def register(self, node_replace: NodeReplace) -> None: ...
+
+    caching: CachingSync
     execution: ExecutionSync
+    execution_lifecycle: ExecutionLifecycleSync
+    node_replacement: NodeReplacementSync

--- a/comfy_api/v0_0_1/generated/ComfyAPISyncStub.pyi
+++ b/comfy_api/v0_0_1/generated/ComfyAPISyncStub.pyi
@@ -1,9 +1,40 @@
 from typing import Any, Dict, List, Optional, Tuple, Union, Set, Sequence, cast, NamedTuple
 from comfy_api.v0_0_1 import ComfyAPIAdapter_v0_0_1
 from PIL.Image import Image
+from comfy_api.latest._caching import CacheProvider
+from comfy_api.latest._execution_lifecycle import LifecycleHandler
+from comfy_api.latest._io import NodeReplace
 from torch import Tensor
 class ComfyAPISyncStub:
     def __init__(self) -> None: ...
+
+    class CachingSync:
+        """
+        External cache provider API for sharing cached node outputs
+        across ComfyUI instances.
+
+        Example::
+
+            from comfy_api.latest import Caching
+
+            class MyCacheProvider(Caching.CacheProvider):
+                async def on_lookup(self, context):
+                    ...  # check external storage
+
+                async def on_store(self, context, value):
+                    ...  # store to external storage
+
+            Caching.register_provider(MyCacheProvider())
+        """
+        def __init__(self) -> None: ...
+        """
+        Register an external cache provider. Providers are called in registration order.
+        """
+        def register_provider(self, provider: CacheProvider) -> None: ...
+        """
+        Unregister a previously registered cache provider.
+        """
+        def unregister_provider(self, provider: CacheProvider) -> None: ...
 
     class ExecutionSync:
         def __init__(self) -> None: ...
@@ -17,4 +48,21 @@ class ComfyAPISyncStub:
         """
         def set_progress(self, value: float, max_value: float, node_id: Union[str, None] = None, preview_image: Union[Image, Tensor, None] = None, ignore_size_limit: bool = False) -> None: ...
 
+    class ExecutionLifecycleSync:
+        def __init__(self) -> None: ...
+        """
+        Register a task lifecycle handler during extension loading.
+        """
+        def register(self, handler: LifecycleHandler) -> None: ...
+
+    class NodeReplacementSync:
+        def __init__(self) -> None: ...
+        """
+        Register a node replacement mapping.
+        """
+        def register(self, node_replace: NodeReplace) -> None: ...
+
+    caching: CachingSync
     execution: ExecutionSync
+    execution_lifecycle: ExecutionLifecycleSync
+    node_replacement: NodeReplacementSync

--- a/comfy_api/v0_0_2/generated/ComfyAPISyncStub.pyi
+++ b/comfy_api/v0_0_2/generated/ComfyAPISyncStub.pyi
@@ -1,9 +1,40 @@
 from typing import Any, Dict, List, Optional, Tuple, Union, Set, Sequence, cast, NamedTuple
 from comfy_api.v0_0_2 import ComfyAPIAdapter_v0_0_2
 from PIL.Image import Image
+from comfy_api.latest._caching import CacheProvider
+from comfy_api.latest._execution_lifecycle import LifecycleHandler
+from comfy_api.latest._io import NodeReplace
 from torch import Tensor
 class ComfyAPISyncStub:
     def __init__(self) -> None: ...
+
+    class CachingSync:
+        """
+        External cache provider API for sharing cached node outputs
+        across ComfyUI instances.
+
+        Example::
+
+            from comfy_api.latest import Caching
+
+            class MyCacheProvider(Caching.CacheProvider):
+                async def on_lookup(self, context):
+                    ...  # check external storage
+
+                async def on_store(self, context, value):
+                    ...  # store to external storage
+
+            Caching.register_provider(MyCacheProvider())
+        """
+        def __init__(self) -> None: ...
+        """
+        Register an external cache provider. Providers are called in registration order.
+        """
+        def register_provider(self, provider: CacheProvider) -> None: ...
+        """
+        Unregister a previously registered cache provider.
+        """
+        def unregister_provider(self, provider: CacheProvider) -> None: ...
 
     class ExecutionSync:
         def __init__(self) -> None: ...
@@ -17,4 +48,21 @@ class ComfyAPISyncStub:
         """
         def set_progress(self, value: float, max_value: float, node_id: Union[str, None] = None, preview_image: Union[Image, Tensor, None] = None, ignore_size_limit: bool = False) -> None: ...
 
+    class ExecutionLifecycleSync:
+        def __init__(self) -> None: ...
+        """
+        Register a task lifecycle handler during extension loading.
+        """
+        def register(self, handler: LifecycleHandler) -> None: ...
+
+    class NodeReplacementSync:
+        def __init__(self) -> None: ...
+        """
+        Register a node replacement mapping.
+        """
+        def register(self, node_replace: NodeReplace) -> None: ...
+
+    caching: CachingSync
     execution: ExecutionSync
+    execution_lifecycle: ExecutionLifecycleSync
+    node_replacement: NodeReplacementSync

--- a/comfy_execution/lifecycle.py
+++ b/comfy_execution/lifecycle.py
@@ -1,0 +1,419 @@
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+import inspect
+import logging
+import queue
+import threading
+import time
+import traceback as traceback_module
+from types import MappingProxyType
+from typing import Any
+
+from comfy_api.latest._execution_lifecycle import (
+    CancelledEvent,
+    FailedEvent,
+    FailureSource,
+    InterruptedEvent,
+    LifecycleEvent,
+    LifecycleHandler,
+    QueuedEvent,
+    StartedEvent,
+    SucceededEvent,
+)
+
+
+logger = logging.getLogger(__name__)
+
+_EVENT_METHODS = {
+    QueuedEvent: "on_queued",
+    StartedEvent: "on_started",
+    SucceededEvent: "on_succeeded",
+    FailedEvent: "on_failed",
+    InterruptedEvent: "on_interrupted",
+    CancelledEvent: "on_cancelled",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _HandlerRegistration:
+    handler: LifecycleHandler
+    methods: Mapping[type, Callable]
+
+
+@dataclass(frozen=True, slots=True)
+class _QueuedLifecycleContext:
+    queued_at_ms: int
+    metadata: Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _ExecutionOutcome:
+    kind: str
+    details: Mapping[str, Any]
+
+
+_EMPTY_MAPPING: Mapping[str, Any] = MappingProxyType({})
+_pending_registrations: list[_HandlerRegistration] = []
+_frozen_routes: Mapping[type, tuple[tuple[LifecycleHandler, Callable], ...]] | None = None
+_dispatch_queue: queue.Queue | None = None
+_dispatch_thread: threading.Thread | None = None
+_STOP = object()
+
+
+def _register_handler(handler: LifecycleHandler) -> None:
+    if _frozen_routes is not None:
+        raise RuntimeError("Execution lifecycle handlers are already frozen")
+    if not isinstance(handler, LifecycleHandler):
+        raise TypeError("handler must be an ExecutionLifecycle.Handler instance")
+    if inspect.iscoroutinefunction(handler.accepts):
+        raise TypeError("LifecycleHandler.accepts must be synchronous")
+    if any(registration.handler is handler for registration in _pending_registrations):
+        logger.warning("Execution lifecycle handler is already registered: %s", type(handler).__name__)
+        return
+
+    methods = {}
+    for event_type, method_name in _EVENT_METHODS.items():
+        method = getattr(handler, method_name)
+        if inspect.iscoroutinefunction(method):
+            raise TypeError(f"LifecycleHandler.{method_name} must be synchronous")
+        if getattr(type(handler), method_name) is not getattr(LifecycleHandler, method_name):
+            methods[event_type] = method
+
+    if not methods:
+        raise TypeError("LifecycleHandler must override at least one event method")
+    _pending_registrations.append(_HandlerRegistration(handler, MappingProxyType(methods)))
+
+
+def _freeze_handler_routes() -> None:
+    global _frozen_routes, _dispatch_queue, _dispatch_thread
+
+    if _frozen_routes is not None:
+        return
+
+    routes = {}
+    for event_type in _EVENT_METHODS:
+        routes[event_type] = tuple(
+            (registration.handler, registration.methods[event_type])
+            for registration in _pending_registrations
+            if event_type in registration.methods
+        )
+    _frozen_routes = MappingProxyType(routes)
+
+    if any(routes.values()):
+        _dispatch_queue = queue.Queue()
+        _dispatch_thread = threading.Thread(
+            target=_dispatch_events,
+            name="execution-lifecycle",
+            daemon=True,
+        )
+        _dispatch_thread.start()
+
+
+def _has_any_handlers() -> bool:
+    return _frozen_routes is not None and any(_frozen_routes.values())
+
+
+def _has_handlers(event_type: type) -> bool:
+    return _frozen_routes is not None and bool(_frozen_routes.get(event_type, ()))
+
+
+def _publish(event: LifecycleEvent) -> None:
+    if not _has_handlers(type(event)):
+        return
+    assert _dispatch_queue is not None
+    _dispatch_queue.put_nowait(event)
+
+
+def _dispatch_events() -> None:
+    assert _dispatch_queue is not None
+    dispatch_queue = _dispatch_queue
+    while True:
+        event = dispatch_queue.get()
+        try:
+            if event is _STOP:
+                return
+            routes = _frozen_routes.get(type(event), ()) if _frozen_routes is not None else ()
+            for handler, method in routes:
+                try:
+                    if handler.accepts(event):
+                        method(event)
+                except BaseException:
+                    logger.exception(
+                        "Execution lifecycle handler %s failed for %s",
+                        type(handler).__name__,
+                        type(event).__name__,
+                    )
+        finally:
+            dispatch_queue.task_done()
+
+
+def _freeze_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        frozen = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("Lifecycle snapshot mapping keys must be strings")
+            frozen[key] = _freeze_value(item)
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_value(item) for item in value)
+    raise TypeError(f"Unsupported lifecycle snapshot value: {type(value).__name__}")
+
+
+def _freeze_metadata(extra_data: Any) -> Mapping[str, Any]:
+    if not isinstance(extra_data, Mapping):
+        return _EMPTY_MAPPING
+    metadata = extra_data.get("execution_lifecycle")
+    if not isinstance(metadata, Mapping):
+        return _EMPTY_MAPPING
+    try:
+        return _freeze_value(metadata)
+    except Exception:
+        logger.warning("Ignoring invalid execution lifecycle metadata", exc_info=True)
+        return _EMPTY_MAPPING
+
+
+def _freeze_history_result(history_result: Any) -> Mapping[str, Any] | None:
+    if not isinstance(history_result, Mapping):
+        return None
+    try:
+        return _freeze_value(history_result)
+    except Exception:
+        logger.warning("Unable to snapshot execution lifecycle history result", exc_info=True)
+        return None
+
+
+def _publish_queued(item, context: _QueuedLifecycleContext) -> None:
+    if not _has_handlers(QueuedEvent):
+        return
+    try:
+        _publish(QueuedEvent(
+            prompt_id=item[1],
+            queue_number=float(item[0]),
+            output_node_ids=tuple(sorted(str(node_id) for node_id in item[4])),
+            metadata=context.metadata,
+            queued_at_ms=context.queued_at_ms,
+        ))
+    except Exception:
+        logger.exception("Unable to publish QueuedEvent")
+
+
+def _publish_cancelled(item, context: _QueuedLifecycleContext, cancelled_at_ms: int) -> None:
+    if not _has_handlers(CancelledEvent):
+        return
+    try:
+        _publish(CancelledEvent(
+            prompt_id=item[1],
+            metadata=context.metadata,
+            queued_at_ms=context.queued_at_ms,
+            cancelled_at_ms=cancelled_at_ms,
+        ))
+    except Exception:
+        logger.exception("Unable to publish CancelledEvent")
+
+
+def _full_type_name(exception_type: type[BaseException]) -> str:
+    if exception_type.__module__ == "builtins":
+        return exception_type.__qualname__
+    return f"{exception_type.__module__}.{exception_type.__qualname__}"
+
+
+def _terminal_message(status_messages: Sequence) -> tuple[str, Mapping[str, Any]] | None:
+    terminal_names = {"execution_error", "execution_interrupted", "execution_success"}
+    for message in reversed(status_messages):
+        if not isinstance(message, (tuple, list)) or len(message) != 2:
+            continue
+        name, details = message
+        if name in terminal_names and isinstance(details, Mapping):
+            return name, details
+    return None
+
+
+class _PromptExecutionLifecycle:
+    def __init__(self, prompt_id: str, queued_context: _QueuedLifecycleContext):
+        self.prompt_id = prompt_id
+        self.queued_context = queued_context
+        self.started_at_ms = 0
+        self._started_at = 0.0
+        self._outcome: _ExecutionOutcome | None = None
+        self._history_result = None
+        self._task_done_succeeded = False
+
+    def __enter__(self):
+        self.started_at_ms = int(time.time() * 1000)
+        self._started_at = time.perf_counter()
+        if _has_handlers(StartedEvent):
+            try:
+                _publish(StartedEvent(
+                    prompt_id=self.prompt_id,
+                    metadata=self.queued_context.metadata,
+                    queued_at_ms=self.queued_context.queued_at_ms,
+                    started_at_ms=self.started_at_ms,
+                ))
+            except Exception:
+                logger.exception("Unable to publish StartedEvent")
+        return self
+
+    def record_executor_result(self, status_messages: Sequence, history_result: Any) -> None:
+        self._history_result = history_result
+        try:
+            terminal = _terminal_message(status_messages)
+            if terminal is None:
+                self._outcome = self._internal_failure(
+                    "MissingTerminalExecutionStatus",
+                    "PromptExecutor returned without a terminal status message",
+                )
+                return
+
+            event_name, details = terminal
+            if event_name == "execution_error":
+                self._outcome = _ExecutionOutcome("node_failure", details)
+            elif event_name == "execution_interrupted":
+                self._outcome = _ExecutionOutcome("interrupted", details)
+            else:
+                self._outcome = _ExecutionOutcome("success", details)
+        except Exception as error:
+            logger.exception("Unable to record execution lifecycle result")
+            self._outcome = self._internal_failure(_full_type_name(type(error)), str(error))
+
+    def mark_task_done_succeeded(self) -> None:
+        self._task_done_succeeded = True
+
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            if exc_type is not None and (self._outcome is None or self._outcome.kind != "node_failure"):
+                self._outcome = self._exception_failure(exc_type, exc, tb)
+            elif self._outcome is None:
+                self._outcome = self._internal_failure(
+                    "MissingTerminalExecutionStatus",
+                    "Execution lifecycle ended without an executor result",
+                )
+
+            if self._outcome.kind in ("success", "interrupted") and not self._task_done_succeeded:
+                self._outcome = self._internal_failure(
+                    "PromptQueueTaskDoneError",
+                    "PromptQueue.task_done did not complete",
+                )
+            self._publish_terminal()
+        except Exception:
+            logger.exception("Unable to publish terminal execution lifecycle event")
+        return False
+
+    def _internal_failure(self, exception_type: str, message: str) -> _ExecutionOutcome:
+        return _ExecutionOutcome("internal_failure", MappingProxyType({
+            "exception_type": exception_type,
+            "exception_message": message,
+            "traceback": (),
+            "timestamp": int(time.time() * 1000),
+        }))
+
+    def _exception_failure(self, exc_type, exc, tb) -> _ExecutionOutcome:
+        return _ExecutionOutcome("internal_failure", MappingProxyType({
+            "exception_type": _full_type_name(exc_type),
+            "exception_message": str(exc),
+            "traceback": tuple(traceback_module.format_exception(exc_type, exc, tb)),
+            "timestamp": int(time.time() * 1000),
+        }))
+
+    def _publish_terminal(self) -> None:
+        finished_at_ms = int(time.time() * 1000)
+        execution_duration_ms = max(0, int((time.perf_counter() - self._started_at) * 1000))
+        outcome = self._outcome
+        assert outcome is not None
+
+        if outcome.kind == "success":
+            if not _has_handlers(SucceededEvent):
+                return
+            event = SucceededEvent(
+                prompt_id=self.prompt_id,
+                metadata=self.queued_context.metadata,
+                history_result=_freeze_history_result(self._history_result),
+                queued_at_ms=self.queued_context.queued_at_ms,
+                started_at_ms=self.started_at_ms,
+                finished_at_ms=finished_at_ms,
+                execution_duration_ms=execution_duration_ms,
+            )
+        elif outcome.kind == "interrupted":
+            if not _has_handlers(InterruptedEvent):
+                return
+            details = outcome.details
+            event = InterruptedEvent(
+                prompt_id=self.prompt_id,
+                metadata=self.queued_context.metadata,
+                node_id=_optional_string(details.get("node_id")),
+                node_type=_optional_string(details.get("node_type")),
+                executed_nodes=_sorted_strings(details.get("executed", ())),
+                history_result=_freeze_history_result(self._history_result),
+                queued_at_ms=self.queued_context.queued_at_ms,
+                started_at_ms=self.started_at_ms,
+                interruption_reported_at_ms=_timestamp(details, finished_at_ms),
+                finished_at_ms=finished_at_ms,
+                execution_duration_ms=execution_duration_ms,
+            )
+        else:
+            if not _has_handlers(FailedEvent):
+                return
+            details = outcome.details
+            event = FailedEvent(
+                prompt_id=self.prompt_id,
+                metadata=self.queued_context.metadata,
+                source=FailureSource.NODE if outcome.kind == "node_failure" else FailureSource.INTERNAL,
+                node_id=_optional_string(details.get("node_id")),
+                node_type=_optional_string(details.get("node_type")),
+                exception_type=str(details.get("exception_type", "ExecutionError")),
+                exception_message=str(details.get("exception_message", "Execution failed")),
+                traceback=tuple(str(line) for line in details.get("traceback", ())),
+                executed_nodes=_sorted_strings(details.get("executed", ())),
+                history_result=_freeze_history_result(self._history_result),
+                history_task_done_succeeded=self._task_done_succeeded,
+                queued_at_ms=self.queued_context.queued_at_ms,
+                started_at_ms=self.started_at_ms,
+                error_reported_at_ms=_timestamp(details, finished_at_ms),
+                finished_at_ms=finished_at_ms,
+                execution_duration_ms=execution_duration_ms,
+            )
+        _publish(event)
+
+
+def _optional_string(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _sorted_strings(values: Any) -> tuple[str, ...]:
+    if not isinstance(values, (list, tuple, set, frozenset)):
+        return ()
+    return tuple(sorted(str(value) for value in values))
+
+
+def _timestamp(details: Mapping[str, Any], default: int) -> int:
+    value = details.get("timestamp")
+    return int(value) if isinstance(value, (int, float)) else default
+
+
+def _wait_for_dispatch_for_tests(timeout: float = 1.0) -> bool:
+    dispatch_queue = _dispatch_queue
+    if dispatch_queue is None:
+        return True
+    deadline = time.monotonic() + timeout
+    with dispatch_queue.all_tasks_done:
+        while dispatch_queue.unfinished_tasks:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            dispatch_queue.all_tasks_done.wait(remaining)
+    return True
+
+
+def _reset_for_tests() -> None:
+    global _pending_registrations, _frozen_routes, _dispatch_queue, _dispatch_thread
+    if _dispatch_queue is not None and _dispatch_thread is not None:
+        _dispatch_queue.put(_STOP)
+        _dispatch_thread.join(timeout=1)
+    _pending_registrations = []
+    _frozen_routes = None
+    _dispatch_queue = None
+    _dispatch_thread = None

--- a/execution.py
+++ b/execution.py
@@ -1,4 +1,5 @@
 import copy
+from collections import deque
 import heapq
 import inspect
 import logging
@@ -47,6 +48,13 @@ from comfy_execution.asset_enrichment import enrich_output_with_assets
 from comfy_api.internal import _ComfyNodeInternal, _NodeOutputInternal, first_real_override, is_class, make_locked_method_func
 from comfy_api.latest import io, _io
 from comfy_execution.cache_provider import _has_cache_providers, _get_cache_providers, _logger as _cache_logger
+from comfy_execution.lifecycle import (
+    _QueuedLifecycleContext,
+    _freeze_metadata,
+    _has_any_handlers,
+    _publish_cancelled,
+    _publish_queued,
+)
 
 
 class ExecutionResult(Enum):
@@ -1258,10 +1266,22 @@ class PromptQueue:
         self.currently_running = {}
         self.history = {}
         self.flags = {}
+        self._queued_lifecycle_contexts = {}
+        self._running_lifecycle_contexts = {}
 
     def put(self, item):
         with self.mutex:
             heapq.heappush(self.queue, item)
+            if _has_any_handlers():
+                try:
+                    context = _QueuedLifecycleContext(
+                        queued_at_ms=int(time.time() * 1000),
+                        metadata=_freeze_metadata(item[3]),
+                    )
+                    self._queued_lifecycle_contexts.setdefault(id(item), deque()).append(context)
+                    _publish_queued(item, context)
+                except Exception:
+                    logging.exception("Unable to initialize execution lifecycle context")
             self.server.queue_updated()
             self.not_empty.notify()
 
@@ -1274,9 +1294,33 @@ class PromptQueue:
             item = heapq.heappop(self.queue)
             i = self.task_counter
             self.currently_running[i] = copy.deepcopy(item)
+            context = self._pop_queued_lifecycle_context(item)
+            if context is not None:
+                self._running_lifecycle_contexts[i] = context
+            elif _has_any_handlers():
+                logging.error("Missing execution lifecycle context for prompt %s", item[1])
             self.task_counter += 1
             self.server.queue_updated()
             return (item, i)
+
+    def _pop_queued_lifecycle_context(self, item):
+        contexts = self._queued_lifecycle_contexts.get(id(item))
+        if not contexts:
+            return None
+        context = contexts.popleft()
+        if not contexts:
+            del self._queued_lifecycle_contexts[id(item)]
+        return context
+
+    def _take_lifecycle_context(self, item_id):
+        with self.mutex:
+            context = self._running_lifecycle_contexts.pop(item_id, None)
+            if context is not None or not _has_any_handlers():
+                return context
+            item = self.currently_running.get(item_id)
+            prompt_id = item[1] if item is not None else "unknown"
+            logging.error("Missing execution lifecycle context for prompt %s", prompt_id)
+            return None
 
     class ExecutionStatus(NamedTuple):
         status_str: Literal['success', 'error']
@@ -1287,6 +1331,7 @@ class PromptQueue:
                   status: Optional['PromptQueue.ExecutionStatus'], process_item=None):
         with self.mutex:
             prompt = self.currently_running.pop(item_id)
+            self._running_lifecycle_contexts.pop(item_id, None)
             if len(self.history) > MAXIMUM_HISTORY_SIZE:
                 self.history.pop(next(iter(self.history)))
 
@@ -1344,22 +1389,40 @@ class PromptQueue:
             return len(self.queue) + len(self.currently_running)
 
     def wipe_queue(self):
+        removed = []
         with self.mutex:
+            cancelled_at_ms = int(time.time() * 1000)
+            for item in self.queue:
+                context = self._pop_queued_lifecycle_context(item)
+                if context is not None:
+                    removed.append((item, context, cancelled_at_ms))
+                elif _has_any_handlers():
+                    logging.error("Missing execution lifecycle context for prompt %s", item[1])
             self.queue = []
             self.server.queue_updated()
+        for item, context, cancelled_at_ms in removed:
+            _publish_cancelled(item, context, cancelled_at_ms)
 
     def delete_queue_item(self, function):
+        removed = None
         with self.mutex:
             for x in range(len(self.queue)):
                 if function(self.queue[x]):
-                    if len(self.queue) == 1:
-                        self.wipe_queue()
-                    else:
-                        self.queue.pop(x)
+                    item = self.queue.pop(x)
+                    if self.queue:
                         heapq.heapify(self.queue)
+                    context = self._pop_queued_lifecycle_context(item)
+                    if context is not None:
+                        removed = (item, context, int(time.time() * 1000))
+                    elif _has_any_handlers():
+                        logging.error("Missing execution lifecycle context for prompt %s", item[1])
                     self.server.queue_updated()
-                    return True
-        return False
+                    break
+            else:
+                return False
+        if removed is not None:
+            _publish_cancelled(*removed)
+        return True
 
     def get_history(self, prompt_id=None, max_items=None, offset=-1, map_function=None):
         with self.mutex:

--- a/main.py
+++ b/main.py
@@ -227,6 +227,7 @@ execute_prestartup_script()
 
 # Main code
 import asyncio
+from contextlib import nullcontext
 import threading
 import gc
 
@@ -238,6 +239,7 @@ import comfy.utils
 
 import execution
 import server
+from comfy_execution.lifecycle import _freeze_handler_routes, _PromptExecutionLifecycle
 from protocol import BinaryEventTypes
 import nodes
 import comfy.model_management
@@ -359,27 +361,37 @@ def prompt_worker(q, server_instance):
         queue_item = q.get(timeout=timeout)
         if queue_item is not None:
             item, item_id = queue_item
+            queued_context = q._take_lifecycle_context(item_id)
             execution_start_time = time.perf_counter()
             prompt_id = item[1]
             server_instance.last_prompt_id = prompt_id
 
-            sensitive = item[5]
-            extra_data = item[3].copy()
-            for k in sensitive:
-                extra_data[k] = sensitive[k]
+            lifecycle_context = (
+                _PromptExecutionLifecycle(prompt_id, queued_context)
+                if queued_context is not None else nullcontext()
+            )
+            with lifecycle_context as prompt_lifecycle:
+                sensitive = item[5]
+                extra_data = item[3].copy()
+                for k in sensitive:
+                    extra_data[k] = sensitive[k]
 
-            asset_seeder.pause()
-            e.execute(item[2], prompt_id, extra_data, item[4])
+                asset_seeder.pause()
+                e.execute(item[2], prompt_id, extra_data, item[4])
 
-            need_gc = True
+                need_gc = True
 
-            remove_sensitive = lambda prompt: prompt[:5] + prompt[6:]
-            q.task_done(item_id,
-                        e.history_result,
-                        status=execution.PromptQueue.ExecutionStatus(
-                            status_str='success' if e.success else 'error',
-                            completed=e.success,
-                            messages=e.status_messages), process_item=remove_sensitive)
+                if prompt_lifecycle is not None:
+                    prompt_lifecycle.record_executor_result(e.status_messages, e.history_result)
+                remove_sensitive = lambda prompt: prompt[:5] + prompt[6:]
+                q.task_done(item_id,
+                            e.history_result,
+                            status=execution.PromptQueue.ExecutionStatus(
+                                status_str='success' if e.success else 'error',
+                                completed=e.success,
+                                messages=e.status_messages), process_item=remove_sensitive)
+                if prompt_lifecycle is not None:
+                    prompt_lifecycle.mark_task_done_succeeded()
             if server_instance.client_id is not None:
                 server_instance.send_sync("executing", {"node": None, "prompt_id": prompt_id}, server_instance.client_id)
 
@@ -522,6 +534,7 @@ def start_comfyui(asyncio_loop=None):
         init_custom_nodes=(not args.disable_all_custom_nodes) or len(args.whitelist_custom_nodes) > 0,
         init_api_nodes=not args.disable_api_nodes
     ))
+    _freeze_handler_routes()
 
     # Re-apply Comfy's cuDNN benchmark policy after custom-node imports. Benchmark
     # mode can request near-card-sized autotune workspaces, and some custom nodes set it at import time.

--- a/tests-unit/execution_test/test_execution_lifecycle.py
+++ b/tests-unit/execution_test/test_execution_lifecycle.py
@@ -1,0 +1,579 @@
+import asyncio
+import threading
+
+import pytest
+
+from comfy.cli_args import args
+from comfy_api.latest import ExecutionLifecycle
+from comfy_api.latest._execution_lifecycle import (
+    CancelledEvent,
+    FailedEvent,
+    FailureSource,
+    InterruptedEvent,
+    LifecycleHandler,
+    QueuedEvent,
+    StartedEvent,
+    SucceededEvent,
+)
+from comfy_execution import lifecycle
+
+
+args.cpu = True
+
+
+@pytest.fixture(autouse=True)
+def reset_lifecycle():
+    lifecycle._reset_for_tests()
+    yield
+    lifecycle._reset_for_tests()
+
+
+def queued_event(prompt_id="prompt-1", metadata=None):
+    return QueuedEvent(
+        prompt_id=prompt_id,
+        queue_number=1.0,
+        output_node_ids=("2",),
+        metadata=metadata or lifecycle._EMPTY_MAPPING,
+        queued_at_ms=100,
+    )
+
+
+def all_events():
+    metadata = lifecycle._EMPTY_MAPPING
+    return [
+        queued_event(metadata=metadata),
+        StartedEvent("prompt-1", metadata, 100, 110),
+        SucceededEvent("prompt-1", metadata, {}, 100, 110, 120, 10),
+        FailedEvent(
+            "prompt-1", metadata, FailureSource.NODE, "1", "Node", "ValueError",
+            "failed", (), (), None, True, 100, 110, 115, 120, 10,
+        ),
+        InterruptedEvent("prompt-1", metadata, "1", "Node", (), None, 100, 110, 115, 120, 10),
+        CancelledEvent("prompt-1", metadata, 100, 120),
+    ]
+
+
+def test_default_handler_methods_are_noops():
+    handler = LifecycleHandler()
+    events = all_events()
+
+    assert handler.accepts(events[0]) is True
+    handler.on_queued(events[0])
+    handler.on_started(events[1])
+    handler.on_succeeded(events[2])
+    handler.on_failed(events[3])
+    handler.on_interrupted(events[4])
+    handler.on_cancelled(events[5])
+
+
+def test_public_namespace_registers_handler():
+    class Handler(ExecutionLifecycle.Handler):
+        def on_failed(self, event):
+            pass
+
+    handler = Handler()
+    asyncio.run(ExecutionLifecycle().register(handler))
+
+    assert lifecycle._pending_registrations[0].handler is handler
+
+
+def test_each_event_routes_to_matching_method_in_fifo_order():
+    calls = []
+
+    class Handler(LifecycleHandler):
+        def on_queued(self, event):
+            calls.append("queued")
+
+        def on_started(self, event):
+            calls.append("started")
+
+        def on_succeeded(self, event):
+            calls.append("succeeded")
+
+        def on_failed(self, event):
+            calls.append("failed")
+
+        def on_interrupted(self, event):
+            calls.append("interrupted")
+
+        def on_cancelled(self, event):
+            calls.append("cancelled")
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    for event in all_events():
+        lifecycle._publish(event)
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert calls == ["queued", "started", "succeeded", "failed", "interrupted", "cancelled"]
+
+
+def test_registration_order_filtering_and_freeze():
+    calls = []
+
+    class Handler(LifecycleHandler):
+        def __init__(self, name, accepted=True):
+            self.name = name
+            self.accepted = accepted
+
+        def accepts(self, event):
+            return self.accepted
+
+        def on_queued(self, event):
+            calls.append(self.name)
+
+    first = Handler("first")
+    rejected = Handler("rejected", False)
+    second = Handler("second")
+    lifecycle._register_handler(first)
+    lifecycle._register_handler(rejected)
+    lifecycle._register_handler(second)
+    lifecycle._register_handler(first)
+    lifecycle._freeze_handler_routes()
+    lifecycle._freeze_handler_routes()
+    lifecycle._publish(queued_event())
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert calls == ["first", "second"]
+    assert isinstance(lifecycle._frozen_routes[QueuedEvent], tuple)
+    with pytest.raises(RuntimeError):
+        lifecycle._register_handler(Handler("late"))
+
+
+@pytest.mark.parametrize("phase", ["accepts", "callback"])
+@pytest.mark.parametrize("exception_type", [RuntimeError, BaseException])
+def test_handler_failure_does_not_stop_other_handlers_or_events(phase, exception_type):
+    calls = []
+
+    class FailingHandler(LifecycleHandler):
+        def accepts(self, event):
+            if phase == "accepts":
+                raise exception_type("accepts failed")
+            return True
+
+        def on_queued(self, event):
+            raise exception_type("callback failed")
+
+    class AcceptedHandler(LifecycleHandler):
+        def on_queued(self, event):
+            calls.append((event.prompt_id, threading.current_thread().name))
+
+    lifecycle._register_handler(FailingHandler())
+    lifecycle._register_handler(AcceptedHandler())
+    lifecycle._freeze_handler_routes()
+    lifecycle._publish(queued_event())
+    lifecycle._publish(queued_event("prompt-2"))
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert calls == [
+        ("prompt-1", "execution-lifecycle"),
+        ("prompt-2", "execution-lifecycle"),
+    ]
+
+
+def test_handler_registration_validation_and_no_handler_fast_path():
+    class EmptyHandler(LifecycleHandler):
+        pass
+
+    class AsyncHandler(LifecycleHandler):
+        async def on_queued(self, event):
+            pass
+
+    class AsyncFilterHandler(LifecycleHandler):
+        async def accepts(self, event):
+            return True
+
+        def on_queued(self, event):
+            pass
+
+    with pytest.raises(TypeError):
+        lifecycle._register_handler(lambda event: None)
+    with pytest.raises(TypeError):
+        lifecycle._register_handler(EmptyHandler())
+    with pytest.raises(TypeError):
+        lifecycle._register_handler(AsyncHandler())
+    with pytest.raises(TypeError):
+        lifecycle._register_handler(AsyncFilterHandler())
+
+    lifecycle._freeze_handler_routes()
+    assert lifecycle._has_any_handlers() is False
+    assert lifecycle._dispatch_thread is None
+
+
+def test_metadata_is_recursively_frozen_and_limited_to_reserved_namespace():
+    extra_data = {
+        "execution_lifecycle": {
+            "business_task_id": "task-1",
+            "listeners": ["business-status"],
+            "nested": {"values": [1, 2]},
+        },
+        "client_id": "secret",
+    }
+
+    metadata = lifecycle._freeze_metadata(extra_data)
+    extra_data["execution_lifecycle"]["business_task_id"] = "changed"
+    extra_data["execution_lifecycle"]["nested"]["values"].append(3)
+
+    assert metadata["business_task_id"] == "task-1"
+    assert metadata["listeners"] == ("business-status",)
+    assert metadata["nested"]["values"] == (1, 2)
+    assert "client_id" not in metadata
+    with pytest.raises(TypeError):
+        metadata["business_task_id"] = "mutated"
+
+
+def test_invalid_and_empty_snapshots_are_distinct():
+    assert lifecycle._freeze_metadata({"execution_lifecycle": {"value": object()}}) == {}
+    assert lifecycle._freeze_history_result({}) == {}
+    assert lifecycle._freeze_history_result({"unsupported": object()}) is None
+
+
+def test_history_snapshot_is_frozen_and_detached():
+    history_result = {
+        "outputs": {
+            "2": {"lifecycle_test": [{"nested": {"values": [1, 2]}}]},
+        },
+    }
+
+    snapshot = lifecycle._freeze_history_result(history_result)
+    history_result["outputs"]["2"]["lifecycle_test"][0]["nested"]["values"].append(3)
+
+    assert snapshot["outputs"]["2"]["lifecycle_test"][0]["nested"]["values"] == (1, 2)
+    with pytest.raises(TypeError):
+        snapshot["outputs"]["2"] = {}
+
+
+def test_execution_context_publishes_started_then_succeeded():
+    events = []
+
+    class Handler(LifecycleHandler):
+        def on_started(self, event):
+            events.append(event)
+
+        def on_succeeded(self, event):
+            events.append(event)
+
+    metadata = lifecycle._freeze_metadata({"execution_lifecycle": {"business_task_id": "task-1"}})
+    context = lifecycle._QueuedLifecycleContext(100, metadata)
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+
+    with lifecycle._PromptExecutionLifecycle("prompt-1", context) as execution_lifecycle:
+        execution_lifecycle.record_executor_result(
+            [("execution_success", {"prompt_id": "prompt-1", "timestamp": 200})],
+            {"outputs": {"2": {"images": [{"filename": "result.png"}]}}},
+        )
+        execution_lifecycle.mark_task_done_succeeded()
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert [type(event) for event in events] == [StartedEvent, SucceededEvent]
+    assert events[0].metadata is metadata
+    assert events[1].metadata is metadata
+    assert events[1].history_result["outputs"]["2"]["images"][0]["filename"] == "result.png"
+
+
+def test_terminal_snapshot_is_not_built_without_matching_handler(monkeypatch):
+    class Handler(LifecycleHandler):
+        def on_started(self, event):
+            pass
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    monkeypatch.setattr(
+        lifecycle,
+        "_freeze_history_result",
+        lambda result: pytest.fail("history snapshot built"),
+    )
+    context = lifecycle._QueuedLifecycleContext(100, lifecycle._EMPTY_MAPPING)
+
+    with lifecycle._PromptExecutionLifecycle("prompt-1", context) as execution_lifecycle:
+        execution_lifecycle.record_executor_result(
+            [("execution_success", {"timestamp": 200})],
+            {"outputs": {"unsupported": object()}},
+        )
+        execution_lifecycle.mark_task_done_succeeded()
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+
+
+def test_node_failure_remains_primary_when_task_done_raises():
+    received = []
+
+    class Handler(LifecycleHandler):
+        def on_failed(self, event):
+            received.append(event)
+
+    context = lifecycle._QueuedLifecycleContext(100, lifecycle._EMPTY_MAPPING)
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+
+    with pytest.raises(RuntimeError, match="task_done failed"):
+        with lifecycle._PromptExecutionLifecycle("prompt-1", context) as execution_lifecycle:
+            execution_lifecycle.record_executor_result(
+                [("execution_error", {
+                    "node_id": "10",
+                    "node_type": "FailingNode",
+                    "executed": ["3", "1"],
+                    "exception_type": "ValueError",
+                    "exception_message": "bad input",
+                    "traceback": ["trace"],
+                    "timestamp": 200,
+                    "current_inputs": {"secret": "do-not-copy"},
+                    "current_outputs": ["do-not-copy"],
+                })],
+                {"outputs": {}},
+            )
+            raise RuntimeError("task_done failed")
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    event = received[0]
+    assert event.source is FailureSource.NODE
+    assert event.exception_type == "ValueError"
+    assert event.executed_nodes == ("1", "3")
+    assert event.history_task_done_succeeded is False
+    assert not hasattr(event, "current_inputs")
+    assert not hasattr(event, "current_outputs")
+
+
+def test_missing_terminal_status_is_internal_failure():
+    received = []
+
+    class Handler(LifecycleHandler):
+        def on_failed(self, event):
+            received.append(event)
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    context = lifecycle._QueuedLifecycleContext(100, lifecycle._EMPTY_MAPPING)
+
+    with lifecycle._PromptExecutionLifecycle("prompt-1", context) as execution_lifecycle:
+        execution_lifecycle.record_executor_result([], {"outputs": {}})
+        execution_lifecycle.mark_task_done_succeeded()
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert received[0].source is FailureSource.INTERNAL
+    assert received[0].exception_type == "MissingTerminalExecutionStatus"
+    assert received[0].history_task_done_succeeded is True
+
+
+def test_escaping_exception_does_not_use_stale_history_and_propagates():
+    received = []
+
+    class Handler(LifecycleHandler):
+        def on_failed(self, event):
+            received.append(event)
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    context = lifecycle._QueuedLifecycleContext(100, lifecycle._EMPTY_MAPPING)
+
+    with pytest.raises(ValueError, match="prepare failed"):
+        with lifecycle._PromptExecutionLifecycle("prompt-1", context):
+            raise ValueError("prepare failed")
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert received[0].source is FailureSource.INTERNAL
+    assert received[0].exception_type == "ValueError"
+    assert received[0].history_result is None
+
+
+def test_task_done_failure_replaces_interrupted_terminal_event():
+    failures = []
+    interruptions = []
+
+    class Handler(LifecycleHandler):
+        def on_failed(self, event):
+            failures.append(event)
+
+        def on_interrupted(self, event):
+            interruptions.append(event)
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    context = lifecycle._QueuedLifecycleContext(100, lifecycle._EMPTY_MAPPING)
+
+    with pytest.raises(RuntimeError, match="history failed"):
+        with lifecycle._PromptExecutionLifecycle("prompt-1", context) as execution_lifecycle:
+            execution_lifecycle.record_executor_result(
+                [("execution_interrupted", {"timestamp": 200})],
+                {"outputs": {}},
+            )
+            raise RuntimeError("history failed")
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert failures[0].source is FailureSource.INTERNAL
+    assert failures[0].history_task_done_succeeded is False
+    assert interruptions == []
+
+
+def test_interrupted_event_is_distinct_terminal_event():
+    received = []
+
+    class Handler(LifecycleHandler):
+        def on_interrupted(self, event):
+            received.append(event)
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    context = lifecycle._QueuedLifecycleContext(100, lifecycle._EMPTY_MAPPING)
+
+    with lifecycle._PromptExecutionLifecycle("prompt-1", context) as execution_lifecycle:
+        execution_lifecycle.record_executor_result(
+            [("execution_interrupted", {
+                "node_id": "10",
+                "node_type": "Sampler",
+                "executed": ["3", "1"],
+                "timestamp": 200,
+            })],
+            {"outputs": {}},
+        )
+        execution_lifecycle.mark_task_done_succeeded()
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert isinstance(received[0], InterruptedEvent)
+    assert received[0].executed_nodes == ("1", "3")
+    assert received[0].interruption_reported_at_ms == 200
+
+
+def test_prompt_queue_uses_same_context_for_queued_and_cancelled_events():
+    import execution
+
+    events = []
+
+    class Handler(LifecycleHandler):
+        def on_queued(self, event):
+            events.append(event)
+
+        def on_cancelled(self, event):
+            events.append(event)
+
+    class Server:
+        def queue_updated(self):
+            pass
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    prompt_queue = execution.PromptQueue(Server())
+    item = (
+        1.0,
+        "prompt-1",
+        {},
+        {"execution_lifecycle": {"business_task_id": "task-1"}},
+        {"2", "1"},
+        {"api_key": "secret"},
+    )
+
+    prompt_queue.put(item)
+    assert prompt_queue.delete_queue_item(lambda queued: queued[1] == "prompt-1")
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    queued, cancelled = events
+    assert queued.output_node_ids == ("1", "2")
+    assert queued.metadata is cancelled.metadata
+    assert "api_key" not in queued.metadata
+    assert queued.queued_at_ms == cancelled.queued_at_ms
+    assert prompt_queue._queued_lifecycle_contexts == {}
+
+
+def test_prompt_queue_get_preserves_contract_and_exposes_private_context():
+    import execution
+
+    class Handler(LifecycleHandler):
+        def on_started(self, event):
+            pass
+
+    class Server:
+        def queue_updated(self):
+            pass
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    prompt_queue = execution.PromptQueue(Server())
+    item = (
+        1.0,
+        "prompt-1",
+        {},
+        {"execution_lifecycle": {"business_task_id": "task-1"}},
+        set(),
+        {},
+    )
+    prompt_queue.put(item)
+
+    returned_item, item_id = prompt_queue.get(timeout=0)
+    context = prompt_queue._take_lifecycle_context(item_id)
+
+    assert returned_item is item
+    assert item_id == 0
+    assert context.metadata["business_task_id"] == "task-1"
+    assert prompt_queue._queued_lifecycle_contexts == {}
+    assert prompt_queue._running_lifecycle_contexts == {}
+
+
+def test_no_handlers_create_no_queue_context_or_metadata_snapshot(monkeypatch):
+    import execution
+
+    class Server:
+        def queue_updated(self):
+            pass
+
+    lifecycle._freeze_handler_routes()
+    monkeypatch.setattr(lifecycle, "_freeze_metadata", lambda extra_data: pytest.fail("metadata copied"))
+    prompt_queue = execution.PromptQueue(Server())
+    item = (1.0, "prompt-1", {}, {"execution_lifecycle": {"task": "ignored"}}, set(), {})
+
+    prompt_queue.put(item)
+    returned_item, item_id = prompt_queue.get(timeout=0)
+
+    assert returned_item is item
+    assert item_id == 0
+    assert prompt_queue._queued_lifecycle_contexts == {}
+    assert prompt_queue._running_lifecycle_contexts == {}
+    assert prompt_queue._take_lifecycle_context(item_id) is None
+
+
+def test_missing_expected_context_returns_none_without_rebuilding(caplog):
+    import execution
+
+    class Handler(LifecycleHandler):
+        def on_started(self, event):
+            pass
+
+    class Server:
+        def queue_updated(self):
+            pass
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    prompt_queue = execution.PromptQueue(Server())
+    prompt_queue.currently_running[7] = (1.0, "prompt-7", {}, {}, set(), {})
+
+    assert prompt_queue._take_lifecycle_context(7) is None
+    assert "Missing execution lifecycle context for prompt prompt-7" in caplog.text
+
+
+def test_wipe_queue_cancels_duplicate_prompt_ids_with_independent_contexts():
+    import execution
+
+    cancelled = []
+
+    class Handler(LifecycleHandler):
+        def on_cancelled(self, event):
+            cancelled.append(event)
+
+    class Server:
+        def queue_updated(self):
+            pass
+
+    lifecycle._register_handler(Handler())
+    lifecycle._freeze_handler_routes()
+    prompt_queue = execution.PromptQueue(Server())
+    first = (1.0, "same-prompt", {}, {"execution_lifecycle": {"task": "first"}}, set(), {})
+    second = (2.0, "same-prompt", {}, {"execution_lifecycle": {"task": "second"}}, set(), {})
+    prompt_queue.put(first)
+    prompt_queue.put(second)
+
+    prompt_queue.wipe_queue()
+
+    assert lifecycle._wait_for_dispatch_for_tests()
+    assert {event.metadata["task"] for event in cancelled} == {"first", "second"}
+    assert prompt_queue._queued_lifecycle_contexts == {}


### PR DESCRIPTION
## Summary

Add a typed prompt lifecycle API for V3 server extensions.

Extensions can register one `ExecutionLifecycle.Handler` during `on_load()` and override callbacks for queued, started, succeeded, failed, interrupted, and cancelled prompts. Handler filtering and callbacks run on a dedicated FIFO dispatcher thread, and handler failures are isolated from prompt execution and from other handlers.

The queue and worker integration records immutable lifecycle metadata at enqueue time, publishes cancellation only for prompts removed before execution, and publishes one concrete terminal event for prompts that start. Successful and interrupted terminal events are emitted after `PromptQueue.task_done()` returns.

## Compatibility

- Keeps the six-element queue item unchanged.
- Keeps `PromptQueue.get()` returning `(item, item_id)`.
- Keeps the existing `ExecutionStatus` calculation based on `PromptExecutor.success`.
- Does not change HTTP, WebSocket, history, job, or workflow formats.
- Does not add dependencies or outbound I/O.
- Does no per-prompt lifecycle allocation or snapshot work when no handler is registered.

## Tests

- `tests-unit/execution_test`: 128 passed
- `tests-unit/jobs_cancel_test/jobs_cancel_test.py`: 22 passed
- `tests/execution/test_execution.py --skip-timing-checks`: 156 passed
- Ruff checks passed for all changed Python files.
- Generated synchronous API stubs are reproducible.
- `git diff --check` passed.

## Related issues

Proposed in #15341.

Addresses the Python backend portion of #8029.

Related to #11540. This change adds a server-extension completion boundary; it does not move or replace the existing `execution_success` WebSocket event.
