### PR TITLE
fix(bytedance): Layer Separation price badge never matches the size widget

### DIFF
--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -1168,7 +1168,7 @@ class ByteDanceSeedreamLayerSeparationNode(IO.ComfyNode):
                 depends_on=IO.PriceBadgeDepends(widgets=["size"]),
                 expr="""
                 (
-                  widgets.size in ["1k", "1.5k"]
+                  $lowercase(widgets.size) in ["1k", "1.5k"]
                     ? {
                         "type": "usd",
                         "usd": 0.032,


### PR DESCRIPTION
Targets `feat/api-nodes/bytedance-layer-separation`, the branch of https://github.com/Comfy-Org/ComfyUI/pull/15351.

### The bug

`ByteDanceSeedreamLayerSeparationNode`'s price badge tests

```
widgets.size in ["1k", "1.5k"]
```

against a combo declared as

```python
IO.Combo.Input("size", options=["auto", "1K", "1.5K", "2K"], default="auto", ...)
```

JSONata `in` is case-sensitive, so the condition is **false for every value the widget can hold**. The `range_usd` branch is therefore the only branch that ever renders — a user who explicitly picks `1K` or `1.5K` still sees `$0.032 - $0.064` instead of the flat `$0.032`.

### Reproduction

Evaluated with the same `jsonata` package the frontend uses to render the badge:

```
$ node -e "const j=require('jsonata'); const e='widgets.size in [\"1k\",\"1.5k\"]';
  (async()=>{for(const s of ['auto','1K','1.5K','2K']) console.log(s, await j(e).evaluate({widgets:{size:s}}))})();"
auto  false
1K    false
1.5K  false
2K    false
```

After this change:

```
auto   range_usd 0.032-0.064
1K     usd 0.032
1.5K   usd 0.032
2K     range_usd 0.032-0.064
undef  range_usd 0.032-0.064   (unchanged fallback)
```

### Why `$lowercase` rather than rewriting the literals as `["1K", "1.5K"]`

Both fix today's bug. `$lowercase` additionally survives a label-casing change to the combo, which is exactly the failure mode being fixed. Fallback behaviour for an absent/undefined `widgets.size` is unchanged (JSONata propagates undefined, the `in` test is false, the range branch renders).

### Not changed — one open question for @bigcat88

`2K` currently falls into the `range_usd 0.032 - 0.064` branch. If 2K is a known flat price (the range's max being exactly 2x the min suggests 0.064), the badge should say so. I did not guess at a billing number; please confirm and I will follow up, or fold it into this PR.

This is the item Christian raised in Slack (`price badge is "2K" in one place and "2k" in another`) and it blocks the pricing checkbox on https://github.com/Comfy-Org/ComfyUI/pull/15351.

### Testing

No Python-side test: the expression is JSONata and is only evaluated in the frontend, and this repo has no price-badge test harness. Verified with the `jsonata` package as shown above. `ruff check` clean.


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

