### PR TITLE
ci: remove desktop release dispatch (no listener, archived target)

### DIFF
--- a/.github/workflows/release-webhook.yml
+++ b/.github/workflows/release-webhook.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   send-webhook:
     runs-on: ubuntu-latest
-    env:
-      DESKTOP_REPO_DISPATCH_TOKEN: ${{ secrets.DESKTOP_REPO_DISPATCH_TOKEN }}
     steps:
       - name: Send release webhook
         env:
@@ -108,37 +106,3 @@ jobs:
             --fail --silent --show-error
           
           echo "✅ Release webhook sent successfully"
-
-      - name: Send repository dispatch to desktop
-        env:
-          DISPATCH_TOKEN: ${{ env.DESKTOP_REPO_DISPATCH_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${DISPATCH_TOKEN:-}" ]; then
-            echo "::error::DESKTOP_REPO_DISPATCH_TOKEN is required but not set."
-            exit 1
-          fi
-
-          PAYLOAD="$(jq -n \
-            --arg release_tag "$RELEASE_TAG" \
-            --arg release_url "$RELEASE_URL" \
-            '{
-              event_type: "comfyui_release_published",
-              client_payload: {
-                release_tag: $release_tag,
-                release_url: $release_url
-              }
-            }')"
-
-          curl -fsSL \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-            https://api.github.com/repos/Comfy-Org/desktop/dispatches \
-            -d "$PAYLOAD"
-
-          echo "✅ Dispatched ComfyUI release ${RELEASE_TAG} to Comfy-Org/desktop"


### PR DESCRIPTION
## Summary

Removes the `Send repository dispatch to desktop` step from the release webhook workflow, along with the `DESKTOP_REPO_DISPATCH_TOKEN` wiring (this workflow was its only consumer).

Supersedes #15381, which retargeted the dispatch from the archived `Comfy-Org/desktop` to `Comfy-Org/Comfy-Desktop` — see that PR for the full investigation (credit @christian-byrne). Deleting is the better end state:

- **No consumer.** No `repository_dispatch` / `comfyui_release_published` listener exists in any Comfy-Org/Comfy-Desktop workflow. The POST returns 204 regardless, so a retargeted step would log "✅ Dispatched" on every release while doing nothing.
- **Never ran anyway.** The step has been skipped on every release since at least v0.20.1 (2026-04-27) because the preceding webhook step fails first — and nothing downstream was missed.
- **Purpose is obsolete.** #12398 intended auto-bump PRs for a pinned ComfyUI version; Comfy-Desktop now resolves the ComfyUI version at runtime from the R2 standalone catalog.
- **Carrying cost.** Keeping it means maintaining a cross-repo write-scoped PAT solely to emit an event nobody consumes.

If Desktop wants release-triggered automation later, it should be designed listener-first; re-adding the send half is trivial.

## Follow-ups (not in this PR)

- Delete the `DESKTOP_REPO_DISPATCH_TOKEN` secret from repo settings (org admin).
- The `Send release webhook` step still fails with a 500 from `RELEASE_GITHUB_WEBHOOK_URL` on every release — that endpoint needs an owner.