### PR TITLE
[DRAFT] fix(ByteDance): Layer Separation bounding boxes are exclusive, not inclusive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,12 @@
 
 - Follow existing node conventions: `INPUT_TYPES`, `RETURN_TYPES`, `FUNCTION`,
   `CATEGORY`, and registration through the local mapping used by that file.
+- Treat legacy combo inputs, `io.Combo`, and `io.DynamicCombo` values as
+  untrusted when they affect filesystem access. Any value used as a file or
+  folder name, path component, format, or extension must be validated again at
+  the load/save boundary using an existing `folder_paths` resolver or
+  containment helper, or a fixed allowlist/mapping. Do not rely only on the
+  advertised combo options or prompt validation.
 - Keep node changes backward compatible by default. Add inputs with sensible
   defaults and avoid changing output types unless the request requires it.
 - Model implementations should add the minimal number of ComfyUI nodes required

--- a/README.md
+++ b/README.md
@@ -145,11 +145,19 @@ ComfyUI follows a weekly release cycle targeting Monday but this regularly chang
 
 # Installing
 
+## Windows and Mac
+
+We highly recommend using the [desktop app](https://comfy.org/download):
+
+### [Link to Download](https://comfy.org/download)
+
+The desktop app is the easiest and best way to use ComfyUI for new users.
+
 ## Windows Portable
 
-There is a portable standalone build for Windows that should work for running on Nvidia GPUs or for running on your CPU only on the [releases page](https://github.com/comfyanonymous/ComfyUI/releases).
+There is a portable standalone build for Windows that should work for running on Nvidia GPUs or for running on your CPU only. It is not recommended for regular users. Regular users should use the desktop app above.
 
-### [Direct link to download](https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia.7z)
+[Direct link to download (nvidia)](https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia.7z)
 
 Simply download, extract with [7-Zip](https://7-zip.org) or with the windows explorer on recent windows versions and run. For smaller models you normally only need to put the checkpoints (the huge ckpt/safetensors files) in: ComfyUI\models\checkpoints but many of the larger models have multiple files. Make sure to follow the instructions to know which subfolder to put them in ComfyUI\models\
 
@@ -165,7 +173,7 @@ The portable above currently comes with python 3.13 and pytorch cuda 13.0. Updat
 
 [Portable for Nvidia GPUs](https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia.7z) (supports 20 series and above).
 
-[Portable for Nvidia GPUs with pytorch cuda 12.6 and python 3.12](https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia_cu126.7z) (Supports Nvidia 10 series and older GPUs).
+[Portable for Nvidia GPUs with pytorch cuda 12.6 and python 3.12](https://github.com/comfyanonymous/ComfyUI/releases/latest/download/ComfyUI_windows_portable_nvidia_cu126.7z) (Supports Nvidia 10 series and older GPUs, DO NOT USE THIS ON NEWER 20 SERIES AND ABOVE GPUS).
 
 #### How do I share models between another UI and ComfyUI?
 

--- a/README.md
+++ b/README.md
@@ -66,67 +66,24 @@ Supports all operating systems and GPU types (NVIDIA, AMD, Intel, Apple Silicon,
 See what ComfyUI can do with the [newer template workflows](https://comfy.org/workflows) or old [example workflows](https://comfyanonymous.github.io/ComfyUI_examples/).
 
 ## Features
-- Nodes/graph/flowchart interface to experiment and create complex Stable Diffusion workflows without needing to code anything.
-- NOTE: There are many more models supported than the list below, if you want to see what is supported see our templates list inside ComfyUI.
-- Image Models
-   - SD1.x, SD2.x ([unCLIP](https://comfyanonymous.github.io/ComfyUI_examples/unclip/))
-   - [SDXL](https://comfyanonymous.github.io/ComfyUI_examples/sdxl/), [SDXL Turbo](https://comfyanonymous.github.io/ComfyUI_examples/sdturbo/)
-   - [Stable Cascade](https://comfyanonymous.github.io/ComfyUI_examples/stable_cascade/)
-   - [SD3 and SD3.5](https://comfyanonymous.github.io/ComfyUI_examples/sd3/)
-   - Pixart Alpha and Sigma
-   - [AuraFlow](https://comfyanonymous.github.io/ComfyUI_examples/aura_flow/)
-   - [HunyuanDiT](https://comfyanonymous.github.io/ComfyUI_examples/hunyuan_dit/)
-   - [Flux](https://comfyanonymous.github.io/ComfyUI_examples/flux/)
-   - [Lumina Image 2.0](https://comfyanonymous.github.io/ComfyUI_examples/lumina2/)
-   - [HiDream](https://comfyanonymous.github.io/ComfyUI_examples/hidream/)
-   - [Qwen Image](https://comfyanonymous.github.io/ComfyUI_examples/qwen_image/)
-   - [Hunyuan Image 2.1](https://comfyanonymous.github.io/ComfyUI_examples/hunyuan_image/)
-   - [Flux 2](https://comfyanonymous.github.io/ComfyUI_examples/flux2/)
-   - [Z Image](https://comfyanonymous.github.io/ComfyUI_examples/z_image/)
-   - Ernie Image
-- Image Editing Models
-   - [Omnigen 2](https://comfyanonymous.github.io/ComfyUI_examples/omnigen/)
-   - [Flux Kontext](https://comfyanonymous.github.io/ComfyUI_examples/flux/#flux-kontext-image-editing-model)
-   - [HiDream E1.1](https://comfyanonymous.github.io/ComfyUI_examples/hidream/#hidream-e11)
-   - [Qwen Image Edit](https://comfyanonymous.github.io/ComfyUI_examples/qwen_image/#edit-model)
-- Video Models
-   - [Stable Video Diffusion](https://comfyanonymous.github.io/ComfyUI_examples/video/)
-   - [Mochi](https://comfyanonymous.github.io/ComfyUI_examples/mochi/)
-   - [LTX-Video](https://comfyanonymous.github.io/ComfyUI_examples/ltxv/)
-   - [Hunyuan Video](https://comfyanonymous.github.io/ComfyUI_examples/hunyuan_video/)
-   - [Wan 2.1](https://comfyanonymous.github.io/ComfyUI_examples/wan/)
-   - [Wan 2.2](https://comfyanonymous.github.io/ComfyUI_examples/wan22/)
-   - [Hunyuan Video 1.5](https://docs.comfy.org/tutorials/video/hunyuan/hunyuan-video-1-5)
-- Audio Models
-   - [Stable Audio](https://comfyanonymous.github.io/ComfyUI_examples/audio/)
-   - [ACE Step](https://comfyanonymous.github.io/ComfyUI_examples/audio/)
-- 3D Models
-   - [Hunyuan3D 2.0](https://docs.comfy.org/tutorials/3d/hunyuan3D-2)
-- Asynchronous Queue system
-- Many optimizations: Only re-executes the parts of the workflow that changes between executions.
-- Smart memory management: can automatically run large models on GPUs with as low as 1GB vram with smart offloading.
-- Works even if you don't have a GPU with: ```--cpu``` (slow)
-- Can load ckpt and safetensors: All in one checkpoints or standalone diffusion models, VAEs and CLIP models.
-- Safe loading of ckpt, pt, pth, etc.. files.
-- Embeddings/Textual inversion
-- [Loras (regular, locon and loha)](https://comfyanonymous.github.io/ComfyUI_examples/lora/)
-- [Hypernetworks](https://comfyanonymous.github.io/ComfyUI_examples/hypernetworks/)
-- Loading full workflows (with seeds) from generated PNG, WebP and FLAC files.
-- Saving/Loading workflows as Json files.
-- Nodes interface can be used to create complex workflows like one for [Hires fix](https://comfyanonymous.github.io/ComfyUI_examples/2_pass_txt2img/) or much more advanced ones.
-- [Area Composition](https://comfyanonymous.github.io/ComfyUI_examples/area_composition/)
-- [Inpainting](https://comfyanonymous.github.io/ComfyUI_examples/inpaint/) with both regular and inpainting models.
-- [ControlNet and T2I-Adapter](https://comfyanonymous.github.io/ComfyUI_examples/controlnet/)
-- [Upscale Models (ESRGAN, ESRGAN variants, SwinIR, Swin2SR, etc...)](https://comfyanonymous.github.io/ComfyUI_examples/upscale_models/)
-- [GLIGEN](https://comfyanonymous.github.io/ComfyUI_examples/gligen/)
-- [Model Merging](https://comfyanonymous.github.io/ComfyUI_examples/model_merging/)
-- [LCM models and Loras](https://comfyanonymous.github.io/ComfyUI_examples/lcm/)
-- Latent previews with [TAESD](#how-to-show-high-quality-previews)
-- Works fully offline: core will never download anything unless you want to.
-- Optional API nodes to use paid models from external providers through the online [Comfy API](https://docs.comfy.org/tutorials/api-nodes/overview) disable with: `--disable-api-nodes`
-- [Config file](extra_model_paths.yaml.example) to set the search paths for models.
+- A visual node graph for building and reusing image, video, audio, 3D, and text workflows without code.
+- Reusable subgraphs, workflow templates, App Mode, and a local API for integrating workflows into applications.
+- Efficient local execution with asynchronous queueing, partial graph re-execution, smart VRAM and RAM management, model offloading, and support for quantized models.
+- Broad native model support. This is a representative list; browse the [workflow library](https://comfy.org/workflows/) for maintained, ready-to-run templates.
+  - [Image generation](https://comfy.org/workflows/tag/text-to-image/): Stable Diffusion 1.5, SDXL, SD3.5, Flux.1, Flux.2, Qwen Image, Z-Image, Hunyuan Image 2.1, HiDream, Lumina Image 2.0, Chroma, Anima, LongCat Image, Ideogram 4, Krea 2, MageFlow, Microsoft Lens, PixelDiT, Kandinsky 5, and Ernie Image.
+  - [Image editing](https://comfy.org/workflows/tag/image-edit/): Flux Kontext, Flux.2 Klein, Qwen Image Edit, HiDream E1.1 and O1, OmniGen2, Boogu, JoyImage Edit, MageFlow Edit, and LongCat Image Edit.
+  - [Video generation](https://comfy.org/workflows/tag/video-generation/): Wan 2.1 and 2.2, LTX-Video 2 and 2.3, HunyuanVideo 1.5, Kandinsky 5 Video, CogVideoX, Cosmos Predict2, Bernini-R, SCAIL 2, and Mochi.
+  - [Audio and video generation](https://comfy.org/workflows/): MiniMax H3 and LTX-AV.
+  - [Audio generation](https://comfy.org/workflows/tag/text-to-audio/): ACE-Step 1.5 and Stable Audio 3.
+  - [3D and vision](https://comfy.org/workflows/): Hunyuan3D 2.1, TripoSplat, SeedVR2, SUPIR, Depth Anything 3, MoGe, SAM 3 and 3.1, RT-DETRv4, and BiRefNet.
+  - [Text generation](https://comfy.org/workflows/tag/text-generation/): Gemma 3 and 4, Qwen3, Qwen3.5, and Qwen3-VL, including multimodal inputs.
+- Load complete checkpoints or separate diffusion models, VAEs, text encoders, LoRAs, ControlNets, adapters, and upscalers from supported model formats.
+- Built-in tools for inpainting, outpainting, reference conditioning, masks and compositing, model merging, upscaling, frame interpolation, segmentation, depth estimation, and media processing.
+- Save and load workflows as JSON, or recover complete workflows and seeds from supported generated media.
+- Runs fully offline: core does not download anything unless you request it. Use `--disable-api-nodes` to disable the optional paid [Comfy API nodes](https://docs.comfy.org/tutorials/api-nodes/overview) and force all built-in functionality to stay offline.
+- Extend ComfyUI with custom nodes
+- Configure additional model locations with [`extra_model_paths.yaml`](extra_model_paths.yaml.example).
 
-Workflow examples can be found on the [Examples page](https://comfyanonymous.github.io/ComfyUI_examples/)
 
 ## Release Process
 

--- a/comfy/ldm/lightricks/av_model.py
+++ b/comfy/ldm/lightricks/av_model.py
@@ -16,7 +16,9 @@ from comfy.ldm.lightricks.model import (
 from comfy.ldm.lightricks.symmetric_patchifier import AudioPatchifier
 from comfy.ldm.lightricks.embeddings_connector import Embeddings1DConnector
 import comfy.ldm.common_dit
+import comfy.model_management
 import comfy.model_prefetch
+import comfy.quant_ops
 
 class CompressedTimestep:
     """Store video timestep embeddings in compressed form using per-frame indexing."""
@@ -271,7 +273,10 @@ class BasicAVTransformerBlock(nn.Module):
         if run_vx:
             # video self-attention
             vshift_msa, vscale_msa = (self.get_ada_values(self.scale_shift_table, vx.shape[0], v_timestep, slice(0, 2)))
-            norm_vx = comfy.ldm.common_dit.rms_norm(vx) * (1 + vscale_msa) + vshift_msa
+            if comfy.model_management.in_training:
+                norm_vx = comfy.ldm.common_dit.rms_norm(vx) * (1 + vscale_msa) + vshift_msa
+            else:
+                norm_vx = comfy.quant_ops.ck.rms_adaln(vx, vscale_msa, vshift_msa)
             del vshift_msa, vscale_msa
             attn1_out = self.attn1(norm_vx, pe=v_pe, mask=self_attention_mask, transformer_options=transformer_options)
             del norm_vx
@@ -305,7 +310,6 @@ class BasicAVTransformerBlock(nn.Module):
 
         # video - audio cross attention.
         if run_a2v or run_v2a:
-            vx_norm3 = comfy.ldm.common_dit.rms_norm(vx)
             ax_norm3 = comfy.ldm.common_dit.rms_norm(ax)
 
             # audio to video cross attention
@@ -315,7 +319,10 @@ class BasicAVTransformerBlock(nn.Module):
                 scale_ca_video_hidden_states_a2v_v, shift_ca_video_hidden_states_a2v_v = self.get_ada_values(
                     self.scale_shift_table_a2v_ca_video[:4, :], vx.shape[0], v_cross_scale_shift_timestep)[:2]
 
-                vx_scaled = vx_norm3 * (1 + scale_ca_video_hidden_states_a2v_v) + shift_ca_video_hidden_states_a2v_v
+                if comfy.model_management.in_training:
+                    vx_scaled = comfy.ldm.common_dit.rms_norm(vx) * (1 + scale_ca_video_hidden_states_a2v_v) + shift_ca_video_hidden_states_a2v_v
+                else:
+                    vx_scaled = comfy.quant_ops.ck.rms_adaln(vx, scale_ca_video_hidden_states_a2v_v, shift_ca_video_hidden_states_a2v_v)
                 ax_scaled = ax_norm3 * (1 + scale_ca_audio_hidden_states_a2v) + shift_ca_audio_hidden_states_a2v
                 del scale_ca_video_hidden_states_a2v_v, shift_ca_video_hidden_states_a2v_v, scale_ca_audio_hidden_states_a2v, shift_ca_audio_hidden_states_a2v
 
@@ -334,7 +341,10 @@ class BasicAVTransformerBlock(nn.Module):
                     self.scale_shift_table_a2v_ca_video[:4, :], vx.shape[0], v_cross_scale_shift_timestep)[2:4]
 
                 ax_scaled = ax_norm3 * (1 + scale_ca_audio_hidden_states_v2a) + shift_ca_audio_hidden_states_v2a
-                vx_scaled = vx_norm3 * (1 + scale_ca_video_hidden_states_v2a) + shift_ca_video_hidden_states_v2a
+                if comfy.model_management.in_training:
+                    vx_scaled = comfy.ldm.common_dit.rms_norm(vx) * (1 + scale_ca_video_hidden_states_v2a) + shift_ca_video_hidden_states_v2a
+                else:
+                    vx_scaled = comfy.quant_ops.ck.rms_adaln(vx, scale_ca_video_hidden_states_v2a, shift_ca_video_hidden_states_v2a)
                 del scale_ca_video_hidden_states_v2a, shift_ca_video_hidden_states_v2a, scale_ca_audio_hidden_states_v2a, shift_ca_audio_hidden_states_v2a
 
                 v2a_out = self.video_to_audio_attn(ax_scaled, context=vx_scaled, pe=a_cross_pe, k_pe=v_cross_pe, transformer_options=transformer_options)
@@ -344,12 +354,14 @@ class BasicAVTransformerBlock(nn.Module):
                 ax.addcmul_(v2a_out, gate_out_v2a)
                 del gate_out_v2a, v2a_out
 
-            del vx_norm3, ax_norm3
 
         # video feedforward
         if run_vx:
             vshift_mlp, vscale_mlp = self.get_ada_values(self.scale_shift_table, vx.shape[0], v_timestep, slice(3, 5))
-            vx_scaled = comfy.ldm.common_dit.rms_norm(vx) * (1 + vscale_mlp) + vshift_mlp
+            if comfy.model_management.in_training:
+                vx_scaled = comfy.ldm.common_dit.rms_norm(vx) * (1 + vscale_mlp) + vshift_mlp
+            else:
+                vx_scaled = comfy.quant_ops.ck.rms_adaln(vx, vscale_mlp, vshift_mlp)
             del vshift_mlp, vscale_mlp
 
             ff_out = self.ff(vx_scaled)

--- a/comfy/ldm/lightricks/model.py
+++ b/comfy/ldm/lightricks/model.py
@@ -13,6 +13,7 @@ import comfy.patcher_extension
 import comfy.ldm.modules.attention
 import comfy.ldm.common_dit
 import comfy.model_management
+import comfy.ops
 import comfy.quant_ops
 
 from .symmetric_patchifier import SymmetricPatchifier, latent_to_pixel_coords
@@ -321,7 +322,11 @@ class FeedForward(nn.Module):
         )
 
     def forward(self, x):
-        return self.net(x)
+        # net = [GELU_approx(proj), Dropout, Linear]; the fused path skips the
+        # Dropout, so leave it to the stock path whenever it could be active.
+        if comfy.model_management.in_training:
+            return self.net(x)
+        return comfy.ops.linear_input_act(self.net[2], self.net[0].proj(x), "gelu_tanh")
 
 def apply_rotary_emb(input_tensor, freqs_cis):
     rotation_matrix, split_pe = freqs_cis
@@ -535,7 +540,12 @@ class BasicTransformerBlock(nn.Module):
     def forward(self, x, context=None, attention_mask=None, timestep=None, pe=None, transformer_options={}, self_attention_mask=None, prompt_timestep=None):
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (self.scale_shift_table[None, None, :6].to(device=x.device, dtype=x.dtype) + timestep.reshape(x.shape[0], timestep.shape[1], self.scale_shift_table.shape[0], -1)[:, :, :6, :]).unbind(dim=2)
 
-        x += self.attn1(comfy.ldm.common_dit.rms_norm(x) * (1 + scale_msa) + shift_msa, pe=pe, mask=self_attention_mask, transformer_options=transformer_options) * gate_msa
+        if comfy.model_management.in_training:
+            norm_x = comfy.ldm.common_dit.rms_norm(x) * (1 + scale_msa) + shift_msa
+        else:
+            norm_x = comfy.quant_ops.ck.rms_adaln(x, scale_msa, shift_msa)
+
+        x += self.attn1(norm_x, pe=pe, mask=self_attention_mask, transformer_options=transformer_options) * gate_msa
 
         if self.cross_attention_adaln:
             shift_q_mca, scale_q_mca, gate_mca = (self.scale_shift_table[None, None, 6:9].to(device=x.device, dtype=x.dtype) + timestep.reshape(x.shape[0], timestep.shape[1], self.scale_shift_table.shape[0], -1)[:, :, 6:9, :]).unbind(dim=2)
@@ -589,7 +599,10 @@ def apply_cross_attention_adaln(
         prompt_scale_shift_table[None, None].to(device=x.device, dtype=x.dtype)
         + prompt_timestep.reshape(batch_size, prompt_timestep.shape[1], 2, -1)
     ).unbind(dim=2)
-    attn_input = comfy.ldm.common_dit.rms_norm(x) * (1 + q_scale) + q_shift
+    if comfy.model_management.in_training:
+        attn_input = comfy.ldm.common_dit.rms_norm(x) * (1 + q_scale) + q_shift
+    else:
+        attn_input = comfy.quant_ops.ck.rms_adaln(x, q_scale, q_shift)
     encoder_hidden_states = context * (1 + scale_kv) + shift_kv
     return attn(attn_input, context=encoder_hidden_states, mask=attention_mask, transformer_options=transformer_options) * q_gate
 

--- a/comfy/ldm/minimax/audio_vae.py
+++ b/comfy/ldm/minimax/audio_vae.py
@@ -35,7 +35,8 @@ class Snake1d(nn.Module):
         self.alpha = nn.Parameter(torch.empty(1, channels, 1))
 
     def forward(self, x):
-        return snake(x, self.alpha, self.alpha)
+        alpha = comfy.ops.cast_to_input(self.alpha, x)
+        return snake(x, alpha, alpha)
 
 
 class SnakeBeta(nn.Module):
@@ -47,8 +48,8 @@ class SnakeBeta(nn.Module):
         self.beta = nn.Parameter(torch.empty(in_features))
 
     def forward(self, x):
-        alpha = torch.exp(self.alpha).view(1, -1, 1)
-        beta = torch.exp(self.beta).view(1, -1, 1)
+        alpha = torch.exp(comfy.ops.cast_to_input(self.alpha, x)).view(1, -1, 1)
+        beta = torch.exp(comfy.ops.cast_to_input(self.beta, x)).view(1, -1, 1)
         return snake(x, alpha, beta)
 
 
@@ -239,7 +240,7 @@ class CausalAttention(nn.Module):
     def forward(self, x):
         B, N, C = x.shape
         weight, _, offload_stream = comfy.ops.cast_bias_weight(self.qkv, x, offloadable=True)
-        qkv = F.linear(x, weight=weight, bias=torch.cat((self.q_bias, self.zero_k_bias, self.v_bias)))
+        qkv = F.linear(x, weight=weight, bias=comfy.ops.cast_to_input(torch.cat((self.q_bias, self.zero_k_bias, self.v_bias)), x))
         comfy.ops.uncast_bias_weight(self.qkv, weight, None, offload_stream)
         q, k, v = qkv.reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4).unbind(0)
 

--- a/comfy/ldm/minimax/vae.py
+++ b/comfy/ldm/minimax/vae.py
@@ -199,11 +199,11 @@ class RotaryEmbeddingND(nn.Module):
 
 class FeedForward(nn.Module):
     # Gated SiLU FFN.
-    def __init__(self, dim, mult=4, bias=True):
+    def __init__(self, dim, mult=4, bias=True, operations=ops):
         super().__init__()
         inner_dim = dim * mult
-        self.w1 = ops.Linear(dim, inner_dim * 2, bias=bias)
-        self.w2 = ops.Linear(inner_dim, dim, bias=bias)
+        self.w1 = operations.Linear(dim, inner_dim * 2, bias=bias)
+        self.w2 = operations.Linear(inner_dim, dim, bias=bias)
 
     def forward(self, x):
         gate, x = self.w1(x).chunk(2, dim=-1)
@@ -211,15 +211,15 @@ class FeedForward(nn.Module):
 
 
 class Attention(nn.Module):
-    def __init__(self, heads, dim_head, bias=True, eps=1e-5):
+    def __init__(self, heads, dim_head, bias=True, eps=1e-5, operations=ops):
         super().__init__()
         self.dim_head = dim_head
         self.heads = heads
         inner_dim = dim_head * heads
         self.norm_q = ops.RMSNorm(dim_head, eps=eps, elementwise_affine=False)
         self.norm_k = ops.RMSNorm(dim_head, eps=eps, elementwise_affine=False)
-        self.to_qkv = ops.Linear(inner_dim, inner_dim * 3, bias=bias)
-        self.to_out = ops.Linear(inner_dim, inner_dim, bias=bias)
+        self.to_qkv = operations.Linear(inner_dim, inner_dim * 3, bias=bias)
+        self.to_out = operations.Linear(inner_dim, inner_dim, bias=bias)
 
     def forward(self, x, rotary_pos_emb=None):
         batch_size, seq_len, _ = x.shape
@@ -242,14 +242,14 @@ class Attention(nn.Module):
 
 
 class TransformerBlock(nn.Module):
-    def __init__(self, heads, dim_head, bias=True, eps=1e-5):
+    def __init__(self, heads, dim_head, bias=True, eps=1e-5, operations=ops):
         super().__init__()
         dim = heads * dim_head
         self.norm1 = ops.RMSNorm(dim, elementwise_affine=True, eps=eps)
-        self.attn = Attention(heads=heads, dim_head=dim_head, bias=bias, eps=eps)
+        self.attn = Attention(heads=heads, dim_head=dim_head, bias=bias, eps=eps, operations=operations)
         self.scale1 = nn.Parameter(torch.empty(dim))
         self.norm2 = ops.RMSNorm(dim, elementwise_affine=True, eps=eps)
-        self.ff = FeedForward(dim=dim, bias=bias)
+        self.ff = FeedForward(dim=dim, bias=bias, operations=operations)
         self.scale2 = nn.Parameter(torch.empty(dim))
 
     def forward(self, x, rotary_pos_emb=None):
@@ -259,7 +259,7 @@ class TransformerBlock(nn.Module):
 
 class ViT3DDecoder(nn.Module):
     def __init__(self, patch_size=16, patch_size_t=4, in_channels=24, out_channels=3, num_layers=36, heads=32, dim_head=64, rope_theta=100.0,
-                 rope_dim_ratio=0.75, bias=True, eps=1e-5, num_register_tokens=4):
+                 rope_dim_ratio=0.75, bias=True, eps=1e-5, num_register_tokens=4, operations=ops):
         super().__init__()
         dim = heads * dim_head
         self.patch_size = patch_size
@@ -274,7 +274,7 @@ class ViT3DDecoder(nn.Module):
         self.register_buffer("mask_token", torch.empty(1, 1, dim))
 
         self.transformer_blocks = nn.ModuleList(
-            [TransformerBlock(heads=heads, dim_head=dim_head, bias=bias, eps=eps)
+            [TransformerBlock(heads=heads, dim_head=dim_head, bias=bias, eps=eps, operations=operations)
              for _ in range(num_layers)]
         )
 
@@ -337,6 +337,7 @@ class MiniMaxH3VideoVAE(nn.Module):
         tile_size=256,
         tile_overlap_min=64,
         tiling=True,
+        operations=ops,
     ):
         super().__init__()
         self.vae_ratio = int(math.prod(space_down))
@@ -372,6 +373,7 @@ class MiniMaxH3VideoVAE(nn.Module):
             patch_size_t=self.vae_ratio_t,
             in_channels=z_channels,
             out_channels=out_ch,
+            operations=operations,
         )
 
         self.register_buffer("latents_mean", torch.tensor(LATENTS_MEAN))

--- a/comfy/ldm/minimax/vae.py
+++ b/comfy/ldm/minimax/vae.py
@@ -253,8 +253,8 @@ class TransformerBlock(nn.Module):
         self.scale2 = nn.Parameter(torch.empty(dim))
 
     def forward(self, x, rotary_pos_emb=None):
-        x = x.addcmul_(self.attn(comfy.rmsnorm.rms_norm(x, self.norm1.weight, self.norm1.eps), rotary_pos_emb), self.scale1)
-        return x.addcmul_(self.ff(comfy.rmsnorm.rms_norm(x, self.norm2.weight, self.norm2.eps)), self.scale2)
+        x = x.addcmul_(self.attn(comfy.rmsnorm.rms_norm(x, self.norm1.weight, self.norm1.eps), rotary_pos_emb), comfy.ops.cast_to_input(self.scale1, x))
+        return x.addcmul_(self.ff(comfy.rmsnorm.rms_norm(x, self.norm2.weight, self.norm2.eps)), comfy.ops.cast_to_input(self.scale2, x))
 
 
 class ViT3DDecoder(nn.Module):
@@ -289,7 +289,7 @@ class ViT3DDecoder(nn.Module):
         num_patches = h.shape[1]
         num_suffix = 1 + self.num_register_tokens
 
-        h = torch.cat([h, self.register_tokens.expand(B, -1, -1), torch.zeros_like(h[:, 0:1, :])], dim=1)
+        h = torch.cat([h, comfy.ops.cast_to_input(self.register_tokens, h).expand(B, -1, -1), torch.zeros_like(h[:, 0:1, :])], dim=1)
 
         img_ids = create_token_ids((latent_T, latent_H, latent_W), x.device, x.dtype).expand(B, -1, -1)
         suffix_ids = torch.zeros((B, num_suffix, 3), device=x.device, dtype=img_ids.dtype)

--- a/comfy/ldm/wan/model.py
+++ b/comfy/ldm/wan/model.py
@@ -11,6 +11,7 @@ from comfy.ldm.flux.layers import EmbedND
 from comfy.ldm.flux.math import apply_rope1, rope
 import comfy.ldm.common_dit
 import comfy.model_management
+import comfy.ops
 import comfy.patcher_extension
 
 
@@ -174,6 +175,13 @@ def repeat_e(e, x):
         return torch.repeat_interleave(e, repeats + 1, dim=1)[:, :x.size(1)]
 
 
+class WanFeedForward(nn.Sequential):
+    """[Linear, GELU(tanh), Linear], with the GELU folded into the down-projection."""
+
+    def forward(self, x):
+        return comfy.ops.linear_input_act(self[2], self[0](x), "gelu_tanh")
+
+
 class WanAttentionBlock(nn.Module):
 
     def __init__(self,
@@ -207,7 +215,7 @@ class WanAttentionBlock(nn.Module):
                                                                       qk_norm,
                                                                       eps, operation_settings=operation_settings)
         self.norm2 = operation_settings.get("operations").LayerNorm(dim, eps, elementwise_affine=False, device=operation_settings.get("device"), dtype=operation_settings.get("dtype"))
-        self.ffn = nn.Sequential(
+        self.ffn = WanFeedForward(
             operation_settings.get("operations").Linear(dim, ffn_dim, device=operation_settings.get("device"), dtype=operation_settings.get("dtype")), nn.GELU(approximate='tanh'),
             operation_settings.get("operations").Linear(ffn_dim, dim, device=operation_settings.get("device"), dtype=operation_settings.get("dtype")))
 

--- a/comfy/ldm/wan/uni3c.py
+++ b/comfy/ldm/wan/uni3c.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 
 from comfy.ldm.flux.layers import EmbedND
-from .model import WanSelfAttention
+from .model import WanFeedForward, WanSelfAttention
 
 
 class Uni3CLayerNormZero(nn.Module):
@@ -41,7 +41,7 @@ class Uni3CAttentionBlock(nn.Module):
         self.norm1 = Uni3CLayerNormZero(time_embed_dim, dim, device=device, dtype=dtype, operations=operations)
         self.self_attn = WanSelfAttention(dim, num_heads, qk_norm=True, eps=eps, operation_settings=operation_settings)
         self.norm2 = Uni3CLayerNormZero(time_embed_dim, dim, device=device, dtype=dtype, operations=operations)
-        self.ffn = nn.Sequential(
+        self.ffn = WanFeedForward(
             operations.Linear(dim, ffn_dim, device=device, dtype=dtype), nn.GELU(approximate='tanh'),
             operations.Linear(ffn_dim, dim, device=device, dtype=dtype))
 

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -2112,9 +2112,6 @@ class MiniMaxH3(BaseModel):
         out['minimax_payload'] = comfy.conds.CONDConstant(payload)
         return out
 
-    def scale_latent_inpaint(self, sigma, noise, latent_image, **kwargs):
-        return latent_image
-
 class TripoSplat(BaseModel):
     def __init__(self, model_config, model_type=ModelType.FLOW, device=None):
         super().__init__(model_config, model_type, device=device, unet_model=comfy.ldm.triposplat.model.LatentSeqMMFlowModel)

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1543,13 +1543,31 @@ def cast_to_device(tensor, device, dtype, copy=False):
 PINNED_MEMORY = {}
 TOTAL_PINNED_MEMORY = 0
 MAX_PINNED_MEMORY = -1
+
+def get_disk_swap_total():
+    if not os.path.exists("/proc/swaps"):
+        return 0
+
+    total = 0
+    try:
+        with open("/proc/swaps", encoding="utf-8") as swaps:
+            next(swaps, None)
+            for line in swaps:
+                filename, _, size, _, _ = line.rsplit(maxsplit=4)
+                if os.path.basename(os.path.realpath(filename)).startswith("zram"):
+                    continue
+                total += int(size) * 1024
+    except:
+        logging.warning("Could not get amount of swap memory on system.")
+    return total
+
 if not args.disable_pinned_memory:
     if is_nvidia() or is_amd():
         ram = get_total_memory(torch.device("cpu"))
         if WINDOWS:
             MAX_PINNED_MEMORY = ram * 0.40  # Windows limit is apparently 50%
         else:
-            MAX_PINNED_MEMORY = ram * 0.90
+            MAX_PINNED_MEMORY = max(ram * 0.40, min(ram * 0.90, ram - 4 * 1024 ** 3, ram + get_disk_swap_total() - 16 * 1024 ** 3))
         logging.info("Enabled pinned memory {}".format(MAX_PINNED_MEMORY // (1024 * 1024)))
 
 PINNING_ALLOWED_TYPES = set(["Tensor", "Parameter", "QuantizedTensor"])

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -73,6 +73,8 @@ try:
             ]
 
             def scaled_dot_product_attention(q, k, v, *args, **kwargs):
+                if q.nelement() < 1024 * 128:  # arbitrary number, for small inputs cudnn attention seems slower
+                    return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)
                 attn_mask = args[0] if len(args) > 0 else kwargs.get("attn_mask")
                 if kwargs.get("enable_gqa", False) and attn_mask is not None and not comfy.model_management.is_nvidia():
                     k, v = repeat_kv_for_gqa(k, v, q.shape[-3], -3)

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -940,7 +940,11 @@ class VAE:
                 if not comfy.memory_management.aimdo_enabled:
                     self.disable_offload = True
             elif "decoder.transformer_blocks.0.scale1" in sd and "encoder.down.5.block.0.conv1.weight" in sd:  # MiniMax H3 video VAE
-                self.first_stage_model = comfy.ldm.minimax.vae.MiniMaxH3VideoVAE()
+                minimax_ops = comfy.ops.disable_weight_init
+                minimax_quant = comfy.utils.detect_layer_quantization(sd, "")
+                if minimax_quant is not None:  # int8+convrot quantized decoder
+                    minimax_ops = comfy.ops.mixed_precision_ops(minimax_quant, dtype if dtype is not None else torch.float16)
+                self.first_stage_model = comfy.ldm.minimax.vae.MiniMaxH3VideoVAE(operations=minimax_ops)
                 self.latent_channels = 24
                 self.latent_dim = 3
                 # frames 17k+5 <-> latents 5k+2, 16x spatial

--- a/comfy_api/latest/_ui.py
+++ b/comfy_api/latest/_ui.py
@@ -260,6 +260,7 @@ class ImageSaveHelper:
 class AudioSaveHelper:
     """A helper class with static methods to handle audio saving and metadata."""
     _OPUS_RATES = [8000, 12000, 16000, 24000, 48000]
+    _FORMATS = {"flac", "mp3", "opus"}
 
     @staticmethod
     def save_audio(
@@ -270,6 +271,9 @@ class AudioSaveHelper:
         format: str = "flac",
         quality: str = "128k",
     ) -> list[SavedResult]:
+        if format not in AudioSaveHelper._FORMATS:
+            raise ValueError(f"Unsupported audio format: {format!r}")
+
         full_output_folder, filename, counter, subfolder, _ = folder_paths.get_save_image_path(
             filename_prefix, _get_directory_by_folder_type(folder_type)
         )

--- a/comfy_api_nodes/apis/bfl.py
+++ b/comfy_api_nodes/apis/bfl.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class BFLFluxExpandImageRequest(BaseModel):
@@ -121,6 +121,8 @@ class BFLFluxProGenerateResponse(BaseModel):
 class BFLStatus(str, Enum):
     task_not_found = "Task not found"
     pending = "Pending"
+    reasoning = "Reasoning"
+    generating = "Generating"
     request_moderated = "Request Moderated"
     content_moderated = "Content Moderated"
     ready = "Ready"
@@ -132,3 +134,35 @@ class BFLFluxStatusResponse(BaseModel):
     status: BFLStatus = Field(...)
     result: dict[str, Any] | None = Field(None)
     progress: float | None = Field(None, ge=0.0, le=1.0)
+
+
+class Flux3VideoRequest(BaseModel):
+    """Fields shared by every generation mode of /v1/flux-3-video."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt: str = Field(...)
+    aspect_ratio: str = Field("auto")
+    duration: int | str = Field("auto", description="Whole seconds, or 'auto'.")
+    resolution: str = Field("hd", description="'hd' is the 720p class, 'fhd' the 1080p class.")
+    generate_audio: bool = Field(True)
+    safety_tolerance: int = Field(2, description="0 is the strictest; conditioned modes cap at 2.")
+
+
+class Flux3TextToVideoRequest(Flux3VideoRequest):
+    mode: str = Field("t2v")
+
+
+class Flux3ImageToVideoRequest(Flux3VideoRequest):
+    mode: str = Field("i2v")
+    keyframes: list[str] | list[tuple[float, str]] = Field(
+        ...,
+        description="Images (URL or base64), or [seconds, image] pairs pinning each to a time.",
+    )
+
+
+class Flux3VideoContinuationRequest(Flux3VideoRequest):
+    mode: str = Field("v2v")
+    start_video: str = Field(
+        ..., description="MP4 (URL or base64); the new clip carries on from its final frames."
+    )

--- a/comfy_api_nodes/apis/bytedance.py
+++ b/comfy_api_nodes/apis/bytedance.py
@@ -35,6 +35,23 @@ class Seedream4TaskCreationRequest(BaseModel):
     optimize_prompt_options: Seedream5OptimizePromptOptions | None = None
 
 
+class Seedream5LayerOptimizePromptOptions(BaseModel):
+    mode: Literal["standard", "fast"] = Field(...)
+
+
+class Seedream5LayerSeparationRequest(BaseModel):
+    model: str = Field(...)
+    prompt: str | None = Field(None)
+    image: str = Field(..., description="Single image URL")
+    size: str = Field("auto")
+    seed: int = Field(..., ge=0, le=2147483647)
+    response_format: str = Field("url")
+    output_format: str = Field("png")
+    layer_decomposition: bool = Field(True)
+    watermark: bool = Field(False)
+    optimize_prompt_options: Seedream5LayerOptimizePromptOptions | None = Field(None)
+
+
 class ImageTaskCreationResponse(BaseModel):
     model: str = Field(...)
     created: int = Field(..., description="Unix timestamp (in seconds) indicating time when the request was created.")

--- a/comfy_api_nodes/apis/topaz.py
+++ b/comfy_api_nodes/apis/topaz.py
@@ -20,6 +20,41 @@ class ImageEnhanceRequest(BaseModel):
     color_preservation: str = Field("true", description="To preserve the original color")
 
 
+class ImageEnhanceRequestV2(BaseModel):
+    model: str = Field(...)
+    output_format: str = Field("png")
+    source_url: str = Field(...)
+    output_width: Optional[int] = Field(None)
+    output_height: Optional[int] = Field(None)
+    crop_to_fill: Optional[bool] = Field(None, description="Available for Reimagine only")
+    prompt: Optional[str] = Field(None, description="Available for Reimagine and Bloom 2")
+    creativity: Optional[int] = Field(None, description="From 1 to 9; available for Reimagine and Bloom 2")
+    subject_detection: Optional[str] = Field(None, description="Available for Reimagine only")
+    face_enhancement: Optional[bool] = Field(None, description="Available for Reimagine only")
+    face_enhancement_creativity: Optional[float] = Field(None, description="Is ignored if face_enhancement is false")
+    face_enhancement_strength: Optional[float] = Field(None, description="Is ignored if face_enhancement is false")
+    face_preservation: Optional[str] = Field(
+        None, description='String "true" or "false"; available for Reimagine only'
+    )
+    color_preservation: Optional[str] = Field(
+        None, description='String "true" or "false"; available for Reimagine and Bloom 2'
+    )
+    autoprompt: Optional[str] = Field(
+        None, description='String "true" or "false"; auto-generate a prompt, available for Bloom 2 only'
+    )
+    seed: Optional[int] = Field(None, description="Available for Bloom 2 only")
+    enhancement_strength: Optional[str] = Field(
+        None, description="low, medium or high; available for Wonder 3.5 only"
+    )
+    grain: Optional[str] = Field(
+        None, description='String "true" or "false"; available for Bloom 2 and Wonder 3.5'
+    )
+    grain_model: Optional[str] = Field(None, description="silver, gaussian or grey")
+    grain_strength: Optional[float] = Field(None, description="From 0 to 1")
+    grain_size: Optional[float] = Field(None, description="From 1 to 5")
+    grain_density: Optional[float] = Field(None, description="From 0 to 1")
+
+
 class ImageAsyncTaskResponse(BaseModel):
     process_id: str = Field(...)
 

--- a/comfy_api_nodes/nodes_bfl.py
+++ b/comfy_api_nodes/nodes_bfl.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 from pydantic import BaseModel
 from typing_extensions import override
@@ -14,16 +16,23 @@ from comfy_api_nodes.apis.bfl import (
     BFLFluxVTORequest,
     BFLStatus,
     Flux2ProGenerateRequest,
+    Flux3ImageToVideoRequest,
+    Flux3TextToVideoRequest,
+    Flux3VideoContinuationRequest,
+    Flux3VideoRequest,
 )
 from comfy_api_nodes.util import (
     ApiEndpoint,
     convert_mask_to_image,
     download_url_to_image_tensor,
+    download_url_to_video_output,
     get_number_of_images,
     poll_op,
     resize_mask_to_image,
     sync_op,
     tensor_to_base64_string,
+    upload_images_to_comfyapi,
+    upload_video_to_comfyapi,
     validate_aspect_ratio_string,
     validate_image_dimensions,
     validate_string,
@@ -1007,6 +1016,385 @@ class Flux2ImageNode(IO.ComfyNode):
         return IO.NodeOutput(await download_url_to_image_tensor(response.result["sample"]))
 
 
+_FLUX3_ASPECT_RATIOS = ["auto", "21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"]
+_FLUX3_MIN_DURATION = 5
+_FLUX3_MAX_DURATION = 20
+_FLUX3_DURATIONS = ["auto"] + [str(i) for i in range(_FLUX3_MIN_DURATION, _FLUX3_MAX_DURATION + 1)]
+_FLUX3_RESOLUTIONS = {"720p": "hd", "1080p": "fhd"}
+_FLUX3_MAX_IMAGES = 10
+_FLUX3_MIN_IMAGE_SIDE = 256
+_FLUX3_MAX_IMAGE_ASPECT = 64
+
+
+def _flux3_validate_image(image: torch.Tensor) -> None:
+    validate_image_dimensions(image, min_width=_FLUX3_MIN_IMAGE_SIDE, min_height=_FLUX3_MIN_IMAGE_SIDE)
+    height, width = image.shape[-3], image.shape[-2]
+    if max(width, height) > _FLUX3_MAX_IMAGE_ASPECT * min(width, height):
+        raise ValueError(
+            f"Image aspect ratio is too extreme ({width}x{height}); "
+            f"FLUX 3 accepts at most {_FLUX3_MAX_IMAGE_ASPECT}:1."
+        )
+
+
+def _flux3_collect_images(images: dict | None, field_name: str) -> list[torch.Tensor]:
+    """Flatten Autogrow slots (each possibly batched) into single images and validate them."""
+    flat: list[torch.Tensor] = []
+    for tensor in (images or {}).values():
+        if tensor is None:
+            continue
+        if tensor.ndim == 4:
+            flat.extend(tensor[i] for i in range(tensor.shape[0]))
+        else:
+            flat.append(tensor)
+    if len(flat) > _FLUX3_MAX_IMAGES:
+        raise ValueError(f"FLUX 3 supports at most {_FLUX3_MAX_IMAGES} {field_name}, got {len(flat)}.")
+    for tensor in flat:
+        _flux3_validate_image(tensor)
+    return flat
+
+
+def _flux3_parse_times(value: str, image_count: int, duration: int | str) -> list[float]:
+    """Parse one keyframe time in seconds per image: increasing, inside the clip."""
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    if len(parts) != image_count:
+        raise ValueError(
+            f"Give one time per keyframe image: got {len(parts)} time(s) for {image_count} image(s)."
+        )
+    try:
+        times = [float(part) for part in parts]
+    except ValueError as exc:
+        raise ValueError(f"Keyframe times must be numbers in seconds, comma-separated; got '{value}'.") from exc
+    if not all(math.isfinite(time) for time in times):
+        raise ValueError(f"Keyframe times must be finite numbers in seconds; got '{value}'.")
+    if any(later <= earlier for earlier, later in zip(times, times[1:])):
+        raise ValueError(f"Keyframe times must increase; got {times}.")
+    if times[0] < 0:
+        raise ValueError(f"Keyframe times cannot be negative; got {times[0]}.")
+    cap = _FLUX3_MAX_DURATION if duration == "auto" else int(duration)
+    if times[-1] > cap:
+        raise ValueError(f"Keyframe time {times[-1]}s is past the end of a {cap}s clip.")
+    return times
+
+
+class Flux3VideoNodeBase(IO.ComfyNode):
+    """Shared widgets, request plumbing and polling for the FLUX 3 generation modes."""
+
+    RATE_HD: float
+    RATE_FHD: float
+
+    @classmethod
+    def common_inputs(cls) -> list:
+        return [
+            IO.Combo.Input(
+                "aspect_ratio",
+                options=_FLUX3_ASPECT_RATIOS,
+                default="auto",
+                tooltip="Output aspect ratio. 'auto' picks one from the prompt and inputs.",
+            ),
+            IO.Combo.Input(
+                "duration",
+                options=_FLUX3_DURATIONS,
+                default="auto",
+                tooltip="Clip length in seconds. 'auto' fits the length to the content.",
+            ),
+            IO.Combo.Input(
+                "resolution",
+                options=list(_FLUX3_RESOLUTIONS),
+                default="720p",
+                tooltip="Output resolution.",
+            ),
+            IO.Boolean.Input(
+                "generate_audio",
+                default=True,
+                tooltip="Generate synchronized audio (ambient, speech, effects). "
+                "Off produces a video with no audio track.",
+            ),
+            IO.Int.Input(
+                "safety_tolerance",
+                default=2,
+                min=0,
+                max=4,
+                advanced=True,
+                tooltip="Moderation tolerance, 0 is the strictest. Requests that send images or "
+                "video are capped at 2 whatever you set here.",
+            ),
+            IO.Int.Input(
+                "seed",
+                default=42,
+                min=0,
+                max=0xFFFFFFFF,
+                control_after_generate=True,
+                tooltip="Seed to determine if node should re-run; FLUX 3 picks its own seed, so "
+                "actual results are nondeterministic regardless of this value.",
+            ),
+        ]
+
+    @classmethod
+    def common_fields(
+        cls,
+        prompt: str,
+        aspect_ratio: str,
+        duration: str,
+        resolution: str,
+        generate_audio: bool,
+        safety_tolerance: int,
+    ) -> dict:
+        validate_string(prompt, field_name="prompt", min_length=1)
+        return {
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": duration if duration == "auto" else int(duration),
+            "resolution": _FLUX3_RESOLUTIONS[resolution],
+            "generate_audio": generate_audio,
+            "safety_tolerance": safety_tolerance,
+        }
+
+    @classmethod
+    def price_badge(cls) -> IO.PriceBadge:
+        return IO.PriceBadge(
+            depends_on=IO.PriceBadgeDepends(widgets=["resolution", "duration"]),
+            expr=f"""
+                (
+                  $rate := widgets.resolution = "1080p" ? {cls.RATE_FHD} : {cls.RATE_HD};
+                  $type(widgets.duration) = "string" and widgets.duration != "auto"
+                    ? {{"type":"usd","usd": $rate * $number(widgets.duration)}}
+                    : {{"type":"usd","usd": $rate, "format": {{"suffix": "/second"}}}}
+                )
+                """,
+        )
+
+
+async def _flux3_execute(cls: type[IO.ComfyNode], request: Flux3VideoRequest) -> IO.NodeOutput:
+    initial_response = await sync_op(
+        cls,
+        ApiEndpoint(path="/proxy/bfl/v1/flux-3-video", method="POST"),
+        response_model=BFLFluxProGenerateResponse,
+        data=request,
+    )
+
+    def price_extractor(_r: BaseModel) -> float | None:
+        return None if initial_response.cost is None else initial_response.cost / 100
+
+    response = await poll_op(
+        cls,
+        ApiEndpoint(initial_response.polling_url),
+        response_model=BFLFluxStatusResponse,
+        status_extractor=lambda r: r.status,
+        progress_extractor=lambda r: r.progress,
+        price_extractor=price_extractor,
+        completed_statuses=[BFLStatus.ready],
+        failed_statuses=[
+            BFLStatus.request_moderated,
+            BFLStatus.content_moderated,
+            BFLStatus.error,
+            BFLStatus.task_not_found,
+        ],
+        queued_statuses=[BFLStatus.pending],
+        poll_interval=8.0,
+        # a failed task answers the poll with a retryable-class HTTP 5xx (500 and 503 observed);
+        # a small retry budget surfaces real failures quickly
+        max_retries_per_poll=3,
+    )
+    return IO.NodeOutput(await download_url_to_video_output(response.result["sample"]))
+
+
+class Flux3TextToVideoNode(Flux3VideoNodeBase):
+    RATE_HD = 0.2431
+    RATE_FHD = 0.4147
+
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="Flux3TextToVideoNode",
+            display_name="Flux 3 Text to Video",
+            category="partner/video/BFL",
+            description="Generates a video with synchronized audio from a text prompt via FLUX 3.",
+            inputs=[
+                IO.String.Input(
+                    "prompt",
+                    multiline=True,
+                    default="",
+                    tooltip="What you want, in plain language; the prompt is interpreted and expanded "
+                    "before generation. Describe ambient sound, music and speech separately for layered audio.",
+                ),
+                *cls.common_inputs(),
+            ],
+            outputs=[IO.Video.Output()],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=cls.price_badge(),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        prompt: str,
+        aspect_ratio: str,
+        duration: str,
+        resolution: str,
+        generate_audio: bool,
+        safety_tolerance: int,
+        seed: int,
+    ) -> IO.NodeOutput:
+        request = Flux3TextToVideoRequest(
+            **cls.common_fields(prompt, aspect_ratio, duration, resolution, generate_audio, safety_tolerance)
+        )
+        return await _flux3_execute(cls, request)
+
+
+class Flux3ImageToVideoNode(Flux3VideoNodeBase):
+    RATE_HD = 0.2431
+    RATE_FHD = 0.4147
+
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="Flux3ImageToVideoNode",
+            display_name="Flux 3 Image to Video",
+            category="partner/video/BFL",
+            description="Animates 1 to 10 images with FLUX 3. Each image becomes a frame of the clip: "
+            "one image opens it, two morph from the first to the second, and more are spread across it "
+            "or pinned to times you choose.",
+            inputs=[
+                IO.String.Input(
+                    "prompt",
+                    multiline=True,
+                    default="",
+                    tooltip="How the scene should move and sound; the prompt is interpreted and "
+                    "expanded before generation.",
+                ),
+                IO.Autogrow.Input(
+                    "keyframes",
+                    template=IO.Autogrow.TemplatePrefix(
+                        IO.Image.Input("image", tooltip="Keyframe image."),
+                        prefix="image_",
+                        min=1,
+                        max=_FLUX3_MAX_IMAGES,
+                    ),
+                    tooltip="1 to 10 images, in playback order. Minimum 256x256 pixels each.",
+                ),
+                IO.DynamicCombo.Input(
+                    "placement",
+                    options=[
+                        IO.DynamicCombo.Option("spread across the clip", []),
+                        IO.DynamicCombo.Option(
+                            "at times",
+                            [
+                                IO.String.Input(
+                                    "times",
+                                    default="0",
+                                    tooltip="One time in seconds per image, comma-separated and "
+                                    "increasing, e.g. '0, 2.5, 5'.",
+                                ),
+                            ],
+                        ),
+                    ],
+                    tooltip="'spread across the clip' lets FLUX 3 place the images (one opens the clip, "
+                    "two become its start and end); 'at times' pins every image to a second you choose.",
+                ),
+                *cls.common_inputs(),
+            ],
+            outputs=[IO.Video.Output()],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=cls.price_badge(),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        prompt: str,
+        keyframes: IO.Autogrow.Type,
+        placement: dict,
+        aspect_ratio: str,
+        duration: str,
+        resolution: str,
+        generate_audio: bool,
+        safety_tolerance: int,
+        seed: int,
+    ) -> IO.NodeOutput:
+        fields = cls.common_fields(prompt, aspect_ratio, duration, resolution, generate_audio, safety_tolerance)
+        images = _flux3_collect_images(keyframes, "keyframes")
+        if not images:
+            raise ValueError("Connect at least one keyframe image.")
+        times = None
+        if placement["placement"] == "at times":
+            times = _flux3_parse_times(placement["times"], len(images), fields["duration"])
+        elif len(images) >= 3 and fields["duration"] == "auto":
+            # spread images land evenly between the first and last, which needs a known length
+            raise ValueError(
+                f"Spreading {len(images)} images across the clip needs an explicit duration: "
+                "set duration, or place the images yourself with 'at times'."
+            )
+        urls = await upload_images_to_comfyapi(
+            cls, images, max_images=_FLUX3_MAX_IMAGES, wait_label="Uploading keyframes"
+        )
+        request = Flux3ImageToVideoRequest(
+            keyframes=list(zip(times, urls)) if times is not None else urls,
+            **fields,
+        )
+        return await _flux3_execute(cls, request)
+
+
+class Flux3VideoContinuationNode(Flux3VideoNodeBase):
+    RATE_HD = 0.5863
+    RATE_FHD = 0.7579
+
+    @classmethod
+    def define_schema(cls) -> IO.Schema:
+        return IO.Schema(
+            node_id="Flux3VideoContinuationNode",
+            display_name="Flux 3 Video Continuation",
+            category="partner/video/BFL",
+            description="Continues a video with FLUX 3: the new clip carries on from the final frames "
+            "of the one you provide.",
+            inputs=[
+                IO.Video.Input("video", tooltip="The clip to continue."),
+                IO.String.Input(
+                    "prompt",
+                    multiline=True,
+                    default="",
+                    tooltip="What the continuation should show; the prompt is interpreted and expanded "
+                    "before generation.",
+                ),
+                *cls.common_inputs(),
+            ],
+            outputs=[IO.Video.Output()],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=cls.price_badge(),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        video: Input.Video,
+        prompt: str,
+        aspect_ratio: str,
+        duration: str,
+        resolution: str,
+        generate_audio: bool,
+        safety_tolerance: int,
+        seed: int,
+    ) -> IO.NodeOutput:
+        fields = cls.common_fields(prompt, aspect_ratio, duration, resolution, generate_audio, safety_tolerance)
+        url = await upload_video_to_comfyapi(cls, video, wait_label="Uploading source video")
+        request = Flux3VideoContinuationRequest(start_video=url, **fields)
+        return await _flux3_execute(cls, request)
+
+
 class BFLExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
@@ -1021,6 +1409,9 @@ class BFLExtension(ComfyExtension):
             Flux2ProImageNode,
             Flux2MaxImageNode,
             Flux2ImageNode,
+            Flux3TextToVideoNode,
+            Flux3ImageToVideoNode,
+            Flux3VideoContinuationNode,
         ]
 
 

--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -34,6 +34,8 @@ from comfy_api_nodes.apis.bytedance import (
     SeedanceVirtualLibraryCreateAssetRequest,
     Seedream4Options,
     Seedream4TaskCreationRequest,
+    Seedream5LayerOptimizePromptOptions,
+    Seedream5LayerSeparationRequest,
     Seedream5OptimizePromptOptions,
     TaskAudioContent,
     TaskAudioContentUrl,
@@ -94,6 +96,8 @@ SEEDREAM_PRESETS = {
     "seedream-4-5-251128": RECOMMENDED_PRESETS_SEEDREAM_4_5,
     "seedream-4-0-250828": RECOMMENDED_PRESETS_SEEDREAM_4_0,
 }
+
+SEEDREAM_LAYER_SEPARATION_MODEL = "seedream-5-0-pro-260628"
 
 # Long-running tasks endpoints(e.g., video)
 BYTEPLUS_TASK_ENDPOINT = "/proxy/byteplus/api/v3/contents/generations/tasks"
@@ -1034,6 +1038,303 @@ class ByteDanceSeedreamNodeV2(IO.ComfyNode):
         if fail_on_partial and len(urls) < len(response.data):
             raise RuntimeError(f"Only {len(urls)} of {len(response.data)} images were generated before error.")
         return IO.NodeOutput(torch.cat([await download_url_to_image_tensor(i) for i in urls]))
+
+
+class ByteDanceSeedreamLayerSeparationNode(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="ByteDanceSeedreamLayerSeparationNode",
+            display_name="ByteDance Seedream 5.0 Pro Layer Separation",
+            category="partner/image/ByteDance",
+            search_aliases=["layer separation", "split layers", "decompose", "cutout", "RGBA layers"],
+            description=(
+                "Decompose an image into a background plate plus up to 16 repositionable transparent layers, "
+                "each with stacking order, bounding box, name and description."
+            ),
+            inputs=[
+                IO.Image.Input(
+                    "image",
+                    tooltip=(
+                        "The image to separate. Exactly one image, at least 512x512 pixels, aspect ratio "
+                        "between 1:16 and 16:1. Inputs larger than about 4MP are downscaled before upload."
+                    ),
+                ),
+                IO.String.Input(
+                    "prompt",
+                    multiline=True,
+                    default="",
+                    tooltip=(
+                        "How to separate the image. Leave empty to auto-detect and separate all major elements. "
+                        "Describe elements in natural language to control the separation, or target exact regions "
+                        "with <bbox>left top right bottom</bbox> tags (0-1000 per-mille coordinates)."
+                    ),
+                ),
+                IO.Combo.Input(
+                    "size",
+                    options=["auto", "1K", "1.5K", "2K"],
+                    default="auto",
+                    tooltip="Output resolution level. 'auto' follows the input image size (clamped to the 1K-2K range).",
+                ),
+                IO.Int.Input(
+                    "seed",
+                    default=0,
+                    min=0,
+                    max=2147483647,
+                    step=1,
+                    display_mode=IO.NumberDisplay.number,
+                    control_after_generate=True,
+                    tooltip="Seed to use for generation.",
+                ),
+                IO.Combo.Input(
+                    "prompt_optimization",
+                    options=["standard", "fast"],
+                    default="standard",
+                    optional=True,
+                    advanced=True,
+                    tooltip="Prompt-optimization mode: 'standard' gives higher quality, 'fast' shorter generation time.",
+                ),
+                IO.Boolean.Input(
+                    "watermark",
+                    default=False,
+                    optional=True,
+                    advanced=True,
+                    tooltip='Whether to add an "AI generated" watermark to the images.',
+                ),
+                IO.Boolean.Input(
+                    "crop_layers",
+                    default=False,
+                    optional=True,
+                    label_on="minimal size",
+                    label_off="full canvas",
+                    tooltip=(
+                        "Full canvas: each layer is placed on a base-sized canvas at its bounding-box position - "
+                        "recompose directly with ImageCompositeMasked. Minimal size: each layer is cropped to its "
+                        "bounding box (padded to the largest layer for batching) and the bboxes output carries its "
+                        "placement - the pairing expected by Create Layered Image."
+                    ),
+                ),
+            ],
+            outputs=[
+                IO.Image.Output(
+                    display_name="base_image",
+                    tooltip=(
+                        "The base image (background plate) the layers stack onto. Wire to image_0 of "
+                        "Create Layered Image."
+                    ),
+                ),
+                IO.Mask.Output(
+                    display_name="base_mask",
+                    tooltip=(
+                        "Transparency of the base image (1 = transparent, LoadImage convention); currently "
+                        "always fully opaque. Wire to mask_0 of Create Layered Image."
+                    ),
+                ),
+                IO.Image.Output(
+                    display_name="layers",
+                    tooltip=(
+                        "Transparent layers ordered bottom to top; wire to image_1 of Create Layered Image "
+                        "(the batch expands into one editor layer per element). Full canvas mode: placed on a "
+                        "black base-sized canvas at their bounding-box position. Minimal size mode: cropped to "
+                        "their bounding box, anchored top-left, padded to the largest layer."
+                    ),
+                ),
+                IO.Mask.Output(
+                    display_name="masks",
+                    tooltip=(
+                        "Per-layer transparency, index-aligned with the layers batch (1 = transparent, "
+                        "LoadImage convention); wire to mask_1 of Create Layered Image. For "
+                        "ImageCompositeMasked-style compositing, add InvertMask first."
+                    ),
+                ),
+                IO.BoundingBox.Output(
+                    display_name="bboxes",
+                    tooltip=(
+                        "Placement boxes for Create Layered Image, index-aligned with its expanded inputs: the "
+                        "first entry covers the base image, the rest place each layer 1:1 in either mode. "
+                        "metadata carries name, desc, z_index, native_size and content_rect = [left, top, width, "
+                        "height], the layer's true bounding box in base-image pixels."
+                    ),
+                ),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=IO.PriceBadge(
+                depends_on=IO.PriceBadgeDepends(widgets=["size"]),
+                expr="""
+                (
+                  widgets.size in ["1k", "1.5k"]
+                    ? {
+                        "type": "usd",
+                        "usd": 0.032,
+                        "format": { "suffix": " x images/Run", "approximate": true }
+                      }
+                    : {
+                        "type": "range_usd",
+                        "min_usd": 0.032,
+                        "max_usd": 0.064,
+                        "format": { "suffix": " x images/Run", "approximate": true }
+                      }
+                )
+                """,
+            ),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        image: Input.Image,
+        prompt: str = "",
+        size: str = "auto",
+        seed: int = 0,
+        prompt_optimization: str = "standard",
+        watermark: bool = False,
+        crop_layers: bool = False,
+    ) -> IO.NodeOutput:
+        if get_number_of_images(image) != 1:
+            raise ValueError("Only a single input image is supported.")
+        validate_image_aspect_ratio(image, (1, 16), (16, 1))
+        validate_image_dimensions(image, min_width=512, min_height=512)
+
+        request = Seedream5LayerSeparationRequest(
+            model=SEEDREAM_LAYER_SEPARATION_MODEL,
+            prompt=prompt.strip() or None,
+            image=await upload_image_to_comfyapi(cls, image),
+            size=size,
+            seed=seed,
+            watermark=watermark,
+            optimize_prompt_options=(
+                Seedream5LayerOptimizePromptOptions(mode="fast") if prompt_optimization == "fast" else None
+            ),
+        )
+        response = await sync_op(
+            cls,
+            ApiEndpoint(path=BYTEPLUS_IMAGE_ENDPOINT, method="POST"),
+            response_model=ImageTaskCreationResponse,
+            data=request,
+            wait_label="Separating layers",
+        )
+        if response.error:
+            raise RuntimeError(
+                f"ByteDance request failed. Code: {response.error['code']}, message: {response.error['message']}"
+            )
+        data = [d for d in (response.data or []) if isinstance(d, dict)]
+        if not data or "url" not in data[0]:
+            raise RuntimeError("Unexpected response: no base image returned.")
+        base_item = data[0]
+        if base_item.get("bounding_box") is not None or int(base_item.get("z_index") or 0) != 0:
+            raise RuntimeError("Unexpected response: the first item is not the base image.")
+        layer_items = [d for d in data[1:] if "url" in d]
+        if not layer_items:
+            raise RuntimeError("The model returned no layers. Try a different prompt or input image.")
+        layer_items.sort(key=lambda d: d["z_index"] if isinstance(d.get("z_index"), int) else 1_000_000)
+
+        base_image = (await download_url_to_image_tensor(str(base_item["url"]), cls=cls))[..., :3]
+        height, width = base_image.shape[1], base_image.shape[2]
+
+        entries = []
+        for item in layer_items:
+            flags = []
+            rgba = (await download_url_to_image_tensor(str(item["url"]), cls=cls))[0]
+            native_h, native_w = rgba.shape[0], rgba.shape[1]
+            absolute = (item.get("bounding_box") or {}).get("absolute")
+            if isinstance(absolute, (list, tuple)) and len(absolute) == 4:
+                left, top, right, bottom = (int(round(v)) for v in absolute)
+                rect_w, rect_h = right - left + 1, bottom - top + 1  # inclusive right/bottom
+                if rect_w <= 0 or rect_h <= 0:
+                    flags.append("bbox_degenerate")
+            else:
+                flags.append("bbox_missing")
+                left, top, rect_w, rect_h = 0, 0, width, height
+            if "bbox_degenerate" not in flags and (native_w, native_h) != (rect_w, rect_h):
+                # premultiply before resizing: interpolating straight alpha bleeds the undefined
+                # colors of transparent pixels into the anti-aliased edges
+                rgba = rgba.clone()
+                rgba[..., :3] *= rgba[..., 3:4]
+                rgba = (
+                    torch.nn.functional.interpolate(
+                        rgba.permute(2, 0, 1).unsqueeze(0),
+                        size=(rect_h, rect_w),
+                        mode="bilinear",
+                        antialias=True,
+                    )
+                    .squeeze(0)
+                    .permute(1, 2, 0)
+                )
+                alpha = rgba[..., 3:4]
+                rgba = torch.cat([rgba[..., :3] / alpha.clamp(min=1e-6), alpha], dim=-1).clamp(0, 1)
+                flags.append("resized_to_bbox")
+            entries.append({"item": item, "rgba": rgba, "left": left, "top": top,
+                            "rect_w": rect_w, "rect_h": rect_h,
+                            "native_size": f"{native_w}x{native_h}", "flags": flags})
+
+        if crop_layers:
+            canvas_w = max((e["rect_w"] for e in entries if "bbox_degenerate" not in e["flags"]), default=1)
+            canvas_h = max((e["rect_h"] for e in entries if "bbox_degenerate" not in e["flags"]), default=1)
+        else:
+            canvas_w, canvas_h = width, height
+        base_mask = torch.zeros((1, height, width))
+        layers = torch.zeros((len(entries), canvas_h, canvas_w, 3))
+        # Create Layered Image / LoadImage mask convention: 1 = transparent
+        masks = torch.ones((len(entries), canvas_h, canvas_w))
+        bboxes = [
+            {
+                "x": 0,
+                "y": 0,
+                "width": width,
+                "height": height,
+                "metadata": {
+                    "name": "background",
+                    "desc": None,
+                    "z_index": 0,
+                    "native_size": f"{width}x{height}",
+                    "content_rect": [0, 0, width, height],
+                    "flags": [],
+                },
+            }
+        ]
+        for i, e in enumerate(entries):
+            rgba, left, top, rect_w, rect_h, flags = (
+                e["rgba"], e["left"], e["top"], e["rect_w"], e["rect_h"], e["flags"]
+            )
+            if "bbox_degenerate" not in flags:
+                # straight (unpremultiplied) RGB: downstream compositing applies the mask itself
+                if crop_layers:
+                    layers[i, :rect_h, :rect_w] = rgba[..., :3]
+                    masks[i, :rect_h, :rect_w] = 1.0 - rgba[..., 3]
+                else:
+                    x0, y0 = max(left, 0), max(top, 0)
+                    x1, y1 = min(left + rect_w, width), min(top + rect_h, height)
+                    if x0 < x1 and y0 < y1:
+                        patch = rgba[y0 - top : y1 - top, x0 - left : x1 - left]
+                        layers[i, y0:y1, x0:x1] = patch[..., :3]
+                        masks[i, y0:y1, x0:x1] = 1.0 - patch[..., 3]
+                    else:
+                        flags.append("bbox_out_of_canvas")
+            # placement box sized to this layer's tensor so Create Layered Image renders it 1:1;
+            # the true content rect travels in metadata
+            bboxes.append(
+                {
+                    "x": left if crop_layers else 0,
+                    "y": top if crop_layers else 0,
+                    "width": canvas_w,
+                    "height": canvas_h,
+                    "metadata": {
+                        "name": e["item"].get("name"),
+                        "desc": e["item"].get("description"),
+                        "z_index": e["item"].get("z_index"),
+                        "native_size": e["native_size"],
+                        "content_rect": [left, top, max(rect_w, 0), max(rect_h, 0)],
+                        "flags": flags,
+                    },
+                }
+            )
+        return IO.NodeOutput(base_image, base_mask, layers, masks, bboxes)
 
 
 class ByteDanceTextToVideoNode(IO.ComfyNode):
@@ -2887,6 +3188,7 @@ class ByteDanceExtension(ComfyExtension):
             ByteDanceImageNode,
             ByteDanceSeedreamNode,
             ByteDanceSeedreamNodeV2,
+            ByteDanceSeedreamLayerSeparationNode,
             ByteDanceTextToVideoNode,
             ByteDanceImageToVideoNode,
             ByteDanceFirstLastFrameNode,

--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -1245,7 +1245,7 @@ class ByteDanceSeedreamLayerSeparationNode(IO.ComfyNode):
             absolute = (item.get("bounding_box") or {}).get("absolute")
             if isinstance(absolute, (list, tuple)) and len(absolute) == 4:
                 left, top, right, bottom = (int(round(v)) for v in absolute)
-                rect_w, rect_h = right - left + 1, bottom - top + 1  # inclusive right/bottom
+                rect_w, rect_h = right - left, bottom - top  # exclusive right/bottom
                 if rect_w <= 0 or rect_h <= 0:
                     flags.append("bbox_degenerate")
             else:

--- a/comfy_api_nodes/nodes_kling.py
+++ b/comfy_api_nodes/nodes_kling.py
@@ -5,17 +5,13 @@ For source of truth on the allowed permutations of request fields, please refere
 """
 
 import logging
-import math
 import re
 
 import torch
 from typing_extensions import override
 
-from comfy_api.latest import IO, ComfyExtension, Input, InputImpl
+from comfy_api.latest import IO, ComfyExtension, Input
 from comfy_api_nodes.apis import (
-    KlingCameraControl,
-    KlingCameraConfig,
-    KlingCameraControlType,
     KlingVideoGenDuration,
     KlingVideoGenMode,
     KlingVideoGenAspectRatio,
@@ -30,23 +26,12 @@ from comfy_api_nodes.apis import (
     KlingLipSyncInputObject,
     KlingLipSyncRequest,
     KlingLipSyncResponse,
-    KlingVirtualTryOnModelName,
-    KlingVirtualTryOnRequest,
-    KlingVirtualTryOnResponse,
     KlingVideoResult,
     KlingImageResult,
     KlingImageGenerationsRequest,
     KlingImageGenerationsResponse,
     KlingImageGenImageReferenceType,
     KlingImageGenAspectRatio,
-    KlingVideoEffectsRequest,
-    KlingVideoEffectsResponse,
-    KlingDualCharacterEffectsScene,
-    KlingSingleImageEffectsScene,
-    KlingDualCharacterEffectInput,
-    KlingSingleImageEffectInput,
-    KlingCharacterEffectModelName,
-    KlingSingleImageEffectModelName,
 )
 from comfy_api_nodes.apis.kling import (
     ImageToVideoWithAudioRequest,
@@ -119,9 +104,6 @@ PATH_TEXT_TO_VIDEO = f"/proxy/kling/{KLING_API_VERSION}/videos/text2video"
 PATH_IMAGE_TO_VIDEO = f"/proxy/kling/{KLING_API_VERSION}/videos/image2video"
 PATH_VIDEO_EXTEND = f"/proxy/kling/{KLING_API_VERSION}/videos/video-extend"
 PATH_LIP_SYNC = f"/proxy/kling/{KLING_API_VERSION}/videos/lip-sync"
-PATH_VIDEO_EFFECTS = f"/proxy/kling/{KLING_API_VERSION}/videos/effects"
-PATH_CHARACTER_IMAGE = f"/proxy/kling/{KLING_API_VERSION}/images/generations"
-PATH_VIRTUAL_TRY_ON = f"/proxy/kling/{KLING_API_VERSION}/images/kolors-virtual-try-on"
 PATH_IMAGE_GENERATIONS = f"/proxy/kling/{KLING_API_VERSION}/images/generations"
 
 MAX_PROMPT_LENGTH_T2V = 2500
@@ -133,21 +115,11 @@ MAX_PROMPT_LENGTH_LIP_SYNC = 120
 AVERAGE_DURATION_T2V = 319
 AVERAGE_DURATION_I2V = 164
 AVERAGE_DURATION_LIP_SYNC = 455
-AVERAGE_DURATION_VIRTUAL_TRY_ON = 19
 AVERAGE_DURATION_IMAGE_GEN = 32
-AVERAGE_DURATION_VIDEO_EFFECTS = 320
 AVERAGE_DURATION_VIDEO_EXTEND = 320
 
 
 MODE_TEXT2VIDEO = {
-    "standard mode / 5s duration / kling-v1-6": ("std", "5", "kling-v1-6"),
-    "standard mode / 10s duration / kling-v1-6": ("std", "10", "kling-v1-6"),
-    "pro mode / 5s duration / kling-v2-master": ("pro", "5", "kling-v2-master"),
-    "pro mode / 10s duration / kling-v2-master": ("pro", "10", "kling-v2-master"),
-    "standard mode / 5s duration / kling-v2-master": ("std", "5", "kling-v2-master"),
-    "standard mode / 10s duration / kling-v2-master": ("std", "10", "kling-v2-master"),
-    "pro mode / 5s duration / kling-v2-1-master": ("pro", "5", "kling-v2-1-master"),
-    "pro mode / 10s duration / kling-v2-1-master": ("pro", "10", "kling-v2-1-master"),
     "pro mode / 5s duration / kling-v2-5-turbo": ("pro", "5", "kling-v2-5-turbo"),
     "pro mode / 10s duration / kling-v2-5-turbo": ("pro", "10", "kling-v2-5-turbo"),
 }
@@ -160,12 +132,6 @@ See: [Kling API Docs Capability Map](https://app.klingai.com/global/dev/document
 
 
 MODE_START_END_FRAME = {
-    "pro mode / 5s duration / kling-v1-5": ("pro", "5", "kling-v1-5"),
-    "pro mode / 10s duration / kling-v1-5": ("pro", "10", "kling-v1-5"),
-    "pro mode / 5s duration / kling-v1-6": ("pro", "5", "kling-v1-6"),
-    "pro mode / 10s duration / kling-v1-6": ("pro", "10", "kling-v1-6"),
-    "pro mode / 5s duration / kling-v2-1": ("pro", "5", "kling-v2-1"),
-    "pro mode / 10s duration / kling-v2-1": ("pro", "10", "kling-v2-1"),
     "pro mode / 5s duration / kling-v2-5-turbo": ("pro", "5", "kling-v2-5-turbo"),
     "pro mode / 10s duration / kling-v2-5-turbo": ("pro", "10", "kling-v2-5-turbo"),
 }
@@ -287,11 +253,6 @@ async def finish_omni_video_task(cls: type[IO.ComfyNode], response: TaskStatusRe
     return IO.NodeOutput(await download_url_to_video_output(final_response.data.task_result.videos[0].url))
 
 
-def is_valid_camera_control_configs(configs: list[float]) -> bool:
-    """Verifies that at least one camera control configuration is non-zero."""
-    return any(not math.isclose(value, 0.0) for value in configs)
-
-
 def is_valid_task_creation_response(response: KlingText2VideoResponse) -> bool:
     """Verifies that the initial response contains a task ID."""
     return bool(response.data.task_id)
@@ -307,7 +268,7 @@ def is_valid_video_response(response: KlingText2VideoResponse) -> bool:
     )
 
 
-def is_valid_image_response(response: KlingVirtualTryOnResponse) -> bool:
+def is_valid_image_response(response: KlingImageGenerationsResponse) -> bool:
     """Verifies that the response contains a task result with at least one image."""
     return (
         response.data is not None
@@ -430,7 +391,6 @@ async def execute_text2video(
     model_mode: str,
     duration: str,
     aspect_ratio: str,
-    camera_control: KlingCameraControl | None = None,
 ) -> IO.NodeOutput:
     validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_T2V)
     task_creation_response = await sync_op(
@@ -445,7 +405,6 @@ async def execute_text2video(
             model_name=model_name,
             cfg_scale=cfg_scale,
             aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
-            camera_control=camera_control,
         ),
     )
 
@@ -475,18 +434,10 @@ async def execute_image2video(
     model_mode: str,
     aspect_ratio: str,
     duration: str,
-    camera_control: KlingCameraControl | None = None,
     end_frame: torch.Tensor | None = None,
 ) -> IO.NodeOutput:
     validate_prompts(prompt, negative_prompt, MAX_PROMPT_LENGTH_I2V)
     validate_input_image(start_frame)
-
-    if camera_control is not None:
-        # Camera control type for image 2 video is always `simple`
-        camera_control.type = KlingCameraControlType.simple
-
-    if model_mode == "std" and model_name == KlingVideoGenModelName.kling_v2_5_turbo.value:
-        model_mode = "pro"  # October 5: currently "std" mode is not supported for this model
 
     task_creation_response = await sync_op(
         cls,
@@ -505,7 +456,6 @@ async def execute_image2video(
             cfg_scale=cfg_scale,
             mode=KlingVideoGenMode(model_mode),
             duration=KlingVideoGenDuration(duration),
-            camera_control=camera_control,
         ),
     )
 
@@ -523,59 +473,6 @@ async def execute_image2video(
 
     video = get_video_from_response(final_response)
     return IO.NodeOutput(await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration))
-
-
-async def execute_video_effect(
-    cls: type[IO.ComfyNode],
-    dual_character: bool,
-    effect_scene: KlingDualCharacterEffectsScene | KlingSingleImageEffectsScene,
-    model_name: str,
-    duration: KlingVideoGenDuration,
-    image_1: torch.Tensor,
-    image_2: torch.Tensor | None = None,
-    model_mode: KlingVideoGenMode | None = None,
-) -> tuple[InputImpl.VideoFromFile, str, str]:
-    if dual_character:
-        request_input_field = KlingDualCharacterEffectInput(
-            model_name=model_name,
-            mode=model_mode,
-            images=[
-                tensor_to_base64_string(image_1),
-                tensor_to_base64_string(image_2),
-            ],
-            duration=duration,
-        )
-    else:
-        request_input_field = KlingSingleImageEffectInput(
-            model_name=model_name,
-            image=tensor_to_base64_string(image_1),
-            duration=duration,
-        )
-
-    task_creation_response = await sync_op(
-        cls,
-        endpoint=ApiEndpoint(path=PATH_VIDEO_EFFECTS, method="POST"),
-        response_model=KlingVideoEffectsResponse,
-        data=KlingVideoEffectsRequest(
-            effect_scene=effect_scene,
-            input=request_input_field,
-        ),
-    )
-
-    validate_task_creation_response(task_creation_response)
-    task_id = task_creation_response.data.task_id
-
-    final_response = await poll_op(
-        cls,
-        ApiEndpoint(path=f"{PATH_VIDEO_EFFECTS}/{task_id}"),
-        response_model=KlingVideoEffectsResponse,
-        estimated_duration=AVERAGE_DURATION_VIDEO_EFFECTS,
-        status_extractor=lambda r: (r.data.task_status.value if r.data and r.data.task_status else None),
-    )
-    validate_video_result_response(final_response)
-
-    video = get_video_from_response(final_response)
-    return await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration)
 
 
 async def execute_lipsync(
@@ -640,125 +537,6 @@ async def execute_lipsync(
     return IO.NodeOutput(await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration))
 
 
-class KlingCameraControls(IO.ComfyNode):
-    """Kling Camera Controls Node"""
-
-    @classmethod
-    def define_schema(cls) -> IO.Schema:
-        return IO.Schema(
-            node_id="KlingCameraControls",
-            display_name="Kling Camera Controls",
-            category="partner/video/Kling",
-            description="Allows specifying configuration options for Kling Camera Controls and motion control effects.",
-            inputs=[
-                IO.Combo.Input("camera_control_type", options=KlingCameraControlType),
-                IO.Float.Input(
-                    "horizontal_movement",
-                    default=0.0,
-                    min=-10.0,
-                    max=10.0,
-                    step=0.25,
-                    display_mode=IO.NumberDisplay.slider,
-                    tooltip="Controls camera's movement along horizontal axis (x-axis). Negative indicates left, positive indicates right",
-                ),
-                IO.Float.Input(
-                    "vertical_movement",
-                    default=0.0,
-                    min=-10.0,
-                    max=10.0,
-                    step=0.25,
-                    display_mode=IO.NumberDisplay.slider,
-                    tooltip="Controls camera's movement along vertical axis (y-axis). Negative indicates downward, positive indicates upward.",
-                ),
-                IO.Float.Input(
-                    "pan",
-                    default=0.5,
-                    min=-10.0,
-                    max=10.0,
-                    step=0.25,
-                    display_mode=IO.NumberDisplay.slider,
-                    tooltip="Controls camera's rotation in vertical plane (x-axis). Negative indicates downward rotation, positive indicates upward rotation.",
-                ),
-                IO.Float.Input(
-                    "tilt",
-                    default=0.0,
-                    min=-10.0,
-                    max=10.0,
-                    step=0.25,
-                    display_mode=IO.NumberDisplay.slider,
-                    tooltip="Controls camera's rotation in horizontal plane (y-axis). Negative indicates left rotation, positive indicates right rotation.",
-                ),
-                IO.Float.Input(
-                    "roll",
-                    default=0.0,
-                    min=-10.0,
-                    max=10.0,
-                    step=0.25,
-                    display_mode=IO.NumberDisplay.slider,
-                    tooltip="Controls camera's rolling amount (z-axis). Negative indicates counterclockwise, positive indicates clockwise.",
-                ),
-                IO.Float.Input(
-                    "zoom",
-                    default=0.0,
-                    min=-10.0,
-                    max=10.0,
-                    step=0.25,
-                    display_mode=IO.NumberDisplay.slider,
-                    tooltip="Controls change in camera's focal length. Negative indicates narrower field of view, positive indicates wider field of view.",
-                ),
-            ],
-            outputs=[IO.Custom("CAMERA_CONTROL").Output(display_name="camera_control")],
-        )
-
-    @classmethod
-    def validate_inputs(
-        cls,
-        horizontal_movement: float,
-        vertical_movement: float,
-        pan: float,
-        tilt: float,
-        roll: float,
-        zoom: float,
-    ) -> bool | str:
-        if not is_valid_camera_control_configs(
-            [
-                horizontal_movement,
-                vertical_movement,
-                pan,
-                tilt,
-                roll,
-                zoom,
-            ]
-        ):
-            return "Invalid camera control configs: at least one of the values must be non-zero"
-        return True
-
-    @classmethod
-    def execute(
-        cls,
-        camera_control_type: str,
-        horizontal_movement: float,
-        vertical_movement: float,
-        pan: float,
-        tilt: float,
-        roll: float,
-        zoom: float,
-    ) -> IO.NodeOutput:
-        return IO.NodeOutput(
-            KlingCameraControl(
-                type=KlingCameraControlType(camera_control_type),
-                config=KlingCameraConfig(
-                    horizontal=horizontal_movement,
-                    vertical=vertical_movement,
-                    pan=pan,
-                    roll=roll,
-                    tilt=tilt,
-                    zoom=zoom,
-                ),
-            )
-        )
-
-
 class KlingTextToVideoNode(IO.ComfyNode):
     """Kling Text to Video Node"""
 
@@ -782,7 +560,7 @@ class KlingTextToVideoNode(IO.ComfyNode):
                 IO.Combo.Input(
                     "mode",
                     options=modes,
-                    default=modes[8],
+                    default=modes[0],
                     tooltip="The configuration to use for the video generation following the format: mode / duration / model_name.",
                 ),
             ],
@@ -802,25 +580,7 @@ class KlingTextToVideoNode(IO.ComfyNode):
                 expr="""
                 (
                   $m := widgets.mode;
-                  $contains($m,"v2-5-turbo")
-                    ? ($contains($m,"10") ? {"type":"usd","usd":0.7} : {"type":"usd","usd":0.35})
-                    : $contains($m,"v2-1-master")
-                      ? ($contains($m,"10s") ? {"type":"usd","usd":2.8} : {"type":"usd","usd":1.4})
-                      : $contains($m,"v2-master")
-                        ? ($contains($m,"10s") ? {"type":"usd","usd":2.8} : {"type":"usd","usd":1.4})
-                        : $contains($m,"v1-6")
-                          ? (
-                              $contains($m,"pro")
-                                ? ($contains($m,"10s") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                                : ($contains($m,"10s") ? {"type":"usd","usd":0.56} : {"type":"usd","usd":0.28})
-                            )
-                          : $contains($m,"v1")
-                            ? (
-                                $contains($m,"pro")
-                                  ? ($contains($m,"10s") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                                  : ($contains($m,"10s") ? {"type":"usd","usd":0.28} : {"type":"usd","usd":0.14})
-                              )
-                            : {"type":"usd","usd":0.14}
+                  $contains($m,"10") ? {"type":"usd","usd":0.7} : {"type":"usd","usd":0.35}
                 )
                 """,
             ),
@@ -1716,71 +1476,6 @@ class OmniProImageNode(IO.ComfyNode):
         return IO.NodeOutput(torch.cat(tensors, dim=0))
 
 
-class KlingCameraControlT2VNode(IO.ComfyNode):
-    """
-    Kling Text to Video Camera Control Node. This node is a text to video node, but it supports controlling the camera.
-    Duration, mode, and model_name request fields are hard-coded because camera control is only supported in pro mode with the kling-v1-5 model at 5s duration as of 2025-05-02.
-    """
-
-    @classmethod
-    def define_schema(cls) -> IO.Schema:
-        return IO.Schema(
-            node_id="KlingCameraControlT2VNode",
-            display_name="Kling Text to Video (Camera Control)",
-            category="partner/video/Kling",
-            description="Transform text into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original text.",
-            inputs=[
-                IO.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
-                IO.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
-                IO.Float.Input("cfg_scale", default=0.75, min=0.0, max=1.0),
-                IO.Combo.Input(
-                    "aspect_ratio",
-                    options=KlingVideoGenAspectRatio,
-                    default="16:9",
-                ),
-                IO.Custom("CAMERA_CONTROL").Input(
-                    "camera_control",
-                    tooltip="Can be created using the Kling Camera Controls node. Controls the camera movement and motion during the video generation.",
-                ),
-            ],
-            outputs=[
-                IO.Video.Output(),
-                IO.String.Output(display_name="video_id"),
-                IO.String.Output(display_name="duration"),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
-            is_api_node=True,
-            price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.14}""",
-            ),
-        )
-
-    @classmethod
-    async def execute(
-        cls,
-        prompt: str,
-        negative_prompt: str,
-        cfg_scale: float,
-        aspect_ratio: str,
-        camera_control: KlingCameraControl | None = None,
-    ) -> IO.NodeOutput:
-        return await execute_text2video(
-            cls,
-            model_name=KlingVideoGenModelName.kling_v1,
-            cfg_scale=cfg_scale,
-            model_mode=KlingVideoGenMode.std,
-            aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
-            duration=KlingVideoGenDuration.field_5,
-            prompt=prompt,
-            negative_prompt=negative_prompt,
-            camera_control=camera_control,
-        )
-
-
 class KlingImage2VideoNode(IO.ComfyNode):
     """Kling Image to Video Node"""
 
@@ -1796,11 +1491,10 @@ class KlingImage2VideoNode(IO.ComfyNode):
                 IO.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
                 IO.Combo.Input(
                     "model_name",
-                    options=KlingVideoGenModelName,
-                    default="kling-v2-master",
+                    options=["kling-v2-5-turbo"],
                 ),
                 IO.Float.Input("cfg_scale", default=0.8, min=0.0, max=1.0),
-                IO.Combo.Input("mode", options=KlingVideoGenMode, default=KlingVideoGenMode.std),
+                IO.Combo.Input("mode", options=["pro"]),
                 IO.Combo.Input(
                     "aspect_ratio",
                     options=KlingVideoGenAspectRatio,
@@ -1820,29 +1514,10 @@ class KlingImage2VideoNode(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(widgets=["mode", "model_name", "duration"]),
+                depends_on=IO.PriceBadgeDepends(widgets=["duration"]),
                 expr="""
                 (
-                  $mode := widgets.mode;
-                  $model := widgets.model_name;
-                  $dur := widgets.duration;
-                  $contains($model,"v2-5-turbo")
-                    ? ($contains($dur,"10") ? {"type":"usd","usd":0.7} : {"type":"usd","usd":0.35})
-                    : ($contains($model,"v2-1-master") or $contains($model,"v2-master"))
-                      ? ($contains($dur,"10") ? {"type":"usd","usd":2.8} : {"type":"usd","usd":1.4})
-                      : ($contains($model,"v2-1") or $contains($model,"v1-6") or $contains($model,"v1-5"))
-                        ? (
-                            $contains($mode,"pro")
-                              ? ($contains($dur,"10") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                              : ($contains($dur,"10") ? {"type":"usd","usd":0.56} : {"type":"usd","usd":0.28})
-                          )
-                        : $contains($model,"v1")
-                          ? (
-                              $contains($mode,"pro")
-                                ? ($contains($dur,"10") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                                : ($contains($dur,"10") ? {"type":"usd","usd":0.28} : {"type":"usd","usd":0.14})
-                            )
-                          : {"type":"usd","usd":0.14}
+                  $contains(widgets.duration,"10") ? {"type":"usd","usd":0.7} : {"type":"usd","usd":0.35}
                 )
                 """,
             ),
@@ -1859,8 +1534,6 @@ class KlingImage2VideoNode(IO.ComfyNode):
         mode: str,
         aspect_ratio: str,
         duration: str,
-        camera_control: KlingCameraControl | None = None,
-        end_frame: torch.Tensor | None = None,
     ) -> IO.NodeOutput:
         return await execute_image2video(
             cls,
@@ -1872,79 +1545,6 @@ class KlingImage2VideoNode(IO.ComfyNode):
             aspect_ratio=aspect_ratio,
             model_mode=mode,
             duration=duration,
-            camera_control=camera_control,
-            end_frame=end_frame,
-        )
-
-
-class KlingCameraControlI2VNode(IO.ComfyNode):
-    """
-    Kling Image to Video Camera Control Node. This node is a image to video node, but it supports controlling the camera.
-    Duration, mode, and model_name request fields are hard-coded because camera control is only supported in pro mode with the kling-v1-5 model at 5s duration as of 2025-05-02.
-    """
-
-    @classmethod
-    def define_schema(cls) -> IO.Schema:
-        return IO.Schema(
-            node_id="KlingCameraControlI2VNode",
-            display_name="Kling Image to Video (Camera Control)",
-            category="partner/video/Kling",
-            description="Transform still images into cinematic videos with professional camera movements that simulate real-world cinematography. Control virtual camera actions including zoom, rotation, pan, tilt, and first-person view, while maintaining focus on your original image.",
-            inputs=[
-                IO.Image.Input(
-                    "start_frame",
-                    tooltip="Reference Image - URL or Base64 encoded string, cannot exceed 10MB, resolution not less than 300*300px, aspect ratio between 1:2.5 ~ 2.5:1. Base64 should not include data:image prefix.",
-                ),
-                IO.String.Input("prompt", multiline=True, tooltip="Positive text prompt"),
-                IO.String.Input("negative_prompt", multiline=True, tooltip="Negative text prompt"),
-                IO.Float.Input("cfg_scale", default=0.75, min=0.0, max=1.0),
-                IO.Combo.Input(
-                    "aspect_ratio",
-                    options=KlingVideoGenAspectRatio,
-                    default=KlingVideoGenAspectRatio.field_16_9,
-                ),
-                IO.Custom("CAMERA_CONTROL").Input(
-                    "camera_control",
-                    tooltip="Can be created using the Kling Camera Controls node. Controls the camera movement and motion during the video generation.",
-                ),
-            ],
-            outputs=[
-                IO.Video.Output(),
-                IO.String.Output(display_name="video_id"),
-                IO.String.Output(display_name="duration"),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
-            is_api_node=True,
-            price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.49}""",
-            ),
-        )
-
-    @classmethod
-    async def execute(
-        cls,
-        start_frame: torch.Tensor,
-        prompt: str,
-        negative_prompt: str,
-        cfg_scale: float,
-        aspect_ratio: str,
-        camera_control: KlingCameraControl,
-    ) -> IO.NodeOutput:
-        return await execute_image2video(
-            cls,
-            model_name=KlingVideoGenModelName.kling_v1_5,
-            start_frame=start_frame,
-            cfg_scale=cfg_scale,
-            model_mode=KlingVideoGenMode.pro,
-            aspect_ratio=KlingVideoGenAspectRatio(aspect_ratio),
-            duration=KlingVideoGenDuration.field_5,
-            prompt=prompt,
-            negative_prompt=negative_prompt,
-            camera_control=camera_control,
         )
 
 
@@ -1977,7 +1577,7 @@ class KlingStartEndFrameNode(IO.ComfyNode):
                 IO.Combo.Input(
                     "mode",
                     options=modes,
-                    default=modes[6],
+                    default=modes[0],
                     tooltip="The configuration to use for the video generation following the format: mode / duration / model_name.",
                 ),
             ],
@@ -1997,25 +1597,7 @@ class KlingStartEndFrameNode(IO.ComfyNode):
                 expr="""
                 (
                   $m := widgets.mode;
-                  $contains($m,"v2-5-turbo")
-                    ? ($contains($m,"10") ? {"type":"usd","usd":0.7} : {"type":"usd","usd":0.35})
-                    : $contains($m,"v2-1")
-                      ? ($contains($m,"10s") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                      : $contains($m,"v2-master")
-                        ? ($contains($m,"10s") ? {"type":"usd","usd":2.8} : {"type":"usd","usd":1.4})
-                        : $contains($m,"v1-6")
-                          ? (
-                              $contains($m,"pro")
-                                ? ($contains($m,"10s") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                                : ($contains($m,"10s") ? {"type":"usd","usd":0.56} : {"type":"usd","usd":0.28})
-                            )
-                          : $contains($m,"v1")
-                            ? (
-                                $contains($m,"pro")
-                                  ? ($contains($m,"10s") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                                  : ($contains($m,"10s") ? {"type":"usd","usd":0.28} : {"type":"usd","usd":0.14})
-                              )
-                            : {"type":"usd","usd":0.14}
+                  $contains($m,"10") ? {"type":"usd","usd":0.7} : {"type":"usd","usd":0.35}
                 )
                 """,
             ),
@@ -2124,169 +1706,6 @@ class KlingVideoExtendNode(IO.ComfyNode):
 
         video = get_video_from_response(final_response)
         return IO.NodeOutput(await download_url_to_video_output(str(video.url)), str(video.id), str(video.duration))
-
-
-class KlingDualCharacterVideoEffectNode(IO.ComfyNode):
-    """Kling Dual Character Video Effect Node"""
-
-    @classmethod
-    def define_schema(cls) -> IO.Schema:
-        return IO.Schema(
-            node_id="KlingDualCharacterVideoEffectNode",
-            display_name="Kling Dual Character Video Effects",
-            category="partner/video/Kling",
-            description="Achieve different special effects when generating a video based on the effect_scene. First image will be positioned on left side, second on right side of the composite.",
-            inputs=[
-                IO.Image.Input("image_left", tooltip="Left side image"),
-                IO.Image.Input("image_right", tooltip="Right side image"),
-                IO.Combo.Input(
-                    "effect_scene",
-                    options=[i.value for i in KlingDualCharacterEffectsScene],
-                ),
-                IO.Combo.Input(
-                    "model_name",
-                    options=[i.value for i in KlingCharacterEffectModelName],
-                    default="kling-v1",
-                ),
-                IO.Combo.Input(
-                    "mode",
-                    options=[i.value for i in KlingVideoGenMode],
-                    default="std",
-                ),
-                IO.Combo.Input(
-                    "duration",
-                    options=[i.value for i in KlingVideoGenDuration],
-                ),
-            ],
-            outputs=[
-                IO.Video.Output(),
-                IO.String.Output(display_name="duration"),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
-            is_api_node=True,
-            price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(widgets=["mode", "model_name", "duration"]),
-                expr="""
-                (
-                  $mode := widgets.mode;
-                  $model := widgets.model_name;
-                  $dur := widgets.duration;
-                  ($contains($model,"v1-6") or $contains($model,"v1-5"))
-                    ? (
-                        $contains($mode,"pro")
-                          ? ($contains($dur,"10") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                          : ($contains($dur,"10") ? {"type":"usd","usd":0.56} : {"type":"usd","usd":0.28})
-                      )
-                    : $contains($model,"v1")
-                      ? (
-                          $contains($mode,"pro")
-                            ? ($contains($dur,"10") ? {"type":"usd","usd":0.98} : {"type":"usd","usd":0.49})
-                            : ($contains($dur,"10") ? {"type":"usd","usd":0.28} : {"type":"usd","usd":0.14})
-                        )
-                      : {"type":"usd","usd":0.14}
-                )
-                """,
-            ),
-        )
-
-    @classmethod
-    async def execute(
-        cls,
-        image_left: torch.Tensor,
-        image_right: torch.Tensor,
-        effect_scene: KlingDualCharacterEffectsScene,
-        model_name: KlingCharacterEffectModelName,
-        mode: KlingVideoGenMode,
-        duration: KlingVideoGenDuration,
-    ) -> IO.NodeOutput:
-        video, _, duration = await execute_video_effect(
-            cls,
-            dual_character=True,
-            effect_scene=effect_scene,
-            model_name=model_name,
-            model_mode=mode,
-            duration=duration,
-            image_1=image_left,
-            image_2=image_right,
-        )
-        return IO.NodeOutput(video, duration)
-
-
-class KlingSingleImageVideoEffectNode(IO.ComfyNode):
-    """Kling Single Image Video Effect Node"""
-
-    @classmethod
-    def define_schema(cls) -> IO.Schema:
-        return IO.Schema(
-            node_id="KlingSingleImageVideoEffectNode",
-            display_name="Kling Video Effects",
-            category="partner/video/Kling",
-            description="Achieve different special effects when generating a video based on the effect_scene.",
-            inputs=[
-                IO.Image.Input(
-                    "image",
-                    tooltip=" Reference Image. URL or Base64 encoded string (without data:image prefix). File size cannot exceed 10MB, resolution not less than 300*300px, aspect ratio between 1:2.5 ~ 2.5:1",
-                ),
-                IO.Combo.Input(
-                    "effect_scene",
-                    options=[i.value for i in KlingSingleImageEffectsScene],
-                ),
-                IO.Combo.Input(
-                    "model_name",
-                    options=[i.value for i in KlingSingleImageEffectModelName],
-                ),
-                IO.Combo.Input(
-                    "duration",
-                    options=[i.value for i in KlingVideoGenDuration],
-                ),
-            ],
-            outputs=[
-                IO.Video.Output(),
-                IO.String.Output(display_name="video_id"),
-                IO.String.Output(display_name="duration"),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
-            is_api_node=True,
-            price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(widgets=["effect_scene"]),
-                expr="""
-                (
-                  ($contains(widgets.effect_scene,"dizzydizzy") or $contains(widgets.effect_scene,"bloombloom"))
-                    ? {"type":"usd","usd":0.49}
-                    : {"type":"usd","usd":0.28}
-                )
-                """,
-            ),
-        )
-
-    @classmethod
-    async def execute(
-        cls,
-        image: torch.Tensor,
-        effect_scene: KlingSingleImageEffectsScene,
-        model_name: KlingSingleImageEffectModelName,
-        duration: KlingVideoGenDuration,
-    ) -> IO.NodeOutput:
-        return IO.NodeOutput(
-            *(
-                await execute_video_effect(
-                    cls,
-                    dual_character=False,
-                    effect_scene=effect_scene,
-                    model_name=model_name,
-                    duration=duration,
-                    image_1=image,
-                )
-            )
-        )
 
 
 class KlingLipSyncAudioToVideoNode(IO.ComfyNode):
@@ -2409,73 +1828,6 @@ class KlingLipSyncTextToVideoNode(IO.ComfyNode):
         )
 
 
-class KlingVirtualTryOnNode(IO.ComfyNode):
-    """Kling Virtual Try On Node."""
-
-    @classmethod
-    def define_schema(cls) -> IO.Schema:
-        return IO.Schema(
-            node_id="KlingVirtualTryOnNode",
-            display_name="Kling Virtual Try On",
-            category="partner/image/Kling",
-            description="Kling Virtual Try On Node. Input a human image and a cloth image to try on the cloth on the human. You can merge multiple clothing item pictures into one image with a white background.",
-            inputs=[
-                IO.Image.Input("human_image"),
-                IO.Image.Input("cloth_image"),
-                IO.Combo.Input(
-                    "model_name",
-                    options=[i.value for i in KlingVirtualTryOnModelName],
-                    default="kolors-virtual-try-on-v1",
-                ),
-            ],
-            outputs=[
-                IO.Image.Output(),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
-            is_api_node=True,
-            price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.7}""",
-            ),
-        )
-
-    @classmethod
-    async def execute(
-        cls,
-        human_image: torch.Tensor,
-        cloth_image: torch.Tensor,
-        model_name: KlingVirtualTryOnModelName,
-    ) -> IO.NodeOutput:
-        task_creation_response = await sync_op(
-            cls,
-            ApiEndpoint(path=PATH_VIRTUAL_TRY_ON, method="POST"),
-            response_model=KlingVirtualTryOnResponse,
-            data=KlingVirtualTryOnRequest(
-                human_image=tensor_to_base64_string(human_image),
-                cloth_image=tensor_to_base64_string(cloth_image),
-                model_name=model_name,
-            ),
-        )
-
-        validate_task_creation_response(task_creation_response)
-        task_id = task_creation_response.data.task_id
-
-        final_response = await poll_op(
-            cls,
-            ApiEndpoint(path=f"{PATH_VIRTUAL_TRY_ON}/{task_id}"),
-            response_model=KlingVirtualTryOnResponse,
-            estimated_duration=AVERAGE_DURATION_VIRTUAL_TRY_ON,
-            status_extractor=lambda r: (r.data.task_status.value if r.data and r.data.task_status else None),
-        )
-        validate_image_result_response(final_response)
-
-        images = get_images_from_response(final_response)
-        return IO.NodeOutput(await image_result_to_node_output(images))
-
-
 class KlingImageGenerationNode(IO.ComfyNode):
     """Kling Image Generation Node. Generate an image from a text prompt with an optional reference image."""
 
@@ -2514,7 +1866,7 @@ class KlingImageGenerationNode(IO.ComfyNode):
                     tooltip="Subject reference similarity",
                     advanced=True,
                 ),
-                IO.Combo.Input("model_name", options=["kling-v3", "kling-v2", "kling-v1-5"]),
+                IO.Combo.Input("model_name", options=["kling-v3", "kling-v2"]),
                 IO.Combo.Input(
                     "aspect_ratio",
                     options=[i.value for i in KlingImageGenAspectRatio],
@@ -2550,14 +1902,10 @@ class KlingImageGenerationNode(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(widgets=["model_name", "n"], inputs=["image"]),
+                depends_on=IO.PriceBadgeDepends(widgets=["model_name", "n"]),
                 expr="""
                 (
-                  $m := widgets.model_name;
-                  $base :=
-                    $contains($m,"kling-v1-5")
-                      ? (inputs.image.connected ? 0.028 : 0.014)
-                      : $contains($m,"kling-v3") ? 0.028 : 0.014;
+                  $base := $contains(widgets.model_name,"kling-v3") ? 0.028 : 0.014;
                   {"type":"usd","usd": $base * widgets.n}
                 )
                 """,
@@ -3394,19 +2742,13 @@ class KlingExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
         return [
-            KlingCameraControls,
             KlingTextToVideoNode,
             KlingImage2VideoNode,
-            KlingCameraControlI2VNode,
-            KlingCameraControlT2VNode,
             KlingStartEndFrameNode,
             KlingVideoExtendNode,
             KlingLipSyncAudioToVideoNode,
             KlingLipSyncTextToVideoNode,
-            KlingVirtualTryOnNode,
             KlingImageGenerationNode,
-            KlingSingleImageVideoEffectNode,
-            KlingDualCharacterVideoEffectNode,
             OmniProTextToVideoNode,
             OmniProFirstLastFrameNode,
             OmniProImageToVideoNode,

--- a/comfy_api_nodes/nodes_reve.py
+++ b/comfy_api_nodes/nodes_reve.py
@@ -137,6 +137,7 @@ class ReveImageCreateNode(IO.ComfyNode):
                 IO.Hidden.unique_id,
             ],
             is_api_node=True,
+            is_deprecated=True,
             price_badge=IO.PriceBadge(
                 depends_on=IO.PriceBadgeDepends(
                     widgets=["upscale", "upscale.upscale_factor"],
@@ -228,6 +229,7 @@ class ReveImageEditNode(IO.ComfyNode):
                 IO.Hidden.unique_id,
             ],
             is_api_node=True,
+            is_deprecated=True,
             price_badge=IO.PriceBadge(
                 depends_on=IO.PriceBadgeDepends(
                     widgets=["model", "upscale", "upscale.upscale_factor"],
@@ -337,6 +339,7 @@ class ReveImageRemixNode(IO.ComfyNode):
                 IO.Hidden.unique_id,
             ],
             is_api_node=True,
+            is_deprecated=True,
             price_badge=IO.PriceBadge(
                 depends_on=IO.PriceBadgeDepends(
                     widgets=["model", "upscale", "upscale.upscale_factor"],

--- a/comfy_api_nodes/nodes_topaz.py
+++ b/comfy_api_nodes/nodes_topaz.py
@@ -12,6 +12,7 @@ from comfy_api_nodes.apis.topaz import (
     ImageAsyncTaskResponse,
     ImageDownloadResponse,
     ImageEnhanceRequest,
+    ImageEnhanceRequestV2,
     ImageStatusResponse,
     OutputInformationVideo,
     Resolution,
@@ -51,7 +52,7 @@ class TopazImageEnhance(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="TopazImageEnhance",
-            display_name="Topaz Image Enhance",
+            display_name="Topaz Image Enhance (Legacy)",
             category="partner/image/Topaz",
             description="Industry-standard upscaling and image enhancement.",
             inputs=[
@@ -162,6 +163,7 @@ class TopazImageEnhance(IO.ComfyNode):
                 IO.Hidden.unique_id,
             ],
             is_api_node=True,
+            is_deprecated=True,
         )
 
     @classmethod
@@ -220,6 +222,355 @@ class TopazImageEnhance(IO.ComfyNode):
             estimated_duration=60,
         )
 
+        results = await sync_op(
+            cls,
+            ApiEndpoint(path=f"/proxy/topaz/image/v1/download/{initial_response.process_id}"),
+            response_model=ImageDownloadResponse,
+            monitor_progress=False,
+        )
+        return IO.NodeOutput(await download_url_to_image_tensor(results.download_url))
+
+
+class TopazImageEnhanceV2(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TopazImageEnhanceV2",
+            display_name="Topaz Image Enhance",
+            category="partner/image/Topaz",
+            description="Industry-standard upscaling and image enhancement.",
+            inputs=[
+                IO.Image.Input("image"),
+                IO.DynamicCombo.Input(
+                    "model",
+                    options=[
+                        IO.DynamicCombo.Option(
+                            "Reimagine",
+                            [
+                                IO.String.Input(
+                                    "prompt",
+                                    multiline=True,
+                                    default="",
+                                    tooltip="Optional text prompt for creative upscaling guidance.",
+                                ),
+                                IO.Int.Input(
+                                    "creativity",
+                                    default=3,
+                                    min=1,
+                                    max=9,
+                                    step=1,
+                                    display_mode=IO.NumberDisplay.slider,
+                                ),
+                                IO.Combo.Input(
+                                    "subject_detection",
+                                    options=["All", "Foreground", "Background"],
+                                    advanced=True,
+                                ),
+                                IO.Boolean.Input(
+                                    "face_enhancement",
+                                    default=True,
+                                    tooltip="Enhance faces (if present) during processing.",
+                                    advanced=True,
+                                ),
+                                IO.Float.Input(
+                                    "face_enhancement_creativity",
+                                    default=0.0,
+                                    min=0.0,
+                                    max=1.0,
+                                    step=0.01,
+                                    display_mode=IO.NumberDisplay.number,
+                                    tooltip="Set the creativity level for face enhancement.",
+                                    advanced=True,
+                                ),
+                                IO.Float.Input(
+                                    "face_enhancement_strength",
+                                    default=1.0,
+                                    min=0.0,
+                                    max=1.0,
+                                    step=0.01,
+                                    display_mode=IO.NumberDisplay.number,
+                                    tooltip="Controls how sharp enhanced faces are relative to the background.",
+                                    advanced=True,
+                                ),
+                                IO.Boolean.Input(
+                                    "face_preservation",
+                                    default=True,
+                                    tooltip="Preserve subjects' facial identity.",
+                                    advanced=True,
+                                ),
+                                IO.Boolean.Input(
+                                    "color_preservation",
+                                    default=True,
+                                    tooltip="Preserve the original colors.",
+                                    advanced=True,
+                                ),
+                                IO.Boolean.Input(
+                                    "crop_to_fill",
+                                    default=False,
+                                    tooltip="By default, the image is letterboxed when the output aspect "
+                                    "ratio differs. Enable to crop the image to fill the output dimensions.",
+                                    advanced=True,
+                                ),
+                            ],
+                        ),
+                        IO.DynamicCombo.Option(
+                            "Bloom 2",
+                            [
+                                IO.String.Input(
+                                    "prompt",
+                                    multiline=True,
+                                    default="",
+                                    tooltip="Optional text prompt for generation. "
+                                    "Leave empty to auto-generate a prompt from the input image.",
+                                ),
+                                IO.Int.Input(
+                                    "creativity",
+                                    default=3,
+                                    min=1,
+                                    max=9,
+                                    step=1,
+                                    display_mode=IO.NumberDisplay.slider,
+                                    tooltip="1 is restrained enhancement, 9 is pronounced reinterpretation "
+                                    "with newly generated detail.",
+                                ),
+                                IO.Int.Input(
+                                    "seed",
+                                    default=2,
+                                    min=1,
+                                    max=2000,
+                                    control_after_generate=True,
+                                    tooltip="Seed for reproducible generation.",
+                                ),
+                                IO.Boolean.Input(
+                                    "color_preservation",
+                                    default=True,
+                                    tooltip="Preserve the original colors.",
+                                    advanced=True,
+                                ),
+                                IO.Boolean.Input(
+                                    "grain",
+                                    default=False,
+                                    tooltip="Add grain to the output image.",
+                                    advanced=True,
+                                ),
+                                IO.Combo.Input(
+                                    "grain_model",
+                                    options=["silver", "gaussian", "grey"],
+                                    tooltip="Is ignored if grain is disabled.",
+                                    advanced=True,
+                                ),
+                                IO.Float.Input(
+                                    "grain_strength",
+                                    default=0.5,
+                                    min=0.0,
+                                    max=1.0,
+                                    step=0.01,
+                                    display_mode=IO.NumberDisplay.number,
+                                    tooltip="Strength of the grain effect. Is ignored if grain is disabled.",
+                                    advanced=True,
+                                ),
+                                IO.Float.Input(
+                                    "grain_size",
+                                    default=1.0,
+                                    min=1.0,
+                                    max=5.0,
+                                    step=0.1,
+                                    display_mode=IO.NumberDisplay.number,
+                                    tooltip="Size of the grain particles. Is ignored if grain is disabled.",
+                                    advanced=True,
+                                ),
+                                IO.Float.Input(
+                                    "grain_density",
+                                    default=0.5,
+                                    min=0.0,
+                                    max=1.0,
+                                    step=0.01,
+                                    display_mode=IO.NumberDisplay.number,
+                                    tooltip="Intensity of the grain effect. Is ignored if grain is disabled.",
+                                    advanced=True,
+                                ),
+                            ],
+                        ),
+                        IO.DynamicCombo.Option(
+                            "Wonder 3.5",
+                            [
+                                IO.Combo.Input(
+                                    "enhancement_strength",
+                                    options=["low", "medium", "high"],
+                                    default="high",
+                                    tooltip="Enhancement level for varying input conditions.",
+                                ),
+                                IO.Boolean.Input(
+                                    "grain",
+                                    default=False,
+                                    tooltip="Add grain to the output image.",
+                                    advanced=True,
+                                ),
+                                IO.Combo.Input(
+                                    "grain_model",
+                                    options=["silver", "gaussian", "grey"],
+                                    tooltip="Is ignored if grain is disabled.",
+                                    advanced=True,
+                                ),
+                                IO.Float.Input(
+                                    "grain_strength",
+                                    default=0.5,
+                                    min=0.0,
+                                    max=1.0,
+                                    step=0.01,
+                                    display_mode=IO.NumberDisplay.number,
+                                    tooltip="Strength of the grain effect. Is ignored if grain is disabled.",
+                                    advanced=True,
+                                ),
+                                IO.Float.Input(
+                                    "grain_size",
+                                    default=1.0,
+                                    min=1.0,
+                                    max=5.0,
+                                    step=0.1,
+                                    display_mode=IO.NumberDisplay.number,
+                                    tooltip="Size of the grain particles. Is ignored if grain is disabled.",
+                                    advanced=True,
+                                ),
+                                IO.Float.Input(
+                                    "grain_density",
+                                    default=0.5,
+                                    min=0.0,
+                                    max=1.0,
+                                    step=0.01,
+                                    display_mode=IO.NumberDisplay.number,
+                                    tooltip="Intensity of the grain effect. Is ignored if grain is disabled.",
+                                    advanced=True,
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                IO.Int.Input(
+                    "output_width",
+                    default=0,
+                    min=0,
+                    max=32000,
+                    step=1,
+                    display_mode=IO.NumberDisplay.number,
+                    optional=True,
+                    tooltip="Zero value means to calculate automatically (usually it will be original size "
+                    "or scaled proportionally to output_height if specified). "
+                    "Wonder 3.5 supports upscale factors from 1x to 6x only. "
+                    "Bloom 2 and Wonder 3.5 preserve the input aspect ratio and treat the "
+                    "requested size as a target.",
+                    advanced=True,
+                ),
+                IO.Int.Input(
+                    "output_height",
+                    default=0,
+                    min=0,
+                    max=32000,
+                    step=1,
+                    display_mode=IO.NumberDisplay.number,
+                    optional=True,
+                    tooltip="Zero value means to output in the same height as original or scaled "
+                    "proportionally to output_width if specified. "
+                    "Wonder 3.5 supports upscale factors from 1x to 6x only. "
+                    "Bloom 2 and Wonder 3.5 preserve the input aspect ratio and treat the "
+                    "requested size as a target.",
+                    advanced=True,
+                ),
+            ],
+            outputs=[
+                IO.Image.Output(),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=IO.PriceBadge(
+                depends_on=IO.PriceBadgeDepends(widgets=["model"]),
+                expr="""
+                (
+                  $usdPer8Mp := $lookup(
+                    {"reimagine": 0.32, "bloom 2": 0.4576, "wonder 3.5": 0.1144},
+                    $lookup(widgets, "model")
+                  );
+                  {"type":"usd","usd": $usdPer8Mp, "format": {"suffix": "/8MP", "approximate": true}}
+                )
+                """,
+            ),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        image: Input.Image,
+        model: dict,
+        output_width: int = 0,
+        output_height: int = 0,
+    ) -> IO.NodeOutput:
+        if get_number_of_images(image) != 1:
+            raise ValueError("Only one input image is supported.")
+        model_choice = model["model"]
+        download_url = await upload_images_to_comfyapi(
+            cls, image, max_images=1, mime_type="image/png", total_pixels=4096 * 4096
+        )
+        request = ImageEnhanceRequestV2(
+            model=model_choice,
+            source_url=download_url[0],
+            output_width=output_width if output_width else None,
+            output_height=output_height if output_height else None,
+        )
+        if model_choice == "Reimagine":
+            request.prompt = model["prompt"]
+            request.creativity = model["creativity"]
+            request.subject_detection = model["subject_detection"]
+            request.face_enhancement = model["face_enhancement"]
+            request.face_enhancement_creativity = model["face_enhancement_creativity"]
+            request.face_enhancement_strength = model["face_enhancement_strength"]
+            request.face_preservation = str(model["face_preservation"]).lower()
+            request.color_preservation = str(model["color_preservation"]).lower()
+            request.crop_to_fill = model["crop_to_fill"]
+        elif model_choice == "Bloom 2":
+            prompt = model["prompt"].strip()
+            if prompt:
+                request.prompt = prompt
+                request.autoprompt = "false"
+            else:
+                request.autoprompt = "true"
+            request.creativity = model["creativity"]
+            request.seed = model["seed"]
+            request.color_preservation = str(model["color_preservation"]).lower()
+            if model["grain"]:
+                request.grain = "true"
+                request.grain_model = model["grain_model"]
+                request.grain_strength = model["grain_strength"]
+                request.grain_size = model["grain_size"]
+                request.grain_density = model["grain_density"]
+        else:
+            request.enhancement_strength = model["enhancement_strength"]
+            if model["grain"]:
+                request.grain = "true"
+                request.grain_model = model["grain_model"]
+                request.grain_strength = model["grain_strength"]
+                request.grain_size = model["grain_size"]
+                request.grain_density = model["grain_density"]
+        initial_response = await sync_op(
+            cls,
+            ApiEndpoint(path="/proxy/topaz/image/v1/enhance-gen/async", method="POST"),
+            response_model=ImageAsyncTaskResponse,
+            data=request,
+            content_type="multipart/form-data",
+        )
+        await poll_op(
+            cls,
+            poll_endpoint=ApiEndpoint(path=f"/proxy/topaz/image/v1/status/{initial_response.process_id}"),
+            response_model=ImageStatusResponse,
+            status_extractor=lambda x: x.status,
+            progress_extractor=lambda x: getattr(x, "progress", 0),
+            price_extractor=lambda x: x.credits * (0.08 if model_choice == "Reimagine" else 0.1144),
+            poll_interval=8.0,
+            estimated_duration=60,
+        )
         results = await sync_op(
             cls,
             ApiEndpoint(path=f"/proxy/topaz/image/v1/download/{initial_response.process_id}"),
@@ -818,6 +1169,7 @@ class TopazExtension(ComfyExtension):
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
         return [
             TopazImageEnhance,
+            TopazImageEnhanceV2,
             TopazVideoEnhance,
             TopazVideoEnhanceV2,
         ]

--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -195,7 +195,7 @@ class LoadImageDataSetFromFolderNode(io.ComfyNode):
 
     @classmethod
     def execute(cls, folder):
-        sub_input_dir = os.path.join(folder_paths.get_input_directory(), folder)
+        sub_input_dir = secure_subfolder_path(folder_paths.get_input_directory(), folder)
         valid_extensions = [".png", ".jpg", ".jpeg", ".webp"]
         image_files = [
             f
@@ -241,7 +241,7 @@ class LoadImageTextDataSetFromFolderNode(io.ComfyNode):
     def execute(cls, folder):
         logging.info(f"Loading images from folder: {folder}")
 
-        sub_input_dir = os.path.join(folder_paths.get_input_directory(), folder)
+        sub_input_dir = secure_subfolder_path(folder_paths.get_input_directory(), folder)
         valid_extensions = [".png", ".jpg", ".jpeg", ".webp"]
 
         image_files = []
@@ -310,7 +310,7 @@ class LoadVideoDataSetFromFolderNode(io.ComfyNode):
 
     @classmethod
     def execute(cls, folder):
-        sub_input_dir = os.path.join(folder_paths.get_input_directory(), folder)
+        sub_input_dir = secure_subfolder_path(folder_paths.get_input_directory(), folder)
         video_files = sorted([
             f for f in os.listdir(sub_input_dir)
             if any(f.lower().endswith(ext) for ext in VALID_VIDEO_EXTENSIONS)
@@ -357,7 +357,7 @@ class LoadVideoTextDataSetFromFolderNode(io.ComfyNode):
 
     @classmethod
     def execute(cls, folder):
-        sub_input_dir = os.path.join(folder_paths.get_input_directory(), folder)
+        sub_input_dir = secure_subfolder_path(folder_paths.get_input_directory(), folder)
 
         video_files = []
         for item in sorted(os.listdir(sub_input_dir)):

--- a/comfy_extras/nodes_gaussian_splat.py
+++ b/comfy_extras/nodes_gaussian_splat.py
@@ -471,6 +471,12 @@ def _mat_to_quat(m):
 
 
 class SplatToFile3D(IO.ComfyNode):
+    FORMAT_WRITERS = {
+        "ply": _gaussian_ply_bytes,
+        "ksplat": _gaussian_ksplat_bytes,
+        "spz": _gaussian_spz_bytes,
+    }
+
     @classmethod
     def define_schema(cls):
         return IO.Schema(
@@ -482,7 +488,7 @@ class SplatToFile3D(IO.ComfyNode):
                         "Supports one item per batch only.",
             inputs=[
                 IO.Splat.Input("splat"),
-                IO.Combo.Input("format", options=["ply", "ksplat", "spz"],  # TODO: add "splat" when we have a writer for it
+                IO.Combo.Input("format", options=list(cls.FORMAT_WRITERS),  # TODO: add "splat" when we have a writer for it
                                tooltip="ply: standard 3D Gaussian Splat with full spherical harmonics. "
                                        "ksplat: mkkellogg SplatBuffer (level 0, uncompressed), base color only "
                                        "spz: Niantic gzip-compressed (~10x smaller), base color only "
@@ -493,10 +499,13 @@ class SplatToFile3D(IO.ComfyNode):
 
     @classmethod
     def execute(cls, splat, format="ply") -> IO.NodeOutput:
+        writer = cls.FORMAT_WRITERS.get(format)
+        if writer is None:
+            raise ValueError(f"Unsupported splat format: {format!r}")
+
         if splat.positions.shape[0] > 1:
             logging.warning("SplatToFile3D supports one item per batch only. Got %d; using first.", splat.positions.shape[0])
         end = _real_len(splat, 0)
-        writer = {"ksplat": _gaussian_ksplat_bytes, "spz": _gaussian_spz_bytes}.get(format, _gaussian_ply_bytes)
         data = writer(splat.positions[0, :end], splat.scales[0, :end],
                       splat.rotations[0, :end], splat.opacities[0, :end], splat.sh[0, :end])
         return IO.NodeOutput(Types.File3D(BytesIO(data), file_format=format))

--- a/nodes.py
+++ b/nodes.py
@@ -633,15 +633,18 @@ class DiffusersLoader:
     SEARCH_ALIASES = ["load diffusers model"]
 
     @classmethod
-    def INPUT_TYPES(cls):
+    def _model_paths(cls):
         paths = []
         for search_path in folder_paths.get_folder_paths("diffusers"):
             if os.path.exists(search_path):
                 for root, subdir, files in os.walk(search_path, followlinks=True):
                     if "model_index.json" in files:
                         paths.append(os.path.relpath(root, start=search_path))
+        return paths
 
-        return {"required": {"model_path": (paths,), }}
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"model_path": (cls._model_paths(),), }}
     RETURN_TYPES = ("MODEL", "CLIP", "VAE")
     FUNCTION = "load_checkpoint"
     DEPRECATED = True
@@ -649,14 +652,20 @@ class DiffusersLoader:
     CATEGORY = "model/loaders"
 
     def load_checkpoint(self, model_path, output_vae=True, output_clip=True):
+        if model_path not in self._model_paths():
+            raise ValueError(f"Invalid diffusers model path: {model_path!r}")
+
+        resolved_model_path = None
         for search_path in folder_paths.get_folder_paths("diffusers"):
             if os.path.exists(search_path):
                 path = os.path.join(search_path, model_path)
-                if os.path.exists(path):
-                    model_path = path
+                if os.path.isfile(os.path.join(path, "model_index.json")):
+                    resolved_model_path = path
                     break
+        if resolved_model_path is None:
+            raise FileNotFoundError(f"Diffusers model {model_path!r} not found.")
 
-        return comfy.diffusers_load.load_diffusers(model_path, output_vae=output_vae, output_clip=output_clip, embedding_directory=folder_paths.get_folder_paths("embeddings"))
+        return comfy.diffusers_load.load_diffusers(resolved_model_path, output_vae=output_vae, output_clip=output_clip, embedding_directory=folder_paths.get_folder_paths("embeddings"))
 
 
 class unCLIPCheckpointLoader:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.47.12
-comfyui-workflow-templates==0.11.27
+comfyui-workflow-templates==0.11.31
 comfyui-embedded-docs==0.5.9
 torch
 torchsde

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy>=2.0.0
 filelock
 av>=16.0.0
 comfy-kitchen==0.2.26
-comfy-aimdo==0.4.11
+comfy-aimdo==0.4.13
 requests
 simpleeval>=1.0.0
 blake3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.47.12
+comfyui-frontend-package==1.48.6
 comfyui-workflow-templates==0.11.31
 comfyui-embedded-docs==0.5.9
 torch


### PR DESCRIPTION
Found during QA of #15351 against staging. **One line.**

`bounding_box.absolute` is exclusive on right/bottom; the node adds 1 to each.

Live staging response:

```
bounding_box.absolute : [691, 219, 1765, 2048]
returned PNG          : 1074x1829
right - left          : 1074   ✅
right - left + 1      : 1075   ❌
```

Three independent confirmations:

1. `right - left` equals the returned PNG width exactly.
2. The sibling `normalized` per-mille box gives `(861-337)/1000 * 2048 = 1073.2` and `(1000-107)/1000 * 2048 = 1828.9` → rounds to 1074x1829.
3. `bottom` is **2048** on a 2048px-tall image. Valid inclusive rows are 0..2047, so 2048 can only be an exclusive edge.

### What it costs today, on every layer of every generation

- The size check `(native_w, native_h) != (rect_w, rect_h)` **always** fails, so every layer is resampled 1074x1829 → 1075x1830 through bilinear interpolation for no reason. Real resampling blur, every time.
- That also drags each layer through premultiply → resize → unpremultiply, including the `alpha.clamp(min=1e-6)` divide that can blow out soft edges.
- `resized_to_bbox` fires on **100%** of layers, so the flag is dead as the diagnostic it was meant to be.
- Placement runs 1px oversized — in full-canvas mode `top + rect_h` = 2049 on a 2048px canvas, so the bottom row is silently clipped.

Draft for @bigcat88 to take or fold into #15351 directly. cc @christian-byrne

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

