### PR TITLE
Fix MiniMax H3 audio VAE DynamicVRAM thrashing

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -978,6 +978,7 @@ class VAE:
                 self.process_output = lambda audio: audio
                 self.process_input = lambda audio: audio
                 self.working_dtypes = [torch.float32]
+                self.disable_offload = True
                 # encode gets the waveform shape [B, 2, samples], decode the latent shape [B, 32, 2, T]
                 def estimate_encode_memory(samples, dtype):
                     return (900 * samples + 105_000_000) * model_management.dtype_size(dtype) * 1.03


### PR DESCRIPTION
## Summary

- fully load the MiniMax H3 audio VAE instead of using DynamicVRAM weight streaming
- keep global DynamicVRAM behavior and the MiniMax H3 video VAE unchanged

## Problem

`MiniMaxH3AudioVAE` is about 577 MB, but it currently inherits `disable_offload = False`. That selects `CoreModelPatcher`, so its weights are streamed during decode. In the reproduced Windows/NVIDIA path this caused repeated VRAM transfers and made a 5-second audio decode take about 153 seconds.

This also avoids the exact `576MB Staged, 401 weights` DynamicVRAM path reported in #15276 and the broader host-buffer failures discussed in #15255.

## Change

Set the VAE-owned `disable_offload` flag when the MiniMax H3 audio checkpoint is detected. This selects the regular `ModelPatcher` and the existing full-load decode path, matching other audio VAE integrations that disable offloading.

The tradeoff is keeping about 577 MB resident while the audio VAE is loaded. Global DynamicVRAM remains enabled for larger models.

## Validation

- `python -m py_compile comfy/sd.py`
- `git diff --check`
- loaded `minimax_h3_audio_vae_fp32.safetensors` through `comfy.sd.VAE`
- verified `disable_offload == True`, `ModelPatcher`, and `is_dynamic() == False`
- decoded a `[1, 32, 2, 200]` 5-second latent to finite `[1, 160000, 2]` audio
- RTX PRO 6000 Blackwell, PyTorch 2.9.1+cu130: 0.447 s decode, 686.83 MiB CUDA peak
- ComfyUI queue smoke test logged `loaded completely; 577.08 MB loaded, full load: True` and completed the prompt in 0.70 s
