### PR TITLE
[DRAFT] feat(ByteDance): LAYERS output on Seedream Layer Separation

### DIFF
--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -1136,32 +1136,42 @@ class ByteDanceSeedreamLayerSeparationNode(IO.ComfyNode):
                     ),
                 ),
                 IO.Image.Output(
-                    display_name="layers",
+                    display_name="layers_batch",
                     tooltip=(
-                        "Transparent layers ordered bottom to top; batch after base_image and feed the result "
-                        "to the image input of Create Layered Image (each batch frame becomes one editor "
-                        "layer). Full canvas mode: placed on a black base-sized canvas at their bounding-box "
-                        "position. Minimal size mode: cropped to their bounding box, anchored top-left, padded "
-                        "to the largest layer."
+                        "Transparent layers ordered bottom to top as a plain image batch, for graphs that "
+                        "composite by hand (ImageCompositeMasked, after an InvertMask on masks). To drive "
+                        "Create Layered Image, use the layers output instead - it carries per-layer placement "
+                        "that a batch cannot. Full canvas mode: placed on a black base-sized canvas at their "
+                        "bounding-box position. Minimal size mode: cropped to their bounding box, anchored "
+                        "top-left, padded to the largest layer."
                     ),
                 ),
                 IO.Mask.Output(
                     display_name="masks",
                     tooltip=(
-                        "Per-layer transparency, index-aligned with the layers batch (1 = transparent, "
-                        "LoadImage convention); batch after base_mask and feed the result to the mask input "
-                        "of Create Layered Image. For ImageCompositeMasked-style compositing, add InvertMask "
-                        "first - that node treats 1 as opaque."
+                        "Per-layer transparency, index-aligned with layers_batch (1 = transparent, LoadImage "
+                        "convention). For ImageCompositeMasked-style compositing, add InvertMask first - that "
+                        "node treats 1 as opaque."
                     ),
                 ),
                 IO.BoundingBox.Output(
                     display_name="bboxes",
                     tooltip=(
-                        "Placement boxes for Create Layered Image, index-aligned with its image batch frames: the "
-                        "first entry covers the base image, the rest place each layer 1:1. metadata carries name, "
-                        "desc, z_index, native_size, content_rect = [left, top, width, height] (the layer's true "
-                        "bounding box in base-image pixels) and flags - a layer whose flags include "
-                        "bbox_degenerate or bbox_out_of_canvas came back fully transparent."
+                        "Placement boxes index-aligned with layers_batch: the first entry covers the base "
+                        "image, the rest place each layer. metadata carries name, desc, z_index, native_size, "
+                        "content_rect = [left, top, width, height] (the layer's true bounding box in "
+                        "base-image pixels) and flags - a layer whose flags include bbox_degenerate or "
+                        "bbox_out_of_canvas came back fully transparent."
+                    ),
+                ),
+                IO.Layers.Output(
+                    display_name="layers",
+                    tooltip=(
+                        "The full layer stack as a document: the base plate at z_index 0 with each separated "
+                        "element above it, carrying its own placement, name and stacking order. Wire straight "
+                        "into the layers input of Create Layered Image - no batching or Add Layer needed. "
+                        "Works in either crop mode; minimal size keeps each layer at its own size, which is "
+                        "the cheaper option for large images."
                     ),
                 ),
             ],
@@ -1347,7 +1357,51 @@ class ByteDanceSeedreamLayerSeparationNode(IO.ComfyNode):
                     },
                 }
             )
