### PR TITLE
Fail fast when an Autogrow group input is given a value directly

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -1112,6 +1112,12 @@ class Autogrow(ComfyTypeI):
     @staticmethod
     def _expand_schema_for_dynamic(out_dict: dict[str, Any], live_inputs: dict[str, Any], value: tuple[str, dict[str, Any]], input_type: str, curr_prefix: list[str] | None):
         # NOTE: purposely do not include self in out_dict; instead use only the template inputs
+        finalized_prefix = finalize_prefix(curr_prefix)
+        if finalized_prefix in live_inputs:
+            raise ValueError(
+                f"Input '{finalized_prefix}' is an Autogrow group and cannot be given a value directly; "
+                f"wire each sub-slot individually using a dotted key, e.g. '{finalized_prefix}.<name>'."
+            )
         # need to figure out names based on template type
         is_names = ("names" in value[1]["template"])
         is_prefix = ("prefix" in value[1]["template"])
@@ -1156,7 +1162,6 @@ class Autogrow(ComfyTypeI):
                 new_dict_added_to = True
         # account for the edge case that all inputs are optional and no values are received
         if not new_dict_added_to:
-            finalized_prefix = finalize_prefix(curr_prefix)
             out_dict["dynamic_paths"][finalized_prefix] = finalized_prefix
             out_dict["dynamic_paths_default_value"][finalized_prefix] = DynamicPathsDefaultValue.EMPTY_DICT
         parse_class_inputs(out_dict, live_inputs, new_dict, curr_prefix)

--- a/tests-unit/comfy_api_test/autogrow_nested_input_test.py
+++ b/tests-unit/comfy_api_test/autogrow_nested_input_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+from comfy_api.latest._io import Autogrow, Image, create_input_dict_v1, get_finalized_class_inputs
+
+
+def _autogrow_class_inputs():
+    autogrow_input = Autogrow.Input(
+        "images",
+        template=Autogrow.TemplateNames(
+            Image.Input("image"),
+            names=["image_1", "image_2"],
+            min=0,
+        ),
+    )
+    return create_input_dict_v1([autogrow_input])
+
+
+def test_autogrow_rejects_nested_dict_on_group_key():
+    class_inputs = _autogrow_class_inputs()
+
+    with pytest.raises(ValueError):
+        get_finalized_class_inputs(class_inputs, {"images": {"image_1": ["14", 0]}})
+
+
+def test_autogrow_accepts_dotted_sub_slot_key():
+    class_inputs = _autogrow_class_inputs()
+
+    _, _, v3_data = get_finalized_class_inputs(class_inputs, {"images.image_1": ["14", 0]})
+
+    assert v3_data["dynamic_paths"] == {"images.image_1": "images.image_1"}
+
+
+def test_autogrow_defaults_to_empty_dict_when_nothing_provided():
+    class_inputs = _autogrow_class_inputs()
+
+    _, _, v3_data = get_finalized_class_inputs(class_inputs, {})
+
+    assert v3_data["dynamic_paths"] == {"images": "images"}
+    assert v3_data["dynamic_paths_default_value"] == {"images": "empty_dict"}

--- a/tests-unit/comfy_api_test/autogrow_nested_input_test.py
+++ b/tests-unit/comfy_api_test/autogrow_nested_input_test.py
@@ -18,7 +18,7 @@ def _autogrow_class_inputs():
 def test_autogrow_rejects_nested_dict_on_group_key():
     class_inputs = _autogrow_class_inputs()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Input 'images' is an Autogrow group.*dotted key"):
         get_finalized_class_inputs(class_inputs, {"images": {"image_1": ["14", 0]}})
 
 
@@ -28,6 +28,7 @@ def test_autogrow_accepts_dotted_sub_slot_key():
     _, _, v3_data = get_finalized_class_inputs(class_inputs, {"images.image_1": ["14", 0]})
 
     assert v3_data["dynamic_paths"] == {"images.image_1": "images.image_1"}
+    assert v3_data.get("dynamic_paths_default_value", {}) == {}
 
 
 def test_autogrow_defaults_to_empty_dict_when_nothing_provided():


### PR DESCRIPTION
Fixes #15305

## Problem

Wiring a link into a sub-slot of an `io.Autogrow` input via the raw `/prompt`
API JSON using the nested-dict shape that matches the Python kwarg layout
(`"images": {"image_1": ["14", 0]}`) passes `/prompt` validation and runs to
`status_str: success` with zero errors, but the node receives an empty
`images` dict — the link is silently dropped.

Root cause: `Autogrow._expand_schema_for_dynamic`
(`comfy_api/latest/_io.py`) only recognizes dotted sub-slot keys
(`images.image_1`) as valid ways to supply a sub-slot value. The group's own
bare id (`images`) is never included in the finalized input schema, so when
a raw dict is given directly under that key it doesn't match any expected
sub-slot path. `new_dict_added_to` stays `False`, and the code falls into
the "no sub-slots provided" branch, silently defaulting the whole group to
an empty dict.

## Fix

Raise a clear `ValueError` in `Autogrow._expand_schema_for_dynamic` when the
group's own finalized prefix (e.g. `images`) is present in the raw prompt
inputs. This is never a valid shape for an Autogrow input — sub-slots must
always be supplied as dotted keys — so previously-silent data loss now
surfaces as a validation error during `validate_inputs`/`get_input_data`
instead of executing with wrong data.

## Testing

Added `tests-unit/comfy_api_test/autogrow_nested_input_test.py`, which
exercises `comfy_api.latest._io.get_finalized_class_inputs` directly against
an `io.Autogrow` schema:

- nested-dict on the group key now raises `ValueError` (previously silently
  produced an empty dict with no error — confirmed this test fails without
  the fix)
- the correct dotted-key shape (`images.image_1`) still resolves normally
- omitting the input entirely still falls back to the empty-dict default
  with no error

```
$ python -m pytest tests-unit/comfy_api_test/autogrow_nested_input_test.py -v
tests-unit/comfy_api_test/autogrow_nested_input_test.py::test_autogrow_rejects_nested_dict_on_group_key PASSED
tests-unit/comfy_api_test/autogrow_nested_input_test.py::test_autogrow_accepts_dotted_sub_slot_key PASSED
tests-unit/comfy_api_test/autogrow_nested_input_test.py::test_autogrow_defaults_to_empty_dict_when_nothing_provided PASSED
3 passed in 1.49s
```

Full unit suite and ruff also pass:

```
$ python -m pytest tests-unit -q
1130 passed, 10 skipped, 12 warnings in 30.00s

$ ruff check .
All checks passed!
```

## AI assistance disclosure

This change was written with AI assistance (Claude Code), reviewed and
tested by me before submission.
