### PR TITLE
feat(api_nodes): add MiniMax Hailuo-03 / H3 model support for T2V and I2V

### DIFF
--- a/comfy_api_nodes/apis/__init__.py
+++ b/comfy_api_nodes/apis/__init__.py
@@ -1638,6 +1638,8 @@ class MiniMaxModel(str, Enum):
     I2V_01_live = 'I2V-01-live'
     T2V_01 = 'T2V-01'
     Hailuo_02 = 'MiniMax-Hailuo-02'
+    Hailuo_03 = 'MiniMax-Hailuo-03'
+    H3 = 'MiniMax-H3'
 
 
 class SubjectReferenceItem(BaseModel):
@@ -1661,7 +1663,7 @@ class MinimaxVideoGenerationRequest(BaseModel):
     )
     model: MiniMaxModel = Field(
         ...,
-        description='Required. ID of model. Options: T2V-01-Director, I2V-01-Director, S2V-01, I2V-01, I2V-01-live, T2V-01',
+        description='Required. ID of model. Options: T2V-01-Director, I2V-01-Director, S2V-01, I2V-01, I2V-01-live, T2V-01, MiniMax-Hailuo-02, MiniMax-Hailuo-03, MiniMax-H3',
     )
     prompt: Optional[str] = Field(
         None,

--- a/comfy_api_nodes/nodes_minimax.py
+++ b/comfy_api_nodes/nodes_minimax.py
@@ -157,7 +157,7 @@ class MinimaxTextToVideoNode(IO.ComfyNode):
                 ),
                 IO.Combo.Input(
                     "model",
-                    options=["T2V-01", "T2V-01-Director"],
+                    options=["T2V-01", "T2V-01-Director", "MiniMax-Hailuo-03", "MiniMax-H3", "MiniMax-Hailuo-02"],
                     default="T2V-01",
                     tooltip="Model to use for video generation",
                 ),
@@ -228,7 +228,7 @@ class MinimaxImageToVideoNode(IO.ComfyNode):
                 ),
                 IO.Combo.Input(
                     "model",
-                    options=["I2V-01-Director", "I2V-01", "I2V-01-live"],
+                    options=["I2V-01", "I2V-01-Director", "I2V-01-live", "MiniMax-Hailuo-03", "MiniMax-H3", "MiniMax-Hailuo-02"],
                     default="I2V-01",
                     tooltip="Model to use for video generation",
                 ),
@@ -348,7 +348,7 @@ class MinimaxSubjectToVideoNode(IO.ComfyNode):
 
 
 class MinimaxHailuoVideoNode(IO.ComfyNode):
-    """Generates videos from prompt, with optional start frame using the new MiniMax Hailuo-02 model."""
+    """Generates videos from prompt, with optional start frame using MiniMax Hailuo models (MiniMax-Hailuo-03 / H3, MiniMax-Hailuo-02)."""
 
     @classmethod
     def define_schema(cls) -> IO.Schema:
@@ -363,6 +363,13 @@ class MinimaxHailuoVideoNode(IO.ComfyNode):
                     multiline=True,
                     default="",
                     tooltip="Text prompt to guide the video generation.",
+                ),
+                IO.Combo.Input(
+                    "model",
+                    options=["MiniMax-Hailuo-03", "MiniMax-H3", "MiniMax-Hailuo-02"],
+                    default="MiniMax-Hailuo-03",
+                    tooltip="Model to use for video generation.",
+                    optional=True,
                 ),
                 IO.Int.Input(
                     "seed",
@@ -418,7 +425,7 @@ class MinimaxHailuoVideoNode(IO.ComfyNode):
         prompt_optimizer: bool = True,
         duration: int = 6,
         resolution: str = "768P",
-        model: str = "MiniMax-Hailuo-02",
+        model: str = "MiniMax-Hailuo-03",
     ) -> IO.NodeOutput:
         auth = {
             "auth_token": cls.hidden.auth_token_comfy_org,


### PR DESCRIPTION
Adds support for MiniMax Hailuo-03 and MiniMax-H3 models to MiniMax API video generation nodes (Text-to-Video and Image-to-Video).