-        return IO.NodeOutput(base_image, base_mask, layers, masks, bboxes)
+
+        # Layer stack as a document. One item per layer, each carrying its own placement, so the
+        # per-layer positions survive - a plain image batch shares a single placement across every
+        # frame. In crop mode each item stays at its own size; in full-canvas mode placement is
+        # already baked into the pixels, so the items sit at the origin.
+        document: IO.Layers.Document = {
+            "version": 1,
+            "canvas": (width, height),
+            "layers": [
+                {
+                    "image": base_image,
+                    "mask": base_mask,
+                    "type": "raster",
+                    "x": 0,
+                    "y": 0,
+                    "z_index": 0,
+                    "name": "background",
+                }
+            ],
+        }
+        for i, e in enumerate(entries):
+            if "bbox_degenerate" in e["flags"] or "bbox_out_of_canvas" in e["flags"]:
+                continue  # came back fully transparent; nothing to composite
+            if crop_layers:
+                item_x, item_y = e["left"], e["top"]
+                image = layers[i : i + 1, : e["rect_h"], : e["rect_w"]]
+                mask = masks[i : i + 1, : e["rect_h"], : e["rect_w"]]
+            else:
+                item_x, item_y = 0, 0
+                image = layers[i : i + 1]
+                mask = masks[i : i + 1]
+            item: IO.Layers.LayerItem = {
+                "image": image,
+                "mask": mask,
+                "type": "raster",
+                "x": item_x,
+                "y": item_y,
+                "z_index": i + 1,
+            }
+            name = e["item"].get("name")
+            if isinstance(name, str) and name:
+                item["name"] = name
+            document["layers"].append(item)
+
+        return IO.NodeOutput(base_image, base_mask, layers, masks, bboxes, document)
 
 
 class ByteDanceTextToVideoNode(IO.ComfyNode):


### PR DESCRIPTION
> **Stacked.** Base is #15366 (for the tooltip context). Also requires #15317, which supplies the `LAYERS` io type — this does not import without it.

Renames the existing `layers` IMAGE output to **`layers_batch`** and adds a new **`layers`** output of type `LAYERS`: the base plate at `z_index` 0 with each element above it, carrying its own placement, name and stacking order. Wires straight into Create Layered Image — no Batch Images, no Add Layer.

```
base_image    -> IMAGE
base_mask     -> MASK
layers_batch  -> IMAGE          (renamed)
masks         -> MASK
bboxes        -> BOUNDING_BOX
layers        -> LAYERS         (new)
```

### Why

The outputs currently cannot drive the compositor with placement intact. `expand_item_frames` applies an item’s single `x`/`y`/`w`/`h`/`name`/`z_index` to every frame of a batch, so 16 layers share one placement. That is why full-canvas mode is the only workable path today — placement is baked into the pixels, so `x=0, y=0` is correct for all of them. It costs ~768MB of layer tensors plus ~268MB of masks at 2K with 16 layers, and leaves minimal-size mode unusable with the compositor.

One document item per layer sidesteps this with **no change to the compositor**: `document_items` already sorts by `z_index`, `expand_item_frames` already handles single-frame items correctly.

### The `bboxes` output is currently dead

Its tooltip promises “Placement boxes for Create Layered Image”, but the bbox input it was written against was removed in `1c4953ff`. #15386 revives it generally for any bbox producer; this PR is the direct path for this node specifically. **They are alternatives — pick one.**

### Notes

- New output is **appended**, not placed next to `layers_batch`, since outputs are wired by index and reordering breaks saved workflows. Happy to move it; the node is unreleased.
- Layers flagged `bbox_degenerate` / `bbox_out_of_canvas` are skipped rather than added as invisible items.
- Crop mode keeps each item at its own size; full-canvas mode puts items at the origin since placement is already in the pixels.

### Before judging round-trip fidelity

The compositor composites in **linear light** (`srgb_to_linear` in, `linear_to_srgb` out — symmetric and deliberate). Hard edges reconstruct to within **0.50/255**; anti-aliased edges diverge by up to **~30/255** if the model decomposed assuming sRGB-space compositing. Worth confirming with ByteDance which space they assume — the claim that elements “directly restore the original image” only holds under one of them.

Draft for @bigcat88 and @jtydhr88. cc @christian-byrne

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

